### PR TITLE
chore: update default Google Apps Script API URL

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbzYDpEr09ArxaY5it5DR99MTZqD9ak9GjOSG7-jHFihxtJoaLBOtbP3lpZqii5pvRDF/exec';
+  'https://script.google.com/macros/s/AKfycbyn82P3Zfz0W6L7wcIRuS6pBwUuM1vHmZAxwr8IC31h1sNxtC7hCaAsYnsnBN1E3GSE/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `DEFAULT_API_URL` in `frontend/src/config.js` to the new Web App deployment.

Runtime override order is unchanged: `window.__DASHBOARD_CONFIG__.apiUrl`, then `?apiUrl=`, then this default.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

