### PR TITLE
Update default Apps Script API URL

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbzVDZLA6Jhj2XtnK-7_l7oVztnQRnLIKD5pWoANbEyZ8mCyoEGWFijd_DfMvtm_MW3p/exec';
+  'https://script.google.com/macros/s/AKfycbzYDpEr09ArxaY5it5DR99MTZqD9ak9GjOSG7-jHFihxtJoaLBOtbP3lpZqii5pvRDF/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
### Motivation
- Point the frontend to the newly deployed Apps Script Web App `/exec` endpoint by updating the single source-of-truth so the app uses the new backend URL without changing any logic, UI, cache, or platform.

### Description
- Replaced the `DEFAULT_API_URL` value in `frontend/src/config.js` from `https://script.google.com/macros/s/AKfycbzVDZLA6Jhj2XtnK-7_l7oVztnQRnLIKD5pWoANbEyZ8mCyoEGWFijd_DfMvtm_MW3p/exec` to `https://script.google.com/macros/s/AKfycbzYDpEr09ArxaY5it5DR99MTZqD9ak9GjOSG7-jHFihxtJoaLBOtbP3lpZqii5pvRDF/exec` and made no other code changes.

### Testing
- Located occurrences with `rg`, applied the replacement via a small script, verified the change with `git diff` and `nl -ba frontend/src/config.js`, and committed the update; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cdf00af0832bb31c989d4330f141)