### PR TITLE
Warmup, cache TTL tuning, targeted invalidation and frontend perf improvements

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -11,3 +11,15 @@ function doGet() {
 function doPost(e) {
   return handlePost_(e);
 }
+
+/**
+ * Warmup entrypoint for time-driven trigger.
+ * Keeps Apps Script runtime warm without any data mutation.
+ */
+function keepWarm() {
+  try {
+    getSpreadsheet_();
+  } catch (e) {
+    // warmup only — intentionally ignored
+  }
+}

--- a/backend/README.txt
+++ b/backend/README.txt
@@ -15,6 +15,10 @@
 3. ב-config.gs עדכנו CONFIG.SPREADSHEET_ID לגיליון היעד.
 4. שמרו, פריסה > ניהול פריסות > פריסה מחדש של ה-Web App (אם משתמשים ב-web app).
 5. בדקו את כתובת /exec (או ה-URL המלא של הפריסה).
+6. לאחר deploy של שינויי cache משמעותיים (למשל שינוי TTL), מומלץ להריץ חד-פעמית:
+   - Deploy חדש (כך שמפתחות גרסה יתעדכנו), או
+   - פונקציית write שמבצעת bump לגרסת cache (למשל save קטן ב-data views).
+   אין צורך ב-invalidate אגרסיבי אוטומטי.
 
 תלות בין קבצים (Apps Script טוען הכול לגלובל):
 - Code.gs -> router.gs -> שאר המודולים.
@@ -22,6 +26,17 @@
 - router.gs קורא ל-getSettingText_ (settings.gs).
 - settings.gs תלוי ב-helpers.gs, config.gs, sheets.gs בלבד — קובץ עצמאי קטן.
 - sheets.gs משתמש ב-yesNo_ מ-helpers.gs וב-CONFIG מ-config.gs.
+
+================================================================================
+Warmup Trigger (מומלץ לצמצום cold start)
+================================================================================
+לאחר העלאת Code.gs שמכיל keepWarm():
+1. פתחו Apps Script project.
+2. עברו ל-Triggers.
+3. Add Trigger לפונקציה: keepWarm.
+4. Event source: Time-driven.
+5. Type: Every 10 minutes.
+הפונקציה לא מבצעת כתיבה/side-effects — רק warming של סביבת הריצה.
 
 ================================================================================
 א. גיליונות חובה (שמות בדיוק כמו ב-config.gs / CONFIG.SHEETS)

--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -2324,7 +2324,11 @@ function buildMeetingsMap_() {
     }
   });
 
-  scriptCachePutJson_(cacheKey, map, CONFIG.SCRIPT_CACHE_SECONDS || 120);
+  scriptCachePutJson_(
+    cacheKey,
+    map,
+    CONFIG.MEETINGS_MAP_CACHE_SECONDS || CONFIG.SCRIPT_CACHE_SECONDS || 120
+  );
   if (__rqCache_) {
     __rqCache_.meetingsMap = map;
   }

--- a/backend/config.gs
+++ b/backend/config.gs
@@ -6,7 +6,9 @@ const CONFIG = {
   LATE_END_DATE_CUTOFF: '2026-06-15',
   SESSION_CACHE_SECONDS: 60 * 60 * 8,
   /** Script cache TTL for dashboard / permissions list (seconds). */
-  SCRIPT_CACHE_SECONDS: 300,
+  SCRIPT_CACHE_SECONDS: 1800,
+  /** Meetings map changes less frequently; keep a dedicated longer TTL. */
+  MEETINGS_MAP_CACHE_SECONDS: 3600,
   SHEETS: {
     DATA_SHORT: 'data_short',
     DATA_LONG: 'data_long',

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5,17 +5,11 @@ import { translateApiErrorForUser } from './screens/shared/ui-hebrew.js';
 /**
  * Actions that modify server-side data.
  *
- * After any of these actions succeeds, clearScreenDataCache() is called
- * automatically (see bottom of request()). This wipes the entire
- * state.screenDataCache so that every screen — activities, finance,
- * permissions, exceptions, end-dates, instructors, my-data, week, month,
- * dashboard, etc. — fetches fresh data on its next render.
+ * After mutating actions succeed, cache invalidation runs automatically
+ * (see bottom of request()).
  *
- * Calendar views (week, month, dashboard) are therefore always stale-safe:
- * any admin action (deactivateUser, reactivateUser, deleteUser, savePermission,
- * addUser) or finance mutation (saveFinanceRow, syncFinance, saveActivity)
- * triggers a full cache wipe, ensuring calendar screens never show stale data
- * after a mutation elsewhere in the app.
+ * Heavy mutations trigger full cache invalidation; lightweight mutations
+ * only clear related screens for faster post-save navigation.
  *
  * Screens that expose their own save forms (activities.js, finance.js,
  * permissions.js) additionally call the bind-injected clearScreenDataCache?.()
@@ -64,6 +58,36 @@ const READ_ACTIONS = {
 const API_TIMEOUT_MS_READ = 20000;
 const API_TIMEOUT_MS_WRITE = 30000;
 const PERF_MAX_REQUESTS = 150;
+
+function invalidateScreenDataByAction(action) {
+  const heavyMutations = new Set([
+    'saveActivity',
+    'addActivity',
+    'submitEditRequest',
+    'reviewEditRequest',
+    'saveFinanceRow',
+    'syncFinance',
+    'addUser',
+    'deactivateUser',
+    'reactivateUser',
+    'deleteUser'
+  ]);
+  const targetedMutations = {
+    savePrivateNote: ['activities:', 'operations:'],
+    savePermission: ['permissions']
+  };
+  if (heavyMutations.has(action)) {
+    clearScreenDataCache();
+    return;
+  }
+  const prefixes = targetedMutations[action];
+  if (!prefixes || !prefixes.length) return;
+  Object.keys(state.screenDataCache || {}).forEach((key) => {
+    if (prefixes.some((prefix) => key === prefix || key.startsWith(prefix))) {
+      delete state.screenDataCache[key];
+    }
+  });
+}
 
 function isPerfDebugEnabled() {
   try {
@@ -189,7 +213,7 @@ async function request(action, payload = {}) {
     throw new Error(translateApiErrorForUser(json.error));
   }
   if (MUTATING_ACTIONS[action]) {
-    clearScreenDataCache();
+    invalidateScreenDataByAction(action);
   }
   pushPerfRequest({
     action,

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -120,6 +120,31 @@ function flushPaint() {
 }
 
 function screenLoadingMarkup() {
+  if (state.route === 'activities') {
+    return `
+      <div class="ds-loading-card" dir="rtl" role="status" aria-live="polite">
+        <p>טוען פעילויות…</p>
+        <div class="ds-skeleton" aria-hidden="true">
+          <div class="ds-skeleton-line"></div>
+          <div class="ds-skeleton-line"></div>
+          <div class="ds-skeleton-line"></div>
+          <div class="ds-skeleton-line ds-skeleton-line--short"></div>
+        </div>
+      </div>
+    `;
+  }
+  if (state.route === 'week') {
+    return `
+      <div class="ds-loading-card" dir="rtl" role="status" aria-live="polite">
+        <p>טוען שבוע…</p>
+        <div class="ds-skeleton" aria-hidden="true">
+          <div class="ds-skeleton-line"></div>
+          <div class="ds-skeleton-line"></div>
+          <div class="ds-skeleton-line"></div>
+        </div>
+      </div>
+    `;
+  }
   return `
     <div class="ds-loading-card" dir="rtl" role="status" aria-live="polite">
       <div class="ds-spinner" aria-hidden="true"></div>
@@ -361,30 +386,34 @@ function closeMobileNav() {
   setMobileNavOpen(false);
 }
 
-function screenDataCacheKey() {
-  if (state.route === 'activities') {
-    return `activities:${state.activityTab || 'all'}:${state.activityFinanceStatus || ''}:${state.activitySearch || ''}:${state.activityQuickFamily || ''}:${state.activityQuickManager || ''}:${state.activityEndingCurrentMonth ? '1' : '0'}`;
+function buildScreenDataCacheKey(route, cacheState = state) {
+  if (route === 'activities') {
+    return `activities:${cacheState.activityTab || 'all'}:${cacheState.activityFinanceStatus || ''}:${cacheState.activitySearch || ''}:${cacheState.activityQuickFamily || ''}:${cacheState.activityQuickManager || ''}:${cacheState.activityEndingCurrentMonth ? '1' : '0'}`;
   }
-  if (state.route === 'finance') {
-    const df = state.financeDateFrom || '';
-    const dt = state.financeDateTo || '';
-    return `finance:${df}:${dt}:${state.financeSearch || ''}:${state.financeStatusFilter || ''}:${state.financeTab || 'active'}:${state.financeMonthYm || ''}`;
+  if (route === 'finance') {
+    const df = cacheState.financeDateFrom || '';
+    const dt = cacheState.financeDateTo || '';
+    return `finance:${df}:${dt}:${cacheState.financeSearch || ''}:${cacheState.financeStatusFilter || ''}:${cacheState.financeTab || 'active'}:${cacheState.financeMonthYm || ''}`;
   }
-  if (state.route === 'operations') {
-    return `operations:${state.operationsSearch || ''}:${state.operationsActivityType || ''}`;
+  if (route === 'operations') {
+    return `operations:${cacheState.operationsSearch || ''}:${cacheState.operationsActivityType || ''}`;
   }
-  if (state.route === 'dashboard') {
-    const ym = state.dashboardMonthYm && /^\d{4}-\d{2}$/.test(state.dashboardMonthYm) ? state.dashboardMonthYm : 'default';
+  if (route === 'dashboard') {
+    const ym = cacheState.dashboardMonthYm && /^\d{4}-\d{2}$/.test(cacheState.dashboardMonthYm) ? cacheState.dashboardMonthYm : 'default';
     return `dashboard:${ym}`;
   }
-  if (state.route === 'week') {
-    return `week:${state.weekOffset || 0}`;
+  if (route === 'week') {
+    return `week:${cacheState.weekOffset || 0}`;
   }
-  if (state.route === 'month') {
-    const ym = state.monthYm && /^\d{4}-\d{2}$/.test(state.monthYm) ? state.monthYm : 'current';
+  if (route === 'month') {
+    const ym = cacheState.monthYm && /^\d{4}-\d{2}$/.test(cacheState.monthYm) ? cacheState.monthYm : 'current';
     return `month:${ym}`;
   }
-  return state.route;
+  return route;
+}
+
+function screenDataCacheKey() {
+  return buildScreenDataCacheKey(state.route, state);
 }
 
 /**
@@ -462,6 +491,35 @@ async function backgroundRefreshScreen(screen, cacheKey) {
   } catch {
     inflightRequests.delete(cacheKey);
   }
+}
+
+function prefetchFromDashboardIfNeeded() {
+  if (state.route !== 'dashboard') return;
+  const targets = [
+    {
+      key: buildScreenDataCacheKey('activities', { ...state, route: 'activities' }),
+      load: () => api.activities({ activity_type: 'all' })
+    },
+    {
+      key: buildScreenDataCacheKey('week', { ...state, route: 'week', weekOffset: 0 }),
+      load: () => api.week({ week_offset: 0 })
+    }
+  ];
+  targets.forEach((target) => {
+    if (state.screenDataCache[target.key]) return;
+    if (inflightRequests.has(target.key)) return;
+    const request = target.load()
+      .then((data) => {
+        const entry = { data, t: Date.now() };
+        state.screenDataCache[target.key] = entry;
+        persistCacheEntry(target.key, entry);
+      })
+      .catch(() => {})
+      .finally(() => {
+        inflightRequests.delete(target.key);
+      });
+    inflightRequests.set(target.key, request);
+  });
 }
 
 function setShellNavBusy(busy) {
@@ -703,6 +761,7 @@ async function mountScreen() {
       });
       if (routeChanged) lastRenderedRoute = state.route;
       if (isStale) backgroundRefreshScreen(screen, cacheKey);
+      prefetchFromDashboardIfNeeded();
       recordRenderPerf(state.route, 'mount-total', performance.now() - mountStartMs, { cache_key: cacheKey });
       return;
     }
@@ -722,6 +781,7 @@ async function mountScreen() {
     });
     if (routeChanged) lastRenderedRoute = state.route;
     if (isStale) backgroundRefreshScreen(screen, cacheKey);
+    prefetchFromDashboardIfNeeded();
     recordRenderPerf(state.route, 'mount-total', performance.now() - mountStartMs, { cache_key: cacheKey });
     return;
   } else {
@@ -744,6 +804,7 @@ async function mountScreen() {
       cache_key: cacheKey
     });
     if (routeChanged) lastRenderedRoute = state.route;
+    prefetchFromDashboardIfNeeded();
   } catch (err) {
     const screenRoot = document.getElementById('screenRoot');
     if (screenRoot) {

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -203,7 +203,7 @@ export const activitiesScreen = {
     const bindActivityEditForm = (contentRoot) =>
       bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender });
     const detailCache = new Map();
-    const loadingDetailMarkup = '<div class="ds-loading-card" dir="rtl"><p>טוען פירוט פעילות…</p></div>';
+    const loadingDetailMarkup = '<div class="ds-loading-card" dir="rtl"><p>משלים פירוט פעילות…</p></div>';
 
     async function loadDetailRow(summaryRow) {
       const cacheKey = `${summaryRow.source_sheet || ''}|${summaryRow.RowID || ''}`;
@@ -216,15 +216,13 @@ export const activitiesScreen = {
 
     async function openActivityDetail(summaryRow) {
       if (!summaryRow || !ui) return;
-      ui.openDrawer({
-        title: '',
-        content: loadingDetailMarkup
-      });
-      const row = await loadDetailRow(summaryRow);
+      const cacheKey = `${summaryRow.source_sheet || ''}|${summaryRow.RowID || ''}`;
+      const cached = detailCache.get(cacheKey);
+      const initialRow = cached || summaryRow;
       ui.openDrawer({
         title: '',
         content: activityDrawerContent(
-          row,
+          initialRow,
           canSeePrivateNotes,
           canEditActivity,
           hideEmpIds,
@@ -234,6 +232,29 @@ export const activitiesScreen = {
         ),
         onOpen: bindActivityEditForm
       });
+      if (cached) return;
+
+      const contentRoot = document.querySelector('.drawer-content');
+      if (contentRoot) contentRoot.insertAdjacentHTML('beforeend', loadingDetailMarkup);
+      try {
+        const row = await loadDetailRow(summaryRow);
+        ui.openDrawer({
+          title: '',
+          content: activityDrawerContent(
+            row,
+            canSeePrivateNotes,
+            canEditActivity,
+            hideEmpIds,
+            hideRowId,
+            hideActivityNo,
+            state?.clientSettings || {}
+          ),
+          onOpen: bindActivityEditForm
+        });
+      } catch {
+        const loadingNode = document.querySelector('.drawer-content .ds-loading-card');
+        if (loadingNode) loadingNode.remove();
+      }
     }
 
     root.querySelectorAll('[data-family]').forEach((node) => {

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -340,15 +340,20 @@ export const monthScreen = {
       if (/^\d{4}-\d{2}$/.test(String(currentYm || ''))) return currentYm;
       return `${spec.y}-${String(spec.mo).padStart(2, '0')}`;
     };
+    let navDebounceTimer = null;
+    const queueMonthShift = (delta) => {
+      if (navDebounceTimer) clearTimeout(navDebounceTimer);
+      navDebounceTimer = setTimeout(() => {
+        state.monthYm = shiftMonthYm(resolveBaseYm(), delta);
+        try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
+        rerender?.();
+      }, 150);
+    };
     root.querySelector('[data-month-prev]')?.addEventListener('click', () => {
-      state.monthYm = shiftMonthYm(resolveBaseYm(), -1);
-      try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
-      rerender?.();
+      queueMonthShift(-1);
     });
     root.querySelector('[data-month-next]')?.addEventListener('click', () => {
-      state.monthYm = shiftMonthYm(resolveBaseYm(), 1);
-      try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
-      rerender?.();
+      queueMonthShift(1);
     });
 
     ui?.bindInteractiveCards(root, (action) => {

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -201,13 +201,20 @@ export const weekScreen = {
     const bindActivityEditForm = (contentRoot) =>
       bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender });
 
+    let navDebounceTimer = null;
+    const queueWeekShift = (delta) => {
+      if (navDebounceTimer) clearTimeout(navDebounceTimer);
+      navDebounceTimer = setTimeout(() => {
+        state.weekOffset = (state.weekOffset || 0) + delta;
+        rerender?.();
+      }, 150);
+    };
+
     root.querySelector('[data-week-prev]')?.addEventListener('click', () => {
-      state.weekOffset = (state.weekOffset || 0) - 1;
-      rerender?.();
+      queueWeekShift(-1);
     });
     root.querySelector('[data-week-next]')?.addEventListener('click', () => {
-      state.weekOffset = (state.weekOffset || 0) + 1;
-      rerender?.();
+      queueWeekShift(1);
     });
 
     root.addEventListener('click', (ev) => {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 88;
+const CACHE_VERSION = 89;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [
@@ -7,7 +7,15 @@ const APP_SHELL = [
   './frontend/src/main.js',
   './frontend/src/api.js',
   './frontend/src/state.js',
+  './frontend/src/cache-persist.js',
   './frontend/src/config.js',
+  './frontend/src/screens/dashboard.js',
+  './frontend/src/screens/activities.js',
+  './frontend/src/screens/week.js',
+  './frontend/src/screens/month.js',
+  './frontend/src/screens/finance.js',
+  './frontend/src/screens/shared/layout.js',
+  './frontend/src/screens/shared/ui-hebrew.js',
   './frontend/src/screens/shared/interactions.js',
   './frontend/src/styles/main.css',
   './frontend/public/manifest.json',


### PR DESCRIPTION
### Motivation
- Reduce Apps Script cold-start latency and unnecessary sheet rebuilds by adding a safe warmup and longer cache TTLs. 
- Improve perceived and real frontend responsiveness when opening details and navigating calendar views without changing API shapes or business logic. 
- Reduce full-cache wipes after small mutations by invalidating only the affected screen keys.

### Description
- Backend: added a no-side-effect warmup entrypoint `keepWarm()` (`backend/Code.gs`), increased `CONFIG.SCRIPT_CACHE_SECONDS` to `1800` and added `CONFIG.MEETINGS_MAP_CACHE_SECONDS = 3600`, and wired `buildMeetingsMap_()` to use the dedicated TTL (`backend/config.gs`, `backend/actions.gs`), plus README notes about one-time invalidate/deploy steps (`backend/README.txt`).
- Activities UX: open drawer immediately from summary data and show background loading + memoize detail per `source_sheet|RowID` to avoid duplicate detail calls (`frontend/src/screens/activities.js`).
- Targeted cache invalidation & prefetch: implemented `invalidateScreenDataByAction()` to clear either full cache for heavy mutations or only related `screenDataCache` prefixes for lightweight mutations and replaced blunt `clearScreenDataCache()` call in the request flow; added safe cache-key builder and quiet prefetch from dashboard for `activities` and `week` using real keys (`frontend/src/api.js`, `frontend/src/main.js`, `frontend/src/cache-persist.js` usage). 
- Navigation and perceived load improvements: added small skeleton loading states for `activities`/`week`, extracted `buildScreenDataCacheKey()` helper, added quiet `prefetchFromDashboardIfNeeded()`, and added a gentle 150ms debounce to week/month navigation (`frontend/src/main.js`, `frontend/src/screens/week.js`, `frontend/src/screens/month.js`).
- Service Worker: bumped `CACHE_VERSION` and expanded `APP_SHELL` to include core screen/shared modules used on common routes to improve shell caching (`sw.js`).

### Testing
- Ran automated test suite with `npm test`, which passed: 19/19 tests OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8beb498ec832bb940378065eac58e)