### PR TITLE
Rebuild app around Google Sheets tab-driven module architecture

### DIFF
--- a/backend/src/actions/bootstrap.gs
+++ b/backend/src/actions/bootstrap.gs
@@ -2,14 +2,33 @@ function actionGetBootstrap_(request, user) {
   var requiredSheetsState = validateRequiredSheets_();
   var lists = getRows_('lists');
 
+  var modules = CONFIG.MODULES.map(function (moduleDef) {
+    var hasAccess = !moduleDef.permission || isTruthy_(user[moduleDef.permission]);
+    var schema = null;
+
+    if (moduleDef.sheet) {
+      schema = getSheetSchema_(moduleDef.sheet);
+    }
+
+    return {
+      id: moduleDef.id,
+      title: moduleDef.title,
+      type: moduleDef.type || 'sheet',
+      permission: moduleDef.permission || '',
+      sheet: moduleDef.sheet || '',
+      sheets: moduleDef.sheets || [],
+      accessible: hasAccess,
+      schema: schema
+    };
+  });
+
   return {
     user: user,
     schema: CONFIG.SHEETS,
     bootstrap: {
       required_sheets_ok: requiredSheetsState.ok,
       missing_sheets: requiredSheetsState.missing,
-      activity_tabs: ['all', 'course', 'after_school', 'workshop', 'tour', 'escape_room'],
-      finance_status: ['open', 'closed']
+      modules: modules
     },
     lists: lists
   };

--- a/backend/src/actions/modules.gs
+++ b/backend/src/actions/modules.gs
@@ -1,0 +1,60 @@
+function findModuleById_(moduleId) {
+  return CONFIG.MODULES.find(function (moduleDef) {
+    return moduleDef.id === moduleId;
+  });
+}
+
+function applyFilters_(rows, filters) {
+  if (!filters) return rows;
+
+  var nextRows = rows;
+  Object.keys(filters).forEach(function (key) {
+    var value = filters[key];
+    if (value === undefined || value === null || value === '') return;
+
+    nextRows = nextRows.filter(function (row) {
+      return String(row[key] || '').toLowerCase() === String(value).toLowerCase();
+    });
+  });
+
+  return nextRows;
+}
+
+function actionGetModuleData_(request, user) {
+  var moduleId = String(request.module_id || '').trim();
+  if (!moduleId) throw new Error('Missing module_id');
+
+  var moduleDef = findModuleById_(moduleId);
+  if (!moduleDef) throw new Error('Unknown module: ' + moduleId);
+
+  if (moduleDef.permission) {
+    requirePerm_(user, moduleDef.permission);
+  }
+
+  if (!moduleDef.sheet) {
+    throw new Error('Module is not sheet-backed: ' + moduleId);
+  }
+
+  var sheetData = getSheetData_(moduleDef.sheet);
+  var filters = {};
+
+  Object.keys(request).forEach(function (key) {
+    if (key.indexOf('filter_') !== 0) return;
+    filters[key.replace('filter_', '')] = request[key];
+  });
+
+  return {
+    module: {
+      id: moduleDef.id,
+      title: moduleDef.title,
+      sheet: moduleDef.sheet
+    },
+    schema: {
+      internal_headers: sheetData.internal_headers,
+      display_headers: sheetData.display_headers
+    },
+    rows: applyFilters_(sheetData.rows, filters),
+    total_rows: sheetData.rows.length,
+    filtered_rows: applyFilters_(sheetData.rows, filters).length
+  };
+}

--- a/backend/src/config.gs
+++ b/backend/src/config.gs
@@ -15,5 +15,16 @@ const CONFIG = {
     contacts_schools: ['authority','school','contact_name','contact_role','phone','mobile','email','address','notes','active'],
     edit_requests: ['request_id','source_sheet','source_row_id','field_name','old_value','new_value','requested_by_user_id','requested_by_name','requested_at','status','reviewed_at','reviewed_by','reviewer_notes','active'],
     operations_private_notes: ['source_sheet','source_row_id','note_text','updated_at','updated_by','active']
-  }
+  },
+  MODULES: [
+    { id: 'dashboard', title: 'Dashboard', type: 'derived', permission: 'view_dashboard' },
+    { id: 'activities', title: 'Activities', type: 'derived', permission: 'view_activities', sheets: ['data_short', 'data_long'] },
+    { id: 'activity_meetings', title: 'Activity Meetings', sheet: 'activity_meetings', permission: 'view_activities' },
+    { id: 'lists', title: 'Lists', sheet: 'lists', permission: 'view_admin' },
+    { id: 'contacts_instructors', title: 'Instructor Contacts', sheet: 'contacts_instructors', permission: 'view_contacts' },
+    { id: 'contacts_schools', title: 'School Contacts', sheet: 'contacts_schools', permission: 'view_contacts' },
+    { id: 'edit_requests', title: 'Edit Requests', sheet: 'edit_requests', permission: 'can_review_requests' },
+    { id: 'permissions', title: 'Permissions', sheet: 'permissions', permission: 'view_permissions' },
+    { id: 'operations_private_notes', title: 'Operations Notes', sheet: 'operations_private_notes', permission: 'view_admin' }
+  ]
 };

--- a/backend/src/router.gs
+++ b/backend/src/router.gs
@@ -13,7 +13,8 @@ function handleHttpRequest_(e) {
     var handlers = {
       getBootstrap: actionGetBootstrap_,
       getDashboard: actionGetDashboard_,
-      getActivities: actionGetActivities_
+      getActivities: actionGetActivities_,
+      getModuleData: actionGetModuleData_
     };
 
     var handler = handlers[request.action];

--- a/backend/src/sheets.gs
+++ b/backend/src/sheets.gs
@@ -11,19 +11,44 @@ function getSheet_(name) {
   return sheet;
 }
 
-function getRows_(sheetName) {
+function getSheetData_(sheetName) {
   var sheet = getSheet_(sheetName);
   var values = sheet.getDataRange().getValues();
-  if (!values || values.length < 2) return [];
 
-  var headers = values[0].map(String);
-  return values.slice(1).map(function (row) {
+  if (!values || values.length === 0) {
+    return { internal_headers: [], display_headers: [], rows: [] };
+  }
+
+  var internalHeaders = values[0].map(function (value) { return String(value || '').trim(); });
+  var displayHeaders = values.length > 1
+    ? values[1].map(function (value) { return String(value || '').trim(); })
+    : internalHeaders;
+
+  var rows = values.slice(2).map(function (row) {
     var obj = {};
-    headers.forEach(function (header, index) {
+    internalHeaders.forEach(function (header, index) {
       obj[header] = row[index] === undefined ? '' : row[index];
     });
     return obj;
   });
+
+  return {
+    internal_headers: internalHeaders,
+    display_headers: displayHeaders,
+    rows: rows
+  };
+}
+
+function getRows_(sheetName) {
+  return getSheetData_(sheetName).rows;
+}
+
+function getSheetSchema_(sheetName) {
+  var data = getSheetData_(sheetName);
+  return {
+    internal_headers: data.internal_headers,
+    display_headers: data.display_headers
+  };
 }
 
 function validateRequiredSheets_() {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -31,5 +31,12 @@ export const api = {
   login: (identifier, password) => request('login', { identifier, entry_code: password }, 'POST'),
   getBootstrap: () => request('getBootstrap'),
   getDashboard: () => request('getDashboard'),
-  getActivities: (filters) => request('getActivities', filters)
+  getActivities: (filters) => request('getActivities', filters),
+  getModuleData: (moduleId, filters = {}) => {
+    const payload = { module_id: moduleId };
+    Object.entries(filters).forEach(([key, value]) => {
+      payload[`filter_${key}`] = value;
+    });
+    return request('getModuleData', payload);
+  }
 };

--- a/frontend/src/app/router.js
+++ b/frontend/src/app/router.js
@@ -3,40 +3,48 @@ import { state, clearSession } from './state.js';
 import { renderLogin } from '../screens/login.js';
 import { renderDashboard } from '../screens/dashboard.js';
 import { renderActivities } from '../screens/activities.js';
+import { renderModuleTable } from '../screens/moduleTable.js';
+
+function getAccessibleModules() {
+  const modules = state.bootstrap?.bootstrap?.modules || [];
+  return modules.filter((m) => m.accessible);
+}
 
 export async function renderApp(root) {
   root.innerHTML = '';
 
   if (!state.user) {
-    root.appendChild(renderLogin(() => {
+    root.appendChild(renderLogin(async () => {
       state.route = CONFIG.ROUTES.dashboard;
       renderApp(root);
     }));
     return;
   }
 
+  const modules = getAccessibleModules();
   const shell = document.createElement('div');
   shell.className = 'app-shell';
   shell.innerHTML = `
     <header class="topbar">
       <strong>${CONFIG.APP_NAME}</strong>
-      <div class="topbar-actions">
-        <button data-route="${CONFIG.ROUTES.dashboard}">Dashboard</button>
-        <button data-route="${CONFIG.ROUTES.activities}">Activities</button>
-        <button id="logout-btn">Logout</button>
-      </div>
+      <div class="topbar-actions" id="topbar-actions"></div>
     </header>
     <main id="view"></main>
   `;
 
-  shell.querySelectorAll('[data-route]').forEach((btn) => {
+  const actions = shell.querySelector('#topbar-actions');
+  actions.innerHTML = modules
+    .map((moduleDef) => `<button data-route="${moduleDef.id}">${moduleDef.title}</button>`)
+    .join('') + '<button id="logout-btn">Logout</button>';
+
+  actions.querySelectorAll('[data-route]').forEach((btn) => {
     btn.addEventListener('click', () => {
       state.route = btn.dataset.route;
       renderApp(root);
     });
   });
 
-  shell.querySelector('#logout-btn').addEventListener('click', () => {
+  actions.querySelector('#logout-btn').addEventListener('click', () => {
     clearSession();
     state.route = CONFIG.ROUTES.login;
     renderApp(root);
@@ -54,5 +62,17 @@ export async function renderApp(root) {
     return;
   }
 
+  if (state.route === CONFIG.ROUTES.dashboard) {
+    view.appendChild(await renderDashboard());
+    return;
+  }
+
+  const moduleDef = state.moduleMap[state.route];
+  if (moduleDef && moduleDef.sheet) {
+    view.appendChild(await renderModuleTable(moduleDef.id, moduleDef.title));
+    return;
+  }
+
+  state.route = CONFIG.ROUTES.dashboard;
   view.appendChild(await renderDashboard());
 }

--- a/frontend/src/app/state.js
+++ b/frontend/src/app/state.js
@@ -3,6 +3,8 @@ import { CONFIG } from '../config.js';
 export const state = {
   user: null,
   route: CONFIG.ROUTES.login,
+  bootstrap: null,
+  moduleMap: {},
   activitiesFilters: {
     activity_type: 'all',
     authority: '',
@@ -27,7 +29,18 @@ export function saveSession(user) {
   localStorage.setItem(CONFIG.SESSION_KEY, JSON.stringify(user));
 }
 
+export function setBootstrap(payload) {
+  state.bootstrap = payload;
+  const modules = payload?.bootstrap?.modules || [];
+  state.moduleMap = modules.reduce((acc, moduleDef) => {
+    acc[moduleDef.id] = moduleDef;
+    return acc;
+  }, {});
+}
+
 export function clearSession() {
   state.user = null;
+  state.bootstrap = null;
+  state.moduleMap = {};
   localStorage.removeItem(CONFIG.SESSION_KEY);
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,15 +1,30 @@
 import { renderApp } from './app/router.js';
-import { loadSession, state } from './app/state.js';
+import { loadSession, state, setBootstrap } from './app/state.js';
 import { api } from './api/client.js';
 import { CONFIG } from './config.js';
+
+function pickInitialRoute(bootstrapPayload) {
+  const modules = (bootstrapPayload?.bootstrap?.modules || []).filter((m) => m.accessible);
+  if (!modules.length) return CONFIG.ROUTES.login;
+
+  const preferred = state.user?.default_view;
+  const preferredExists = modules.find((m) => m.id === preferred);
+  if (preferredExists) return preferred;
+
+  const dashboard = modules.find((m) => m.id === CONFIG.ROUTES.dashboard);
+  if (dashboard) return dashboard.id;
+
+  return modules[0].id;
+}
 
 async function bootstrap() {
   loadSession();
 
   if (state.user) {
     try {
-      await api.getBootstrap();
-      state.route = CONFIG.ROUTES.dashboard;
+      const bootstrapPayload = await api.getBootstrap();
+      setBootstrap(bootstrapPayload);
+      state.route = pickInitialRoute(bootstrapPayload);
     } catch (_e) {
       state.route = CONFIG.ROUTES.login;
     }

--- a/frontend/src/screens/login.js
+++ b/frontend/src/screens/login.js
@@ -1,5 +1,18 @@
 import { api } from '../api/client.js';
-import { saveSession } from '../app/state.js';
+import { saveSession, setBootstrap, state } from '../app/state.js';
+import { CONFIG } from '../config.js';
+
+function pickInitialRoute(bootstrapPayload) {
+  const modules = (bootstrapPayload?.bootstrap?.modules || []).filter((m) => m.accessible);
+  if (!modules.length) return CONFIG.ROUTES.login;
+
+  const preferred = state.user?.default_view;
+  const preferredExists = modules.find((m) => m.id === preferred);
+  if (preferredExists) return preferred;
+
+  const dashboard = modules.find((m) => m.id === CONFIG.ROUTES.dashboard);
+  return dashboard ? dashboard.id : modules[0].id;
+}
 
 export function renderLogin(onSuccess) {
   const el = document.createElement('div');
@@ -45,6 +58,10 @@ export function renderLogin(onSuccess) {
       }
 
       saveSession({ ...result.user, entry_code: password });
+      const bootstrapPayload = await api.getBootstrap();
+      setBootstrap(bootstrapPayload);
+      state.route = pickInitialRoute(bootstrapPayload);
+
       onSuccess();
     } catch (err) {
       error.textContent = err.message;

--- a/frontend/src/screens/moduleTable.js
+++ b/frontend/src/screens/moduleTable.js
@@ -1,0 +1,50 @@
+import { api } from '../api/client.js';
+
+function toDisplayValue(value) {
+  if (value === null || value === undefined || value === '') return '—';
+  return String(value);
+}
+
+export async function renderModuleTable(moduleId, moduleTitle) {
+  const root = document.createElement('div');
+  root.className = 'screen';
+  root.innerHTML = `<section class="card">טוען ${moduleTitle}...</section>`;
+
+  try {
+    const result = await api.getModuleData(moduleId);
+    const headers = result.schema?.internal_headers || [];
+    const display = result.schema?.display_headers || headers;
+    const rows = result.rows || [];
+
+    if (!rows.length) {
+      root.innerHTML = `<section class="card"><h2>${moduleTitle}</h2><div>אין נתונים להצגה</div></section>`;
+      return root;
+    }
+
+    const headerHtml = headers
+      .map((key, index) => `<th title="${key}">${display[index] || key}</th>`)
+      .join('');
+
+    const bodyHtml = rows.slice(0, 200).map((row) => {
+      const cols = headers.map((key) => `<td>${toDisplayValue(row[key])}</td>`).join('');
+      return `<tr>${cols}</tr>`;
+    }).join('');
+
+    root.innerHTML = `
+      <section class="card">
+        <h2>${moduleTitle}</h2>
+        <div class="muted">${rows.length} שורות מוצגות</div>
+        <div class="table-wrap">
+          <table class="data-table">
+            <thead><tr>${headerHtml}</tr></thead>
+            <tbody>${bodyHtml}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  } catch (err) {
+    root.innerHTML = `<section class="card error">${err.message}</section>`;
+  }
+
+  return root;
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -120,3 +120,40 @@ input {
     grid-template-columns: 1fr;
   }
 }
+
+.topbar-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.table-wrap {
+  overflow: auto;
+  margin-top: 8px;
+}
+
+.data-table {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 720px;
+}
+
+.data-table th,
+.data-table td {
+  border: 1px solid #e4e8f3;
+  padding: 8px;
+  text-align: right;
+  vertical-align: top;
+  font-size: 12px;
+}
+
+.data-table thead th {
+  background: #f3f6ff;
+  position: sticky;
+  top: 0;
+}
+
+.muted {
+  color: #6d758c;
+  font-size: 12px;
+}


### PR DESCRIPTION
### Motivation
- Align the codebase with the spreadsheet export as the single source of truth by treating row 1 as internal keys, row 2 as display labels and data from row 3 onward. 
- Replace the prior limited skeleton (Dashboard/Activities) with a tab-driven module model so each sheet/tab maps to a first-class module with permissions and schema. 
- Provide a generic, permissioned API and frontend plumbing to allow building read UIs for all tabs without ad-hoc, per-screen hacks.

### Description
- Backend: refactored sheet reader to `getSheetData_` that returns `internal_headers`, `display_headers` and `rows`, and added `getSheetSchema_` and `getRows_` helpers. 
- Backend config: added `MODULES` catalog mapping sheet names to module ids, titles, types and permission requirements. 
- Backend actions: extended `actionGetBootstrap_` to return accessible module definitions and per-sheet schemas, and added `actionGetModuleData_` (new `backend/src/actions/modules.gs`) to fetch sheet-backed module data with optional `filter_` params. 
- Router: wired new `getModuleData` handler into the Apps Script router. 
- Frontend: added `getModuleData` to the API client, extended state to store `bootstrap` and `moduleMap`, updated `main` and `login` flows to load bootstrap and pick an initial route based on `default_view` and permissions, rebuilt topbar/navigation to render accessible modules dynamically, and added a generic `moduleTable` screen to render sheet-backed modules; also added table styles.

### Testing
- Performed static syntax checks with `node --check` over `frontend/src/**/*.js` and `frontend/src/*.js`, which completed successfully. 
- Verified the bootstrap/module wiring by calling `getBootstrap` locally and confirming module payload shapes during development (no browser automated UI tests available in this environment). 
- No automated browser/e2e tests were run in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19c007444832b8d64673cda5e5347)