### PR TITLE
Activities add flow + Contacts add/edit controls + API URL update

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyn82P3Zfz0W6L7wcIRuS6pBwUuM1vHmZAxwr8IC31h1sNxtC7hCaAsYnsnBN1E3GSE/exec';
+  'https://script.google.com/macros/s/AKfycbzp-2PONYVLPzchWgr4IcEABuldObzxGkCBxCV4lMW61A5Jn_2V9QTz3RZ2yvRRYY2-/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Added add/edit controls for Contacts screen records.
- Updated default frontend API URL to the new Google Apps Script deployment.

### Contacts changes

- Added a top "➕ הוספה" button in Contacts, contextual to the active tab (instructors/schools).
- Added an edit (✎) button per instructor card and per school-contact entry.
- Added modal forms for create/edit flows for both instructor and school contacts.
- Wired frontend API calls for contact mutations.

### Backend changes for Contacts persistence

- Added `addContact` and `saveContact` actions.
- Added row-index based updates for contacts (`_row_index`) to support precise editing.
- Connected new actions in router and routed permissions through `contacts` access checks.
- Invalidated data-view cache on contact mutations so UI reflects saved sheet changes.

### API URL update

- Updated `frontend/src/config.js` `DEFAULT_API_URL` to:
  - `https://script.google.com/macros/s/AKfycbzp-2PONYVLPzchWgr4IcEABuldObzxGkCBxCV4lMW61A5Jn_2V9QTz3RZ2yvRRYY2-/exec`

## Testing

- `npm test` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

