### PR TITLE
Simplify admin home screen and improve meeting date handling

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -469,17 +469,24 @@ function actionActivities_(user, payload) {
   });
 
   var noteMap = buildPrivateNotesMap_();
+  var activitiesMeetingsMap = buildMeetingsMap_();
 
   return {
     activity_type_counts: activityTypeCounts,
     rows: rows.map(function(row) {
       var noteKey = row.source_sheet + '|' + row.RowID;
       var noteRow = noteMap[noteKey];
-      var meetingDates = activityDateColumnsFromRow_(row).slice();
-      meetingDates = meetingDates.filter(function(v, i, arr) {
-        return !!v && arr.indexOf(v) === i;
-      }).sort();
-      var computedStartDate = normalizeDateTextToIso_(row.Date1);
+      /* activity_meetings כמקור אמת לתאריכים; fallback לעמודות Date1-Date35 */
+      var meetingsFromSheet = activitiesMeetingsMap[text_(row.RowID)];
+      var meetingDates;
+      if (meetingsFromSheet && meetingsFromSheet.length) {
+        meetingDates = meetingsFromSheet.slice().sort();
+      } else {
+        meetingDates = activityDateColumnsFromRow_(row).filter(function(v, i, arr) {
+          return !!v && arr.indexOf(v) === i;
+        }).sort();
+      }
+      var computedStartDate = meetingDates.length ? meetingDates[0] : normalizeDateTextToIso_(row.Date1);
       var computedEndDate = meetingDates.length ? meetingDates[meetingDates.length - 1] : '';
       var meetingSchedule = meetingDates.map(function(dateKey) {
         return {
@@ -856,7 +863,8 @@ function actionEndDates_(user) {
     throw new Error('Forbidden');
   }
 
-  var rows = buildLongRows_()
+  var longRows = enrichRowsWithMeetings_(buildLongRows_().slice());
+  var rows = longRows
     .filter(function(row) {
       return !!text_(row.end_date);
     })
@@ -1506,6 +1514,25 @@ function actionSavePrivateNote_(user, payload) {
   };
 }
 
+/**
+ * מחשב מחדש start_date ו-end_date לפי גיליון activity_meetings כמקור אמת.
+ * תאריך התחלה = הרשומה הקטנה ביותר (meeting_no=1 בפועל לאחר מיון).
+ * תאריך סיום = הרשומה הגדולה ביותר (תאריך אחרון תקין).
+ * כשאין רשומות בגיליון — נשארים הערכים המחושבים מ-Date1-Date35.
+ */
+function enrichRowsWithMeetings_(rows) {
+  var meetingsMap = buildMeetingsMap_();
+  rows.forEach(function(row) {
+    var dates = meetingsMap[text_(row.RowID)];
+    if (dates && dates.length) {
+      var sorted = dates.slice().sort();
+      row.start_date = sorted[0];
+      row.end_date = sorted[sorted.length - 1];
+    }
+  });
+  return rows;
+}
+
 function allActivities_() {
   if (__rqCache_ && Object.prototype.hasOwnProperty.call(__rqCache_, 'allActivities')) {
     return __rqCache_.allActivities;
@@ -1518,6 +1545,7 @@ function allActivities_() {
       list = list.concat(buildLongRows_());
     }
   });
+  enrichRowsWithMeetings_(list);
   if (__rqCache_) {
     __rqCache_.allActivities = list;
   }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -90,7 +90,7 @@ const screenLabels = {
   'end-dates': 'תאריכי סיום',
   'my-data': 'הנתונים שלי',
   permissions: 'הרשאות',
-  'admin-home': 'בית — ניהול'
+  'admin-home': 'לוח בקרה – מנהל מערכת'
 };
 
 const screens = {
@@ -109,7 +109,7 @@ const screens = {
   'admin-home': adminHomeScreen
 };
 
-const NAV_HIDDEN_ROUTES = new Set(['contacts', 'instructor-contacts', 'week', 'month', 'exceptions', 'instructors']);
+const NAV_HIDDEN_ROUTES = new Set(['contacts', 'instructor-contacts', 'week', 'month', 'exceptions', 'instructors', 'permissions', 'end-dates']);
 
 function systemNameRaw() {
   return String(state?.clientSettings?.system_name || 'Dashboard Taasiyeda').trim() || 'Dashboard Taasiyeda';

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -238,7 +238,7 @@ export const activitiesScreen = {
       .join('');
 
     const familyChips = [
-      { key: '', label: 'כל המשפחות' },
+      { key: '', label: 'הכל' },
       { key: 'short', label: FAMILY_LABEL_SHORT },
       { key: 'long', label: FAMILY_LABEL_LONG }
     ]
@@ -276,11 +276,12 @@ export const activitiesScreen = {
 
     const userRoutes = Array.isArray(state?.routes) ? state.routes : [];
     const shortcutDefs = [
-      { route: 'week',        label: 'שבוע',       icon: '📅' },
-      { route: 'month',       label: 'חודש',       icon: '📆' },
-      { route: 'exceptions',  label: 'חריגות',     icon: '⚠️' },
-      { route: 'instructors', label: 'מדריכים',    icon: '👥' },
-      { route: 'contacts',    label: 'אנשי קשר',  icon: '🏫' },
+      { route: 'week',        label: 'שבוע',         icon: '📅' },
+      { route: 'month',       label: 'חודש',         icon: '📆' },
+      { route: 'exceptions',  label: 'חריגות',       icon: '⚠️' },
+      { route: 'instructors', label: 'מדריכים',      icon: '👥' },
+      { route: 'end-dates',   label: 'תאריכי סיום',  icon: '🗓️' },
+      { route: 'contacts',    label: 'אנשי קשר',    icon: '🏫' },
     ];
     const shortcutsHtml = shortcutDefs
       .filter((d) => userRoutes.includes(d.route))

--- a/frontend/src/screens/admin-home.js
+++ b/frontend/src/screens/admin-home.js
@@ -1,58 +1,33 @@
 import { escapeHtml } from './shared/html.js';
-import { hebrewRole } from './shared/ui-hebrew.js';
 import {
   dsPageHeader,
   dsCard,
   dsScreenStack,
-  dsKpiGrid,
-  dsStatusChip,
   dsEmptyState
 } from './shared/layout.js';
 
 const SCREEN_META = {
-  dashboard:        { label: 'לוח בקרה',          icon: '📊' },
-  activities:       { label: 'פעילויות',            icon: '📋' },
-  finance:          { label: 'כספים',               icon: '💰' },
-  permissions:      { label: 'הרשאות',              icon: '🔑' },
-  'admin-home':     { label: 'בית — ניהול',         icon: '🏠' },
-  exceptions:       { label: 'חריגות',              icon: '⚠️' },
-  instructors:      { label: 'מדריכים',             icon: '👥' },
-  'end-dates':      { label: 'תאריכי סיום',          icon: '📅' },
-  'my-data':        { label: 'הנתונים שלי',          icon: '👤' },
-  week:             { label: 'שבוע',                icon: '📆' },
-  month:            { label: 'חודש',                icon: '🗓️' }
+  dashboard:        { label: 'לוח בקרה',               icon: '📊' },
+  activities:       { label: 'פעילויות',                icon: '📋' },
+  finance:          { label: 'כספים',                   icon: '💰' },
+  permissions:      { label: 'הרשאות',                  icon: '🔑' },
+  exceptions:       { label: 'חריגות',                  icon: '⚠️' },
+  instructors:      { label: 'מדריכים',                 icon: '👥' },
+  'end-dates':      { label: 'תאריכי סיום',              icon: '📅' },
+  'my-data':        { label: 'הנתונים שלי',              icon: '👤' },
+  week:             { label: 'שבוע',                    icon: '📆' },
+  month:            { label: 'חודש',                    icon: '🗓️' }
 };
 
-const ADMIN_SECTION_ROUTES = ['permissions'];
-const HIGHLIGHT_ROUTES = ['finance', 'activities', 'dashboard', 'exceptions'];
+const ADMIN_TOOL_ROUTES = ['permissions'];
+const NAV_ROUTES = ['dashboard', 'activities', 'finance', 'exceptions'];
 
 export const adminHomeScreen = {
-  load: ({ api }) => api.permissions().catch(() => ({ rows: [], error: 'permissions_denied' })),
+  load: () => Promise.resolve({}),
 
   render(data, { state } = {}) {
-    const safeRows = Array.isArray(data?.rows) ? data.rows : [];
     const routes = Array.isArray(state?.routes) ? state.routes : [];
 
-    /* Admin-centric KPIs: access-rights overview from permissions rows */
-    const activeRows = safeRows.filter((r) => String(r.active || '').toLowerCase() === 'yes');
-    const activeCount = activeRows.length;
-    const inactiveCount = safeRows.length - activeCount;
-    /* Access grants among active users */
-    const withFinance = activeRows.filter((r) => String(r.view_finance || '').toLowerCase() === 'yes').length;
-    const withPermissions = activeRows.filter((r) => String(r.view_permissions || '').toLowerCase() === 'yes').length;
-    const adminCount = safeRows.filter((r) => r.display_role === 'admin').length;
-    const reviewerCount = safeRows.filter((r) => r.display_role === 'operations_reviewer').length;
-    const accessibleRoutes = routes.length;
-
-    const kpis = [
-      { label: 'משתמשים פעילים', value: String(activeCount), hint: `${inactiveCount} לא פעילים` },
-      { label: 'גישה לכספים', value: String(withFinance), hint: 'מתוך פעילים' },
-      { label: 'גישה להרשאות', value: String(withPermissions), hint: 'מתוך פעילים' },
-      { label: 'מנהלים / בקרים', value: `${adminCount} / ${reviewerCount}` },
-      { label: 'מסכים נגישים', value: String(accessibleRoutes), hint: 'למשתמש הנוכחי' }
-    ];
-
-    /* Navigation cards — only for routes the user has access to */
     function navCard(route) {
       if (!routes.includes(route)) return '';
       const meta = SCREEN_META[route] || { label: route, icon: '▶' };
@@ -62,70 +37,30 @@ export const adminHomeScreen = {
       </button>`;
     }
 
-    const adminCards = ADMIN_SECTION_ROUTES.map(navCard).filter(Boolean).join('');
-    const highlightCards = HIGHLIGHT_ROUTES.map(navCard).filter(Boolean).join('');
+    const toolCards = ADMIN_TOOL_ROUTES.map(navCard).filter(Boolean).join('');
+    const navCards = NAV_ROUTES.map(navCard).filter(Boolean).join('');
 
-    const adminSection = adminCards
+    const toolSection = toolCards
       ? `<div class="ds-admin-section">
           <p class="ds-admin-section-heading">כלי ניהול</p>
-          <div class="ds-admin-ctrl-grid">${adminCards}</div>
+          <div class="ds-admin-ctrl-grid">${toolCards}</div>
         </div>`
       : '';
 
-    const highlightSection = highlightCards
+    const navSection = navCards
       ? `<div class="ds-admin-section">
-          <p class="ds-admin-section-heading">מסכים מהירים</p>
-          <div class="ds-admin-ctrl-grid">${highlightCards}</div>
+          <p class="ds-admin-section-heading">ניווט</p>
+          <div class="ds-admin-ctrl-grid">${navCards}</div>
         </div>`
       : '';
 
-    /* Role breakdown table */
-    const roleRows = [
-      { role: 'admin', count: adminCount },
-      { role: 'operations_reviewer', count: reviewerCount },
-      { role: 'authorized_user', count: safeRows.filter((r) => r.display_role === 'authorized_user').length },
-      { role: 'instructor', count: safeRows.filter((r) => r.display_role === 'instructor').length }
-    ].filter((r) => r.count > 0);
-
-    const roleTable = roleRows.length === 0
-      ? dsEmptyState('אין נתוני משתמשים')
-      : `<table class="ds-table" style="max-width:360px;">
-          <thead><tr><th>תפקיד</th><th style="text-align:center;">כמות</th><th style="text-align:center;">פעילים</th></tr></thead>
-          <tbody>
-            ${roleRows.map((r) => {
-              const active = safeRows.filter((u) => u.display_role === r.role && String(u.active || '').toLowerCase() === 'yes').length;
-              return `<tr>
-                <td>${escapeHtml(hebrewRole(r.role))}</td>
-                <td style="text-align:center;">${r.count}</td>
-                <td style="text-align:center;">${dsStatusChip(String(active), active === r.count ? 'success' : 'warning')}</td>
-              </tr>`;
-            }).join('')}
-          </tbody>
-        </table>`;
-
-    /* Recently inactive users */
-    const recentInactive = safeRows
-      .filter((r) => String(r.active || '').toLowerCase() !== 'yes')
-      .slice(0, 8);
-
-    const inactiveSection = recentInactive.length === 0 ? '' : dsCard({
-      title: 'משתמשים לא פעילים',
-      badge: String(inactiveCount),
-      body: `<div style="padding:var(--ds-space-3);display:flex;flex-direction:column;gap:6px;">
-        ${recentInactive.map((r) => `<div style="display:flex;align-items:center;gap:8px;padding:5px 0;border-bottom:1px solid var(--ds-border);">
-          <span style="font-weight:600;font-size:0.88rem;flex:1;">${escapeHtml(r.full_name || r.user_id)}</span>
-          ${dsStatusChip(hebrewRole(r.display_role), 'neutral')}
-        </div>`).join('')}
-      </div>`,
-      padded: false
-    });
+    const body = toolSection + navSection || dsEmptyState('אין מסכים נגישים');
 
     return dsScreenStack(`
-      ${dsPageHeader('בית — ניהול', 'לוח בקרה למנהלי מערכת')}
-      ${dsKpiGrid(kpis)}
-      ${dsCard({ title: 'ניווט', body: adminSection + highlightSection || dsEmptyState('אין מסכים נגישים'), padded: !(adminSection || highlightSection) })}
-      ${dsCard({ title: 'התפלגות תפקידים', body: roleTable, padded: true })}
-      ${inactiveSection}
+      ${dsPageHeader('לוח בקרה – מנהל מערכת')}
+      <div style="display:flex;justify-content:center;">
+        ${dsCard({ title: 'ניווט וכלי ניהול', body, padded: !(toolSection || navSection) })}
+      </div>
     `);
   },
 
@@ -134,7 +69,6 @@ export const adminHomeScreen = {
       card.addEventListener('click', () => {
         const target = card.dataset.adminNav;
         if (!target) return;
-        /* Dispatch app:navigate so the shell handles it — works for hidden routes too */
         document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: target } }));
       });
     });

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -58,6 +58,19 @@ function filterKpiCards(cards, showOnlyNonzero) {
 }
 
 
+function renderAdminNavBar(state) {
+  const routes = Array.isArray(state?.routes) ? state.routes : [];
+  const adminRoutes = [
+    { route: 'admin-home', label: 'ניהול מערכת', icon: '🏠' },
+    { route: 'permissions', label: 'הרשאות', icon: '🔑' }
+  ].filter((r) => routes.includes(r.route));
+  if (!adminRoutes.length) return '';
+  const btns = adminRoutes
+    .map((r) => `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-goto-route="${escapeHtml(r.route)}"><span aria-hidden="true">${r.icon}</span> ${escapeHtml(r.label)}</button>`)
+    .join('');
+  return `<div class="ds-screen-shortcuts ds-screen-shortcuts--admin" dir="rtl">${btns}</div>`;
+}
+
 export const dashboardScreen = {
   async load({ api, state }) {
     let ym = state.dashboardMonthYm;
@@ -67,7 +80,7 @@ export const dashboardScreen = {
     state.dashboardMonthYm = ym;
     return api.dashboard({ month: ym });
   },
-  render(data) {
+  render(data, { state } = {}) {
     const ym = data?.month || currentMonthYm();
     const curYm = currentMonthYm();
     const canGoNext = ym < curYm;
@@ -124,8 +137,12 @@ export const dashboardScreen = {
       }>▶</button>
     </div>`;
 
+    const isAdmin = state?.user?.display_role === 'admin';
+    const adminNavBar = isAdmin ? renderAdminNavBar(state) : '';
+
     return dsScreenStack(`
       ${dsPageHeader('לוח בקרה')}
+      ${adminNavBar}
       ${monthNav}
       <div data-dash-data-area>
         <div class="ds-kpi-grid ds-dashboard-kpi-grid">${kpiHtml}</div>
@@ -138,6 +155,13 @@ export const dashboardScreen = {
     `);
   },
   bind({ root, ui, state, api, rerender, clearScreenDataCache }) {
+    root.querySelectorAll('[data-goto-route]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const target = btn.dataset.gotoRoute;
+        if (!target) return;
+        document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: target } }));
+      });
+    });
     function showDataAreaLoading() {
       const area = root.querySelector('[data-dash-data-area]');
       if (area) {


### PR DESCRIPTION
## Summary
This PR simplifies the admin home screen by removing KPI metrics and user statistics, while improving how activity meeting dates are calculated across the application. It also adds admin navigation shortcuts to the dashboard and updates screen labels and navigation routes.

## Key Changes

**Admin Home Screen Simplification:**
- Removed KPI grid displaying user counts, access grants, and role breakdowns
- Removed role distribution table and inactive users section
- Removed dependency on permissions API data
- Simplified layout to show only navigation and admin tools cards
- Renamed "מסכים מהירים" (Quick Screens) to "ניווט" (Navigation)
- Updated screen title from "בית — ניהול" to "לוח בקרה – מנהל מערכת"

**Meeting Date Handling:**
- Added `buildMeetingsMap_()` function to extract meeting dates from the `activity_meetings` sheet as the source of truth
- Created `enrichRowsWithMeetings_()` function to recalculate `start_date` and `end_date` based on meeting data
- Updated `actionActivities_()` to use meeting dates when available, falling back to Date1-Date35 columns
- Updated `actionEndDates_()` to enrich rows with meeting data before filtering
- Applied meeting enrichment to `allActivities_()` cache

**Dashboard Improvements:**
- Added admin navigation bar (`renderAdminNavBar()`) for admins to quickly access admin-home and permissions screens
- Updated dashboard render to accept state parameter and conditionally show admin nav bar
- Added click handlers for admin navigation buttons

**Navigation Updates:**
- Added 'end-dates' to activities screen shortcuts
- Updated `NAV_HIDDEN_ROUTES` to include 'permissions' and 'end-dates' (hidden from main nav)
- Renamed admin section routes constant from `ADMIN_SECTION_ROUTES` to `ADMIN_TOOL_ROUTES`
- Renamed highlight routes constant from `HIGHLIGHT_ROUTES` to `NAV_ROUTES`
- Updated activities screen filter label from "כל המשפחות" to "הכל"

## Implementation Details
- Meeting dates are now sourced from a dedicated sheet (`activity_meetings`) rather than scattered across Date1-Date35 columns
- The enrichment function preserves fallback behavior when meeting data is unavailable
- Admin shortcuts on dashboard are only shown to users with 'admin' role
- Removed unused imports (`hebrewRole`, `dsKpiGrid`, `dsStatusChip`) from admin-home screen

https://claude.ai/code/session_01SN82wMqDUCpTUwZYXArqR3