### PR TITLE
Add dashboard snapshot caching layer for improved performance

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -23,3 +23,11 @@ function keepWarm() {
     // warmup only — intentionally ignored
   }
 }
+
+/**
+ * Time-driven trigger entrypoint for rebuilding dashboard snapshots.
+ * Set up as a separate trigger — do not add snapshot logic inside keepWarm.
+ */
+function refreshDashboardSnapshotsTrigger() {
+  refreshDashboardSnapshots_();
+}

--- a/backend/config.gs
+++ b/backend/config.gs
@@ -20,7 +20,10 @@ const CONFIG = {
     CONTACTS_INSTRUCTORS: 'contacts_instructors',
     SCHOOLS: 'contacts_schools',
     EDIT_REQUESTS: 'edit_requests',
-    PRIVATE_NOTES: 'operations_private_notes'
+    PRIVATE_NOTES: 'operations_private_notes',
+    DASHBOARD_SUMMARY_SNAPSHOT: 'dashboard_summary_snapshot',
+    DASHBOARD_BY_MANAGER_SNAPSHOT: 'dashboard_by_manager_snapshot',
+    DASHBOARD_REFRESH_CONTROL: 'dashboard_refresh_control'
   },
   /** ברירת מחדל כשגיליון lists ריק או חסר — מיושר ל־lists במקור הנתונים */
   DEFAULT_PROGRAM_ACTIVITY_TYPES: ['course', 'after_school'],

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -1,0 +1,383 @@
+/**
+ * dashboard-snapshot.gs
+ *
+ * קריאה וכתיבה של snapshots קלים ללוח הבקרה.
+ * לא משנה לוגיקה עסקית — actionDashboard_ הוא מקור האמת.
+ * Snapshot הוא שכבת cache/write-through בלבד.
+ *
+ * גיליונות: dashboard_summary_snapshot, dashboard_by_manager_snapshot,
+ *            dashboard_refresh_control
+ */
+
+var SNAPSHOT_ADMIN_USER_ = { user_id: 'snapshot_refresh', display_role: 'admin' };
+
+var SUMMARY_SNAPSHOT_HEADERS_ = [
+  'month_ym', 'month_label', 'updated_at',
+  'total_short_activities', 'total_long_activities',
+  'active_courses_current_month', 'active_workshops_current_month',
+  'active_tours_current_month', 'active_after_school_current_month',
+  'active_escape_room_current_month',
+  'finance_open_count', 'exceptions_count', 'active_instructors_count',
+  'course_endings_current_month', 'active_courses_next_month',
+  'missing_instructor_count', 'missing_start_date_count', 'late_end_date_count',
+  'north_active_instructors_names', 'south_active_instructors_names'
+];
+
+var BY_MANAGER_SNAPSHOT_HEADERS_ = [
+  'month_ym', 'activity_manager', 'manager_display_name',
+  'total_short', 'total_long', 'total', 'num_instructors',
+  'course_endings', 'finance_open', 'exceptions',
+  'active_instructors_names', 'updated_at'
+];
+
+var REFRESH_CONTROL_HEADERS_ = ['key', 'value', 'label_he'];
+
+var SNAPSHOT_MANAGER_DISPLAY_NAMES_ = {
+  'גיל נאמן':          'מחוז צפון',
+  'לינוי שמואל מזרחי': 'מחוז דרום'
+};
+
+// ─── header helpers ───────────────────────────────────────────────────────────
+
+function ensureSnapshotSheetHeaders_(sheetName, requiredHeaders) {
+  var ss = getSpreadsheet_();
+  var sheet = ss.getSheetByName(sheetName);
+  if (!sheet) return false;
+
+  var lastCol = sheet.getLastColumn();
+  var existingHeaders = [];
+  if (lastCol > 0) {
+    existingHeaders = sheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
+  }
+
+  var nonEmpty = existingHeaders.filter(Boolean);
+  var missingHeaders = requiredHeaders.filter(function(h) {
+    return nonEmpty.indexOf(h) < 0;
+  });
+  if (missingHeaders.length === 0) return true;
+
+  if (nonEmpty.length === 0) {
+    sheet.getRange(CONFIG.HEADER_ROW, 1, 1, requiredHeaders.length).setValues([requiredHeaders]);
+  } else {
+    var nextCol = nonEmpty.length + 1;
+    missingHeaders.forEach(function(h, i) {
+      sheet.getRange(CONFIG.HEADER_ROW, nextCol + i).setValue(h);
+    });
+  }
+
+  if (__rqCache_) {
+    if (__rqCache_.headers) delete __rqCache_.headers[sheetName];
+    if (__rqCache_.readRows) delete __rqCache_.readRows[sheetName];
+    if (__rqCache_.sheetMeta) delete __rqCache_.sheetMeta[sheetName];
+    if (__rqCache_.sheetByName) delete __rqCache_.sheetByName[sheetName];
+  }
+  return true;
+}
+
+// ─── A. actionDashboardSnapshot_ ─────────────────────────────────────────────
+
+function actionDashboardSnapshot_(user, payload) {
+  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+
+  var permission = getPermissionRow_(user.user_id);
+  var canViewFinance = user.display_role === 'admin' ||
+    yesNo_(permission.view_finance) === 'yes';
+
+  var ym = dashboardPayloadYm_(payload || {});
+
+  var snap = null;
+  var byManagerRows = [];
+
+  var ss = getSpreadsheet_();
+
+  if (ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT)) {
+    var summaryRows = readRows_(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT);
+    snap = summaryRows.find(function(r) { return text_(r.month_ym) === ym; }) || null;
+  }
+
+  if (ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT)) {
+    var allByMgr = readRows_(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT);
+    byManagerRows = allByMgr.filter(function(r) { return text_(r.month_ym) === ym; });
+  }
+
+  var s = snap || {};
+
+  var totalShort     = parseInt(text_(s.total_short_activities),   10) || 0;
+  var totalLong      = parseInt(text_(s.total_long_activities),    10) || 0;
+  var totalInstr     = parseInt(text_(s.active_instructors_count), 10) || 0;
+  var courseEndings  = parseInt(text_(s.course_endings_current_month), 10) || 0;
+  var financeOpen    = parseInt(text_(s.finance_open_count),       10) || 0;
+  var exceptCount    = parseInt(text_(s.exceptions_count),         10) || 0;
+  var activeCurrent  = parseInt(text_(s.active_courses_current_month), 10) || 0;
+  var activeNext     = parseInt(text_(s.active_courses_next_month), 10) || 0;
+  var missingInstr   = parseInt(text_(s.missing_instructor_count), 10) || 0;
+  var missingDate    = parseInt(text_(s.missing_start_date_count), 10) || 0;
+  var lateEnd        = parseInt(text_(s.late_end_date_count),      10) || 0;
+
+  var northStr = text_(s.north_active_instructors_names);
+  var southStr = text_(s.south_active_instructors_names);
+  var northArr = northStr
+    ? northStr.split(',').map(function(n) { return n.trim(); }).filter(Boolean)
+    : [];
+  var southArr = southStr
+    ? southStr.split(',').map(function(n) { return n.trim(); }).filter(Boolean)
+    : [];
+
+  var byActivityManager = byManagerRows.map(function(r) {
+    var row = {
+      activity_manager: text_(r.activity_manager),
+      total_short:     parseInt(text_(r.total_short),    10) || 0,
+      total_long:      parseInt(text_(r.total_long),     10) || 0,
+      total:           parseInt(text_(r.total),          10) || 0,
+      num_instructors: parseInt(text_(r.num_instructors),10) || 0,
+      course_endings:  parseInt(text_(r.course_endings), 10) || 0,
+      exceptions:      parseInt(text_(r.exceptions),     10) || 0
+    };
+    if (canViewFinance) {
+      row.finance_open = parseInt(text_(r.finance_open), 10) || 0;
+    }
+    return row;
+  });
+
+  var snapshotData = {
+    total_short_activities:    totalShort,
+    total_long_activities:     totalLong,
+    active_instructors_count:  totalInstr,
+    course_endings_current_month: courseEndings,
+    finance_open_count:        canViewFinance ? financeOpen : 0,
+    exceptions_count:          exceptCount,
+    active_courses_current_month: activeCurrent,
+    active_courses_next_month: activeNext,
+    missing_instructor_count:  missingInstr,
+    missing_start_date_count:  missingDate,
+    late_end_date_count:       lateEnd
+  };
+
+  var kpiCards = buildDashboardSnapshotKpis_(snapshotData, canViewFinance);
+
+  return {
+    month: ym,
+    can_view_finance: canViewFinance,
+    totals: {
+      total_short_activities:           totalShort,
+      total_long_activities:            totalLong,
+      total_instructors:                totalInstr,
+      total_course_endings_current_month: courseEndings,
+      short: totalShort,
+      long:  totalLong
+    },
+    by_activity_manager: byActivityManager,
+    summary: {
+      active_courses_current_month: activeCurrent,
+      ending_courses_current_month: courseEndings,
+      active_courses_next_month:    activeNext,
+      active_instructors:           northArr.concat(southArr),
+      active_instructors_by_manager: {
+        'מחוז צפון': northArr,
+        'מחוז דרום': southArr
+      },
+      missing_instructor_count:  missingInstr,
+      missing_start_date_count:  missingDate,
+      late_end_date_count:       lateEnd,
+      short_activities:          []
+    },
+    kpi_cards: kpiCards,
+    show_only_nonzero_kpis: settingYes_('show_only_nonzero_kpis'),
+    _is_snapshot: true
+  };
+}
+
+// ─── B. buildDashboardSnapshotKpis_ ──────────────────────────────────────────
+
+function buildDashboardSnapshotKpis_(snapshot, canViewFinance) {
+  var cards = [
+    {
+      id: 'short', action: 'kpi|short',
+      title: String(snapshot.total_short_activities || 0),
+      subtitle: 'חד-יומי',
+      value: snapshot.total_short_activities || 0
+    },
+    {
+      id: 'long', action: 'kpi|long',
+      title: String(snapshot.total_long_activities || 0),
+      subtitle: 'תוכניות',
+      value: snapshot.total_long_activities || 0
+    },
+    {
+      id: 'instructors', action: 'kpi|instructors',
+      title: String(snapshot.active_instructors_count || 0),
+      subtitle: 'מדריכים פעילים',
+      value: snapshot.active_instructors_count || 0
+    },
+    {
+      id: 'endings', action: 'kpi|endings',
+      title: String(snapshot.course_endings_current_month || 0),
+      subtitle: 'סיומי קורסים',
+      value: snapshot.course_endings_current_month || 0
+    },
+    {
+      id: 'exceptions', action: 'kpi|exceptions',
+      title: String(snapshot.exceptions_count || 0),
+      subtitle: 'חריגות (קורסים)',
+      value: snapshot.exceptions_count || 0
+    }
+  ];
+
+  if (canViewFinance) {
+    cards.push({
+      id: 'finance_open', action: 'kpi|finance_open',
+      title: String(snapshot.finance_open_count || 0),
+      subtitle: 'כספים פתוחים',
+      value: snapshot.finance_open_count || 0,
+      requires_finance: true
+    });
+  }
+
+  return cards;
+}
+
+// ─── C. refreshDashboardSnapshots_ ───────────────────────────────────────────
+
+function refreshDashboardSnapshots_() {
+  var hadCache = !!__rqCache_;
+  if (!hadCache) {
+    beginRequestCache_();
+  }
+
+  try {
+    var today = formatDate_(new Date());
+    var currentYm = today.slice(0, 7);
+    var months = [shiftYm_(currentYm, -1), currentYm, shiftYm_(currentYm, 1)];
+    var errors = [];
+
+    months.forEach(function(ym) {
+      try {
+        var fullData = actionDashboard_(SNAPSHOT_ADMIN_USER_, { month: ym });
+        writeDashboardSummarySnapshotRow_(ym, fullData);
+        replaceDashboardByManagerSnapshotRows_(ym, fullData);
+      } catch (e) {
+        errors.push(ym + ': ' + (e && e.message ? e.message : String(e)));
+      }
+    });
+
+    var status  = errors.length === 0 ? 'ok' : 'partial';
+    var message = errors.length === 0 ? 'all months updated' : errors.join('; ');
+    updateDashboardRefreshControl_(status, message);
+  } finally {
+    if (!hadCache) {
+      __rqCache_ = null;
+    }
+  }
+}
+
+// ─── D. writeDashboardSummarySnapshotRow_ ────────────────────────────────────
+
+function writeDashboardSummarySnapshotRow_(ym, fullData) {
+  var sheetName = CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT;
+  ensureSnapshotSheetHeaders_(sheetName, SUMMARY_SNAPSHOT_HEADERS_);
+
+  var summary = fullData.summary || {};
+  var totals  = fullData.totals  || {};
+
+  // Extract north/south instructor names from summary if available
+  var byMgrNames = summary.active_instructors_by_manager || {};
+  var northNames = (byMgrNames['מחוז צפון'] || byMgrNames['גיל נאמן'] || []).join(', ');
+  var southNames = (byMgrNames['מחוז דרום'] || byMgrNames['לינוי שמואל מזרחי'] || []).join(', ');
+
+  // Fall back to active_instructors list if per-manager names are absent
+  if (!northNames && !southNames && Array.isArray(summary.active_instructors)) {
+    northNames = summary.active_instructors.join(', ');
+  }
+
+  // Extract per-type activity counts from kpi_cards when available
+  var kpiAll = Array.isArray(fullData.kpi_cards) ? fullData.kpi_cards : [];
+  var counts = {};
+  kpiAll.forEach(function(card) { counts[card.id] = card.value || 0; });
+
+  var financeOpen = canViewFinanceFromKpis_(kpiAll, fullData);
+  var exceptions  = counts['exceptions'] || 0;
+
+  var rowObj = {
+    month_ym:                          ym,
+    month_label:                       ym,
+    updated_at:                        formatDate_(new Date()),
+    total_short_activities:            totals.total_short_activities || totals.short || 0,
+    total_long_activities:             totals.total_long_activities  || totals.long  || 0,
+    active_courses_current_month:      counts['active_courses']      || summary.active_courses_current_month || 0,
+    active_workshops_current_month:    counts['active_workshops']    || 0,
+    active_tours_current_month:        counts['active_tours']        || 0,
+    active_after_school_current_month: counts['active_after_school'] || 0,
+    active_escape_room_current_month:  counts['active_escape_room']  || 0,
+    finance_open_count:                financeOpen,
+    exceptions_count:                  exceptions,
+    active_instructors_count:          totals.total_instructors || 0,
+    course_endings_current_month:      summary.ending_courses_current_month || totals.total_course_endings_current_month || 0,
+    active_courses_next_month:         summary.active_courses_next_month || 0,
+    missing_instructor_count:          summary.missing_instructor_count  || 0,
+    missing_start_date_count:          summary.missing_start_date_count  || 0,
+    late_end_date_count:               summary.late_end_date_count       || 0,
+    north_active_instructors_names:    northNames,
+    south_active_instructors_names:    southNames
+  };
+
+  upsertRowByKey_(sheetName, 'month_ym', rowObj);
+}
+
+function canViewFinanceFromKpis_(kpiAll, fullData) {
+  var card = kpiAll.find(function(c) { return c.id === 'finance_open'; });
+  if (card) return card.value || 0;
+  if (fullData.can_view_finance === false) return 0;
+  var totals = fullData.totals || {};
+  return totals.finance_open || 0;
+}
+
+// ─── E. replaceDashboardByManagerSnapshotRows_ ───────────────────────────────
+
+function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
+  var sheetName = CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT;
+  ensureSnapshotSheetHeaders_(sheetName, BY_MANAGER_SNAPSHOT_HEADERS_);
+
+  deleteRowsByKey_(sheetName, 'month_ym', ym);
+
+  var byManager = Array.isArray(fullData.by_activity_manager) ? fullData.by_activity_manager : [];
+  var updatedAt = formatDate_(new Date());
+
+  byManager.forEach(function(row) {
+    var manager = text_(row.activity_manager);
+    if (!manager || manager === 'unassigned') return;
+    var displayName = SNAPSHOT_MANAGER_DISPLAY_NAMES_[manager] || manager;
+    var rowObj = {
+      month_ym:               ym,
+      activity_manager:       manager,
+      manager_display_name:   displayName,
+      total_short:            row.total_short    || 0,
+      total_long:             row.total_long     || 0,
+      total:                  row.total          || 0,
+      num_instructors:        row.num_instructors|| 0,
+      course_endings:         row.course_endings || 0,
+      finance_open:           row.finance_open   || 0,
+      exceptions:             row.exceptions     || 0,
+      active_instructors_names: text_(row.active_instructors_names) || '',
+      updated_at:             updatedAt
+    };
+    appendRow_(sheetName, rowObj);
+  });
+}
+
+// ─── F. updateDashboardRefreshControl_ ───────────────────────────────────────
+
+function updateDashboardRefreshControl_(status, message) {
+  var sheetName = CONFIG.SHEETS.DASHBOARD_REFRESH_CONTROL;
+  ensureSnapshotSheetHeaders_(sheetName, REFRESH_CONTROL_HEADERS_);
+
+  var now = new Date().toISOString();
+  var entries = [
+    { key: 'last_refresh_at', value: now,     label_he: 'עדכון אחרון' },
+    { key: 'last_status',     value: status,  label_he: 'סטטוס' },
+    { key: 'last_message',    value: message, label_he: 'הודעה' }
+  ];
+
+  entries.forEach(function(entry) {
+    upsertRowByKey_(sheetName, 'key', entry);
+  });
+}

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -23,6 +23,7 @@ function handlePost_(e) {
       login: function() { return actionLogin_(payload); },
       bootstrap: function() { return actionBootstrap_(user); },
       dashboard: function() { return actionDashboard_(user, payload); },
+      dashboardSnapshot: function() { return actionDashboardSnapshot_(user, payload); },
       activities: function() { return actionActivities_(user, payload); },
       activityDetail: function() { return actionActivityDetail_(user, payload); },
       week: function() { return actionWeek_(user, payload); },
@@ -60,6 +61,7 @@ function handlePost_(e) {
 
     var ACTION_ROUTE_MAP = {
       dashboard: 'dashboard',
+      dashboardSnapshot: 'dashboard',
       activities: 'activities',
       activityDetail: 'activities',
       week: 'week',
@@ -105,6 +107,18 @@ function handlePost_(e) {
     markRequestPerf_('action_start');
     var writeData = handlers[action]();
     markRequestPerf_('action_done');
+
+    var SNAPSHOT_INVALIDATING_ACTIONS_ = {
+      addActivity: true,
+      saveActivity: true,
+      reviewEditRequest: true,
+      saveFinanceRow: true,
+      syncFinance: true
+    };
+    if (SNAPSHOT_INVALIDATING_ACTIONS_[action]) {
+      try { updateDashboardRefreshControl_('pending', 'refresh_needed'); } catch (_e) {}
+    }
+
     return jsonResponse_({
       ok: true,
       data: writeData
@@ -128,6 +142,7 @@ function isReadActionCacheable_(action, user) {
   var map = {
     bootstrap: true,
     dashboard: true,
+    dashboardSnapshot: true,
     activities: true,
     activityDetail: true,
     week: true,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -36,6 +36,7 @@ const MUTATING_ACTIONS = {
 const READ_ACTIONS = {
   bootstrap: true,
   dashboard: true,
+  dashboardSnapshot: true,
   activities: true,
   activityDetail: true,
   week: true,
@@ -226,6 +227,7 @@ export const api = {
   login: (user_id, entry_code) => request('login', { user_id, entry_code }),
   bootstrap: () => request('bootstrap'),
   dashboard: (filters) => request('dashboard', filters || {}),
+  dashboardSnapshot: (filters) => request('dashboardSnapshot', filters || {}),
   activities: (filters) => request('activities', filters),
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
   week: (params) => request('week', params || {}),

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -125,7 +125,7 @@ export const dashboardScreen = {
       ym = currentMonthYm();
     }
     state.dashboardMonthYm = ym;
-    return api.dashboard({ month: ym });
+    return api.dashboardSnapshot({ month: ym });
   },
   render(data, { state } = {}) {
     const ym = data?.month || currentMonthYm();
@@ -266,9 +266,14 @@ export const dashboardScreen = {
         const adjKey = `dashboard:${adjYm}`;
         const hit = state.screenDataCache[adjKey];
         if (hit && Date.now() - hit.t < DASHBOARD_TTL_MS) return;
-        api.dashboard({ month: adjYm }).then((d) => {
+        api.dashboardSnapshot({ month: adjYm }).then((d) => {
           if (!state.screenDataCache[adjKey] || Date.now() - state.screenDataCache[adjKey].t > DASHBOARD_TTL_MS) {
             state.screenDataCache[adjKey] = { data: d, t: Date.now() };
+          }
+          if (d._is_snapshot) {
+            api.dashboard({ month: adjYm }).then((full) => {
+              state.screenDataCache[adjKey] = { data: full, t: Date.now() };
+            }).catch(() => {});
           }
         }).catch(() => {});
       });
@@ -287,9 +292,17 @@ export const dashboardScreen = {
 
       showDataAreaLoading();
       try {
-        const data = await api.dashboard({ month: nextYm });
-        state.screenDataCache[cacheKey] = { data, t: Date.now() };
+        const snapshotData = await api.dashboardSnapshot({ month: nextYm });
+        state.screenDataCache[cacheKey] = { data: snapshotData, t: Date.now() };
         prefetchAdjacentDashboard(nextYm);
+        if (snapshotData._is_snapshot) {
+          api.dashboard({ month: nextYm }).then((fullData) => {
+            state.screenDataCache[cacheKey] = { data: fullData, t: Date.now() };
+            if ((state.dashboardMonthYm || currentMonthYm()) === nextYm) {
+              rerender();
+            }
+          }).catch(() => {});
+        }
       } catch (_err) {
         clearScreenDataCache?.();
       }
@@ -309,6 +322,21 @@ export const dashboardScreen = {
         handleSummaryClick(target);
       });
     });
+
+    // Background full-hydration when initial render came from snapshot
+    if (data._is_snapshot) {
+      const hydrateYm = ym;
+      const hydrateCacheKey = `dashboard:${/^\d{4}-\d{2}$/.test(hydrateYm) ? hydrateYm : 'default'}`;
+      api.dashboard({ month: hydrateYm }).then((fullData) => {
+        state.screenDataCache[hydrateCacheKey] = { data: fullData, t: Date.now() };
+        if (state.route === 'dashboard' && (state.dashboardMonthYm || currentMonthYm()) === hydrateYm) {
+          rerender();
+        }
+      }).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn('[dashboard] background hydration failed, keeping snapshot', err?.message);
+      });
+    }
 
     // Pre-fetch adjacent months silently after initial render
     prefetchAdjacentDashboard(state.dashboardMonthYm || currentMonthYm());


### PR DESCRIPTION
## Summary
Introduces a lightweight snapshot caching system for the dashboard to improve performance and reduce computation overhead. The snapshot serves as a write-through cache layer that stores pre-computed dashboard data, while the full dashboard logic remains the source of truth.

## Key Changes

**Backend:**
- Added `dashboard-snapshot.gs` with snapshot read/write operations:
  - `actionDashboardSnapshot_()` - Returns cached snapshot data with permission-based finance visibility
  - `refreshDashboardSnapshots_()` - Rebuilds snapshots for current month ±1 on a scheduled trigger
  - `writeDashboardSummarySnapshotRow_()` - Stores aggregated dashboard metrics
  - `replaceDashboardByManagerSnapshotRows_()` - Maintains per-manager activity snapshots
  - `updateDashboardRefreshControl_()` - Tracks refresh status and timing

- Updated `router.gs`:
  - Added `dashboardSnapshot` action handler
  - Invalidates snapshots when data-mutating actions occur (addActivity, saveActivity, etc.)
  - Made snapshot action cacheable for read operations

- Updated `Code.gs`:
  - Added `refreshDashboardSnapshotsTrigger()` entrypoint for time-driven snapshot rebuilds

- Updated `config.gs`:
  - Added three new sheet definitions for snapshot storage

**Frontend:**
- Modified `dashboard.js`:
  - Changed initial dashboard load to use `api.dashboardSnapshot()` for faster response
  - Implemented background hydration: if snapshot is served, full dashboard data is fetched asynchronously in background
  - Added prefetching of adjacent months using snapshots with background full-data refresh
  - Gracefully falls back to snapshot if full data fetch fails

- Updated `api.js`:
  - Added `dashboardSnapshot` to READ_ACTIONS for caching eligibility

## Implementation Details

- Snapshots are stored in three dedicated sheets: summary metrics, by-manager breakdown, and refresh control metadata
- The `_is_snapshot` flag indicates when data came from cache, triggering background full-hydration
- Snapshot invalidation is automatic: mutating actions mark snapshots as pending refresh
- Time-driven trigger rebuilds snapshots for current and adjacent months to keep data fresh
- Finance data visibility is respected in snapshots based on user permissions
- Manager display names are mapped from user IDs to regional labels (North/South districts)

https://claude.ai/code/session_01U2ZpxXfpFsSx6btcwgGT9b