### PR TITLE
chore: update Apps Script Web App URL in config

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyVB8siKOQMk-ANatLLxjwtNPN0X6uoebjJ_D33z5MYRY7-LmGZ5uWSuNpC0dPzqX_8/exec';
+  'https://script.google.com/macros/s/AKfycbxVf-UTy3bZA-0hGu8VMADGr6RnA3yJ2X8hBJfDF3Rlj2enppXrLN6QuhWKGfWx47R8/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
### Motivation
- לעדכן את נקודת הכניסה של ה־Apps Script באפליקציה כדי להשתמש בכתובת ה־Web App החדשה ולהשאיר את הכתובת במקום מרכזי אחד בלבד (`config.js`).

### Description
- שונה `DEFAULT_API_URL` בקובץ `frontend/src/config.js` להכתובת החדשה של ה־Apps Script Web App.

### Testing
- רץ חיפוש כלל־פרויקט (`rg`) כדי לאתר מופעים של ה־URL הישן והאימות הראה שהמופע הישן הוחלף; החיפוש הצליח ללא מציאת שאריות ישנות.  
- ביצעתי commit של הקובץ (`git commit`) והבדיקה הראתה שינוי יחיד בקובץ `frontend/src/config.js` שהתווסף באופן תקין.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6844d0ed0832bba7f4c609c0aab0c)