### PR TITLE
Activity drawer: separate view and edit UI by default

### DIFF
--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -111,7 +111,7 @@ function fieldViewEdit(label, viewHtml, editHtml) {
     <div class="activity-drawer__field">
       <div class="activity-drawer__label">${escapeHtml(label)}</div>
       <div class="activity-drawer__view" data-mode="view">${viewHtml}</div>
-      <div class="activity-drawer__edit" data-mode="edit">${editHtml}</div>
+      <div class="activity-drawer__edit" data-mode="edit" hidden>${editHtml}</div>
     </div>
   `;
 }
@@ -220,7 +220,7 @@ function blockContent(row, { settings = {} } = {}) {
         ${fieldViewOnly('שעות', escapeHtml(hoursLabel))}
         ${fieldViewOnly('יום', escapeHtml(dayLabel))}
       </div>
-      <div class="activity-drawer__edit-grid activity-drawer__grid activity-drawer__grid--two" data-mode="edit">
+      <div class="activity-drawer__edit-grid activity-drawer__grid activity-drawer__grid--two" data-mode="edit" hidden>
         <div class="activity-drawer__field activity-drawer__field--full">
           <div class="activity-drawer__label">${escapeHtml(nameLabel)}</div>
           ${activityNameSelectHtml('activity_name', row.activity_name, allActivityNames, activityType)}
@@ -302,14 +302,14 @@ function blockDates(row, { canEdit = false } = {}) {
   const chainToggle = isOnce
     ? ''
     : `
-      <div class="activity-drawer__date-mode" data-mode="edit" data-chain-toggle>
+      <div class="activity-drawer__date-mode" data-mode="edit" data-chain-toggle hidden>
         <button type="button" class="activity-drawer__toggle" data-date-mode="single">בודד</button>
         <button type="button" class="activity-drawer__toggle is-active" data-date-mode="chain">שרשרת</button>
       </div>
     `;
   const addMeetingBtn = isOnce
     ? ''
-    : `<button type="button" class="activity-drawer__action activity-drawer__action--ghost" data-action="add-meeting" data-mode="edit">➕ הוסף מפגש</button>`;
+    : `<button type="button" class="activity-drawer__action activity-drawer__action--ghost" data-action="add-meeting" data-mode="edit" hidden>➕ הוסף מפגש</button>`;
   const moreBtn = !isOnce && schedule.length > 6
     ? `<div data-mode="view"><button type="button" class="activity-drawer__more" data-action="toggle-more">+עוד</button></div>`
     : '';
@@ -336,12 +336,12 @@ function blockDates(row, { canEdit = false } = {}) {
         ${viewChips}
       </div>
       ${moreBtn}
-      <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit>
+      <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit hidden>
         ${datePickers}
       </div>
       ${chainToggle}
       ${addMeetingBtn}
-      <div class="activity-drawer__edit-actions" data-mode="edit">
+      <div class="activity-drawer__edit-actions" data-mode="edit" hidden>
         <button type="button" class="activity-drawer__action activity-drawer__action--primary" data-action="save-edit">שמור</button>
         <button type="button" class="activity-drawer__action" data-action="cancel-edit">ביטול</button>
         <p class="ds-activity-edit-status ds-muted" role="status"></p>
@@ -384,7 +384,7 @@ function singleForm(row, { settings = {}, privateNote = null, canEdit = false, s
   const computedEnd = autoEndDate(row);
   const activityType = String(row.activity_type || '').trim();
   return `
-    <form class="activity-drawer__form" data-drawer-form
+    <form class="activity-drawer__form" data-drawer-form data-editing="no"
       data-source-sheet="${escapeHtml(String(row.source_sheet || ''))}"
       data-row-id="${escapeHtml(String(row.RowID || ''))}"
       data-auto-end-date="${escapeHtml(computedEnd)}"

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -5989,6 +5989,11 @@ select.ds-input {
   min-height: 1.2em;
 }
 
+/* Until JS runs, keep edit UI out of layout (HTML also sets hidden on edit blocks) */
+.activity-drawer__form[data-editing="no"] [data-mode="edit"] {
+  display: none !important;
+}
+
 .activity-drawer__view-grid .activity-drawer__field {
   margin: 0;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The activity side drawer briefly showed both read-only fields and edit controls before `bindActivityEditForm` initialized `setEditMode`. This change makes edit blocks hidden in the server-rendered HTML and adds a CSS guard so only one mode is visible until the user clicks edit.

## Changes

- Mark all `data-mode="edit"` regions with `hidden` in `activity-detail-html.js`.
- Set `data-editing="no"` on the drawer form by default.
- Add `.activity-drawer__form[data-editing="no"] [data-mode="edit"] { display: none !important; }` as a fallback until JavaScript runs.

## Testing

- `npm install && npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

