### PR TITLE
chore(config): update default Apps Script deployment URL

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -2,7 +2,7 @@ const runtimeConfig = globalThis.__DASHBOARD_CONFIG__ || {};
 
 /** פריסת Web App נוכחית — ניתן לדרוס ב־`window.__DASHBOARD_CONFIG__.apiUrl` או ב־`?apiUrl=` */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyB8JYE9Far7rvD8aKMljQwiQ6X7fHdUhTSs56kE4TsL96rjxPOmrKwafH6WtY2qyM/exec';
+  'https://script.google.com/macros/s/AKfycbwsDBJ8tbAfHE1GoMGi55_7Y9_rHxiXVCNKvqI-6a7WGr5LwE-29Z-yRvBbMZOF9seK/exec';
 
 const API_URL =
   runtimeConfig.apiUrl ||


### PR DESCRIPTION
### Motivation
- לעדכן את נקודת ה־Web App הדיפולטית בקונפיגורציית הפרונטאנד כדי שתחבר לפריסת ה־Apps Script החדשה בלי לשנות את מנגנון ה־override הקיים.

### Description
- שונתה הערך של `DEFAULT_API_URL` ב־`frontend/src/config.js` לכתובת ה־Web App שסופקה, כאשר ההתנהגות של `window.__DASHBOARD_CONFIG__.apiUrl` ופרמטר `?apiUrl=` נשמרת ללא שינוי.

### Testing
- אימתתי שהחלפת הכתובת התבצעה בקובץ באמצעות `rg -n "AKfy|DEFAULT_API_URL|apiUrl" frontend/src/config.js` וסקירה קצרה של הקובץ עם `nl -ba frontend/src/config.js`, והבדיקות האוטומטיות הראו שהמחרוזת הוחלפה כראוי ללא שינויים לוגיים נוספים.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4126c5934832b921476cd3d2b0cdf)