### PR TITLE
Phase 9–11: design-system polish, accessibility states, and PWA / deploy hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@
 2. הריצו שרת סטטי מהשורש (למשל `python -m http.server 5173`).
 3. פתחו `http://localhost:5173`.
 
+### בדיקת PWA בסיסית (Phase 11)
+
+1. ודאו ש־`index.html` טוען את `frontend/public/manifest.json`.
+2. ודאו שבדפדפן מופיע service worker פעיל (`sw.js`) תחת אותו origin.
+3. לאחר שינויי frontend משמעותיים, העלו `CACHE_VERSION` ב־`sw.js` כדי לרענן cache shell.
+4. בדקו שהאייקונים ב־manifest נטענים מהנתיבים ב־`frontend/assets/pwa/`.
+
 ## Backend setup (Apps Script)
 
 1. צרו/פתחו פרויקט Apps Script.
@@ -61,8 +68,16 @@
 6. פרסו כ־Web App (execute as owner + access לפי צורך ארגוני).
 7. עדכנו את `apiUrl` ב־frontend לנקודת `/exec` של הפריסה.
 
+### Backend deploy hygiene (ללא ambiguity)
+
+- מקור האמת לקוד backend הוא רק `backend/*.gs` (לא להעתיק חלקית מקבצים חיצוניים).
+- בכל פריסה יש לוודא שקיים `Code.gs` עם `doGet/doPost`, וש־`router.gs` כולל את ה־handlers המעודכנים.
+- לאחר שינוי הרשאות/פעולות, בצעו deploy חדש ל־Web App ועדכנו את URL ב־frontend config.
+- מומלץ לשמור מזהה פריסה (Deployment ID) ותאריך בפרויקט/כרטיס שינוי.
+
 ## הערות תחזוקה
 
 - אין לפזר URL קשיח של API בקוד מסכים/שירותים; המקור היחיד הוא `frontend/src/config.js` (או `window.__DASHBOARD_CONFIG__` / פרמטר `?apiUrl=` לפי סעיף Frontend setup).
 - שכבת אינטראקציה משותפת (drawer/modal) נמצאת ב־`frontend/src/screens/shared/interactions.js` ומוזנת מ־`main.js` ל־`bind` של מסכים (`ui`).
 - בשינוי סכימה/שדות ב־Sheets, יש לעדכן mapping מתאים ב־`backend/actions.gs` ו־`backend/sheets.gs`.
+- לשחרור frontend: להריץ בדיקה מקומית, לוודא טעינת manifest+SW, ולעדכן cache version במידת הצורך כדי למנוע shell מיושן.

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,30 +1,40 @@
 {
+  "id": "./index.html",
   "name": "תעשיידע — לוח בקרה פנימי",
   "short_name": "תעשיידע",
+  "description": "מערכת ניהול פנימית לפעילויות, הרשאות ותפעול.",
   "start_url": "../../index.html",
   "scope": "../../",
   "display": "standalone",
+  "orientation": "portrait-primary",
   "background_color": "#111827",
   "theme_color": "#111827",
   "lang": "he",
   "dir": "rtl",
+  "categories": ["business", "productivity"],
   "icons": [
     {
-      "src": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Crect width='128' height='128' rx='24' fill='%23111827'/%3E%3Cpath d='M24 72h80v16H24zm0-32h80v16H24z' fill='%23f8fafc'/%3E%3C/svg%3E",
-      "sizes": "128x128",
-      "type": "image/svg+xml",
-      "purpose": "any"
-    },
-    {
-      "src": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'%3E%3Crect width='192' height='192' rx='36' fill='%23111827'/%3E%3Cpath d='M36 108h120v24H36zm0-48h120v24H36z' fill='%23f8fafc'/%3E%3C/svg%3E",
+      "src": "../assets/pwa/icon-192.png",
       "sizes": "192x192",
-      "type": "image/svg+xml",
+      "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Crect width='512' height='512' rx='96' fill='%23111827'/%3E%3Cpath d='M96 288h320v64H96zm0-128h320v64H96z' fill='%23f8fafc'/%3E%3C/svg%3E",
+      "src": "../assets/pwa/icon-512.png",
       "sizes": "512x512",
-      "type": "image/svg+xml",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "../assets/pwa/icon-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "../assets/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
       "purpose": "any"
     }
   ]

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -199,9 +199,9 @@ export const activitiesScreen = {
       ${dsToolbar(`
         <label class="compact-toggle"><input id="toggle-view" type="checkbox" ${compactView ? 'checked' : ''} ${forceCompact ? 'disabled' : ''} /> תצוגה קומפקטית</label>
         ${hasAnyFilter ? '<button type="button" class="ds-btn ds-btn--sm" data-clear-filters>ניקוי מסננים</button>' : ''}
-        ${state.activityQuickManager ? `<span class="ds-chip ds-chip--neutral">אחראי: ${escapeHtml(state.activityQuickManager)}</span>` : ''}
-        ${state.activityEndingCurrentMonth ? '<span class="ds-chip ds-chip--neutral">מסיימי קורס החודש</span>' : ''}
-        ${state.activityQuickFamily ? `<span class="ds-chip ds-chip--neutral">משפחה: ${state.activityQuickFamily === 'short' ? 'קצרות' : 'ארוכות'}</span>` : ''}
+        ${state.activityQuickManager ? `<span class="ds-chip ds-chip--status ds-chip--status-neutral">אחראי: ${escapeHtml(state.activityQuickManager)}</span>` : ''}
+        ${state.activityEndingCurrentMonth ? '<span class="ds-chip ds-chip--status ds-chip--status-neutral">מסיימי קורס החודש</span>' : ''}
+        ${state.activityQuickFamily ? `<span class="ds-chip ds-chip--status ds-chip--status-neutral">משפחה: ${state.activityQuickFamily === 'short' ? 'קצרות' : 'ארוכות'}</span>` : ''}
         ${forceCompact ? '<span class="ds-muted">במובייל צר מופעלת תצוגה קומפקטית אוטומטית</span>' : ''}
       `)}
       ${compactView

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -34,9 +34,9 @@ export const exceptionsScreen = {
     );
 
     const summaryChips = `
-      <span class="ds-chip ds-chip--warn">חסר מדריך: ${counts.missing_instructor}</span>
-      <span class="ds-chip ds-chip--warn">חסר תאריך התחלה: ${counts.missing_start_date}</span>
-      <span class="ds-chip ds-chip--danger">תאריך סיום מאוחר: ${counts.late_end_date}</span>
+      <span class="ds-chip ds-chip--status ds-chip--status-warning">חסר מדריך: ${counts.missing_instructor}</span>
+      <span class="ds-chip ds-chip--status ds-chip--status-warning">חסר תאריך התחלה: ${counts.missing_start_date}</span>
+      <span class="ds-chip ds-chip--status ds-chip--status-danger">תאריך סיום מאוחר: ${counts.late_end_date}</span>
     `;
 
     const tableBlock =

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -40,6 +40,8 @@
 
   --ds-status-neutral: #334155;
   --ds-status-neutral-soft: #e2e8f0;
+  --ds-status-neutral-border: #cbd5e1;
+  --ds-status-danger-border: #fecaca;
   --ds-status-warning-border: #fed7aa;
   --ds-status-success-border: #bbf7d0;
 
@@ -219,13 +221,23 @@ select {
 }
 
 .shell-close-btn {
-  inline-size: 36px;
-  block-size: 36px;
+  inline-size: 40px;
+  block-size: 40px;
   border-radius: var(--ds-radius-sm);
   border: 1px solid var(--ds-shell-border);
   background: rgba(255, 255, 255, 0.06);
   color: var(--ds-shell-text);
   font-size: 1rem;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.shell-close-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.shell-close-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(232, 234, 239, 0.26);
 }
 
 @media (min-width: 960px) {
@@ -287,7 +299,8 @@ select {
   background: rgba(255, 255, 255, 0.04);
   color: var(--ds-shell-text);
   border-radius: var(--ds-radius-sm);
-  padding: 8px 10px;
+  min-height: 40px;
+  padding: 10px 12px;
   font-size: 0.82rem;
   font-weight: 500;
   text-align: right;
@@ -309,6 +322,11 @@ select {
 
 .shell-nav__btn:active:not(:disabled) {
   transform: translateY(1px);
+}
+
+.shell-nav__btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(232, 234, 239, 0.24);
 }
 
 .shell-nav__btn.is-active {
@@ -619,8 +637,8 @@ select {
 }
 
 .ds-icon-btn {
-  inline-size: 34px;
-  block-size: 34px;
+  inline-size: 40px;
+  block-size: 40px;
   border: 1px solid var(--ds-border);
   border-radius: var(--ds-radius-sm);
   background: var(--ds-surface);
@@ -651,6 +669,7 @@ select {
   background: var(--ds-card-interactive-bg);
   border-radius: var(--ds-radius-md);
   box-shadow: var(--ds-shadow-xs);
+  min-height: 44px;
   padding: var(--ds-space-3) var(--ds-space-4);
   display: flex;
   flex-direction: column;
@@ -685,6 +704,8 @@ select {
   opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
+  border-color: var(--ds-muted-border);
+  background: var(--ds-muted-bg);
 }
 
 .ds-interactive-card__title {
@@ -727,7 +748,7 @@ select {
 
 .ds-page-header__title {
   margin: 0;
-  font-size: 1.12rem;
+  font-size: 1.18rem;
   font-weight: 700;
   color: var(--ds-text);
   letter-spacing: -0.01em;
@@ -735,7 +756,7 @@ select {
 
 .ds-page-header__subtitle {
   margin: var(--ds-space-2) 0 0;
-  font-size: 0.84rem;
+  font-size: 0.86rem;
   color: var(--ds-text-muted);
   font-weight: 500;
 }
@@ -754,6 +775,7 @@ select {
   align-items: center;
   justify-content: space-between;
   gap: var(--ds-space-3);
+  min-height: 52px;
   padding: var(--ds-space-3) var(--ds-space-4);
   background: var(--ds-surface-raised);
   border-bottom: 1px solid var(--ds-border);
@@ -761,7 +783,7 @@ select {
 
 .ds-card__title {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: 0.92rem;
   font-weight: 700;
   color: var(--ds-text);
 }
@@ -863,7 +885,8 @@ select {
   color: var(--ds-text);
   font-size: 0.8rem;
   font-weight: 600;
-  padding: 7px 12px;
+  min-height: 40px;
+  padding: 8px 12px;
   line-height: 1.2;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease,
     box-shadow 0.15s ease, transform 0.08s ease, opacity 0.15s ease;
@@ -906,12 +929,17 @@ select {
 }
 
 .ds-btn--sm {
+  min-height: 36px;
   padding: 6px 10px;
   font-size: 0.78rem;
 }
 
 .ds-btn:disabled {
   opacity: 0.65;
+  background: var(--ds-muted-bg);
+  border-color: var(--ds-muted-border);
+  color: var(--ds-interactive-disabled);
+  box-shadow: none;
 }
 
 .ds-btn.is-loading {
@@ -949,7 +977,8 @@ select {
   color: var(--ds-text-secondary);
   font-size: 0.76rem;
   font-weight: 600;
-  padding: 5px 10px;
+  min-height: 34px;
+  padding: 6px 12px;
   border-radius: var(--ds-radius-full);
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease,
     box-shadow 0.15s ease, transform 0.08s ease;
@@ -962,6 +991,11 @@ select {
 
 .ds-chip:active:not(:disabled) {
   transform: translateY(1px);
+}
+
+.ds-chip:focus-visible {
+  outline: none;
+  box-shadow: var(--ds-focus-ring);
 }
 
 .ds-chip.is-active {
@@ -979,21 +1013,50 @@ span.ds-chip {
   pointer-events: none;
 }
 
+.ds-chip:disabled,
+.ds-chip[aria-disabled='true'] {
+  opacity: 0.64;
+  cursor: not-allowed;
+  color: var(--ds-interactive-disabled);
+  background: var(--ds-muted-bg);
+  border-color: var(--ds-muted-border);
+  box-shadow: none;
+}
+
+.ds-chip--status,
+.ds-chip--neutral,
+.ds-chip--warn,
+.ds-chip--danger,
+.ds-chip--ok {
+  min-width: 88px;
+  justify-content: center;
+}
+
+.ds-chip--status-neutral,
+.ds-chip--neutral {
+  background: var(--ds-status-neutral-soft);
+  border-color: var(--ds-status-neutral-border);
+  color: var(--ds-status-neutral);
+}
+
+.ds-chip--status-warning,
 .ds-chip--warn {
   background: var(--ds-warning-soft);
-  border-color: rgba(180, 83, 9, 0.25);
+  border-color: var(--ds-status-warning-border);
   color: var(--ds-warning);
 }
 
+.ds-chip--status-danger,
 .ds-chip--danger {
   background: var(--ds-danger-soft);
-  border-color: rgba(185, 28, 28, 0.22);
+  border-color: var(--ds-status-danger-border);
   color: var(--ds-danger);
 }
 
+.ds-chip--status-success,
 .ds-chip--ok {
   background: var(--ds-success-soft);
-  border-color: rgba(21, 128, 61, 0.22);
+  border-color: var(--ds-status-success-border);
   color: var(--ds-success);
 }
 
@@ -1047,6 +1110,10 @@ span.ds-chip {
   outline: none;
   box-shadow: inset 0 0 0 2px rgba(26, 51, 88, 0.2);
   background: var(--ds-interactive-hover);
+}
+
+.ds-table--interactive tbody tr[role='button'] {
+  min-height: 44px;
 }
 
 /* ——— Compact list rows (activities) ——— */
@@ -1480,6 +1547,9 @@ span.ds-chip {
   text-align: center;
   padding: var(--ds-space-5) var(--ds-space-4);
   color: var(--ds-text-muted);
+  background: var(--ds-surface-subtle);
+  border: 1px dashed var(--ds-border);
+  border-radius: var(--ds-radius-md);
 }
 
 .ds-empty__msg {
@@ -1762,10 +1832,17 @@ select[data-role-select] {
   width: 100%;
   max-width: 220px;
   font-size: 0.78rem;
-  padding: 6px 8px;
+  min-height: 40px;
+  padding: 8px 10px;
   border-radius: var(--ds-radius-sm);
   border: 1px solid var(--ds-border);
   background: var(--ds-surface);
+}
+
+select[data-role-select]:focus-visible {
+  outline: none;
+  border-color: rgba(26, 51, 88, 0.45);
+  box-shadow: var(--ds-focus-ring);
 }
 
 /* ——— Legacy hooks (keep minimal compatibility) ——— */
@@ -1812,6 +1889,16 @@ select[data-role-select] {
 .compact-toggle input {
   width: auto;
   accent-color: var(--ds-accent);
+}
+
+@media (max-width: 760px) {
+  .ds-btn,
+  .ds-chip,
+  .shell-menu-btn,
+  .shell-close-btn,
+  .ds-icon-btn {
+    min-height: 44px;
+  }
 }
 
 .month-grid {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 7;
+const CACHE_VERSION = 8;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [
@@ -9,7 +9,15 @@ const APP_SHELL = [
   './frontend/src/state.js',
   './frontend/src/config.js',
   './frontend/src/styles/main.css',
-  './frontend/public/manifest.json'
+  './frontend/public/manifest.json',
+  './frontend/assets/logo1.png',
+  './frontend/assets/logo2.png',
+  './frontend/assets/apple-touch-icon.png',
+  './frontend/assets/favicon-32.png',
+  './frontend/assets/favicon-16.png',
+  './frontend/assets/pwa/icon-192.png',
+  './frontend/assets/pwa/icon-512.png',
+  './frontend/assets/pwa/icon-maskable-512.png'
 ];
 
 function sameOrigin(url) {
@@ -20,6 +28,7 @@ function shouldHandleFetch(request, url) {
   if (request.mode === 'navigate') return true;
   const p = url.pathname;
   if (p.endsWith('.js') || p.endsWith('.css')) return true;
+  if (p.endsWith('.png') || p.endsWith('.ico') || p.endsWith('.svg')) return true;
   if (p.endsWith('.json') && p.includes('manifest')) return true;
   if (p.endsWith('index.html')) return true;
   return false;


### PR DESCRIPTION
### Motivation
- Finish the final polish phase (Phase 9–11) to unify design tokens/components, complete accessibility and interaction states, and tighten PWA/deploy hygiene without rewriting or changing stack/API contracts.
- Keep RTL and Hebrew UI intact while improving touch targets, focus states and visually consistent status chips across screens.

### Description
- Unified and extended design tokens and visual rules in `frontend/src/styles/main.css`, added consistent status-chip families, improved spacing/typography, and hardened disabled/focus/hover/active states and minimum touch sizes for interactive elements.
- Standardized usage of status chips in screens by updating `frontend/src/screens/activities.js` and `frontend/src/screens/exceptions.js` to use the new `ds-chip--status-*` variants for consistent appearance.
- Improved PWA metadata and assets in `frontend/public/manifest.json`, expanded SW precache asset coverage and bumped cache version in `sw.js`, and added short PWA/deploy sanity guidance to `README.md`.
- Files changed: `frontend/src/styles/main.css`, `frontend/src/screens/activities.js`, `frontend/src/screens/exceptions.js`, `frontend/public/manifest.json`, `sw.js`, `README.md`.

### Testing
- Ran static/quick checks: `node --check sw.js` — success.
- Ran JS checks: `node --check frontend/src/screens/activities.js` and `node --check frontend/src/screens/exceptions.js` — success.
- Validated manifest JSON: `python -m json.tool frontend/public/manifest.json` — success.
- Ran repo flow verifier: `node scripts/verify_flows.mjs` — failed in this environment due to missing `handlePost_` symbol in the local Apps Script runtime harness (failure is in the verifier runtime, not the frontend changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d9702aa8832bad5fc5bedb7c765f)