### PR TITLE
Fix unauthorized error showing error page instead of login screen

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -44,12 +44,14 @@ async function request(action, payload = {}) {
     throw new Error('חסר קישור API. עדכנו frontend/src/config.js או window.__DASHBOARD_CONFIG__.');
   }
 
+  const tokenAtCallTime = state.token;
+
   let response;
   try {
     response = await fetch(config.apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
-      body: JSON.stringify({ action, token: state.token, ...payload })
+      body: JSON.stringify({ action, token: tokenAtCallTime, ...payload })
     });
   } catch {
     throw new Error(translateApiErrorForUser('network_error'));
@@ -62,7 +64,7 @@ async function request(action, payload = {}) {
     throw new Error(translateApiErrorForUser('server_error'));
   }
   if (!json.ok) {
-    if ((json.error || '').toLowerCase() === 'unauthorized') {
+    if ((json.error || '').toLowerCase() === 'unauthorized' && state.token === tokenAtCallTime) {
       setSession(null);
     }
     throw new Error(translateApiErrorForUser(json.error));

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -588,6 +588,12 @@ async function render() {
       return;
     }
     await mountScreen();
+  } catch (err) {
+    if (!state.token) {
+      _pendingRender = true;
+    } else {
+      throw err;
+    }
   } finally {
     _isRendering = false;
     if (_pendingRender) {


### PR DESCRIPTION
Two related bugs:

1. api.js: A stale background request (prefetch with old token) could complete after a fresh login and call setSession(null), wiping the new token. Fix: snapshot the token before the fetch and only clear the session if the token hasn't changed since the request was sent.

2. main.js: When mountScreen() threw due to unauthorized (session cleared by api.request), render() propagated the error instead of redirecting to the login screen. Fix: catch errors in render(); if state.token is empty (cleared by unauthorized), set _pendingRender=true so finally re-runs render() as a login screen.

https://claude.ai/code/session_01Ts6uPCx6sv4f77Bu4btJEp