### PR TITLE
Add opt-in performance diagnostics (backend + frontend) and perf sample script

### DIFF
--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -77,8 +77,83 @@ function parsePayload_(e) {
   return JSON.parse(raw || '{}');
 }
 
-function jsonResponse_(payload) {
+var __rqPerf_ = null;
+
+function perfNowMs_() {
+  return new Date().getTime();
+}
+
+function beginRequestPerf_(action, payload) {
+  var debugFlag = payload && (
+    payload.debug_perf === true ||
+    text_(payload.debug_perf) === '1' ||
+    text_(payload.debug_perf).toLowerCase() === 'true'
+  );
+  __rqPerf_ = {
+    enabled: !!debugFlag,
+    action: text_(action),
+    started_ms: perfNowMs_(),
+    marks: [{ label: 'request_start', at_ms: perfNowMs_() }],
+    sheet_reads: [],
+    sheets_total_ms: 0
+  };
+}
+
+function markRequestPerf_(label) {
+  if (!__rqPerf_ || !__rqPerf_.enabled) return;
+  __rqPerf_.marks.push({ label: text_(label), at_ms: perfNowMs_() });
+}
+
+function trackSheetReadPerf_(meta) {
+  if (!__rqPerf_ || !__rqPerf_.enabled) return;
+  var item = {
+    sheet: text_(meta.sheet),
+    rows: Number(meta.rows || 0),
+    cols: Number(meta.cols || 0),
+    duration_ms: Number(meta.duration_ms || 0),
+    projected: !!meta.projected,
+    from_cache: !!meta.from_cache
+  };
+  __rqPerf_.sheet_reads.push(item);
+  __rqPerf_.sheets_total_ms += item.duration_ms;
+}
+
+function buildPerfPayload_(responsePayload, meta) {
+  if (!__rqPerf_ || !__rqPerf_.enabled) return null;
+  var endMs = perfNowMs_();
+  var marks = __rqPerf_.marks.slice();
+  marks.push({ label: 'response_start', at_ms: endMs });
+  var stepDurations = [];
+  for (var i = 1; i < marks.length; i++) {
+    stepDurations.push({
+      step: marks[i - 1].label + '→' + marks[i].label,
+      duration_ms: marks[i].at_ms - marks[i - 1].at_ms
+    });
+  }
+  var responseSize = JSON.stringify(responsePayload || {}).length;
+  return {
+    action: text_((meta && meta.action) || __rqPerf_.action),
+    cache_hit: !!(meta && meta.cache_hit),
+    errored: !!(meta && meta.errored),
+    total_ms: endMs - __rqPerf_.started_ms,
+    sheets_total_ms: __rqPerf_.sheets_total_ms,
+    sheet_reads: __rqPerf_.sheet_reads,
+    steps: stepDurations,
+    response_size_bytes: responseSize
+  };
+}
+
+function jsonResponse_(payload, perfMeta) {
+  var body = payload || {};
+  var perf = buildPerfPayload_(body, perfMeta);
+  if (perf) {
+    if (body.ok && body.data && typeof body.data === 'object') {
+      body.data.debug_perf = perf;
+    } else {
+      body.debug_perf = perf;
+    }
+  }
   return ContentService
-    .createTextOutput(JSON.stringify(payload))
+    .createTextOutput(JSON.stringify(body))
     .setMimeType(ContentService.MimeType.JSON);
 }

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -16,6 +16,7 @@ function handlePost_(e) {
     beginRequestCache_();
     var payload = parsePayload_(e);
     var action = text_(payload.action);
+    beginRequestPerf_(action, payload);
     var user = action === 'login' ? null : requireAuth_(payload.token);
 
     var handlers = {
@@ -79,21 +80,39 @@ function handlePost_(e) {
       var readKey = buildReadActionCacheKey_(action, user, payload);
       var readHit = scriptCacheGetJson_(readKey);
       if (readHit !== null) {
-        return jsonResponse_({ ok: true, data: readHit });
+        markRequestPerf_('cache_lookup_done');
+        return jsonResponse_({ ok: true, data: readHit }, {
+          action: action,
+          cache_hit: true
+        });
       }
+      markRequestPerf_('cache_lookup_done');
       var readData = handlers[action]();
+      markRequestPerf_('action_done');
       scriptCachePutJson_(readKey, readData, CONFIG.SCRIPT_CACHE_SECONDS || 90);
-      return jsonResponse_({ ok: true, data: readData });
+      return jsonResponse_({ ok: true, data: readData }, {
+        action: action,
+        cache_hit: false
+      });
     }
 
+    markRequestPerf_('action_start');
+    var writeData = handlers[action]();
+    markRequestPerf_('action_done');
     return jsonResponse_({
       ok: true,
-      data: handlers[action]()
+      data: writeData
+    }, {
+      action: action,
+      cache_hit: false
     });
   } catch (error) {
     return jsonResponse_({
       ok: false,
       error: error && error.message ? error.message : 'Unexpected error'
+    }, {
+      action: (__rqPerf_ && __rqPerf_.action) || 'unknown',
+      errored: true
     });
   }
 }

--- a/backend/sheets.gs
+++ b/backend/sheets.gs
@@ -157,6 +157,14 @@ function getRows_(sheetName) {
 function readRows_(sheetName) {
   var cacheKey = sheetName;
   if (__rqCache_ && __rqCache_.readRows[cacheKey]) {
+    trackSheetReadPerf_({
+      sheet: sheetName,
+      rows: __rqCache_.readRows[cacheKey].length,
+      cols: 0,
+      duration_ms: 0,
+      projected: false,
+      from_cache: true
+    });
     return __rqCache_.readRows[cacheKey];
   }
 
@@ -173,7 +181,9 @@ function readRows_(sheetName) {
   }
 
   var headers = getHeaders_(sheet);
+  var readStartMs = perfNowMs_();
   var values = sheet.getRange(dataStart, 1, lastRow - dataStart + 1, lastCol).getValues();
+  var readDurationMs = perfNowMs_() - readStartMs;
 
   var result = values.filter(function(row) {
     return row.some(function(cell) { return text_(cell) !== ''; });
@@ -188,6 +198,14 @@ function readRows_(sheetName) {
   if (__rqCache_) {
     __rqCache_.readRows[cacheKey] = result;
   }
+  trackSheetReadPerf_({
+    sheet: sheetName,
+    rows: values.length,
+    cols: lastCol,
+    duration_ms: readDurationMs,
+    projected: false,
+    from_cache: false
+  });
   return result;
 }
 

--- a/docs/performance-stage1.md
+++ b/docs/performance-stage1.md
@@ -1,0 +1,105 @@
+# Stage 1 Performance Diagnostics (Measurement Only)
+
+מסמך זה מתאר איך להפעיל ולקרוא את המדידה שנוספה בשלב 1, ללא rewrite וללא שינוי UX.
+
+## 1) איך מפעילים מדידה
+
+ב־DevTools Console:
+
+```js
+localStorage.setItem('debug_perf', '1');
+// או:
+window.__DEBUG_PERF__ = true;
+```
+
+לאחר מכן לבצע רענון דף.
+
+> כדי לכבות:
+```js
+localStorage.removeItem('debug_perf');
+window.__DEBUG_PERF__ = false;
+```
+
+## 2) איפה רואים נתונים
+
+### Backend / Sheets / Payload
+
+בכל response של API (כאשר debug פעיל) יתווסף:
+
+```js
+data.debug_perf
+```
+
+שדות מרכזיים:
+- `total_ms` — זמן פעולה בשרת
+- `sheets_total_ms` — סך זמן קריאות שיטס
+- `sheet_reads[]` — פירוט לפי sheet
+- `response_size_bytes` — גודל התשובה בבייטים
+
+### Frontend
+
+ב־Console:
+
+```js
+window.__dsPerf.requests   // היסטוריית קריאות API
+window.__dsPerf.renders    // היסטוריית זמני render
+window.__dsPerf.screens    // אגרגציה לפי action
+```
+
+## 3) איך מאפסים
+
+```js
+window.__resetDsPerf();
+```
+
+או ידנית:
+
+```js
+window.__dsPerf = { requests: [], renders: [], screens: {} };
+```
+
+## 4) איך לזהות מסכים כבדים
+
+1. נקה מדידה (`window.__resetDsPerf()`), פתח מסך יחיד, בצע 3–5 ניווטים.
+2. מיין קריאות backend:
+
+```js
+[...window.__dsPerf.requests]
+  .sort((a, b) => b.duration_ms - a.duration_ms)
+  .slice(0, 10);
+```
+
+3. מיין render:
+
+```js
+[...window.__dsPerf.renders]
+  .sort((a, b) => b.duration_ms - a.duration_ms)
+  .slice(0, 10);
+```
+
+4. חפש התאמה בין:
+   - `duration_ms` גבוה
+   - `backend_debug.sheets_total_ms` גבוה
+   - `payload_bytes` גבוה
+   - `render duration_ms` גבוה
+
+כך אפשר לדעת אם הבעיה היא בעיקר backend, שיטס, payload או render.
+
+## 5) דגימת הרצה מקומית מהירה
+
+לצורך בדיקת end-to-end מקומית (mock data) אפשר להריץ:
+
+```bash
+node scripts/perf_sample.mjs
+```
+
+הסקריפט מחזיר JSON עם:
+- `backend_ms`
+- `sheets_read_ms`
+- `payload_bytes`
+- `render_ms`
+
+למסכים:
+- dashboard
+- activities
+- finance

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -60,12 +60,48 @@ const READ_ACTIONS = {
 
 const API_TIMEOUT_MS_READ = 20000;
 const API_TIMEOUT_MS_WRITE = 30000;
+const PERF_MAX_REQUESTS = 150;
+
+function isPerfDebugEnabled() {
+  try {
+    if (typeof window !== 'undefined' && window.__DEBUG_PERF__ === true) return true;
+    if (typeof localStorage !== 'undefined' && localStorage.getItem('debug_perf') === '1') return true;
+  } catch { /* ignore */ }
+  return false;
+}
+
+function getPerfStore() {
+  if (typeof window === 'undefined') return null;
+  if (!window.__dsPerf) {
+    window.__dsPerf = { requests: [], renders: [], screens: {} };
+    window.__resetDsPerf = () => {
+      window.__dsPerf = { requests: [], renders: [], screens: {} };
+    };
+  }
+  return window.__dsPerf;
+}
+
+function pushPerfRequest(entry) {
+  const store = getPerfStore();
+  if (!store) return;
+  store.requests.push(entry);
+  if (store.requests.length > PERF_MAX_REQUESTS) store.requests.splice(0, store.requests.length - PERF_MAX_REQUESTS);
+  const stats = store.screens[entry.action] || { count: 0, total_ms: 0, max_ms: 0 };
+  stats.count += 1;
+  stats.total_ms += entry.duration_ms || 0;
+  stats.max_ms = Math.max(stats.max_ms, entry.duration_ms || 0);
+  store.screens[entry.action] = stats;
+  if (entry.duration_ms >= 1500 || (entry.payload_bytes || 0) >= 200000) {
+    // eslint-disable-next-line no-console
+    console.warn('[perf][api] heavy request', entry);
+  }
+}
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function postWithTimeout(action, payload, tokenAtCallTime) {
+async function postWithTimeout(action, requestBody) {
   const timeoutMs = READ_ACTIONS[action] ? API_TIMEOUT_MS_READ : API_TIMEOUT_MS_WRITE;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -73,7 +109,7 @@ async function postWithTimeout(action, payload, tokenAtCallTime) {
     return await fetch(config.apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
-      body: JSON.stringify({ action, token: tokenAtCallTime, ...payload }),
+      body: JSON.stringify(requestBody),
       signal: controller.signal
     });
   } finally {
@@ -88,14 +124,22 @@ async function request(action, payload = {}) {
 
   const tokenAtCallTime = state.token;
 
+  const requestBody = {
+    action,
+    token: tokenAtCallTime,
+    ...payload
+  };
+  if (isPerfDebugEnabled()) requestBody.debug_perf = true;
+
+  const requestStart = performance.now();
   let response;
   try {
-    response = await postWithTimeout(action, payload, tokenAtCallTime);
+    response = await postWithTimeout(action, requestBody);
   } catch {
     if (READ_ACTIONS[action]) {
       try {
         await sleep(250);
-        response = await postWithTimeout(action, payload, tokenAtCallTime);
+        response = await postWithTimeout(action, requestBody);
       } catch {
         throw new Error(translateApiErrorForUser('network_error'));
       }
@@ -105,8 +149,10 @@ async function request(action, payload = {}) {
   }
 
   let json;
+  let responseText = '';
   try {
-    json = await response.json();
+    responseText = await response.text();
+    json = JSON.parse(responseText);
   } catch {
     throw new Error(translateApiErrorForUser('server_error'));
   }
@@ -119,6 +165,12 @@ async function request(action, payload = {}) {
   if (MUTATING_ACTIONS[action]) {
     clearScreenDataCache();
   }
+  pushPerfRequest({
+    action,
+    duration_ms: Math.round(performance.now() - requestStart),
+    payload_bytes: responseText.length,
+    backend_debug: json.data && json.data.debug_perf ? json.data.debug_perf : null
+  });
   return json.data;
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -29,6 +29,32 @@ const ui = createSharedInteractionLayer();
 
 /** In-flight API request dedup: prevents duplicate calls when navigating quickly. */
 const inflightRequests = new Map();
+const PERF_MAX_RENDERS = 150;
+
+function recordRenderPerf(route, phase, durationMs, extra = {}) {
+  if (typeof window === 'undefined') return;
+  if (!window.__dsPerf) {
+    window.__dsPerf = { requests: [], renders: [], screens: {} };
+    window.__resetDsPerf = () => {
+      window.__dsPerf = { requests: [], renders: [], screens: {} };
+    };
+  }
+  const entry = {
+    route: String(route || 'unknown'),
+    phase: String(phase || 'render'),
+    duration_ms: Math.round(durationMs),
+    at: new Date().toISOString(),
+    ...extra
+  };
+  window.__dsPerf.renders.push(entry);
+  if (window.__dsPerf.renders.length > PERF_MAX_RENDERS) {
+    window.__dsPerf.renders.splice(0, window.__dsPerf.renders.length - PERF_MAX_RENDERS);
+  }
+  if (entry.duration_ms >= 120) {
+    // eslint-disable-next-line no-console
+    console.warn('[perf][render] heavy render', entry);
+  }
+}
 
 // ─── LocalStorage screen-data cache ───────────────────────────────────────
 // Keys include a user-id prefix so different users on the same browser don't
@@ -405,8 +431,12 @@ async function backgroundRefreshScreen(screen, cacheKey) {
     if (screenDataCacheKey() === cacheKey) {
       const screenRoot = document.getElementById('screenRoot');
       if (screenRoot) {
+        const renderStart = performance.now();
         screenRoot.innerHTML = screen.render(data, { state });
         bindScreen(screen, screenRoot, data);
+        recordRenderPerf(state.route, 'background-refresh-render', performance.now() - renderStart, {
+          cache_key: cacheKey
+        });
       }
     }
   } catch {
@@ -451,6 +481,7 @@ function updateNavActiveClasses() {
  * Falls back to full render() if cache is missing or route has changed.
  */
 function fastRerenderScreen(screen, routeAtBind) {
+  const perfStart = performance.now();
   if (state.route !== routeAtBind) { render(); return; }
   const key = screenDataCacheKey();
   const raw = state.screenDataCache[key];
@@ -460,6 +491,7 @@ function fastRerenderScreen(screen, routeAtBind) {
   if (!screenRoot) { render(); return; }
   screenRoot.innerHTML = screen.render(hit.data, { state });
   bindScreen(screen, screenRoot, hit.data);
+  recordRenderPerf(routeAtBind, 'fast-rerender', performance.now() - perfStart, { cache_key: key });
 }
 
 function clearScreenDataCache() {
@@ -597,6 +629,7 @@ async function restoreSession() {
 }
 
 async function mountScreen() {
+  const mountStartMs = performance.now();
   if (isDesktopViewport()) {
     isMobileNavOpen = false;
     document.body.classList.remove('is-shell-nav-open');
@@ -641,14 +674,21 @@ async function mountScreen() {
     app.innerHTML = shell(shellBody);
     bindShell();
     if (rawEntry) {
+      const renderStart = performance.now();
       const screenRoot = document.getElementById('screenRoot');
       if (screenRoot) bindScreen(screen, screenRoot, rawEntry.data);
+      recordRenderPerf(state.route, 'first-mount-cached', performance.now() - renderStart, {
+        cache_key: cacheKey,
+        stale: !!isStale
+      });
       if (routeChanged) lastRenderedRoute = state.route;
       if (isStale) backgroundRefreshScreen(screen, cacheKey);
+      recordRenderPerf(state.route, 'mount-total', performance.now() - mountStartMs, { cache_key: cacheKey });
       return;
     }
     await flushPaint();
   } else if (rawEntry) {
+    const renderStart = performance.now();
     // Shell exists + have any data (fresh or stale): render immediately, no spinner.
     updateNavActiveClasses();
     const screenRoot = document.getElementById('screenRoot');
@@ -656,8 +696,13 @@ async function mountScreen() {
       screenRoot.innerHTML = screen.render(rawEntry.data, { state });
       bindScreen(screen, screenRoot, rawEntry.data);
     }
+    recordRenderPerf(state.route, 'shell-cached', performance.now() - renderStart, {
+      cache_key: cacheKey,
+      stale: !!isStale
+    });
     if (routeChanged) lastRenderedRoute = state.route;
     if (isStale) backgroundRefreshScreen(screen, cacheKey);
+    recordRenderPerf(state.route, 'mount-total', performance.now() - mountStartMs, { cache_key: cacheKey });
     return;
   } else {
     // No data at all: show loading spinner and fetch.
@@ -670,10 +715,14 @@ async function mountScreen() {
 
   try {
     const data = await loadScreenDataWithCache(screen);
+    const renderStart = performance.now();
     const screenRoot = document.getElementById('screenRoot');
     if (!screenRoot) throw new Error('אזור התצוגה לא זמין');
     screenRoot.innerHTML = screen.render(data, { state });
     bindScreen(screen, screenRoot, data);
+    recordRenderPerf(state.route, 'fresh-data-render', performance.now() - renderStart, {
+      cache_key: cacheKey
+    });
     if (routeChanged) lastRenderedRoute = state.route;
   } catch (err) {
     const screenRoot = document.getElementById('screenRoot');
@@ -687,6 +736,7 @@ async function mountScreen() {
     }
   } finally {
     setShellNavBusy(false);
+    recordRenderPerf(state.route, 'mount-total', performance.now() - mountStartMs, { cache_key: cacheKey });
   }
 }
 

--- a/scripts/perf_sample.mjs
+++ b/scripts/perf_sample.mjs
@@ -1,0 +1,222 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import crypto from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { dashboardScreen } from '../frontend/src/screens/dashboard.js';
+import { activitiesScreen } from '../frontend/src/screens/activities.js';
+import { financeScreen } from '../frontend/src/screens/finance.js';
+
+class MockSheet {
+  constructor(name, values) {
+    this.name = name;
+    this.values = values;
+  }
+  getName() { return this.name; }
+  getLastRow() { return this.values.length; }
+  getLastColumn() { return this.values[0] ? this.values[0].length : 0; }
+  getRange(row, col, numRows, numCols) {
+    const self = this;
+    return {
+      getValues() {
+        const out = [];
+        for (let r = 0; r < numRows; r++) {
+          const line = [];
+          for (let c = 0; c < numCols; c++) {
+            line.push((self.values[row - 1 + r] || [])[col - 1 + c] ?? '');
+          }
+          out.push(line);
+        }
+        return out;
+      },
+      setValues(rows) {
+        for (let r = 0; r < numRows; r++) {
+          for (let c = 0; c < numCols; c++) {
+            if (!self.values[row - 1 + r]) self.values[row - 1 + r] = [];
+            self.values[row - 1 + r][col - 1 + c] = rows[r][c];
+          }
+        }
+      }
+    };
+  }
+  appendRow(row) { this.values.push(row); }
+  deleteRow(row) { this.values.splice(row - 1, 1); }
+}
+
+class MockSpreadsheet {
+  constructor(sheets) { this.sheets = sheets; }
+  getSheetByName(name) { return this.sheets[name] || null; }
+}
+
+function toEvent(body) {
+  return { postData: { contents: JSON.stringify(body) } };
+}
+
+function parseResponse(resp) {
+  return JSON.parse(resp.content);
+}
+
+function padRow(row, len) {
+  const out = row.slice();
+  while (out.length < len) out.push('');
+  return out;
+}
+
+function mkSheet(headers, rows) {
+  const len = headers.length;
+  return [padRow(headers, len), new Array(len).fill(''), ...rows.map((r) => padRow(r, len))];
+}
+
+function buildSheets() {
+  const baseActivityHeaders = [
+    'RowID', 'activity_manager', 'authority', 'school', 'activity_type', 'activity_no', 'activity_name',
+    'sessions', 'price', 'funding', 'start_time', 'end_time', 'emp_id', 'instructor_name', 'emp_id_2',
+    'instructor_name_2', 'start_date', 'end_date', 'status', 'notes', 'finance_status', 'finance_notes'
+  ];
+  for (let i = 1; i <= 35; i++) baseActivityHeaders.push(`Date${i}`);
+
+  return {
+    data_short: new MockSheet('data_short', mkSheet(baseActivityHeaders, [
+      ['SHORT-1', 'M-1', 'AUTH-1', 'School A', 'workshop', 'A-101', 'Short A', '1', '100', 'city', '09:00', '11:00', 'U-INST', 'Inst One', '', '', '2026-04-13', '2026-04-13', 'active', '', 'open', '', '2026-04-13'],
+      ['SHORT-2', 'M-2', 'AUTH-2', 'School B', 'tour', 'A-102', 'Short B', '1', '120', 'city', '10:00', '12:00', 'U-INST', 'Inst One', '', '', '2026-04-14', '2026-04-14', 'active', '', 'closed', '', '2026-04-14']
+    ])),
+    data_long: new MockSheet('data_long', mkSheet(baseActivityHeaders, [
+      ['LONG-1', 'M-1', 'AUTH-1', 'School A', 'course', 'L-201', 'Long A', '8', '200', 'city', '09:00', '12:00', 'U-INST', 'Inst One', '', '', '2026-04-01', '2026-05-31', 'active', '', 'closed', '', '2026-04-03', '2026-04-10', '2026-04-17'],
+      ['LONG-2', 'M-1', 'AUTH-1', 'School A', 'after_school', 'L-202', 'Long B', '10', '210', 'city', '09:00', '12:00', 'U-INST', 'Inst One', '', '', '2026-04-02', '2026-06-15', 'active', '', 'open', '', '2026-04-04', '2026-04-11']
+    ])),
+    activity_meetings: new MockSheet('activity_meetings', mkSheet(
+      ['source_row_id', 'meeting_no', 'meeting_date', 'notes', 'active'],
+      [['LONG-2', '1', '2026-04-04', '', 'yes'], ['LONG-2', '2', '2026-04-11', '', 'yes']]
+    )),
+    permissions: new MockSheet('permissions', mkSheet(
+      [
+        'user_id', 'entry_code', 'full_name', 'display_role', 'display_role2', 'default_view',
+        'view_admin', 'view_dashboard', 'view_activities', 'view_week', 'view_month',
+        'view_instructors', 'view_exceptions', 'view_my_data', 'view_contacts',
+        'view_finance', 'view_permissions', 'can_request_edit', 'can_edit_direct',
+        'can_add_activity', 'can_review_requests', 'active'
+      ],
+      [[
+        'U-REVIEW', 'CODE-REVIEW', 'Ops Reviewer', 'operations reviewer', '', 'dashboard',
+        'yes', 'yes', 'yes', 'yes', 'yes',
+        'yes', 'yes', 'yes', 'yes',
+        'yes', 'yes', 'yes', 'yes',
+        'yes', 'yes', 'yes'
+      ]]
+    )),
+    settings: new MockSheet('settings', mkSheet(
+      ['setting_key', 'setting_value', 'active'],
+      [['data_start_row', '3', 'yes']]
+    )),
+    lists: new MockSheet('lists', mkSheet(['name', 'value', 'active'], [['activity_type', 'workshop', 'yes']])),
+    contacts_instructors: new MockSheet('contacts_instructors', mkSheet(['emp_id', 'full_name', 'active'], [['U-INST', 'Inst One', 'yes']])),
+    contacts_schools: new MockSheet('contacts_schools', mkSheet(['authority', 'school', 'contact_name', 'active'], [['AUTH-1', 'School A', 'School Contact', 'yes']])),
+    edit_requests: new MockSheet('edit_requests', mkSheet(['request_id', 'active'], [])),
+    operations_private_notes: new MockSheet('operations_private_notes', mkSheet(
+      ['source_sheet', 'source_row_id', 'note_text', 'updated_at', 'updated_by', 'active'], []
+    ))
+  };
+}
+
+function buildBackendContext() {
+  const sheets = buildSheets();
+  const spreadsheet = new MockSpreadsheet(sheets);
+  const cache = new Map();
+  const context = {
+    SpreadsheetApp: { openById: () => spreadsheet },
+    CacheService: {
+      getScriptCache: () => ({
+        put: (k, v) => cache.set(k, v),
+        get: (k) => cache.get(k) || null,
+        remove: (k) => cache.delete(k)
+      })
+    },
+    Utilities: {
+      getUuid: () => `uuid-${Math.random().toString(16).slice(2)}`,
+      formatDate: (date) => {
+        const d = new Date(date);
+        const yyyy = d.getUTCFullYear();
+        const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+        const dd = String(d.getUTCDate()).padStart(2, '0');
+        return `${yyyy}-${mm}-${dd}`;
+      },
+      DigestAlgorithm: { MD5: 'md5' },
+      computeDigest: (algo, raw) => Array.from(crypto.createHash('md5').update(String(raw || '')).digest()).map((n) => n > 127 ? n - 256 : n)
+    },
+    Session: { getScriptTimeZone: () => 'Etc/UTC' },
+    ContentService: {
+      MimeType: { JSON: 'application/json' },
+      createTextOutput: (content) => ({ content, setMimeType() { return this; } })
+    },
+    console
+  };
+  vm.createContext(context);
+  const files = fs.readdirSync('backend')
+    .filter((f) => f.endsWith('.gs'))
+    .sort((a, b) => (a === 'Code.gs' ? 1 : b === 'Code.gs' ? -1 : a.localeCompare(b)));
+  for (const file of files) {
+    const source = fs.readFileSync(path.join('backend', file), 'utf8');
+    vm.runInContext(source, context, { filename: file });
+  }
+  return context;
+}
+
+function renderMs(screen, data, state) {
+  const t0 = performance.now();
+  screen.render(data, { state });
+  return Math.round(performance.now() - t0);
+}
+
+function runAction(context, token, action, payload = {}) {
+  const rsp = parseResponse(context.doPost(toEvent({ action, token, debug_perf: true, ...payload })));
+  if (!rsp.ok) throw new Error(`${action} failed: ${rsp.error}`);
+  return rsp.data;
+}
+
+function main() {
+  const context = buildBackendContext();
+  const login = parseResponse(context.doPost(toEvent({
+    action: 'login',
+    user_id: 'U-REVIEW',
+    entry_code: 'CODE-REVIEW'
+  })));
+  if (!login.ok) throw new Error(`login failed: ${login.error}`);
+  const token = login.data.token;
+
+  const dashboard = runAction(context, token, 'dashboard', { month: '2026-04' });
+  const activities = runAction(context, token, 'activities', { activity_type: 'all' });
+  const finance = runAction(context, token, 'finance', {});
+
+  const screenState = {
+    route: 'dashboard',
+    user: { display_role: 'operations_reviewer', user_id: 'U-REVIEW' },
+    financeTab: 'active',
+    financeStatusFilter: '',
+    financeSearch: ''
+  };
+
+  const summary = {
+    dashboard: {
+      backend_ms: dashboard.debug_perf.total_ms,
+      sheets_read_ms: dashboard.debug_perf.sheets_total_ms,
+      payload_bytes: dashboard.debug_perf.response_size_bytes,
+      render_ms: renderMs(dashboardScreen, dashboard, { ...screenState, route: 'dashboard' })
+    },
+    activities: {
+      backend_ms: activities.debug_perf.total_ms,
+      sheets_read_ms: activities.debug_perf.sheets_total_ms,
+      payload_bytes: activities.debug_perf.response_size_bytes,
+      render_ms: renderMs(activitiesScreen, activities, { ...screenState, route: 'activities', activityTab: 'all' })
+    },
+    finance: {
+      backend_ms: finance.debug_perf.total_ms,
+      sheets_read_ms: finance.debug_perf.sheets_total_ms,
+      payload_bytes: finance.debug_perf.response_size_bytes,
+      render_ms: renderMs(financeScreen, finance, { ...screenState, route: 'finance' })
+    }
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Add lightweight, opt-in performance measurement to identify slow backend actions, Sheets reads and frontend render phases without changing UX. 
- Provide a simple end-to-end sample runner to reproduce and measure typical screens locally.

### Description

- Introduce backend instrumentation: `beginRequestPerf_`, `markRequestPerf_`, `trackSheetReadPerf_`, `buildPerfPayload_`, and `perfNowMs_`, and attach `debug_perf` data into API responses when requested via payload. 
- Wire request lifecycle marks into `handlePost_` to capture cache lookups, action start/done and error states, and measure per-sheet read durations in `readRows_` for cached and non-cached reads. 
- Frontend opt-in hooks: `isPerfDebugEnabled`, `getPerfStore`, `pushPerfRequest` and changes to `request`/`postWithTimeout` to send `debug_perf` and store backend-debug and request metrics into `window.__dsPerf.requests`. 
- Render instrumentation in `frontend/src/main.js` via `recordRenderPerf` with hooks added to mount, fast rerender, background refresh and fresh-data renders to collect render durations in `window.__dsPerf.renders`. 
- Add `scripts/perf_sample.mjs` that mocks Sheets/Apps Script environment, exercises `login`, `dashboard`, `activities` and `finance` actions with `debug_perf`, and measures render times for screens; and add `docs/performance-stage1.md` documenting how to enable and read the measurements.

### Testing

- Ran the end-to-end sample script with `node scripts/perf_sample.mjs`, which executed the backend in a VM context, invoked `login` and read actions, and printed a JSON summary of `backend_ms`, `sheets_read_ms`, `payload_bytes` and `render_ms`; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74e5c3bcc832b94abebd3012f40a0)