### PR TITLE
Replace AI dashboard summary with local structured monthly summary

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -37,6 +37,16 @@ function ymBounds_(ym) {
   return { first: first, last: last };
 }
 
+function shiftYm_(ym, deltaMonths) {
+  var parts = String(ym || '').split('-');
+  var y = parseInt(parts[0], 10);
+  var mo = parseInt(parts[1], 10);
+  var shifted = new Date(y, mo - 1 + deltaMonths, 1);
+  var year = shifted.getFullYear();
+  var month = ('0' + (shifted.getMonth() + 1)).slice(-2);
+  return year + '-' + month;
+}
+
 /** פעילות עם טווח תאריכים שחופף לחודש ym (כולל קצה) */
 function activityOverlapsYm_(row, ym) {
   var b = ymBounds_(ym);
@@ -207,6 +217,7 @@ function actionDashboard_(user, payload) {
     yesNo_(permission.view_finance) === 'yes';
 
   var ym = dashboardPayloadYm_(payload || {});
+  var nextYm = shiftYm_(ym, 1);
 
   var allSummary = allActivitiesSummary_();
   var oneDayTypes = configuredOneDayActivityTypes_();
@@ -338,6 +349,30 @@ function actionDashboard_(user, payload) {
     if (primaryExceptionForRow_(row)) exceptionSum += 1;
   });
 
+  var missingInstructorCount = 0;
+  var missingStartDateCount = 0;
+  var lateEndDateCount = 0;
+  longRows.forEach(function(row) {
+    var exceptionTypes = rowExceptionTypes_(row);
+    if (exceptionTypes.indexOf('missing_instructor') >= 0) missingInstructorCount += 1;
+    if (exceptionTypes.indexOf('missing_start_date') >= 0) missingStartDateCount += 1;
+    if (exceptionTypes.indexOf('late_end_date') >= 0) lateEndDateCount += 1;
+  });
+
+  var shortActivitiesByType = {};
+  shortRowsBySource.forEach(function(row) {
+    if (text_(row.source_sheet) !== CONFIG.SHEETS.DATA_SHORT) return;
+    var activityType = text_(row.activity_type);
+    if (!activityType) return;
+    shortActivitiesByType[activityType] = (shortActivitiesByType[activityType] || 0) + 1;
+  });
+  var shortActivitiesSummary = Object.keys(shortActivitiesByType).sort().map(function(typeKey) {
+    return {
+      activity_type: typeKey,
+      count: shortActivitiesByType[typeKey]
+    };
+  });
+
   var kpi_cards_all = [
     { id: 'short', action: 'kpi|short', title: String(shortRows.length), subtitle: 'חד-יומי', value: shortRows.length },
     { id: 'long', action: 'kpi|long', title: String(activeLongRows.length), subtitle: 'תוכניות', value: activeLongRows.length },
@@ -426,6 +461,16 @@ function actionDashboard_(user, payload) {
     by_activity_manager: Object.keys(byManager).sort().map(function(key) {
       return byManager[key];
     }),
+    summary: {
+      active_courses_current_month: countActiveByTypeInYm_(combined, ym, 'course'),
+      ending_courses_current_month: courseEndings,
+      active_courses_next_month: countActiveByTypeInYm_(allSummary, nextYm, 'course'),
+      active_instructors: collectUniqueInstructorNames_(combined),
+      missing_instructor_count: missingInstructorCount,
+      missing_start_date_count: missingStartDateCount,
+      late_end_date_count: lateEndDateCount,
+      short_activities: shortActivitiesSummary
+    },
     kpi_cards: kpi_cards,
     show_only_nonzero_kpis: settingYes_('show_only_nonzero_kpis')
   };
@@ -2175,6 +2220,17 @@ function collectUniqueOperationalEmpIds_(activityRows) {
 
 function countUniqueOperationalInstructors_(activityRows) {
   return collectUniqueOperationalEmpIds_(activityRows).length;
+}
+
+function collectUniqueInstructorNames_(activityRows) {
+  var seen = {};
+  activityRows.forEach(function(row) {
+    var primaryName = text_(row.instructor_name) || text_(row.emp_id);
+    var secondaryName = text_(row.instructor_name_2) || text_(row.emp_id_2);
+    if (primaryName) seen[primaryName] = true;
+    if (secondaryName) seen[secondaryName] = true;
+  });
+  return Object.keys(seen).sort();
 }
 
 /** מפת העשרה: emp_id -> שורה בגיליון contacts_instructors (תצוגה / פרטי קשר בלבד). */

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './shared/html.js';
 import { dsPageHeader, dsCard, dsScreenStack, dsInteractiveCard } from './shared/layout.js';
-import { getHolidayLabel } from './shared/holidays.js';
+import { hebrewActivityType } from './shared/ui-hebrew.js';
 
 const HEBREW_MONTHS = [
   'ינואר',
@@ -36,112 +36,40 @@ function hebrewMonthTitle(ym) {
   return `${name} ${m[1]}`;
 }
 
-function formatDateHe(isoDate) {
-  if (!isoDate) return '';
-  const d = new Date(isoDate);
-  if (Number.isNaN(d.getTime())) return isoDate;
-  return d.toLocaleDateString('he-IL');
+function normalizeNames(names) {
+  const unique = [...new Set((Array.isArray(names) ? names : []).map((n) => String(n || '').trim()).filter(Boolean))];
+  return unique.join(', ');
 }
 
-function monthStartIso(ym) {
-  return `${ym}-01`;
-}
+function renderStructuredSummary(summary, ym) {
+  const monthTitle = hebrewMonthTitle(ym);
+  const nextMonthTitle = hebrewMonthTitle(shiftYm(ym, 1));
+  const instructors = normalizeNames(summary?.active_instructors || []);
+  const shortActivities = Array.isArray(summary?.short_activities) ? summary.short_activities : [];
+  const hasShortActivities = shortActivities.length > 0;
 
-function monthEndIso(ym) {
-  const [y, m] = ym.split('-').map(Number);
-  const end = new Date(y, m, 0);
-  return `${end.getFullYear()}-${String(end.getMonth() + 1).padStart(2, '0')}-${String(end.getDate()).padStart(2, '0')}`;
-}
+  const shortActivitiesHtml = hasShortActivities
+    ? `<div class="ds-summary-panel__block ds-summary-panel__block--short-activities">
+        <h4 class="ds-summary-panel__inner-title"><strong>פעילויות חד-יומיות בחודש זה</strong></h4>
+        <p class="ds-summary-panel__text">בנוסף, במהלך חודש <strong>${escapeHtml(monthTitle)}</strong> צפויות להתקיים גם פעילויות חד-יומיות.</p>
+        <ul class="ds-summary-panel__list">
+          ${shortActivities
+            .map((item) => `<li><strong>${escapeHtml(hebrewActivityType(item.activity_type || ''))}</strong> – <strong>${escapeHtml(String(item.count || 0))}</strong></li>`)
+            .join('')}
+        </ul>
+      </div>`
+    : '';
 
-function getHolidaysInRange(fromYm, toYm) {
-  const from = monthStartIso(fromYm);
-  const to = monthEndIso(toYm);
-  const days = [];
-  const cursor = new Date(from);
-  const last = new Date(to);
-  while (cursor <= last) {
-    const iso = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}-${String(cursor.getDate()).padStart(2, '0')}`;
-    const label = getHolidayLabel(iso);
-    if (label) days.push({ date: iso, label });
-    cursor.setDate(cursor.getDate() + 1);
-  }
-  return days;
-}
-
-function buildNationalPrompt(payload) {
-  const { currentMonth, today, totals, kpiCards, managers, holidays } = payload;
-  const exceptions = Array.isArray(kpiCards) ? (kpiCards.find((k) => k.id === 'exceptions')?.value ?? 0) : 0;
-  return `סיכום מצב ארצי לחודש ${hebrewMonthTitle(currentMonth)}.
-היום: ${formatDateHe(today)}.
-
-נתונים:
-- תוכניות פעילות: ${totals?.total_long ?? 0}
-- מדריכים פעילים: ${totals?.total_instructors ?? 0}
-- חריגות: ${exceptions}
-- סיומי קורסים החודש: ${totals?.total_course_endings_current_month ?? 0}
-
-פירוט מחוזות:
-${(Array.isArray(managers) ? managers : []).map((m) => `${m.activity_manager}: ${m.total_long} תוכניות, ${m.num_instructors} מדריכים, ${m.exceptions} חריגות`).join('\n')}
-
-${holidays.length ? `אירועים בטווח החודשיים הקרובים:\n${holidays.map((h) => `${formatDateHe(h.date)}: ${h.label}`).join('\n')}` : ''}
-
-כתוב סיכום קצר ומדויק למנהל הארצי.`;
-}
-
-function buildManagerPrompt(payload) {
-  const { managerName, currentMonth, today, stats, holidays } = payload;
-  return `סיכום מצב ${managerName} לחודש ${hebrewMonthTitle(currentMonth)}.
-היום: ${formatDateHe(today)}.
-
-נתונים:
-- תוכניות פעילות: ${stats?.total_long ?? 0}
-- מדריכים פעילים: ${stats?.num_instructors ?? 0}
-- חריגות: ${stats?.exceptions ?? 0}
-- סיומי קורסים החודש: ${stats?.course_endings ?? 0}
-
-${holidays.length ? `אירועים בטווח החודשיים הקרובים:\n${holidays.map((h) => `${formatDateHe(h.date)}: ${h.label}`).join('\n')}` : ''}
-
-כתוב סיכום קצר ומדויק למנהל.`;
-}
-
-async function fetchSummary(payload) {
-  const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOARD_CONFIG__) || {};
-  const apiKey = runtimeConfig.anthropicApiKey || runtimeConfig.claudeApiKey || '';
-  const endpoint = runtimeConfig.anthropicUrl || 'https://api.anthropic.com/v1/messages';
-  const systemPrompt = `אתה עוזר ניהולי של מערכת ניהול פעילויות חינוכיות ארצית בישראל.
-תפקידך: לנתח נתונים ולהפיק סיכום תמציתי למנהל.
-
-חוקים:
-- כתוב עברית בלבד
-- 3–5 משפטים קצרים בלבד. אין כותרות, אין bullets, אין bold
-- ניסוח ישיר, עובדתי, ממוקד — לא שיווקי ולא מחמיא
-- הדגש: מה בולט החודש הנוכחי, מה צפוי החודש הבא, אירועים שדורשים תשומת לב
-- אם יש חגים בטווח — ציין אותם רק אם רלוונטיים לפעילות (סיומים, הפסקות)
-- אם יש חריגות גבוהות — ציין בפשטות את המספר
-- אל תמציא נתונים שלא נמסרו לך`;
-  const userPrompt = payload.type === 'national'
-    ? buildNationalPrompt(payload)
-    : buildManagerPrompt(payload);
-  try {
-    const response = await fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(apiKey ? { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' } : {})
-      },
-      body: JSON.stringify({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 300,
-        system: systemPrompt,
-        messages: [{ role: 'user', content: userPrompt }]
-      })
-    });
-    if (!response.ok) return 'לא ניתן לייצר סיכום כרגע.';
-    const data = await response.json();
-    return data.content?.[0]?.text || 'לא ניתן לייצר סיכום כרגע.';
-  } catch (_) {
-    return 'לא ניתן לייצר סיכום כרגע.';
-  }
+  return `<div class="ds-summary-panel__structured">
+    <h3 class="ds-summary-panel__title">סיכום חודשי – <strong>${escapeHtml(monthTitle)}</strong></h3>
+    <p class="ds-summary-panel__text">בחודש <strong>${escapeHtml(monthTitle)}</strong> מתקיימים <strong>${escapeHtml(String(summary?.active_courses_current_month ?? 0))}</strong> קורסים פעילים. במהלך החודש צפויים להסתיים <strong>${escapeHtml(String(summary?.ending_courses_current_month ?? 0))}</strong> קורסים. המדריכים הפעילים החודש הם: <strong>${escapeHtml(instructors)}</strong>.</p>
+    <p class="ds-summary-panel__text">בחודש <strong>${escapeHtml(nextMonthTitle)}</strong> צפויים להיות <strong>${escapeHtml(String(summary?.active_courses_next_month ?? 0))}</strong> קורסים פעילים.</p>
+    <div class="ds-summary-panel__block ds-summary-panel__block--exceptions">
+      <h4 class="ds-summary-panel__inner-title"><strong>חריגות החודש</strong></h4>
+      <p class="ds-summary-panel__text"><strong>${escapeHtml(String(summary?.missing_instructor_count ?? 0))}</strong> קורסים ללא שיבוץ מדריך, <strong>${escapeHtml(String(summary?.missing_start_date_count ?? 0))}</strong> קורסים ללא תאריך התחלה, ו-<strong>${escapeHtml(String(summary?.late_end_date_count ?? 0))}</strong> קורסים המצויים בסיכון עקב תאריך סיום מאוחר.</p>
+    </div>
+    ${shortActivitiesHtml}
+  </div>`;
 }
 
 function goActivitiesDrill(state, patch) {
@@ -213,14 +141,11 @@ export const dashboardScreen = {
         return `<div class="ds-manager-card">
           <div class="ds-manager-card__head">
             <p class="ds-manager-card__name">${escapeHtml(displayName)}</p>
-            <button type="button" class="ds-summary-btn" data-summary-target="${summaryTarget}" aria-label="סיכום AI">✨ סיכום</button>
+            <button type="button" class="ds-summary-btn" data-summary-target="${summaryTarget}" aria-label="סיכום">סיכום</button>
           </div>
           <div class="ds-manager-stats">${statsHtml}</div>
           <div class="ds-summary-panel" data-summary-panel="${summaryTarget}" hidden>
             <div class="ds-summary-panel__content"></div>
-            <div class="ds-summary-panel__footer">
-              <button type="button" class="ds-summary-refresh" data-summary-refresh="${summaryTarget}">↺ רענן</button>
-            </div>
           </div>
         </div>`;
       })
@@ -256,13 +181,10 @@ export const dashboardScreen = {
         ${monthNav}
         <div data-dash-data-area>
           <div class="ds-dashboard-summary-row">
-            <button type="button" class="ds-summary-btn" data-summary-target="national" aria-label="סיכום AI">✨ סיכום</button>
+            <button type="button" class="ds-summary-btn" data-summary-target="national" aria-label="סיכום">סיכום</button>
           </div>
           <div class="ds-summary-panel" data-summary-panel="national" hidden>
             <div class="ds-summary-panel__content"></div>
-            <div class="ds-summary-panel__footer">
-              <button type="button" class="ds-summary-refresh" data-summary-refresh="national">↺ רענן</button>
-            </div>
           </div>
           <div class="ds-kpi-grid ds-dashboard-kpi-grid">${kpiHtml}</div>
           <div style="margin-top: var(--ds-space-3)"></div>
@@ -277,22 +199,7 @@ export const dashboardScreen = {
   },
   bind({ root, ui, state, api, rerender, clearScreenDataCache, data }) {
     const DASHBOARD_TTL_MS = 5 * 60 * 1000;
-    const summaryCache = new Map();
     const ym = data?.month || state.dashboardMonthYm || currentMonthYm();
-    const nextYm = shiftYm(ym, 1);
-    const todayIso = new Date().toISOString().slice(0, 10);
-    const holidays = getHolidaysInRange(ym, nextYm);
-    const managerRows = Array.isArray(data?.by_activity_manager) ? data.by_activity_manager : [];
-    const nationalPayload = {
-      type: 'national',
-      currentMonth: ym,
-      nextMonth: nextYm,
-      today: todayIso,
-      totals: data?.totals || {},
-      kpiCards: data?.kpi_cards || [],
-      managers: managerRows,
-      holidays
-    };
 
     function getSummaryBtn(target) {
       return [...root.querySelectorAll('.ds-summary-btn[data-summary-target]')]
@@ -309,36 +216,20 @@ export const dashboardScreen = {
       if (btn) btn.disabled = !!disabled;
     }
 
-    function showLoading(target) {
-      const panel = getSummaryPanel(target);
-      const content = panel?.querySelector('.ds-summary-panel__content');
-      if (!panel || !content) return;
-      panel.hidden = false;
-      content.innerHTML = '<span class="ds-summary-loading">מנתח נתונים…</span>';
-      toggleSummaryButton(target, true);
-    }
-
-    function showSummary(target, text) {
+    function showSummary(target, htmlText) {
       const panel = getSummaryPanel(target);
       const content = panel?.querySelector('.ds-summary-panel__content');
       const btn = getSummaryBtn(target);
       if (!panel || !content) return;
       panel.hidden = false;
-      content.textContent = text || 'לא ניתן לייצר סיכום כרגע.';
+      content.innerHTML = htmlText;
       if (btn) btn.hidden = true;
       toggleSummaryButton(target, false);
     }
 
-    async function handleSummaryClick(target, payload, forceRefresh = false) {
-      if (forceRefresh) summaryCache.delete(target);
-      if (summaryCache.has(target)) {
-        showSummary(target, summaryCache.get(target));
-        return;
-      }
-      showLoading(target);
-      const text = await fetchSummary(payload);
-      summaryCache.set(target, text);
-      showSummary(target, text);
+    function handleSummaryClick(target) {
+      const nationalSummary = renderStructuredSummary(data?.summary || {}, ym);
+      showSummary(target, nationalSummary);
     }
 
     function showDataAreaLoading() {
@@ -393,50 +284,7 @@ export const dashboardScreen = {
     root.querySelectorAll('.ds-summary-btn[data-summary-target]').forEach((btn) => {
       btn.addEventListener('click', () => {
         const target = btn.dataset.summaryTarget || '';
-        const managerHit = managerRows.find((r) => String(r.activity_manager || '') === decodeURIComponent(target));
-        const payload = target === 'national'
-          ? nationalPayload
-          : {
-              type: 'manager',
-              managerName: managerHit?.activity_manager || decodeURIComponent(target),
-              currentMonth: ym,
-              nextMonth: nextYm,
-              today: todayIso,
-              stats: {
-                total_long: managerHit?.total_long ?? 0,
-                num_instructors: managerHit?.num_instructors ?? 0,
-                exceptions: managerHit?.exceptions ?? 0,
-                course_endings: managerHit?.course_endings ?? 0
-              },
-              holidays
-            };
-        handleSummaryClick(target, payload).catch(() => {});
-      });
-    });
-
-    root.querySelectorAll('.ds-summary-refresh[data-summary-refresh]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const target = btn.dataset.summaryRefresh || '';
-        const managerHit = managerRows.find((r) => String(r.activity_manager || '') === decodeURIComponent(target));
-        const payload = target === 'national'
-          ? nationalPayload
-          : {
-              type: 'manager',
-              managerName: managerHit?.activity_manager || decodeURIComponent(target),
-              currentMonth: ym,
-              nextMonth: nextYm,
-              today: todayIso,
-              stats: {
-                total_long: managerHit?.total_long ?? 0,
-                num_instructors: managerHit?.num_instructors ?? 0,
-                exceptions: managerHit?.exceptions ?? 0,
-                course_endings: managerHit?.course_endings ?? 0
-              },
-              holidays
-            };
-        const openBtn = getSummaryBtn(target);
-        if (openBtn) openBtn.hidden = false;
-        handleSummaryClick(target, payload, true).catch(() => {});
+        handleSummaryClick(target);
       });
     });
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3446,23 +3446,21 @@ select.ds-input {
 .ds-summary-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 10px;
+  padding: 5px 12px;
   border-radius: var(--ds-radius-full);
-  border: 1px solid rgba(99, 102, 241, 0.3);
-  background: rgba(99, 102, 241, 0.07);
-  color: #6366f1;
-  font-size: 0.72rem;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #334155;
+  font-size: 0.74rem;
   font-weight: 600;
   cursor: pointer;
   font-family: inherit;
-  transition: background 0.15s ease, border-color 0.15s ease;
   white-space: nowrap;
 }
 
 .ds-summary-btn:hover {
-  background: rgba(99, 102, 241, 0.14);
-  border-color: rgba(99, 102, 241, 0.5);
+  background: #f8fafc;
+  border-color: #94a3b8;
 }
 
 .ds-summary-btn:disabled {
@@ -3471,50 +3469,70 @@ select.ds-input {
 }
 
 .ds-summary-panel {
-  margin-top: 10px;
-  padding: 12px 14px;
-  background: linear-gradient(135deg, rgba(237,233,254,0.6) 0%, rgba(224,231,255,0.5) 100%);
-  border: 1px solid rgba(99,102,241,0.2);
-  border-radius: var(--ds-radius-md);
-  animation: ds-summary-fadein 0.25s ease;
-}
-
-.ds-summary-panel__content {
-  font-size: 0.84rem;
-  line-height: 1.65;
-  color: var(--ds-text-secondary);
+  margin-top: 12px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  padding: 16px 18px;
   direction: rtl;
   text-align: right;
 }
 
-.ds-summary-panel__footer {
-  margin-top: 8px;
+.ds-summary-panel__content {
+  font-size: 0.88rem;
+  line-height: 1.85;
+  color: #334155;
+}
+
+.ds-summary-panel__title {
+  margin: 0 0 10px;
+  font-size: 1.02rem;
+  line-height: 1.45;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.ds-summary-panel__text {
+  margin: 0;
+  color: #334155;
+}
+
+.ds-summary-panel__structured {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.ds-summary-refresh {
-  font-size: 0.68rem;
-  color: #94a3b8;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-family: inherit;
+.ds-summary-panel__block {
+  border-radius: 10px;
+  padding: 10px 12px;
 }
 
-.ds-summary-refresh:hover {
-  color: #6366f1;
+.ds-summary-panel__block--exceptions {
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
 }
 
-.ds-summary-loading {
-  font-size: 0.8rem;
-  color: #6366f1;
-  font-style: italic;
+.ds-summary-panel__block--short-activities {
+  background: #ecfeff;
+  border: 1px solid #bae6fd;
 }
 
-@keyframes ds-summary-fadein {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+.ds-summary-panel__inner-title {
+  margin: 0 0 6px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #1e293b;
+}
+
+.ds-summary-panel__list {
+  margin: 8px 0 0;
+  padding-right: 18px;
+}
+
+.ds-summary-panel__list li {
+  margin: 3px 0;
 }
 
 .ds-page-shortcuts {


### PR DESCRIPTION
### Motivation
- להסיר שימוש בסיכום מבוסס‑AI וקריאות חיצוניות ולהבטיח סיכום מיידי, קבוע ומבוסס על נתוני ה‑dashboard שהיטענו כבר למסך. 
- לדאוג לעיצוב מקצועי וניהולי לפאנל הסיכום עם טקסט קבוע ושיבוץ ערכים מדויקים מתוך ה‑payload הנוכחי. 

### Description
- הוסר כל קוד הכתוב ליצירת prompt ולקריאה ל‑Anthropic/Claude כולל `buildNationalPrompt`, `buildManagerPrompt` ו־`fetchSummary`, והחלפת כפתור/פאנל הסיכום כדי להפיק תוכן מקומי מידי בלבד (כל השינויים ב`frontend/src/screens/dashboard.js`).
- יישמתי רנדר קבוע ומובנה `renderStructuredSummary` שמטמיע במדויק את הטקסט הקבוע בעברית ומכניס את הערכים מהמוצר (`summary`) במקום המתאים, כולל בלוק "חריגות החודש" ובלוק "פעילויות חד-יומיות בחודש זה" המוצג רק כשיש נתונים (שינויים ב`frontend/src/screens/dashboard.js`).
- הוספתי שדות מינימליים ל‑dashboard response בצד השרת תחת `summary` כדי לספק את הערכים הנדרשים (ללא יצירת route חדש וללא שינויים לוגיים אחרים), כולל ספירת קורסים פעילים נוכחיים/לחל ושדות חריגות ופירוט פעילויות חד‑יומיות (שינויים ב`backend/actions.gs`).
- עדכנתי את העיצוב של פאנל הסיכום ל״כרטיס ניהולי״ נקי עם גבול עדין, פינות מעוגלות, צל רך, יישור RTL, טיפוגרפיה ברורה והבלטת כותרות/מספרים (שינויים ב`frontend/src/styles/main.css`).

### Testing
- הרצת המבחנים האוטומטיים עם `npm test` הסתיימה בהצלחה (כל ה‑19 הבדיקות עברו, `TAP` passthrough). 
- בדקתי שהכפתור "סיכום" בפאנל נפתח ומציג את ה־HTML המבנה מהמייל־payload ללא קריאות רשת נוספות בהפעלה מקומית של מסך הדשבורד.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f9577a08832baad32069ebdcd6d7)