### PR TITLE
Trim dashboard prefetch to activities and week only

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -504,10 +504,6 @@ function prefetchFromDashboardIfNeeded() {
       {
         key: buildScreenDataCacheKey('week', { ...state, route: 'week', weekOffset: 0 }),
         load: () => api.week({ week_offset: 0 })
-      },
-      {
-        key: buildScreenDataCacheKey('month', { ...state, route: 'month', monthYm: state.monthYm || '' }),
-        load: () => api.month(state.monthYm ? { ym: state.monthYm } : {})
       }
     );
   } else if (state.route === 'week') {


### PR DESCRIPTION
### Motivation
- Reduce unnecessary background network and compute load from the dashboard by avoiding prefetching the heavier `month` payload until the month context is actually needed.

### Description
- Removed dashboard-level prefetch of the `month` screen in `frontend/src/main.js`, while keeping prefetch for `activities` and `week` and preserving the adjacent-month prefetch behavior when already on the `month` screen.

### Testing
- Ran `npm test` which executed the UI interaction tests and all tests passed (19/19).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cbf670b0832b86c5dd0a38e16e58)