### PR TITLE
Add opacity transition to modal animations

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -660,7 +660,7 @@ select {
   border-radius: var(--ds-radius-lg);
   box-shadow: var(--ds-shadow-lg);
   transform: translateY(108%);
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease, opacity 0.2s ease;
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - 24px);
@@ -708,11 +708,13 @@ select {
     transform: translate(-50%, calc(-50% + 24px));
     width: min(92vw, 540px);
     max-height: min(82vh, 680px);
+    opacity: 0;
   }
 
   .ds-ui-layer.is-modal-open .ds-modal {
     transform: translate(-50%, -50%);
     pointer-events: auto;
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
Enhanced the modal animation experience by adding opacity transitions alongside the existing transform animations, and implementing fade-in/fade-out effects for modals.

## Key Changes
- Updated the transition property on the modal element to include `opacity 0.2s ease` in addition to the existing `transform 0.2s ease`
- Added `opacity: 0` to the initial modal state (closed state) to create a fade-out effect
- Added `opacity: 1` to the open modal state to create a fade-in effect when the modal is displayed

## Implementation Details
These changes create a smooth fade-in animation when a modal opens and a fade-out animation when it closes, providing a more polished user experience. The opacity transitions are synchronized with the transform animations (both using 0.2s ease timing) to ensure coordinated visual feedback.

https://claude.ai/code/session_01Ts6uPCx6sv4f77Bu4btJEp