### PR TITLE
Update Google Apps Script endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ sw.js                  ← service worker (PWA)
    ```html
    <script>
      window.__DASHBOARD_CONFIG__ = {
-      apiUrl: 'https://script.google.com/macros/s/AKfycbwyJJrBiyDshCE0euBeIZHk0zUlcSn9vlP2xzm2E-F2yiTkykR39Vy8jJgnvLB27p7T/exec'
+      apiUrl: 'https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec'
      };
    </script>
    ```
 2. **query param** — לבדיקות/dev:
-   `?apiUrl=https://script.google.com/macros/s/AKfycbwyJJrBiyDshCE0euBeIZHk0zUlcSn9vlP2xzm2E-F2yiTkykR39Vy8jJgnvLB27p7T/exec`
+   `?apiUrl=https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec`
 3. **DEFAULT_API_URL** ב-`frontend/src/config.js` — ברירת מחדל לייצור.
 
 ### הרצה מקומית

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbwyJJrBiyDshCE0euBeIZHk0zUlcSn9vlP2xzm2E-F2yiTkykR39Vy8jJgnvLB27p7T/exec';
+  'https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
### Motivation
- Replace the hard-coded Google Apps Script Web App URL with the new provided endpoint in the single canonical config location to follow the project's API URL centralization policy and without changing any runtime logic.

### Description
- Replaced the old URL `https://script.google.com/macros/s/AKfycbwyJJrBiyDshCE0euBeIZHk0zUlcSn9vlP2xzm2E-F2yiTkykR39Vy8jJgnvLB27p7T/exec` with the new URL `https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec` in `frontend/src/config.js` (the `DEFAULT_API_URL`) and updated matching examples in `README.md`, with no other code, logic, action names, payloads, headers, fetch structures, or refactors changed.

### Testing
- No automated tests were executed for this change; replacements were verified with source search and `git diff` before committing the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6467222a0832ba4d4d118582d6504)