### PR TITLE
Update Apps Script API URL and bump service worker cache version

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycby7wZJSwm8VnNZVtbmodCSxmdzKLG3IeymcksoO-KdUdGNSHMVXWT69YYl9z97Zw48/exec';
+  'https://script.google.com/macros/s/AKfycbyBS_PFNqfNTZDNODF2chY2E_Xs2kftcoTwrS8SdaCvFDTmZ6wEFopzbwZPSPpg_pmH/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 87;
+const CACHE_VERSION = 88;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- Point the frontend to the new Apps Script deployment URL so runtime calls go to the updated backend and ensure clients fetch the new bundle/config by advancing the service worker cache version.

### Description
- Replaced `DEFAULT_API_URL` in `frontend/src/config.js` with the new Apps Script `exec` URL.
- Bumped `CACHE_VERSION` in `sw.js` from `87` to `88` so the service worker will refresh cached app shell assets (including the updated `config.js`).

### Testing
- Ran repository checks and searches (`rg`) to verify the new URL appears only in `frontend/src/config.js` and that `sw.js` contains the bumped `CACHE_VERSION`; these checks succeeded.
- Verified the `git diff` shows only the two intended files changed and committed the update; commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d3034110832b89291c0a8ad6fea4)