### PR TITLE
Redesign school contacts UI cards and hierarchy

### DIFF
--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -121,30 +121,32 @@ function applySchoolSearch(rows, q) {
 }
 
 function schoolPersonHtml(row) {
-  const name = row.contact_name ? escapeHtml(String(row.contact_name)) : '—';
-  const role = row.role ? escapeHtml(String(row.role)) : '';
-  const phonePrimary = row.phone ? escapeHtml(String(row.phone)) : '';
-  const mobile = row.mobile && row.mobile !== row.phone ? escapeHtml(String(row.mobile)) : '';
+  const name = row.contact_name ? escapeHtml(String(row.contact_name)) : '';
+  const role = row.contact_role ? escapeHtml(String(row.contact_role)) : '';
+  const mobile = row.mobile ? escapeHtml(String(row.mobile)) : '';
   const email = row.email ? escapeHtml(String(row.email)) : '';
-  if (!name && !phonePrimary && !mobile && !email) return '';
+  if (!name && !role && !mobile && !email) return '';
+
+  const contactItems = [
+    mobile ? `<span class="sc-person__contact-item sc-person__contact-item--mobile" dir="ltr">${mobile}</span>` : '',
+    email ? `<span class="sc-person__contact-item sc-person__contact-item--email" dir="ltr"><span class="ci-dv">${email}</span>${copyBtn(email, 'העתק מייל')}</span>` : ''
+  ].filter(Boolean).join('<span class="sc-person__contact-sep" aria-hidden="true">•</span>');
+
   const editBtn = actionBtn('edit-school', {
     _row_index: row._row_index,
     authority: row.authority,
     school: row.school,
     contact_name: row.contact_name
   }, '✎');
-  return `<div class="sc-person">
+
+  return `<article class="sc-person">
     <div class="sc-person__top">
-      <span class="sc-person__name">${name}</span>
-      ${role ? `<span class="sc-person__role">${role}</span>` : ''}
+      ${name ? `<div class="sc-person__name">${name}</div>` : ''}
       <span class="sc-person__actions">${editBtn}</span>
     </div>
-    <div class="sc-person__phones">
-      ${phonePrimary ? `<span class="sc-person__phone"><span aria-hidden="true">☎</span>${phonePrimary}</span>` : ''}
-      ${mobile ? `<span class="sc-person__phone"><span aria-hidden="true">📱</span>${mobile}</span>` : ''}
-    </div>
-    ${email ? `<div class="sc-person__email"><span class="ci-dv">${email}</span>${copyBtn(email, 'העתק מייל')}</div>` : ''}
-  </div>`;
+    ${role ? `<div class="sc-person__role">${role}</div>` : ''}
+    ${contactItems ? `<div class="sc-person__contact-row">${contactItems}</div>` : ''}
+  </article>`;
 }
 
 function groupByAuthorityThenSchool(rows) {
@@ -179,7 +181,10 @@ function renderSchoolCard(schoolName, rows) {
       <span class="sc-card__name">${escapeHtml(schoolName)}</span>
       <span class="sc-card__count">${escapeHtml(countLabel)}</span>
     </summary>
-    <div class="sc-card__body">${personsHtml}</div>
+    <div class="sc-card__body">
+      <div class="sc-contact-section-title">אנשי קשר</div>
+      <div class="sc-contact-list">${personsHtml}</div>
+    </div>
   </details>`;
 }
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4531,60 +4531,109 @@ select.ds-input {
 }
 
 .sc-card__body {
-  padding: 10px 14px;
-  display: flex;
-  flex-direction: column;
+  padding: 12px 14px 14px;
+}
+
+.sc-contact-section-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ds-text-muted);
+  letter-spacing: 0.02em;
+  margin-bottom: 8px;
+}
+
+.sc-contact-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 8px;
 }
 
 .sc-person {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 8px 0;
-  border-bottom: 1px dashed var(--ds-border);
+  gap: 6px;
+  background: var(--ds-surface-subtle);
+  border: 1px solid var(--ds-border);
+  border-radius: 10px;
+  padding: 9px 10px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  min-width: 0;
 }
 
-.sc-person:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.sc-person__top,
-.sc-person__phones,
-.sc-person__email {
+.sc-person__top {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
-  flex-wrap: wrap;
 }
 
 .sc-person__name {
-  font-size: 0.82rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
   font-weight: 700;
   color: var(--ds-text);
+  flex: 1;
+  min-width: 0;
 }
 
 .sc-person__actions {
   margin-inline-start: auto;
+  flex-shrink: 0;
 }
 
 .sc-person__role {
-  font-size: 0.74rem;
-  color: var(--ds-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: var(--ds-text-secondary);
 }
 
-.sc-person__phone {
+.sc-person__contact-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.sc-person__contact-item {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 0.76rem;
+  gap: 6px;
+  font-size: 0.78rem;
   color: var(--ds-text-secondary);
-  direction: ltr;
+  min-width: 0;
 }
 
-.sc-person__email {
-  font-size: 0.76rem;
+.sc-person__contact-item--mobile {
+  letter-spacing: 0.01em;
+}
+
+.sc-person__contact-item--email .ci-dv {
+  overflow-wrap: anywhere;
+}
+
+.sc-person__contact-sep {
+  color: var(--ds-text-muted);
+  font-size: 0.68rem;
+}
+
+@media (max-width: 760px) {
+  .sc-school-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sc-contact-list {
+    grid-template-columns: 1fr;
+  }
+
+  .sc-person__contact-sep {
+    display: none;
+  }
+
+  .sc-person__contact-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 3px;
+  }
 }
 
 @media (max-width: 560px) {


### PR DESCRIPTION
### Motivation
- Improve readability, hierarchy and visual polish of the school contacts area so it is easy to scan (who, role, phone, email) while keeping all business logic intact. 
- Make the contacts area feel like a natural, compact subsection inside each school accordion without changing grouping, fetching, schema or permissions.

### Description
- Updated rendering in `frontend/src/screens/contacts.js` to surface only `contact_name` (primary), `contact_role` (optional), `mobile` (optional) and `email` (optional) and to avoid placeholders or fallbacks for empty fields. 
- Reworked per-contact markup to a compact mini-card (`.sc-person` / `article`) and added a subtle subsection header inside each school card (`אנשי קשר`) so contacts are visually grouped (`renderSchoolCard` now wraps contacts in `.sc-contact-list`).
- Added and adjusted styles in `frontend/src/styles/main.css` to implement the new visual language: `.sc-contact-section-title`, `.sc-contact-list`, `.sc-person`, `.sc-person__name`, `.sc-person__role`, `.sc-person__contact-row`, responsive rules for narrow screens, and subtle depth/borders/padding to match the system UI. 
- Preserved all existing business behavior: grouping, accordion behavior, filtering, sorting, fetch/data mapping, edit action and permissions were not changed.

### Testing
- Ran automated suite with `npm test`, which passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f3f31834832b82f640e5c71109a0)