### PR TITLE
improve contacts page UI: expandable cards, icons, copy-email

### DIFF
--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -1,7 +1,14 @@
 import { escapeHtml } from './shared/html.js';
 import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { hebrewColumn, hebrewEmploymentType } from './shared/ui-hebrew.js';
-import { dsCard, dsScreenStack, dsEmptyState, dsStatusChip } from './shared/layout.js';
+import { dsScreenStack, dsEmptyState, dsStatusChip } from './shared/layout.js';
+
+/* ─── Copy button ─── */
+
+function copyBtn(email) {
+  if (!email) return '';
+  return `<button type="button" class="ci-copy-btn" data-copy-email="${escapeHtml(email)}" title="העתק כתובת מייל" aria-label="העתק מייל">⎘</button>`;
+}
 
 /* ─── Instructor contacts ─── */
 
@@ -16,46 +23,57 @@ function applyInstrSearch(rows, q) {
   );
 }
 
-function instrDrawerHtml(row, hideEmpIds) {
-  const cols = ['emp_id', 'full_name', 'mobile', 'email', 'address', 'employment_type', 'direct_manager', 'active'];
-  const lines = cols.map((col) => {
-    if (hideEmpIds && col === 'emp_id') return '';
-    const raw = row?.[col] ?? '';
-    if (col === 'active') {
-      const label = String(raw).toLowerCase() === 'yes' ? 'כן' : 'לא';
-      const kind  = String(raw).toLowerCase() === 'yes' ? 'success' : 'neutral';
-      return `<p><strong>${escapeHtml(hebrewColumn(col))}:</strong> ${dsStatusChip(label, kind)}</p>`;
+function instrDetailHtml(row, hideEmpIds) {
+  const isActive = String(row.active || '').toLowerCase() !== 'no';
+  const fields = [
+    (!hideEmpIds && row.emp_id)  ? { icon: '#',  label: hebrewColumn('emp_id'),          val: row.emp_id }                               : null,
+    row.employment_type           ? { icon: '💼', label: hebrewColumn('employment_type'), val: hebrewEmploymentType(row.employment_type) } : null,
+    row.email                     ? { icon: '✉',  label: hebrewColumn('email'),           val: row.email, copy: true }                    : null,
+    row.address                   ? { icon: '📍', label: hebrewColumn('address'),         val: row.address }                              : null,
+    row.direct_manager            ? { icon: '👤', label: hebrewColumn('direct_manager'),  val: row.direct_manager }                       : null,
+                                    { icon: '●',  label: hebrewColumn('active'),          status: true, isActive }
+  ].filter(Boolean);
+
+  const linesHtml = fields.map(({ icon, label, val, copy, status, isActive: active }) => {
+    let valueHtml;
+    if (status) {
+      valueHtml = dsStatusChip(active ? 'פעיל' : 'לא פעיל', active ? 'success' : 'neutral');
+    } else if (copy) {
+      valueHtml = `<span class="ci-dv">${escapeHtml(String(val))}</span>${copyBtn(val)}`;
+    } else {
+      valueHtml = `<span class="ci-dv">${escapeHtml(String(val))}</span>`;
     }
-    const val = col === 'employment_type' ? hebrewEmploymentType(raw) : (raw || '—');
-    return `<p><strong>${escapeHtml(hebrewColumn(col))}:</strong> ${escapeHtml(String(val))}</p>`;
-  }).join('');
-  return `<div class="ds-details-grid" dir="rtl">${lines}</div>`;
-}
-
-function renderInstrRow(row) {
-  const name       = escapeHtml(row.full_name || row.emp_id || '—');
-  const phone      = escapeHtml(row.mobile || '');
-  const email      = escapeHtml(row.email  || '');
-  const role       = escapeHtml(hebrewEmploymentType(row.employment_type) || '');
-  const isInactive = String(row.active || '').toLowerCase() === 'no';
-  const parts      = [phone, email].filter(Boolean).join(' · ');
-  return `
-    <div class="ci-row${isInactive ? ' ci-row--inactive' : ''}"
-         data-contact-emp="${encodeURIComponent(row.emp_id || '')}" role="button" tabindex="0">
-      <div class="ci-row__main">
-        <span class="ci-row__name">${name}${isInactive ? ' <span class="ci-row__kind">לא פעיל</span>' : ''}</span>
-        ${role  ? `<span class="ci-row__kind">${role}</span>` : ''}
-        ${parts ? `<span class="ci-row__meta">${parts}</span>` : ''}
-        <span class="ci-row__toggle" aria-hidden="true">&#9658;</span>
-      </div>
+    return `<div class="ci-df">
+      <span class="ci-df__icon" aria-hidden="true">${icon}</span>
+      <span class="ci-df__label">${escapeHtml(label)}</span>
+      <span class="ci-df__value">${valueHtml}</span>
     </div>`;
+  }).join('');
+
+  return `<div class="ci-detail">${linesHtml}</div>`;
 }
 
-function instrTabHtml(rows, searchQ) {
+function renderInstrCard(row, hideEmpIds) {
+  const name      = escapeHtml(row.full_name || row.emp_id || '—');
+  const phone     = escapeHtml(row.mobile || '');
+  const isInactive = String(row.active || '').toLowerCase() === 'no';
+
+  return `
+    <details class="ci-card${isInactive ? ' ci-card--inactive' : ''}">
+      <summary class="ci-card__head">
+        <span class="ci-card__chevron" aria-hidden="true">›</span>
+        <span class="ci-card__name">${name}${isInactive ? ' <span class="ci-card__badge">לא פעיל</span>' : ''}</span>
+        ${phone ? `<span class="ci-card__phone"><span aria-hidden="true">📱</span>${phone}</span>` : ''}
+      </summary>
+      ${instrDetailHtml(row, hideEmpIds)}
+    </details>`;
+}
+
+function instrTabHtml(rows, searchQ, hideEmpIds) {
   const filtered = applyInstrSearch(rows, searchQ);
   const body = filtered.length === 0
     ? dsEmptyState('לא נמצאו אנשי קשר')
-    : `<div class="ci-list">${filtered.map(renderInstrRow).join('')}</div>`;
+    : `<div class="ci-card-list">${filtered.map((r) => renderInstrCard(r, hideEmpIds)).join('')}</div>`;
   return { filtered, body };
 }
 
@@ -73,18 +91,29 @@ function applySchoolSearch(rows, q) {
   );
 }
 
-function schoolDetailLines(row) {
-  const pairs = [
-    ['רכז/ת', row.contact_name],
-    ['טלפון', row.phone || row.mobile],
-    ['נייד',  row.mobile !== row.phone ? row.mobile : ''],
-    ['מייל',  row.email],
-    ['הערות', row.notes]
-  ];
-  return pairs
-    .filter(([, v]) => v && String(v).trim())
-    .map(([lbl, v]) => `<span class="sc-detail"><strong>${escapeHtml(lbl)}:</strong> ${escapeHtml(String(v))}</span>`)
-    .join('');
+function schoolPersonHtml(row) {
+  const fields = [
+    row.contact_name                          ? { icon: '👤', label: 'רכז/ת', val: row.contact_name }  : null,
+    row.phone                                  ? { icon: '☎',  label: 'טלפון', val: row.phone }          : null,
+    row.mobile && row.mobile !== row.phone     ? { icon: '📱', label: 'נייד',  val: row.mobile }         : null,
+    row.email                                  ? { icon: '✉',  label: 'מייל',  val: row.email, copy: true } : null,
+    row.notes                                  ? { icon: '📋', label: 'הערות', val: row.notes }          : null,
+  ].filter(Boolean);
+
+  if (!fields.length) return '';
+
+  const linesHtml = fields.map(({ icon, label, val, copy }) => {
+    const valueHtml = copy
+      ? `<span class="ci-dv">${escapeHtml(String(val))}</span>${copyBtn(val)}`
+      : `<span class="ci-dv">${escapeHtml(String(val))}</span>`;
+    return `<div class="ci-df">
+      <span class="ci-df__icon" aria-hidden="true">${icon}</span>
+      <span class="ci-df__label">${escapeHtml(label)}</span>
+      <span class="ci-df__value">${valueHtml}</span>
+    </div>`;
+  }).join('');
+
+  return `<div class="sc-person">${linesHtml}</div>`;
 }
 
 function groupBySchool(rows) {
@@ -97,35 +126,31 @@ function groupBySchool(rows) {
   return new Map([...map.entries()].sort((a, b) => a[0].localeCompare(b[0], 'he')));
 }
 
-function renderSchoolBlock(schoolName, { authority, rows }) {
-  const rowsHtml = rows.map((row) => {
-    const detail = schoolDetailLines(row);
-    if (!detail) return '';
-    return `<div class="sc-contact-entry">${detail}</div>`;
-  }).join('');
+function renderSchoolCard(schoolName, { authority, rows }) {
+  const personsHtml = rows.map(schoolPersonHtml).filter(Boolean).join('');
+  if (!personsHtml) return '';
 
-  if (!rowsHtml) return '';
+  const countLabel = rows.length === 1 ? '1 איש קשר' : `${rows.length} אנשי קשר`;
 
   return `
-    <details class="sc-school-block">
-      <summary class="sc-school-head">
-        <span class="sc-school-name">${escapeHtml(schoolName)}</span>
-        ${authority ? `<span class="sc-authority">${escapeHtml(String(authority))}</span>` : ''}
-        <span class="sc-count">${rows.length}</span>
+    <details class="sc-card">
+      <summary class="sc-card__head">
+        <span class="sc-card__chevron" aria-hidden="true">›</span>
+        <span class="sc-card__name"><span class="sc-card__school-icon" aria-hidden="true">🏫</span>${escapeHtml(schoolName)}</span>
+        ${authority ? `<span class="sc-card__auth">${escapeHtml(String(authority))}</span>` : ''}
+        <span class="sc-card__count">${escapeHtml(countLabel)}</span>
       </summary>
-      <div class="sc-school-body">${rowsHtml}</div>
+      <div class="sc-card__body">${personsHtml}</div>
     </details>`;
 }
 
 function schoolTabHtml(rows, searchQ) {
   const filtered = applySchoolSearch(rows, searchQ);
   if (filtered.length === 0) return { filtered, body: dsEmptyState('לא נמצאו אנשי קשר') };
-  const groups  = groupBySchool(filtered);
-  let blocksHtml = '';
-  groups.forEach((group, name) => {
-    blocksHtml += renderSchoolBlock(name, group);
-  });
-  return { filtered, body: `<div class="sc-list">${blocksHtml}</div>` };
+  const groups = groupBySchool(filtered);
+  let html = '';
+  groups.forEach((g, name) => { html += renderSchoolCard(name, g); });
+  return { filtered, body: `<div class="sc-card-list">${html}</div>` };
 }
 
 /* ─── Screen ─── */
@@ -138,34 +163,32 @@ export const contactsScreen = {
     const schoolRows = Array.isArray(data?.school_rows)     ? data.school_rows     : [];
     const canViewInstr  = data?.can_view_instructors !== false;
     const canViewSchool = data?.can_view_schools     !== false;
+    const hideEmpIds    = !!state?.clientSettings?.hide_emp_id_on_screens;
 
-    const tab      = state?.contactsTab || (canViewInstr ? 'instr' : 'school');
-    const instrQ   = state?.contactsInstrSearch  || '';
-    const schoolQ  = state?.contactsSchoolSearch || '';
+    const tab     = state?.contactsTab || (canViewInstr ? 'instr' : 'school');
+    const instrQ  = state?.contactsInstrSearch  || '';
+    const schoolQ = state?.contactsSchoolSearch || '';
 
     const tabBtns = [
-      canViewInstr  && { key: 'instr',  label: `אנשי קשר מדריכים · ${instrRows.length}`  },
-      canViewSchool && { key: 'school', label: `אנשי קשר בתי ספר · ${schoolRows.length}` }
+      canViewInstr  && { key: 'instr',  label: `אנשי קשר מדריכים (${instrRows.length})`  },
+      canViewSchool && { key: 'school', label: `אנשי קשר בתי ספר (${schoolRows.length})` }
     ].filter(Boolean).map((t) =>
       `<button type="button" class="ds-chip--tab${tab === t.key ? ' is-active' : ''}" data-contacts-tab="${t.key}">${escapeHtml(t.label)}</button>`
     ).join('');
 
     let searchInput = '';
-    let cardTitle   = '';
-    let cardBody    = '';
+    let listHtml    = '';
 
     if (tab === 'instr' && canViewInstr) {
-      const { filtered, body } = instrTabHtml(instrRows, instrQ);
+      const { body } = instrTabHtml(instrRows, instrQ, hideEmpIds);
       searchInput = `<input id="contacts-instr-search" type="search" class="ds-search-input"
-        placeholder="חיפוש לפי שם / טלפון / מייל..." value="${escapeHtml(instrQ)}" dir="rtl" />`;
-      cardTitle = `אנשי קשר מדריכים · ${filtered.length}`;
-      cardBody  = body;
+        placeholder="חיפוש לפי שם / טלפון / מייל…" value="${escapeHtml(instrQ)}" dir="rtl" />`;
+      listHtml = body;
     } else if (tab === 'school' && canViewSchool) {
-      const { filtered, body } = schoolTabHtml(schoolRows, schoolQ);
+      const { body } = schoolTabHtml(schoolRows, schoolQ);
       searchInput = `<input id="contacts-school-search" type="search" class="ds-search-input"
-        placeholder="חיפוש לפי בית ספר / רשות / איש קשר..." value="${escapeHtml(schoolQ)}" dir="rtl" />`;
-      cardTitle = `אנשי קשר בתי ספר · ${filtered.length}`;
-      cardBody  = body;
+        placeholder="חיפוש לפי בית ספר / רשות / איש קשר…" value="${escapeHtml(schoolQ)}" dir="rtl" />`;
+      listHtml = body;
     }
 
     return dsScreenStack(`
@@ -174,15 +197,12 @@ export const contactsScreen = {
       <div class="ds-screen-top-row">
         ${searchInput}
       </div>
-      ${dsCard({ title: cardTitle, body: cardBody, padded: !cardBody.includes('<div') })}
+      <div class="contacts-list-wrap" dir="rtl">${listHtml}</div>
     `);
   },
 
-  bind({ root, data, state, ui, rerender }) {
+  bind({ root, state, rerender }) {
     bindActNavGrid(root, { state, rerender });
-
-    const instrRows  = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
-    const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
 
     root.querySelectorAll('[data-contacts-tab]').forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -201,20 +221,44 @@ export const contactsScreen = {
       rerender();
     });
 
-    root.querySelectorAll('[data-contact-emp]').forEach((rowEl) => {
-      const empId = decodeURIComponent(rowEl.dataset.contactEmp || '');
-      const open = () => {
-        const row = instrRows.find((r) => String(r.emp_id || '') === empId);
-        if (!row || !ui) return;
-        ui.openDrawer({
-          title:   row.full_name || row.emp_id || '—',
-          content: instrDrawerHtml(row, hideEmpIds)
-        });
-      };
-      rowEl.addEventListener('click', open);
-      rowEl.addEventListener('keydown', (ev) => {
-        if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); open(); }
+    root.querySelectorAll('[data-copy-email]').forEach((btn) => {
+      btn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const email = btn.dataset.copyEmail;
+        const doToast = () => showToast('המייל הועתק ✓');
+        if (navigator.clipboard?.writeText) {
+          navigator.clipboard.writeText(email).then(doToast).catch(() => fallbackCopy(email, doToast));
+        } else {
+          fallbackCopy(email, doToast);
+        }
       });
     });
   }
 };
+
+function fallbackCopy(text, cb) {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  Object.assign(ta.style, { position: 'fixed', opacity: '0', top: '0', left: '0' });
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  try { document.execCommand('copy'); } catch (_) { /* ignore */ }
+  document.body.removeChild(ta);
+  cb?.();
+}
+
+function showToast(msg) {
+  const existing = document.querySelector('.contacts-toast');
+  if (existing) existing.remove();
+  const el = document.createElement('div');
+  el.className = 'contacts-toast';
+  el.textContent = msg;
+  document.body.appendChild(el);
+  requestAnimationFrame(() => el.classList.add('contacts-toast--show'));
+  setTimeout(() => {
+    el.classList.remove('contacts-toast--show');
+    setTimeout(() => el.remove(), 300);
+  }, 1800);
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3805,6 +3805,293 @@ select.ds-input {
   color: var(--ds-text);
 }
 
+/* ——— Contacts page — expandable cards ——— */
+
+.contacts-list-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Instructor cards ── */
+.ci-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ci-card {
+  border: 1px solid var(--ds-border);
+  border-radius: var(--ds-radius-sm);
+  overflow: hidden;
+  background: var(--ds-surface);
+  transition: box-shadow 0.12s;
+}
+
+.ci-card:hover {
+  box-shadow: 0 1px 5px rgba(0,0,0,0.08);
+}
+
+.ci-card[open] {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.09);
+}
+
+.ci-card--inactive {
+  opacity: 0.6;
+}
+
+.ci-card__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-size: 0.85rem;
+  background: var(--ds-surface-subtle);
+}
+
+.ci-card__head::-webkit-details-marker { display: none; }
+
+.ci-card[open] .ci-card__head {
+  background: var(--ds-surface);
+  border-bottom: 1px solid var(--ds-border);
+}
+
+.ci-card__chevron {
+  color: var(--ds-text-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: transform 0.18s ease;
+  flex-shrink: 0;
+}
+
+.ci-card[open] .ci-card__chevron {
+  transform: rotate(90deg);
+}
+
+.ci-card__name {
+  font-weight: 600;
+  color: var(--ds-text);
+  flex: 1;
+  min-width: 0;
+}
+
+.ci-card__badge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--ds-text-muted);
+  background: var(--ds-muted-bg);
+  border: 1px solid var(--ds-muted-border);
+  border-radius: var(--ds-radius-full);
+  padding: 1px 6px;
+  margin-inline-start: 6px;
+  vertical-align: middle;
+}
+
+.ci-card__phone {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78rem;
+  color: var(--ds-text-secondary);
+  flex-shrink: 0;
+  direction: ltr;
+}
+
+/* ── Detail field rows (shared: instructor + school) ── */
+.ci-detail {
+  padding: 10px 14px;
+  background: var(--ds-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.ci-df {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 0.8rem;
+}
+
+.ci-df__icon {
+  font-size: 0.82rem;
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+  color: var(--ds-text-muted);
+}
+
+.ci-df__label {
+  color: var(--ds-text-muted);
+  font-weight: 500;
+  min-width: 74px;
+  flex-shrink: 0;
+}
+
+.ci-df__value {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+  min-width: 0;
+  color: var(--ds-text);
+  flex-wrap: wrap;
+}
+
+.ci-dv {
+  word-break: break-all;
+}
+
+/* ── Copy-email button ── */
+.ci-copy-btn {
+  background: none;
+  border: 1px solid var(--ds-border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: var(--ds-text-muted);
+  padding: 1px 5px;
+  line-height: 1.4;
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+
+.ci-copy-btn:hover {
+  background: var(--ds-interactive-hover);
+  color: var(--ds-accent);
+  border-color: var(--ds-accent);
+}
+
+/* ── School cards ── */
+.sc-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sc-card {
+  border: 1px solid var(--ds-border);
+  border-radius: var(--ds-radius-sm);
+  overflow: hidden;
+  background: var(--ds-surface);
+  transition: box-shadow 0.12s;
+}
+
+.sc-card:hover {
+  box-shadow: 0 1px 5px rgba(0,0,0,0.08);
+}
+
+.sc-card[open] {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.09);
+}
+
+.sc-card__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-size: 0.85rem;
+  background: var(--ds-surface-subtle);
+}
+
+.sc-card__head::-webkit-details-marker { display: none; }
+
+.sc-card[open] .sc-card__head {
+  background: var(--ds-surface);
+  border-bottom: 1px solid var(--ds-border);
+}
+
+.sc-card__chevron {
+  color: var(--ds-text-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: transform 0.18s ease;
+  flex-shrink: 0;
+}
+
+.sc-card[open] .sc-card__chevron {
+  transform: rotate(90deg);
+}
+
+.sc-card__school-icon {
+  margin-inline-end: 4px;
+}
+
+.sc-card__name {
+  font-weight: 600;
+  color: var(--ds-text);
+  flex: 1;
+  min-width: 0;
+}
+
+.sc-card__auth {
+  font-size: 0.74rem;
+  color: var(--ds-text-secondary);
+  font-weight: 400;
+  flex-shrink: 0;
+}
+
+.sc-card__count {
+  font-size: 0.72rem;
+  background: var(--ds-muted-bg);
+  border: 1px solid var(--ds-muted-border);
+  border-radius: var(--ds-radius-full);
+  padding: 1px 8px;
+  color: var(--ds-text-secondary);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.sc-card__body {
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sc-person {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 0;
+  border-bottom: 1px dashed var(--ds-border);
+}
+
+.sc-person:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+/* ── Contacts copy toast ── */
+.contacts-toast {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+  z-index: 9999;
+  background: var(--ds-shell);
+  color: var(--ds-shell-text);
+  padding: 8px 22px;
+  border-radius: var(--ds-radius-full);
+  font-size: 0.82rem;
+  font-weight: 500;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.contacts-toast--show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
 /* ——— Toast notifications ——— */
 .ds-toast {
   position: fixed;


### PR DESCRIPTION
- Instructor contacts: replace drawer with inline <details> cards; closed state shows name + phone only, open shows all fields with field icons (💼 ✉ 📍 👤) and copy-to-clipboard button next to email
- School contacts: replace old sc-school-block with new sc-card pattern; same compact closed/open behaviour, field icons, copy-email
- Shared detail row component (ci-df / ci-dv) used by both tabs
- Copy-email: clipboard API with execCommand fallback + toast feedback
- All new CSS classes added to main.css; old ci-row / sc-school-block classes kept intact (used by instructors.js screen)
- Full RTL, no backend or data-source changes

https://claude.ai/code/session_011YfU9Jj7eZwSZG7BYrjwyv