### PR TITLE
Update default Apps Script API URL in frontend config

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -2,7 +2,7 @@ const runtimeConfig = globalThis.__DASHBOARD_CONFIG__ || {};
 
 /** פריסת Web App נוכחית — ניתן לדרוס ב־`window.__DASHBOARD_CONFIG__.apiUrl` או ב־`?apiUrl=` */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbwsDBJ8tbAfHE1GoMGi55_7Y9_rHxiXVCNKvqI-6a7WGr5LwE-29Z-yRvBbMZOF9seK/exec';
+  'https://script.google.com/macros/s/AKfycbyk1EqZBC2SpOg0nx9pB4ziv2cEw6QOEpk3in18VDg50IK5ban8mhUEdAzbESka0-UU/exec';
 
 const API_URL =
   runtimeConfig.apiUrl ||


### PR DESCRIPTION
### Motivation
- Replace the hard-coded default Apps Script endpoint with the provided production URL while preserving existing runtime override behavior.

### Description
- Updated `DEFAULT_API_URL` in `frontend/src/config.js` to `https://script.google.com/macros/s/AKfycbyk1EqZBC2SpOg0nx9pB4ziv2cEw6QOEpk3in18VDg50IK5ban8mhUEdAzbESka0-UU/exec` and left the runtime override logic via `window.__DASHBOARD_CONFIG__.apiUrl` and `?apiUrl=` unchanged, with no other files modified.

### Testing
- Performed automated verification by inspecting `frontend/src/config.js` to confirm the single-line change, that `config.apiUrl` preserves the override precedence (`window.__DASHBOARD_CONFIG__.apiUrl` > `?apiUrl=` > `DEFAULT_API_URL`), and that no other files were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41cb1e19c832b803ed0af0a511e00)