### PR TITLE
Add permission checks for contact/end-date views, stabilize settings read, and API signature compatibility

### DIFF
--- a/backend/README.txt
+++ b/backend/README.txt
@@ -36,7 +36,7 @@
 - edit_requests
 - operations_private_notes
 
-שורת כותרות: שורה 1. נתונים: משורה 3 (או לפי settings.data_start_row אם מוגדר בגיליון settings).
+שורת כותרות: שורה 1. נתונים: תמיד משורה 3.
 
 ================================================================================
 ב. עמודות מינימליות לפי שימוש בקוד (יישור למקור — הרחבה מותרת)
@@ -49,7 +49,6 @@ permissions (כותרות לדוגמה; חייבות להתאים לגיליון
 settings (שורה 1):
 - setting_key, setting_value, value_type, notes, active
 מפתחות שנקראים בקוד (חלקם אופציונליים — אם חסרים יש ברירות מחדל):
-- data_start_row
 - finance_display_rule (למשל ended_until_today)
 - show_only_nonzero_kpis
 - use_status_with_dates

--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -394,6 +394,10 @@ function actionInstructors_(user) {
 
 function actionContacts_(user) {
   requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  var permission = getPermissionRow_(user.user_id);
+  if (!schoolContactsViewYes_(permission)) {
+    throw new Error('Forbidden');
+  }
 
   var schoolRows = readRows_(CONFIG.SHEETS.SCHOOLS).map(function(row) {
     return {
@@ -414,6 +418,10 @@ function actionContacts_(user) {
 
 function actionInstructorContacts_(user) {
   requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  var permission = getPermissionRow_(user.user_id);
+  if (!instructorContactsViewYes_(permission)) {
+    throw new Error('Forbidden');
+  }
 
   return {
     rows: readRows_(CONFIG.SHEETS.INSTRUCTORS).map(function(row) {
@@ -433,6 +441,10 @@ function actionInstructorContacts_(user) {
 
 function actionEndDates_(user) {
   requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  var permission = getPermissionRow_(user.user_id);
+  if (!endDatesViewYes_(permission)) {
+    throw new Error('Forbidden');
+  }
 
   var rows = buildLongRows_()
     .filter(function(row) {
@@ -462,6 +474,10 @@ function actionEndDates_(user) {
 
 function actionMyData_(user) {
   requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user', 'instructor']);
+  var permission = getPermissionRow_(user.user_id);
+  if (user.display_role !== 'instructor' && !myDataViewYes_(permission)) {
+    throw new Error('Forbidden');
+  }
 
   if (user.display_role === 'instructor') {
     var myEmpId = text_(user.emp_id || user.user_id);
@@ -477,6 +493,10 @@ function actionMyData_(user) {
 
 function actionPermissions_(user) {
   requireAnyRole_(user, ['admin', 'operations_reviewer']);
+  var permission = getPermissionRow_(user.user_id);
+  if (yesNo_(permission.view_permissions) !== 'yes') {
+    throw new Error('Forbidden');
+  }
 
   var cachedPerm = scriptCacheGetJson_(SCRIPT_CACHE_KEY_PERMISSIONS_LIST);
   if (cachedPerm) {
@@ -505,9 +525,6 @@ function actionPermissions_(user) {
           out[h] = yesNo_(row[h]);
         }
       });
-      if (out.view_contacts_instructors === undefined) {
-        out.view_contacts_instructors = yesNo_(row.view_contacts_instructors || row.view_contacts);
-      }
       return out;
     })
   };

--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -85,7 +85,7 @@ function buildRoutesFromPermission_(permission, role) {
     'my-data': '__my_data__',
     contacts: '__school_contacts__',
     finance: 'view_finance',
-    'end-dates': 'view_activities',
+    'end-dates': '__end_dates__',
     permissions: 'view_permissions'
   };
 
@@ -110,16 +110,16 @@ function buildRoutesFromPermission_(permission, role) {
       return yesNo_(permission.view_permissions) === 'yes';
     }
     if (route === 'my-data') {
-      return (
-        yesNo_(permission.view_my_data) === 'yes' ||
-        yesNo_(permission.view_operations_data) === 'yes'
-      );
+      return myDataViewYes_(permission);
     }
     if (route === 'instructor-contacts') {
       return instructorContactsViewYes_(permission);
     }
     if (route === 'contacts') {
       return schoolContactsViewYes_(permission);
+    }
+    if (route === 'end-dates') {
+      return endDatesViewYes_(permission);
     }
     var flag = map[route];
     if (!flag) return false;
@@ -135,16 +135,34 @@ function defaultRouteForRole_(role) {
 function viewKeyToRouteId_(viewKey) {
   var k = text_(viewKey);
   var table = {
+    dashboard: 'dashboard',
     view_dashboard: 'dashboard',
+    activities: 'activities',
     view_activities: 'activities',
+    week: 'week',
     view_week: 'week',
+    month: 'month',
     view_month: 'month',
+    instructors: 'instructors',
     view_instructors: 'instructors',
+    exceptions: 'exceptions',
     view_exceptions: 'exceptions',
+    my_data: 'my-data',
+    'my-data': 'my-data',
     view_my_data: 'my-data',
     view_operations_data: 'my-data',
+    instructor_contacts: 'instructor-contacts',
+    'instructor-contacts': 'instructor-contacts',
     view_contacts_instructors: 'instructor-contacts',
+    'view_contacts_instructors 2': 'instructor-contacts',
+    contacts: 'contacts',
+    view_contacts: 'contacts',
+    end_dates: 'end-dates',
+    'end-dates': 'end-dates',
+    view_end_dates: 'end-dates',
+    finance: 'finance',
     view_finance: 'finance',
+    permissions: 'permissions',
     view_permissions: 'permissions',
     view_admin: 'dashboard',
     view_edit_requests: 'permissions',
@@ -173,12 +191,22 @@ function resolveDefaultRoute_(preferred, routes, role) {
 function instructorContactsViewYes_(permission) {
   if (yesNo_(permission.view_contacts_instructors) === 'yes') return true;
   if (yesNo_(permission['view_contacts_instructors 2']) === 'yes') return true;
-  return yesNo_(permission.view_contacts) === 'yes';
+  return false;
 }
 
 function schoolContactsViewYes_(permission) {
-  if (yesNo_(permission.view_operations_data) === 'yes') return true;
-  return yesNo_(permission.view_dashboard) === 'yes';
+  return yesNo_(permission.view_contacts) === 'yes';
+}
+
+function endDatesViewYes_(permission) {
+  return yesNo_(permission.view_end_dates) === 'yes';
+}
+
+function myDataViewYes_(permission) {
+  return (
+    yesNo_(permission.view_my_data) === 'yes' ||
+    yesNo_(permission.view_operations_data) === 'yes'
+  );
 }
 
 function hasWorkViewForEdit_(permission) {

--- a/backend/sheets.gs
+++ b/backend/sheets.gs
@@ -36,7 +36,7 @@ function getSpreadsheet_() {
 
 /**
  * קורא את גיליון settings בשורת נתונים קבועה (3) בלי לעבור דרך readRows_,
- * כדי למנוע רקורסיה עם getDataStartRow_.
+ * כדי למנוע תלות רקורסיבית.
  */
 function readActiveSettingsMap_() {
   if (__rqCache_ && __rqCache_.settingsMap) {
@@ -60,7 +60,8 @@ function readActiveSettingsMap_() {
       return map;
     }
     var headers = sheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
-    var values = sheet.getRange(CONFIG.DATA_START_ROW, 1, lastRow, lastCol).getValues();
+    var rowCount = lastRow - CONFIG.DATA_START_ROW + 1;
+    var values = sheet.getRange(CONFIG.DATA_START_ROW, 1, rowCount, lastCol).getValues();
     var keyIdx = headers.indexOf('setting_key');
     var valIdx = headers.indexOf('setting_value');
     var actIdx = headers.indexOf('active');
@@ -86,16 +87,7 @@ function readActiveSettingsMap_() {
 }
 
 function getDataStartRow_() {
-  if (__rqCache_ && __rqCache_.effectiveDataStart) {
-    return __rqCache_.effectiveDataStart;
-  }
-  var m = readActiveSettingsMap_();
-  var n = parseInt(text_(m.data_start_row), 10);
-  var d = !isNaN(n) && n > 0 ? n : CONFIG.DATA_START_ROW;
-  if (__rqCache_) {
-    __rqCache_.effectiveDataStart = d;
-  }
-  return d;
+  return CONFIG.DATA_START_ROW;
 }
 
 function getSheet_(sheetName) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -60,7 +60,12 @@ export const api = {
   endDates: () => request('endDates'),
   myData: () => request('myData'),
   permissions: () => request('permissions'),
-  addActivity: (target, data) => request('addActivity', { target, data }),
+  addActivity: (target, data) => {
+    if (typeof target === 'object' && target !== null && data === undefined) {
+      return request('addActivity', { activity: target });
+    }
+    return request('addActivity', { activity: { ...(data || {}), source: target } });
+  },
   /** מקבל אובייקט מלא (כולל source_sheet, changes) או חתימה ישנה (id, changes). */
   saveActivity: (a, b) =>
     b !== undefined && b !== null
@@ -69,5 +74,14 @@ export const api = {
   submitEditRequest: (source_row_id, changes) => request('submitEditRequest', { source_row_id, changes }),
   reviewEditRequest: (request_id, status) => request('reviewEditRequest', { request_id, status }),
   savePermission: (row) => request('savePermission', { row }),
-  savePrivateNote: (source_row_id, note) => request('savePrivateNote', { source_row_id, note })
+  savePrivateNote: (a, b, c) => {
+    if (typeof a === 'object' && a !== null) {
+      return request('savePrivateNote', {
+        source_sheet: a.source_sheet,
+        source_row_id: a.source_row_id,
+        note: a.note ?? a.note_text ?? ''
+      });
+    }
+    return request('savePrivateNote', { source_sheet: a, source_row_id: b, note: c });
+  }
 };

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 11;
+const CACHE_VERSION = 12;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- Enforce per-user permission checks for contacts, instructor contacts, end-dates and my-data routes and endpoints to avoid unauthorized access.
- Remove recursive/dependent settings lookup and make the settings data start row behavior deterministic.
- Keep frontend backwards-compatible with older API call signatures and force a new service-worker cache version so clients pick up changes.

### Description
- Added permission checks in server actions: `actionContacts_`, `actionInstructorContacts_`, `actionEndDates_`, `actionMyData_`, and `actionPermissions_` now validate the caller via `getPermissionRow_` and new helpers (`schoolContactsViewYes_`, `instructorContactsViewYes_`, `endDatesViewYes_`, `myDataViewYes_`).
- Refactored `auth.gs` routing/flags: `buildRoutesFromPermission_` and `viewKeyToRouteId_` updated to use explicit feature helpers and new mappings, and `instructorContactsViewYes_` behavior was changed to remove fallback to `view_contacts`.
- Reworked settings read logic in `sheets.gs`: `readActiveSettingsMap_` uses a computed `rowCount` when reading the settings block, and `getDataStartRow_` now returns the configured `CONFIG.DATA_START_ROW` to avoid recursive dependency.
- Frontend API compatibility: `addActivity` now accepts both the legacy `(target, data)` signature and the new single-object payload, and `savePrivateNote` accepts either an object payload or positional args.
- Miscellaneous: updated `backend/README.txt` to clarify that data always starts at row 3, and bumped the service worker `CACHE_VERSION` to `12` in `sw.js`.

### Testing
- Ran frontend build with `npm run build` and linting with `npm run lint`, both completed successfully.
- Verified the frontend API surface by running the app in development and exercising `addActivity` and `savePrivateNote` calls through the UI (smoke checks passed).
- No new automated backend unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40bc31258832bbee6284a98fa974f)