### PR TITLE
Activity edit: status options + instructor/manager list from permissions

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -1499,6 +1499,10 @@ function actionSaveActivity_(user, payload) {
   Object.keys(datePatch).forEach(function(k) {
     changes[k] = datePatch[k];
   });
+  if (Object.prototype.hasOwnProperty.call(changes, 'status')) {
+    var rawStatus = text_(changes.status).toLowerCase();
+    changes.status = (rawStatus === 'closed' || rawStatus === 'סגור') ? 'סגור' : 'פעיל';
+  }
   if (!effectiveCanEditDirect_(permission, user.display_role)) {
     return actionSubmitEditRequest_(user, {
       source_sheet: sourceSheet,
@@ -2524,8 +2528,36 @@ function buildDropdownOptionsMapFromRows_(rows) {
   return out;
 }
 
+function instructorNamesFromPermissions_() {
+  var rows = readRows_(CONFIG.SHEETS.PERMISSIONS);
+  var out = [];
+  var seen = {};
+  rows.forEach(function(row) {
+    if (yesNo_(row.active) === 'no') return;
+    var role = '';
+    try {
+      role = normalizeRole_(internalRoleFromPermissionRow_(row));
+    } catch (_e) {
+      role = '';
+    }
+    if (role !== 'instructor') return;
+    var name = text_(row.full_name || row.user_id);
+    if (!name || seen[name]) return;
+    seen[name] = true;
+    out.push(name);
+  });
+  return out;
+}
+
 function buildDropdownOptionsMap_() {
-  return buildDropdownOptionsMapFromRows_(readRows_(configuredDropdownSourceSheet_()));
+  var out = buildDropdownOptionsMapFromRows_(readRows_(configuredDropdownSourceSheet_()));
+  var instructors = instructorNamesFromPermissions_();
+  if (instructors.length) {
+    out.instructor_name = instructors.slice();
+    // Product rule: activity manager uses the same instructor list from permissions.
+    out.activity_manager = instructors.slice();
+  }
+  return out;
 }
 
 function buildClientSettingsPayload_() {

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -397,9 +397,6 @@ function blockDates(row, { canEdit = false } = {}) {
   const addMeetingBtn = isOnce
     ? ''
     : `<button type="button" class="activity-drawer__action activity-drawer__action--ghost" data-action="add-meeting" data-mode="edit" hidden>➕ הוסף מפגש</button>`;
-  const moreBtn = !isOnce && schedule.length > 6
-    ? `<div data-mode="view"><button type="button" class="activity-drawer__more" data-action="toggle-more">+עוד</button></div>`
-    : '';
   return `
     <section class="activity-drawer__section">
       <div class="activity-drawer__section-head">
@@ -422,7 +419,6 @@ function blockDates(row, { canEdit = false } = {}) {
       <div class="activity-drawer__dates activity-drawer__dates--view" data-mode="view">
         ${viewChips}
       </div>
-      ${moreBtn}
       <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit hidden>
         ${datePickers}
       </div>

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -32,7 +32,9 @@ function fallback(v) {
 }
 
 function normStatus(v) {
-  return String(v || '').trim().toLowerCase() === 'closed' ? 'closed' : 'open';
+  const raw = String(v || '').trim().toLowerCase();
+  if (raw === 'closed' || raw === 'סגור') return 'closed';
+  return 'open';
 }
 
 function statusText(status) {
@@ -197,8 +199,14 @@ function headerHtml(row, { mode = 'single', summaryDate = '' } = {}) {
 
 function blockPeople(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
-  const managers = toOptions(options.activity_manager);
-  const instructors = toOptions(options.instructor_name);
+  const roleBasedPeople = mergeListStrings(options, [
+    'instructor_name',
+    'instructor_names',
+    'activity_manager',
+    'activity_managers'
+  ]);
+  const managers = roleBasedPeople.length ? roleBasedPeople : toOptions(options.activity_manager);
+  const instructors = roleBasedPeople.length ? roleBasedPeople : toOptions(options.instructor_name);
   const activityType = String(row.activity_type || '').trim();
   const twoInstructors = activityType === 'workshop';
   const instructorFields = twoInstructors
@@ -257,10 +265,16 @@ function blockContent(row, { settings = {} } = {}) {
       ? `${String(row.start_time).trim()}-${String(row.end_time).trim()}`
       : '—';
   const dayLabel = fmtWeekdayShort(firstMeetingDate);
+  const statusOptions = [
+    { value: 'פעיל', label: 'פעיל' },
+    { value: 'סגור', label: 'סגור' }
+  ];
+  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : 'פעיל';
   return `
     <section class="activity-drawer__section">
       <h3 class="activity-drawer__section-title">📚</h3>
       <div class="activity-drawer__view-grid activity-drawer__grid activity-drawer__grid--two" data-mode="view">
+        ${fieldViewOnly('סטטוס', escapeHtml(statusText(row.status)))}
         ${fieldViewOnly('מימון', escapeHtml(fallback(row.funding)))}
         ${fieldViewOnly('כיתה', escapeHtml(classLabel))}
         ${fieldViewOnly('שעות', escapeHtml(hoursLabel))}
@@ -278,6 +292,15 @@ function blockContent(row, { settings = {} } = {}) {
               ? selectHtml({ name: 'funding', value: row.funding, options: fundings })
               : inputHtml({ name: 'funding', value: row.funding })
           }
+        </div>
+        <div class="activity-drawer__field">
+          <div class="activity-drawer__label">סטטוס</div>
+          ${selectHtml({
+            name: 'status',
+            value: normalizedStatus,
+            options: statusOptions.map((o) => o.value),
+            placeholder: 'פעיל'
+          })}
         </div>
         <div class="activity-drawer__field">
           <div class="activity-drawer__label">מחיר</div>

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -12,7 +12,7 @@ function setEditMode(form, editing) {
   form.querySelectorAll('[data-edit-actions]').forEach((el) => el.toggleAttribute('hidden', !editing));
   const editBtn = form.querySelector('[data-action="start-edit"]');
   if (editBtn) editBtn.toggleAttribute('hidden', editing);
-  updateMoreDatesToggle(form);
+  syncMeetingRemoveButtons(form);
 }
 
 function setStatus(statusEl, kind, text) {
@@ -138,23 +138,7 @@ function reindexMeetingDateCards(form) {
 }
 
 function updateMoreDatesToggle(form) {
-  const isEditing = form.dataset.editing === 'yes';
-  const isOnce = form.dataset.isOnce === 'yes';
-  const viewCards = Array.from(form.querySelectorAll('[data-date-card]'));
   const editCards = Array.from(form.querySelectorAll('[data-meeting-dates-edit] .activity-drawer__date-card'));
-  const overflow = Math.max(0, viewCards.length - 6);
-
-  const buttons = Array.from(form.querySelectorAll('[data-action="toggle-more"]'));
-  buttons.forEach((button) => {
-    button.hidden = isEditing || isOnce || overflow === 0;
-    if (!button.hidden) {
-      button.textContent = form.dataset.datesExpanded === 'yes' ? 'פחות ▲' : `+${overflow} עוד ▾`;
-    }
-  });
-
-  viewCards.forEach((card, idx) => {
-    card.hidden = form.dataset.datesExpanded === 'yes' ? false : idx >= 6;
-  });
 
   editCards.forEach((card) => {
     card.hidden = false;
@@ -223,7 +207,6 @@ export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, r
 
       if (ev.target.closest('[data-action="cancel-edit"]')) {
         form.reset();
-        form.dataset.datesExpanded = 'no';
         setStatus(form.querySelector('.ds-activity-edit-status'), '', '');
         updateMeetingWeekdays(form);
         updateMoreDatesToggle(form);
@@ -280,17 +263,12 @@ export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, r
         return;
       }
 
-      if (ev.target.closest('[data-action="toggle-more"]')) {
-        form.dataset.datesExpanded = form.dataset.datesExpanded === 'yes' ? 'no' : 'yes';
-        updateMoreDatesToggle(form);
-      }
     },
     { signal }
   );
 
   contentRoot.querySelectorAll('[data-drawer-form]').forEach((form) => {
     setEditMode(form, false);
-    form.dataset.datesExpanded = 'no';
     reindexMeetingDateCards(form);
     updateMeetingWeekdays(form);
     updateMoreDatesToggle(form);

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -6186,18 +6186,6 @@ select.ds-input {
   color: #6366f1;
 }
 
-.activity-drawer__more {
-  margin-top: 6px;
-  background: transparent;
-  border: 1px dashed #c7d2e0;
-  border-radius: 8px;
-  padding: 3px 10px;
-  font-size: 0.72rem;
-  color: #6366f1;
-  font-weight: 600;
-  cursor: pointer;
-}
-
 .activity-drawer__edit-actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Activity edit drawer improvements:

1. **Status edit options** are now only `פעיל` / `סגור`.
2. **Instructor + Activity Manager** dropdowns use one shared list from active `permissions` rows where `display_role` is `instructor`.
3. **Removed non-functional date expand toggle** (`+עוד`) from the drawer date section:
   - button removed from HTML
   - `datesExpanded` / `toggle-more` logic removed from binder
   - all view date chips are shown directly

## Backend

- `buildDropdownOptions_` now injects role-based people list from permissions.
- `actionSaveActivity_` normalizes saved status to `פעיל` / `סגור`.

## Testing

- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

