### PR TITLE
Update Google Apps Script endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This folder contains a clean, from-scratch foundation for the new internal activ
 ### Frontend
 
 1. `API_URL` is already pre-configured to:
-   `https://script.google.com/macros/s/AKfycbwlJuofD5-Adw1CD1pSdBR3f5RRS-LZsBv1I_zMM1-4UN6maq8qdPZqBQ1Zo4c_fneU/exec`
+   `https://script.google.com/macros/s/AKfycbyfdDwgM9D9nODbAF4JI3I3L20loOJeTuEs0LwNKv_QyXpCun59IHCqO79y0IRKLiN8/exec`
 2. If you deploy a different Apps Script version, update `new-system/frontend/src/config.js`.
 3. Serve `new-system/frontend` as static files (GitHub Pages / simple static hosting).
 

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,5 +1,5 @@
 export const CONFIG = {
-  API_URL: 'https://script.google.com/macros/s/AKfycbwlJuofD5-Adw1CD1pSdBR3f5RRS-LZsBv1I_zMM1-4UN6maq8qdPZqBQ1Zo4c_fneU/exec',
+  API_URL: 'https://script.google.com/macros/s/AKfycbyfdDwgM9D9nODbAF4JI3I3L20loOJeTuEs0LwNKv_QyXpCun59IHCqO79y0IRKLiN8/exec',
   APP_NAME: 'Educational Activities',
   SESSION_KEY: 'new_system_session',
   ROUTES: {


### PR DESCRIPTION
### Motivation
- Keep runtime configuration and documentation in sync by replacing the old Google Apps Script deployment URL with the new provided endpoint.

### Description
- Replaced the Apps Script endpoint URL with `https://script.google.com/macros/s/AKfycbyfdDwgM9D9nODbAF4JI3I3L20loOJeTuEs0LwNKv_QyXpCun59IHCqO79y0IRKLiN8/exec` in `frontend/src/config.js` and in `README.md`.

### Testing
- Verified with `rg` that the new URL is present and the old URL is removed, and committed the changes with `git commit` (commands completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e180b71b60832bb5ed9f00dc3b3d62)