### PR TITLE
Fix login flow and switch frontend to new Apps Script URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ sw.js                  ← service worker (PWA)
    ```html
    <script>
      window.__DASHBOARD_CONFIG__ = {
-      apiUrl: 'https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec'
+      apiUrl: '<YOUR_APPS_SCRIPT_EXEC_URL>'
      };
    </script>
    ```
 2. **query param** — לבדיקות/dev:
-   `?apiUrl=https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec`
+   `?apiUrl=<YOUR_APPS_SCRIPT_EXEC_URL>`
 3. **DEFAULT_API_URL** ב-`frontend/src/config.js` — ברירת מחדל לייצור.
 
 ### הרצה מקומית

--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -1,22 +1,26 @@
 function actionLogin_(payload) {
+  var userId = text_(payload.user_id || payload.userId);
   var entryCode = text_(payload.entry_code || payload.entryCode);
+  if (!userId) throw new Error('user_id is required');
   if (!entryCode) throw new Error('entry_code is required');
 
   var permissionRows = readRows_(CONFIG.SHEETS.PERMISSIONS);
-  var match = permissionRows.find(function(row) {
-    return text_(row.entry_code) === entryCode && yesNo_(row.active) === 'yes';
+  var matchByUser = permissionRows.find(function(row) {
+    return text_(row.user_id) === userId;
   });
 
-  if (!match) throw new Error('Invalid or inactive code');
+  if (!matchByUser) throw new Error('invalid_credentials');
+  if (yesNo_(matchByUser.active) !== 'yes') throw new Error('user_inactive');
+  if (text_(matchByUser.entry_code) !== entryCode) throw new Error('invalid_credentials');
 
-  var role = normalizeRole_(internalRoleFromPermissionRow_(match));
+  var role = normalizeRole_(internalRoleFromPermissionRow_(matchByUser));
   var user = {
-    user_id: text_(match.user_id),
-    full_name: text_(match.full_name),
+    user_id: text_(matchByUser.user_id),
+    full_name: text_(matchByUser.full_name),
     display_role: role,
-    display_role2: text_(match.display_role2),
-    default_view: text_(match.default_view),
-    emp_id: text_(match.user_id)
+    display_role2: text_(matchByUser.display_role2),
+    default_view: text_(matchByUser.default_view),
+    emp_id: text_(matchByUser.user_id)
   };
 
   var token = Utilities.getUuid();
@@ -26,8 +30,8 @@ function actionLogin_(payload) {
     CONFIG.SESSION_CACHE_SECONDS
   );
 
-  var routes = buildRoutesFromPermission_(match, role);
-  var preferred = text_(match.default_view) || defaultRouteForRole_(role);
+  var routes = buildRoutesFromPermission_(matchByUser, role);
+  var preferred = text_(matchByUser.default_view) || defaultRouteForRole_(role);
   var defaultRoute = resolveDefaultRoute_(preferred, routes, role);
 
   return {

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyO8lelLfZEpFAlLji5f6qO5tR7I5uoQK5FfMf2y1XWJj5UreSS4ddEtkKDPzKT7YiwMw/exec';
+  'https://script.google.com/macros/s/AKfycbxRoSefEsfmg-Rmk6F-bewemPlCeus7YnchSXDn1WHt9fVIfRN1Ip7iox2MkSpJ5hh4/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -23,6 +23,7 @@ const loginLogoSrc = new URL('../assets/logo1.png', import.meta.url).href;
 
 let isMobileNavOpen = false;
 let lastRenderedRoute = null;
+let loginInlineError = '';
 const ui = createSharedInteractionLayer();
 
 /** In-flight API request dedup: prevents duplicate calls when navigating quickly. */
@@ -510,18 +511,33 @@ async function render() {
       isMobileNavOpen = false;
       document.body.classList.remove('is-shell-nav-open');
       ui.closeAll();
-      app.innerHTML = loginScreen.render();
+      app.innerHTML = loginScreen.render(escapeHtml(loginInlineError));
       loginScreen.bind({
         root: app,
         onLogin: async (userId, code, errorNode) => {
+          loginInlineError = '';
+          const clearRoutesSnapshot = () => localStorage.removeItem('dashboard_routes');
+          const rollbackToLogin = (message) => {
+            setSession(null);
+            clearRoutesSnapshot();
+            loginInlineError = message;
+          };
           try {
             const data = await api.login(userId, code);
             setSession({ token: data.token, user: data.user });
             applyBootstrapFromLoginData(data);
-            await restoreSession();
-            await render();
+            try {
+              await restoreSession();
+              await mountScreen();
+              loginInlineError = '';
+            } catch {
+              rollbackToLogin('כשל בטעינת נתוני משתמש אחרי התחברות');
+              await render();
+            }
           } catch (error) {
-            if (errorNode) errorNode.textContent = error.message;
+            const msg = translateApiErrorForUser(error?.message);
+            if (errorNode) errorNode.textContent = msg;
+            rollbackToLogin(msg);
             throw error;
           }
         }
@@ -574,12 +590,7 @@ if ('serviceWorker' in navigator) {
 }
 
 render().catch((error) => {
-  const msg = translateApiErrorForUser(error?.message);
-  app.innerHTML = `
-    <div class="login-shell" dir="rtl">
-      <section class="login-card ds-error-page panel--error">
-        <h2>שגיאה</h2>
-        <p>${escapeHtml(msg)}</p>
-      </section>
-    </div>`;
+  loginInlineError = translateApiErrorForUser(error?.message);
+  setSession(null);
+  render().catch(() => {});
 });

--- a/frontend/src/screens/login.js
+++ b/frontend/src/screens/login.js
@@ -1,7 +1,7 @@
 const loginLogoSrc = new URL('../../assets/logo1.png', import.meta.url).href;
 
 export const loginScreen = {
-  render() {
+  render(initialError = '') {
     return `
       <div class="login-shell" dir="rtl">
         <section class="login-card">
@@ -39,7 +39,7 @@ export const loginScreen = {
             <button type="submit" class="login-submit">התחברות</button>
           </form>
 
-          <p id="loginError" class="error"></p>
+          <p id="loginError" class="error">${initialError}</p>
         </section>
       </div>
     `;

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -211,11 +211,15 @@ const API_ERROR_HE = {
   'not found': 'הפריט לא נמצא',
   not_found: 'הפריט לא נמצא',
   bad_request: 'הבקשה אינה תקינה',
+  'user_id is required': 'יש להזין מזהה משתמש',
   invalid_credentials: 'מזהה משתמש או קוד כניסה שגויים',
-  invalid_or_inactive_code: 'קוד כניסה שגוי או לא פעיל',
+  user_inactive: 'המשתמש אינו פעיל',
+  invalid_or_inactive_code: 'מזהה משתמש או קוד כניסה שגויים',
   entry_code_is_required: 'יש להזין קוד כניסה',
+  'entry_code is required': 'יש להזין קוד כניסה',
   invalid_user: 'מזהה משתמש או קוד כניסה שגויים',
   login_failed: 'ההתחברות נכשלה',
+  bootstrap_failed: 'כשל בטעינת נתוני משתמש אחרי התחברות',
   timeout: 'הבקשה נמשכה יותר מהצפוי — נסו שוב',
   request_timeout: 'הבקשה נמשכה יותר מהצפוי — נסו שוב',
   server_error: 'שגיאת שרת — נסו שוב מאוחר יותר',
@@ -230,7 +234,7 @@ const API_ERROR_HE = {
 
 /** Maps common API English errors to Hebrew; leaves Hebrew messages unchanged. */
 export function translateApiErrorForUser(message) {
-  if (message === undefined || message === null || message === '') return 'אירעה שגיאה';
+  if (message === undefined || message === null || message === '') return API_ERROR_HE.server_error;
   const raw = String(message).trim();
   if (/[\u0590-\u05FF]/.test(raw)) return raw;
   const key = raw.toLowerCase();
@@ -238,5 +242,5 @@ export function translateApiErrorForUser(message) {
   if (key.includes('timeout') || key.includes('timed_out')) return API_ERROR_HE.timeout;
   if (/^5\d\d\b/.test(key) || key.includes('internal')) return API_ERROR_HE.server_error;
   if (key.includes('network') || key.includes('fetch')) return API_ERROR_HE.network_error;
-  return 'אירעה שגיאה';
+  return API_ERROR_HE.server_error;
 }


### PR DESCRIPTION
### Motivation
- לתקן regression בתהליך ההתחברות שבו הודעות שגיאה כלליות הפילו את כל ה־UI, ולהתאימו לדרישת אימות לפי `user_id` + `entry_code` + משתמש פעיל.
- לרכז את כתובת ה־Apps Script כמקור אמת יחיד בקובץ הקונפיג (`frontend/src/config.js`) ולמנוע URL קשיח מפוזר.

### Description
- עדכנתי את `DEFAULT_API_URL` ב־`frontend/src/config.js` לכתובת ה־Apps Script החדשה ומנעתי שימוש בכתובות קשיחות בקבצי README (החלפתי לדפלייסה placeholder). (קובץ: `frontend/src/config.js`, `README.md`).
- שיניתי את לוגיקת ההתחברות ב־backend כך ש־`actionLogin_` בודק `user_id` ו־`entry_code`, בודק שדה `active` ומחזיר מפתחות שגיאה ברורים (`invalid_credentials`, `user_inactive`, `user_id is required`). (קובץ: `backend/auth.gs`).
- שיפרתי מיפוי הודעות שגיאה לעברית ב־`translateApiErrorForUser` כדי להציג מסרים ברורים (כולל `user_inactive`, שדות דרושים ו־`bootstrap_failed`). (קובץ: `frontend/src/screens/shared/ui-hebrew.js`).
- עדכנתי את ה־login flow בפרונט־אנד so ש: שגיאות ב־login/bootstrap/טעינת התצוגה הראשונה מוצגות inline בתוך `#loginError`, מבוצע rollback ל־session תקין במקרה של כשל אחרי שמירת token, ולא מפילים את כל האפליקציה למסך שגיאה מלא. (קבצים: `frontend/src/main.js`, `frontend/src/screens/login.js`).
- רשימת קבצים שעודכנו: `frontend/src/config.js`, `frontend/src/main.js`, `frontend/src/screens/login.js`, `frontend/src/screens/shared/ui-hebrew.js`, `backend/auth.gs`, `README.md`.
- פריסה: יש לפרוס מחדש את שני הצדדים — את ה־Frontend (כדי לשחרר `config.js` ו־login flow) וגם את ה־Apps Script (כדי שהשינויים ב־`actionLogin_` יכנסו לפועל).

### Testing
- הרצתי חיפושים על הריפו לאיתור כתובות Apps Script ישנות ו`/dev` והצלחתי לוודא שהכתובת החדשה מופיעה רק ב־`frontend/src/config.js` והכתובת הישנה הוסרה ממקומות פומביים; פקודות שנורו: `rg` על URLים רלוונטיים (החיפוש עבר בהצלחה).
- ביצעתי בדיקה של השינויים המקומיים (המלצות והרצה מקומית) והפעלתי `npm test`; הריצה נכשלה עקב חוסר תלות בסביבת הריצה (`jsdom` לא מותקן) כך שהמבחנים האוטומטיים לא הושלמו בסביבה הזו.
- מצב נוכחי: לוגיקת ה־login והתרגום לשגיאות הוטמעה ומוכנה לבדיקות אינטגרציה; מומלץ להריץ בדיקות ידניות של: התחברות תקינה, התחברות עם user_id/entry_code שגויים, התחברות עם משתמש לא פעיל, restoreSession, bootstrap ו־logout אחרי פריסה ממשית.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64b73a788832b9a3e67c70262a07d)