### PR TITLE
Require username/email plus password in login flow

### DIFF
--- a/backend/src/actions/login.gs
+++ b/backend/src/actions/login.gs
@@ -1,5 +1,8 @@
 function actionLogin_(request) {
-  var user = authenticate_(request.user_id, request.entry_code);
+  var identifier = String(request.identifier || '').trim();
+  if (!identifier || !request.entry_code) return { user: null };
+
+  var user = authenticate_(null, request.entry_code, identifier);
   if (!user) return { user: null };
 
   var safeUser = {};

--- a/backend/src/auth.gs
+++ b/backend/src/auth.gs
@@ -2,14 +2,32 @@ function isTruthy_(value) {
   return value === true || value === 'TRUE' || value === 'yes' || value === 1 || value === '1';
 }
 
-function authenticate_(userId, entryCode) {
+function normalizeAuthValue_(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function authenticate_(userId, entryCode, identifier) {
   if (!entryCode) return null;
+
+  var normalizedIdentifier = normalizeAuthValue_(identifier);
+  var normalizedUserId = normalizeAuthValue_(userId);
 
   var rows = getRows_('permissions');
   var user = rows.find(function (row) {
-    var byCode = String(row.entry_code).trim() === String(entryCode).trim();
-    var byId = userId ? String(row.user_id).trim() === String(userId).trim() : true;
-    return byCode && byId && isTruthy_(row.active);
+    var byCode = String(row.entry_code || '').trim() === String(entryCode || '').trim();
+    var byId = normalizedUserId ? normalizeAuthValue_(row.user_id) === normalizedUserId : true;
+
+    var byIdentifier = true;
+    if (normalizedIdentifier) {
+      var isEmailIdentifier = normalizedIdentifier.indexOf('@') !== -1;
+      if (isEmailIdentifier) {
+        byIdentifier = normalizeAuthValue_(row.email) === normalizedIdentifier;
+      } else {
+        byIdentifier = normalizeAuthValue_(row.user_id) === normalizedIdentifier;
+      }
+    }
+
+    return byCode && byId && byIdentifier && isTruthy_(row.active);
   });
 
   return user || null;

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -28,7 +28,7 @@ async function request(action, params = {}, method = 'GET') {
 }
 
 export const api = {
-  login: (entryCode) => request('login', { entry_code: entryCode }, 'POST'),
+  login: (identifier, password) => request('login', { identifier, entry_code: password }, 'POST'),
   getBootstrap: () => request('getBootstrap'),
   getDashboard: () => request('getDashboard'),
   getActivities: (filters) => request('getActivities', filters)

--- a/frontend/src/screens/login.js
+++ b/frontend/src/screens/login.js
@@ -7,33 +7,44 @@ export function renderLogin(onSuccess) {
   el.innerHTML = `
     <div class="card login-card">
       <h1>כניסה למערכת</h1>
-      <p>הזנת קוד כניסה</p>
-      <input id="entry-code" type="text" inputmode="numeric" placeholder="קוד כניסה" />
+      <p>הזינו שם משתמש/אימייל וסיסמה</p>
+      <input id="login-identifier" type="text" autocomplete="username" placeholder="שם משתמש או אימייל" />
+      <input id="entry-code" type="password" autocomplete="current-password" placeholder="סיסמה" />
       <button id="login-btn">כניסה</button>
       <small id="login-error" class="error"></small>
     </div>
   `;
 
-  const input = el.querySelector('#entry-code');
+  const identifierInput = el.querySelector('#login-identifier');
+  const passwordInput = el.querySelector('#entry-code');
   const btn = el.querySelector('#login-btn');
   const error = el.querySelector('#login-error');
 
   async function submit() {
     error.textContent = '';
-    if (!input.value.trim()) {
-      error.textContent = 'נדרש קוד כניסה';
+
+    const identifier = identifierInput.value.trim();
+    const password = passwordInput.value.trim();
+
+    if (!identifier) {
+      error.textContent = 'נדרש שם משתמש או אימייל';
+      return;
+    }
+
+    if (!password) {
+      error.textContent = 'נדרשת סיסמה';
       return;
     }
 
     btn.disabled = true;
     try {
-      const result = await api.login(input.value.trim());
+      const result = await api.login(identifier, password);
       if (!result.user) {
-        error.textContent = 'קוד שגוי';
+        error.textContent = 'פרטי התחברות שגויים';
         return;
       }
 
-      saveSession({ ...result.user, entry_code: input.value.trim() });
+      saveSession({ ...result.user, entry_code: password });
       onSuccess();
     } catch (err) {
       error.textContent = err.message;
@@ -43,8 +54,10 @@ export function renderLogin(onSuccess) {
   }
 
   btn.addEventListener('click', submit);
-  input.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') submit();
+  [identifierInput, passwordInput].forEach((input) => {
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') submit();
+    });
   });
 
   return el;


### PR DESCRIPTION
### Motivation
- The previous login required only an entry code which did not explicitly identify a user and was not suitable for real internal RBAC needs.
- The change adds an explicit identifier (username or email) plus password to make authentication and role preparation deterministic while keeping the existing session/entry_code mechanics.

### Description
- Frontend UI updated in `frontend/src/screens/login.js` to show `login-identifier` and `entry-code` inputs, validate both fields client-side, and call the new login signature. 
- API client updated in `frontend/src/api/client.js` so `api.login` sends `{ identifier, entry_code }` via `request('login', ...)`.
- Backend login action updated in `backend/src/actions/login.gs` to require both `identifier` and `entry_code` before authenticating and to return the user row with `entry_code` removed. 
- Authentication matcher extended in `backend/src/auth.gs` with `normalizeAuthValue_` and updated `authenticate_` to match the provided identifier against `user_id` (username-style) or `email`, require `entryCode`, and preserve existing `user_id`-based checks for authenticated requests.

### Testing
- `node --check frontend/src/screens/login.js` was run and passed without syntax errors.
- `node --check frontend/src/api/client.js` was run and passed without syntax errors.
- Backend files were copied to `/tmp` and `node --check /tmp/auth.js` and `node --check /tmp/login_action.js` were run to validate JS syntax and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e193935278832ba0207838ddc85933)