### PR TITLE
Validate and normalize meetings map entries in dashboard generation

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -318,7 +318,31 @@ function actionDashboard_(user, payload) {
   var longRowsBySource = allSummary.filter(function(row) {
     if (programTypes.indexOf(text_(row.activity_type)) < 0) return false;
     var rowDates = dashMeetingsMap[text_(row.RowID)];
-    if (rowDates && rowDates.some(function(d) { return d.slice(0, 7) === ym; })) return true;
+    var normalizedRowDates = [];
+    if (rowDates && Object.prototype.toString.call(rowDates) !== '[object Array]') {
+      scriptCacheDebugMark_(
+        'dashboard_invalid_meetings_map_shape',
+        'row:' + text_(row.RowID),
+        0,
+        'type=' + Object.prototype.toString.call(rowDates)
+      );
+      rowDates = null;
+    } else if (rowDates) {
+      var hadNonStringItem = false;
+      normalizedRowDates = rowDates.map(function(d) {
+        if (Object.prototype.toString.call(d) !== '[object String]') hadNonStringItem = true;
+        return text_(d);
+      }).filter(Boolean);
+      if (hadNonStringItem) {
+        scriptCacheDebugMark_(
+          'dashboard_invalid_meetings_map_item',
+          'row:' + text_(row.RowID),
+          0,
+          'sample=' + text_(rowDates[0])
+        );
+      }
+    }
+    if (normalizedRowDates.some(function(d) { return d.slice(0, 7) === ym; })) return true;
     return activityOverlapsYm_(row, ym);
   });
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors in `actionDashboard_` when `buildMeetingsMap_()` returns values that are not arrays or that contain non-string items. 

### Description
- Added defensive checks in `actionDashboard_` to ensure `rowDates` is an array before using `.some`, and to normalize items to strings into `normalizedRowDates`.
- When the meetings map shape or items are invalid, record diagnostic marks via `scriptCacheDebugMark_` with a sample and the detected type.
- Fallback to the existing `activityOverlapsYm_` logic when there are no valid normalized meeting dates.

### Testing
- Ran the existing backend unit test suite and linter; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c0caabf8832b94489f1b1e337680)