### PR TITLE
Phase 1: Foundation cleanup — README, backend entrypoint, runtime API config, design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 # Internal Dashboard System (Google Sheets + Apps Script + Vanilla JS)
 
-This repository is a brand new internal dashboard system built from scratch with:
+מערכת ניהול פנימית מבוססת:
 
-- Vanilla JS (ES modules)
-- Google Apps Script backend
-- Google Sheets as source of truth
-- Mobile-first RTL UI
-- PWA support (manifest + service worker)
+- Frontend: Vanilla JS (ES modules)
+- Backend: Google Apps Script
+- Data source: Google Sheets
+- UI: RTL + עברית
+- PWA: manifest + service worker
 
-## Final Sheets
+## מבנה ריפו בפועל
+
+- `frontend/` — קוד הממשק (`src/` לקוד, `assets/` למדיה).
+- `backend/` — קבצי Apps Script הפעילים.
+  - `Code.gs` — **entrypoint** לפריסה (`doGet`, `doPost`).
+  - `router.gs` — ניתוב בקשות והפעלת handlers.
+  - `actions.gs` — פעולות API.
+  - `auth.gs` — אימות והרשאות.
+  - `sheets.gs` — גישת נתונים ל־Sheets.
+  - `helpers.gs` — utilities כלליים.
+  - `script-cache.gs` — cache לביצועים.
+  - `config.gs` — קונפיגורציית backend.
+- `index.html` — נקודת כניסה ל־frontend.
+- `sw.js` — service worker.
+
+## גיליונות נתונים צפויים
 
 - `data_short`
 - `data_long`
@@ -20,26 +35,33 @@ This repository is a brand new internal dashboard system built from scratch with
 - `edit_requests`
 - `operations_private_notes`
 
-## Key Rules Implemented
+## Frontend setup
 
-- `data_short` = one-day activities, supports `instructor_1` and `instructor_2`.
-- `data_long` = multi-date activities, supports `instructor_1` only.
-- `activity_meetings` stores dates for `data_long` only.
-- `direct_manager` is read only from `contacts_instructors`.
-- Admin + operations reviewer can add/edit source data directly.
-- Authorized user + instructor submit edit requests (no direct source edit).
-- Instructor routes are limited to `my-data`.
-- No settings screen, no lists screen, no heavy approval workflow.
+1. הגדירו API URL באחת מהדרכים הבאות:
+   - ערך runtime לפני טעינת האפליקציה:
+     ```html
+     <script>
+       window.__DASHBOARD_CONFIG__ = {
+         apiUrl: 'https://script.google.com/macros/s/.../exec'
+       };
+     </script>
+     ```
+   - או פרמטר query בזמן פתיחה (לבדיקות):
+     `?apiUrl=https://script.google.com/macros/s/.../exec`
+2. הריצו שרת סטטי מהשורש (למשל `python -m http.server 5173`).
+3. פתחו `http://localhost:5173`.
 
-## Frontend Setup
+## Backend setup (Apps Script)
 
-1. Open `frontend/src/config.js`.
-2. Set `apiUrl` to your deployed Apps Script Web App URL.
-3. Serve repository root with any static server and open `index.html`.
+1. צרו/פתחו פרויקט Apps Script.
+2. העתיקו את כל הקבצים מתוך `backend/*.gs` לפרויקט.
+3. ודאו שהקבצים כוללים את `Code.gs` עם `doGet/doPost` כ־entrypoint.
+4. עדכנו `CONFIG.SPREADSHEET_ID` בתוך `backend/config.gs`.
+5. ודאו שורת headers תואמת לשמות השדות במערכת.
+6. פרסו כ־Web App (execute as owner + access לפי צורך ארגוני).
+7. עדכנו את `apiUrl` ב־frontend לנקודת `/exec` של הפריסה.
 
-## Backend Setup
+## הערות תחזוקה
 
-1. Copy `backend/Code.gs` into Apps Script.
-2. Set `APP_CONFIG.spreadsheetId`.
-3. Ensure each target sheet has a header row matching used keys.
-4. Deploy as Web App (execute as script owner, accessible to required users).
+- אין לפזר URL קשיח של API בקוד מסכים/שירותים; המקור היחיד הוא `frontend/src/config.js`.
+- בשינוי סכימה/שדות ב־Sheets, יש לעדכן mapping מתאים ב־`backend/actions.gs` ו־`backend/sheets.gs`.

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -1,1 +1,13 @@
-// intentionally left empty
+/**
+ * Apps Script entrypoint file.
+ *
+ * Keep `doGet` / `doPost` here so repository setup is explicit and
+ * consistent with Apps Script deployment expectations.
+ */
+function doGet() {
+  return handleGet_();
+}
+
+function doPost(e) {
+  return handlePost_(e);
+}

--- a/backend/README.txt
+++ b/backend/README.txt
@@ -1,21 +1,21 @@
 קבצי Apps Script מוכנים להעלאה.
 
 מה לעשות:
-1. פתח את פרויקט ה-Apps Script.
-2. השאר את הקבצים:
-   - Code.gs
-   - config.gs
-   - helpers.gs
-   - sheets.gs
-   - auth.gs
-   - actions.gs
+1. פתחו פרויקט Apps Script.
+2. העתיקו את כל קבצי `backend/*.gs` לפרויקט:
+   - Code.gs (entrypoint)
    - router.gs
-3. אם כבר יש אצלך קבצים באותם שמות, החלף את התוכן שלהם בתוכן שבקבצים כאן.
-4. בתוך config.gs עדכן:
-   CONFIG.SPREADSHEET_ID
-5. שמור.
-6. פריסה > ניהול פריסות > עריכה/פריסה מחדש.
-7. בדוק את כתובת /exec.
+   - actions.gs
+   - auth.gs
+   - sheets.gs
+   - helpers.gs
+   - script-cache.gs
+   - config.gs
+3. בתוך `config.gs` עדכנו:
+   - `CONFIG.SPREADSHEET_ID`
+4. שמרו את הקבצים.
+5. פריסה > ניהול פריסות > עריכה/פריסה מחדש.
+6. בדקו את כתובת `/exec`.
 
 הערה:
-Code.gs נשאר ריק בכוונה, כדי שלא תישאר גרסה ישנה שמתנגשת עם CONFIG או עם doGet/doPost.
+`Code.gs` מכיל את `doGet`/`doPost` ומפנה ל־router, כדי לשמור setup ברור ועקבי.

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -1,4 +1,4 @@
-function doGet() {
+function handleGet_() {
   var validation = validateRequiredSheets_();
 
   return jsonResponse_({
@@ -11,7 +11,7 @@ function doGet() {
   });
 }
 
-function doPost(e) {
+function handlePost_(e) {
   try {
     beginRequestCache_();
     var payload = parsePayload_(e);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -12,6 +12,10 @@ const MUTATING_ACTIONS = {
 };
 
 async function request(action, payload = {}) {
+  if (!config.apiUrl) {
+    throw new Error('חסר קישור API. עדכנו frontend/src/config.js או window.__DASHBOARD_CONFIG__.');
+  }
+
   let response;
   try {
     response = await fetch(config.apiUrl, {

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,4 +1,10 @@
-const API_URL = 'https://script.google.com/macros/s/AKfycbxvBltVlROk0KoTDwMBtL6QSjaKpZ5wuVYpR4B5KSFi0VBjheu3At9uyATMvP4oAUzY/exec';
+const runtimeConfig = globalThis.__DASHBOARD_CONFIG__ || {};
+
+const API_URL =
+  runtimeConfig.apiUrl ||
+  (typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('apiUrl') || ''
+    : '');
 
 export const config = {
   apiUrl: API_URL

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -34,7 +34,35 @@
   --ds-info: #1d4ed8;
   --ds-info-soft: #dbeafe;
 
+  --ds-surface-overlay: rgba(11, 13, 18, 0.58);
+  --ds-muted-bg: #eef2f7;
+  --ds-muted-border: #d8e0ec;
+
+  --ds-status-neutral: #334155;
+  --ds-status-neutral-soft: #e2e8f0;
+  --ds-status-warning-border: #fed7aa;
+  --ds-status-success-border: #bbf7d0;
+
   --ds-focus-ring: 0 0 0 2px rgba(26, 51, 88, 0.22);
+  --ds-focus-ring-strong: 0 0 0 3px rgba(26, 51, 88, 0.3);
+
+  --ds-interactive-hover: #f1f5f9;
+  --ds-interactive-active: #e2e8f0;
+  --ds-interactive-selected: #e8eef6;
+  --ds-interactive-disabled: #94a3b8;
+
+  --ds-drawer-bg: var(--ds-surface);
+  --ds-drawer-border: var(--ds-border);
+  --ds-modal-bg: var(--ds-surface);
+  --ds-modal-border: var(--ds-border-strong);
+  --ds-backdrop-bg: var(--ds-surface-overlay);
+
+  --ds-card-interactive-bg: var(--ds-surface);
+  --ds-card-interactive-border: var(--ds-border);
+  --ds-day-cell-bg: var(--ds-surface-raised);
+  --ds-day-cell-border: var(--ds-border);
+  --ds-session-card-bg: var(--ds-surface);
+  --ds-session-card-border: var(--ds-border);
 
   --ds-radius-sm: 6px;
   --ds-radius-md: 10px;


### PR DESCRIPTION
### Motivation
- Align repository docs and deployment instructions with the actual layout so backend/frontend can be deployed without guesswork.
- Ensure Apps Script has a clear entrypoint (`doGet`/`doPost`) while keeping existing router logic and API contracts intact.
- Remove the hard-coded Apps Script URL from the source and provide a runtime-configurable `apiUrl` to simplify dev/prod switching.
- Prepare design tokens for upcoming shared interaction components (drawer/modal/cards) to avoid ad-hoc styles later.

### Description
- Updated `README.md` to document the real repo structure, frontend runtime config options, and explicit backend deployment steps using `Code.gs` as the entrypoint.
- Added `doGet`/`doPost` wrapper in `backend/Code.gs` that delegates to the router helpers to keep Apps Script entrypoint explicit and unchanged API behavior.
- Renamed router entry functions to `handleGet_` / `handlePost_` in `backend/router.gs` so `Code.gs` can act as the canonical entry file without changing handlers.
- Improved `frontend/src/config.js` to resolve `apiUrl` from `window.__DASHBOARD_CONFIG__.apiUrl` or a `?apiUrl=` query string, and added a Hebrew runtime error in `frontend/src/api.js` when `apiUrl` is missing.
- Expanded design tokens in `frontend/src/styles/main.css` with overlays, interactive states, drawer/modal/backdrop and card/day/session token names to standardize upcoming UI work.

### Testing
- Ran syntax checks: `node --check frontend/src/config.js`, `node --check frontend/src/api.js`, and `node --check frontend/src/main.js` and they all completed without errors.
- Verified there are no remaining hard-coded `/exec` strings with a repository search (`rg "script.google.com|AKfycb|const API_URL" -n frontend/src README.md backend/README.txt`).
- All automated checks above passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cabda064832b8591e759fe232e02)