### PR TITLE
Per-sheet activity summary caching, projected detail reads, and script-cache robustness improvements

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -638,13 +638,24 @@ function mapActivityDetailRowForDrawer_(row, user) {
 function findActivityRowById_(sourceRowId, sourceSheet) {
   var rowId = text_(sourceRowId);
   if (!rowId) throw new Error('source_row_id is required');
-  var rows = allActivities_();
-  var found = rows.find(function(row) {
-    if (sourceSheet && text_(row.source_sheet) !== text_(sourceSheet)) return false;
-    return text_(row.RowID) === rowId;
-  });
-  if (!found) throw new Error('Row not found: ' + rowId);
-  return found;
+  var sourceCandidates = [];
+  if (sourceSheet) {
+    sourceCandidates = [text_(sourceSheet)];
+  } else {
+    sourceCandidates = configuredActivitiesSources_().filter(function(name) {
+      return name === CONFIG.SHEETS.DATA_SHORT || name === CONFIG.SHEETS.DATA_LONG;
+    });
+  }
+  var cols = projectedActivityColumnsForDetail_();
+  for (var i = 0; i < sourceCandidates.length; i++) {
+    var sheetName = sourceCandidates[i];
+    var rows = readRowsProjected_(sheetName, cols);
+    for (var j = 0; j < rows.length; j++) {
+      if (text_(rows[j].RowID) !== rowId) continue;
+      return mapProjectedActivityDetailRow_(sheetName, rows[j]);
+    }
+  }
+  throw new Error('Row not found: ' + rowId);
 }
 
 function actionActivityDetail_(user, payload) {
@@ -1034,7 +1045,7 @@ function actionOperations_(user, payload) {
   }
   var search = text_((payload || {}).search || '').toLowerCase();
   var activityType = text_((payload || {}).activity_type || '');
-  var rows = allActivities_().filter(function(row) {
+  var rows = allActivitiesSummary_().filter(function(row) {
     if (activityType && text_(row.activity_type) !== activityType) return false;
     if (search) {
       var hay = [row.RowID, row.activity_name, row.activity_type, row.start_date, row.end_date].map(text_).join(' ').toLowerCase();
@@ -1808,23 +1819,109 @@ function projectedActivityColumnsForSummary_() {
   ];
 }
 
+function projectedActivityColumnsForDetail_() {
+  var base = projectedActivityColumnsForSummary_().slice();
+  [
+    'source_sheet',
+    'Date2', 'Date3', 'Date4', 'Date5', 'Date6', 'Date7', 'Date8', 'Date9',
+    'Date10', 'Date11', 'Date12', 'Date13', 'Date14', 'Date15', 'Date16', 'Date17', 'Date18', 'Date19',
+    'Date20', 'Date21', 'Date22', 'Date23', 'Date24', 'Date25', 'Date26', 'Date27', 'Date28', 'Date29',
+    'Date30', 'Date31', 'Date32', 'Date33', 'Date34', 'Date35'
+  ].forEach(function(col) {
+    if (base.indexOf(col) < 0) base.push(col);
+  });
+  return base;
+}
+
+function mapProjectedActivityDetailRow_(sheetName, row) {
+  var out = {
+    source_sheet: sheetName,
+    RowID: text_(row.RowID),
+    activity_manager: text_(row.activity_manager),
+    authority: text_(row.authority),
+    school: text_(row.school),
+    activity_type: text_(row.activity_type),
+    activity_no: text_(row.activity_no),
+    activity_name: text_(row.activity_name),
+    sessions: text_(row.sessions),
+    price: text_(row.price),
+    funding: text_(row.funding),
+    start_time: text_(row.start_time),
+    end_time: text_(row.end_time),
+    emp_id: text_(row.emp_id),
+    instructor_name: text_(row.instructor_name),
+    emp_id_2: text_(row.emp_id_2),
+    instructor_name_2: text_(row.instructor_name_2),
+    start_date: normalizeDateTextToIso_(row.start_date) || normalizeDateTextToIso_(row.Date1),
+    end_date: normalizeDateTextToIso_(row.end_date) || normalizeDateTextToIso_(row.start_date) || normalizeDateTextToIso_(row.Date1),
+    status: text_(row.status),
+    notes: text_(row.notes),
+    finance_status: normalizeFinance_(row.finance_status),
+    finance_notes: text_(row.finance_notes),
+    is_archived: text_(row.is_archived || row.archive || ''),
+    archive: text_(row.archive || row.is_archived || ''),
+    Payer: text_(row.Payer || ''),
+    Payment: text_(row.Payment || '')
+  };
+  for (var i = 1; i <= 35; i++) {
+    out['Date' + i] = normalizeDateTextToIso_(row['Date' + i]);
+  }
+  return out;
+}
+
+function summaryCacheKeyForSheet_(version, sheetName) {
+  return 'pc:activities-summary:' + version + ':' + sheetName;
+}
+
+function readSummaryRowsFromCache_(version, sheetName) {
+  var baseKey = summaryCacheKeyForSheet_(version, sheetName);
+  var direct = scriptCacheGetJson_(baseKey);
+  if (Object.prototype.toString.call(direct) === '[object Array]') return direct;
+  if (!direct || !direct.chunk_count) return null;
+  var total = parseInt(direct.chunk_count, 10) || 0;
+  if (total <= 0) return null;
+  var merged = [];
+  for (var i = 0; i < total; i++) {
+    var chunk = scriptCacheGetJson_(baseKey + ':chunk:' + i);
+    if (Object.prototype.toString.call(chunk) !== '[object Array]') return null;
+    merged = merged.concat(chunk);
+  }
+  return merged;
+}
+
+function writeSummaryRowsToCache_(version, sheetName, rows) {
+  var baseKey = summaryCacheKeyForSheet_(version, sheetName);
+  var ttl = CONFIG.SCRIPT_CACHE_SECONDS || 120;
+  var putResult = scriptCachePutJson_(baseKey, rows, ttl);
+  if (putResult && putResult.ok) return;
+
+  var chunkSize = 200;
+  var chunkCount = Math.ceil(rows.length / chunkSize);
+  for (var i = 0; i < chunkCount; i++) {
+    var chunk = rows.slice(i * chunkSize, (i + 1) * chunkSize);
+    var chunkPut = scriptCachePutJson_(baseKey + ':chunk:' + i, chunk, ttl);
+    if (!chunkPut || !chunkPut.ok) return;
+  }
+  scriptCachePutJson_(baseKey, { chunk_count: chunkCount }, ttl);
+}
+
 function allActivitiesSummary_() {
   if (__rqCache_ && Object.prototype.hasOwnProperty.call(__rqCache_, 'allActivitiesSummary')) {
     return __rqCache_.allActivitiesSummary;
   }
   var version = dataViewsCacheVersion_();
-  var cacheKey = 'pc:activities-summary:' + version;
-  var cached = scriptCacheGetJson_(cacheKey);
-  if (cached && Object.prototype.toString.call(cached) === '[object Array]') {
-    if (__rqCache_) {
-      __rqCache_.allActivitiesSummary = cached;
-    }
-    return cached;
-  }
   var list = [];
   var cols = projectedActivityColumnsForSummary_();
-  configuredActivitiesSources_().forEach(function(sheetName) {
-    if (sheetName !== CONFIG.SHEETS.DATA_SHORT && sheetName !== CONFIG.SHEETS.DATA_LONG) return;
+  var sourceSheets = configuredActivitiesSources_().filter(function(sheetName) {
+    return sheetName === CONFIG.SHEETS.DATA_SHORT || sheetName === CONFIG.SHEETS.DATA_LONG;
+  });
+
+  sourceSheets.forEach(function(sheetName) {
+    var cachedRows = readSummaryRowsFromCache_(version, sheetName);
+    if (cachedRows) {
+      list = list.concat(cachedRows);
+      return;
+    }
     var rows = readRowsProjected_(sheetName, cols).map(function(row) {
       return {
         source_sheet: sheetName,
@@ -1857,13 +1954,14 @@ function allActivitiesSummary_() {
         Date1: normalizeDateTextToIso_(row.Date1)
       };
     });
+    writeSummaryRowsToCache_(version, sheetName, rows);
     list = list.concat(rows);
   });
+
   enrichRowsWithMeetings_(list);
   if (__rqCache_) {
     __rqCache_.allActivitiesSummary = list;
   }
-  scriptCachePutJson_(cacheKey, list, CONFIG.SCRIPT_CACHE_SECONDS || 120);
   return list;
 }
 

--- a/backend/script-cache.gs
+++ b/backend/script-cache.gs
@@ -3,6 +3,7 @@
 var SCRIPT_CACHE_KEY_DASHBOARD = 'pc:dashboard:v2';
 var SCRIPT_CACHE_KEY_PERMISSIONS_LIST = 'pc:permissions:v2';
 var SCRIPT_CACHE_KEY_DATA_VIEWS_VERSION = 'pc:data-views-version:v1';
+var SCRIPT_CACHE_KEY_DEBUG_STATS = 'pc:cache-debug:stats:v1';
 
 function scriptCacheGetJson_(key) {
   try {
@@ -17,10 +18,35 @@ function scriptCachePutJson_(key, value, seconds) {
   try {
     var payload = JSON.stringify(value);
     if (payload.length > 95000) {
-      return;
+      scriptCacheDebugMark_('skip_too_large', key, payload.length);
+      return { ok: false, reason: 'too_large', bytes: payload.length };
     }
     var ttl = seconds || (CONFIG.SCRIPT_CACHE_SECONDS || 90);
     CacheService.getScriptCache().put(key, payload, ttl);
+    return { ok: true, bytes: payload.length };
+  } catch (e) {
+    scriptCacheDebugMark_('put_error', key, 0, String(e && e.message ? e.message : e));
+    return { ok: false, reason: 'exception' };
+  }
+}
+
+function scriptCacheDebugMark_(eventName, key, bytes, errorText) {
+  try {
+    var payload = {
+      event: text_(eventName),
+      key: text_(key),
+      bytes: Number(bytes) || 0,
+      error: text_(errorText || ''),
+      at: new Date().toISOString()
+    };
+    console.warn('[script-cache]', JSON.stringify(payload));
+    var c = CacheService.getScriptCache();
+    var raw = c.get(SCRIPT_CACHE_KEY_DEBUG_STATS);
+    var stats = raw ? JSON.parse(raw) : {};
+    var n = (Number(stats[eventName]) || 0) + 1;
+    stats[eventName] = n;
+    stats.last = payload;
+    c.put(SCRIPT_CACHE_KEY_DEBUG_STATS, JSON.stringify(stats), 21600);
   } catch (e) {}
 }
 
@@ -39,7 +65,8 @@ function dataViewsCacheVersion_() {
     var existing = c.get(SCRIPT_CACHE_KEY_DATA_VIEWS_VERSION);
     if (existing) return existing;
     var fresh = String(new Date().getTime());
-    c.put(SCRIPT_CACHE_KEY_DATA_VIEWS_VERSION, fresh, 21600);
+    // Short TTL so manual edits directly in Sheets won't stay stale for hours.
+    c.put(SCRIPT_CACHE_KEY_DATA_VIEWS_VERSION, fresh, 600);
     return fresh;
   } catch (e) {
     return '0';
@@ -51,7 +78,7 @@ function bumpDataViewsCacheVersion_() {
     CacheService.getScriptCache().put(
       SCRIPT_CACHE_KEY_DATA_VIEWS_VERSION,
       String(new Date().getTime()),
-      21600
+      600
     );
   } catch (e) {}
 }


### PR DESCRIPTION
### Motivation
- Reduce expensive reads of large activity sheets by caching per-sheet summary payloads and avoid repeatedly reading full datasets.
- Allow reliable lookup of a single activity detail by `RowID` by projecting only necessary detail columns from configured activity sheets.
- Make script-cache operations more robust when payloads are too large or when cache puts fail, and shorten data-views cache TTL to surface manual sheet edits faster.

### Description
- Added projection helpers and mappers: `projectedActivityColumnsForDetail_` and `mapProjectedActivityDetailRow_` to read only the needed detail columns for a sheet.
- Rewrote `findActivityRowById_` to iterate configured sheet sources, call `readRowsProjected_` with the detail columns, and return a mapped detail row instead of scanning in-memory lists.
- Introduced per-sheet summary cache helpers `summaryCacheKeyForSheet_`, `readSummaryRowsFromCache_`, and `writeSummaryRowsToCache_` with chunking for large payloads, and updated `allActivitiesSummary_` to use per-sheet caching and write cached chunks.
- Switched `actionOperations_` to query `allActivitiesSummary_` instead of `allActivities_` to benefit from the new summary cache.
- Improved script cache behavior: `scriptCachePutJson_` now returns operation status and logs/skips payloads that exceed length limits, added `scriptCacheDebugMark_` and `SCRIPT_CACHE_KEY_DEBUG_STATS` for simple debug metrics, and made cache version TTLs shorter by changing `dataViewsCacheVersion_`/`bumpDataViewsCacheVersion_` TTL from 21600 to 600 seconds.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e765e5a30c832bbc0e03753ead1772)