### PR TITLE
Fix GitHub Pages blank screen by correcting frontend asset paths

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -2,8 +2,8 @@ const CACHE_NAME = 'new-system-v1';
 const ASSETS = [
   './',
   './index.html',
-  './src/main.js',
-  './src/styles/main.css'
+  './frontend/src/main.js',
+  './frontend/src/styles/main.css'
 ];
 
 self.addEventListener('install', (event) => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -18,7 +18,7 @@ async function bootstrap() {
   await renderApp(document.getElementById('root'));
 
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('./public/sw.js').catch(() => {});
+    navigator.serviceWorker.register('./frontend/public/sw.js').catch(() => {});
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#141824" />
-  <link rel="manifest" href="./public/manifest.json" />
+  <link rel="manifest" href="./frontend/public/manifest.json" />
   <title>Activities System</title>
-  <link rel="stylesheet" href="./src/styles/main.css" />
+  <link rel="stylesheet" href="./frontend/src/styles/main.css" />
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="./src/main.js"></script>
+  <script type="module" src="./frontend/src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- GitHub Pages serves the root `index.html`, but the HTML referenced `./src/*` and `./public/*` assets which actually live under `./frontend/...`, causing the module loader to fail and the app to show a blank white screen.  
- The service worker also cached incorrect relative paths which could prevent assets from being fetched after install.  

### Description
- Updated root `index.html` to point asset paths to `./frontend/public/manifest.json`, `./frontend/src/styles/main.css`, and module entry `./frontend/src/main.js`.  
- Updated service worker registration in `frontend/src/main.js` to register `./frontend/public/sw.js`.  
- Updated cached asset list in `frontend/public/sw.js` to include `./frontend/src/main.js` and `./frontend/src/styles/main.css`.  
- Files changed: `index.html`, `frontend/src/main.js`, and `frontend/public/sw.js`.

### Testing
- Served the repository locally with `python -m http.server` and verified with `curl -I` that `/index.html`, `/frontend/src/main.js`, `/frontend/src/styles/main.css`, and `/frontend/public/sw.js` all returned HTTP 200.  
- No unit tests exist for these assets so only the above automated HTTP checks were run and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e187018f74832b9a6417e8ba204e3b)