### PR TITLE
Stabilize snapshot-first dashboard scaffolding and fallback

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -23,3 +23,7 @@ function keepWarm() {
     // warmup only — intentionally ignored
   }
 }
+
+function refreshDashboardSnapshots() {
+  return refreshDashboardSnapshots_();
+}

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -1,0 +1,326 @@
+var SUMMARY_SNAPSHOT_HEADERS_ = [
+  'month',
+  'can_view_finance',
+  'total_short_activities',
+  'total_long_activities',
+  'total_instructors',
+  'total_course_endings_current_month',
+  'active_courses_current_month',
+  'ending_courses_current_month',
+  'active_courses_next_month',
+  'missing_instructor_count',
+  'missing_start_date_count',
+  'late_end_date_count',
+  'active_instructors_json',
+  'short_activities_json',
+  'kpi_cards_json',
+  'show_only_nonzero_kpis',
+  'updated_at'
+];
+
+var SUMMARY_SNAPSHOT_LABELS_HE_ = [
+  'חודש',
+  'הרשאת כספים',
+  'סה״כ חד-יומי',
+  'סה״כ תוכניות',
+  'סה״כ מדריכים',
+  'סה״כ סיומי קורסים בחודש',
+  'קורסים פעילים בחודש',
+  'קורסים מסתיימים בחודש',
+  'קורסים פעילים בחודש הבא',
+  'ללא מדריך',
+  'ללא תאריך התחלה',
+  'תאריך סיום מאוחר',
+  'מדריכים פעילים (JSON)',
+  'חד-יומי לפי סוג (JSON)',
+  'כרטיסי KPI (JSON)',
+  'הצג רק KPI לא-אפס',
+  'עודכן בתאריך'
+];
+
+var BY_MANAGER_SNAPSHOT_HEADERS_ = [
+  'month',
+  'activity_manager',
+  'total_short',
+  'total_long',
+  'total',
+  'num_instructors',
+  'course_endings',
+  'finance_open',
+  'exceptions',
+  'updated_at'
+];
+
+var BY_MANAGER_SNAPSHOT_LABELS_HE_ = [
+  'חודש',
+  'מנהל פעילות',
+  'חד-יומי',
+  'תוכניות',
+  'סה״כ',
+  'מדריכים פעילים',
+  'סיומי קורסים',
+  'כספים פתוחים',
+  'חריגות',
+  'עודכן בתאריך'
+];
+
+var REFRESH_CONTROL_HEADERS_ = [
+  'key',
+  'last_refresh_at',
+  'last_status',
+  'last_message'
+];
+
+var REFRESH_CONTROL_LABELS_HE_ = [
+  'מפתח',
+  'רענון אחרון',
+  'סטטוס אחרון',
+  'הודעה אחרונה'
+];
+
+function invalidateSnapshotSheetCache_(sheetName) {
+  if (!__rqCache_ || !sheetName) return;
+  if (__rqCache_.headers) delete __rqCache_.headers[sheetName];
+  if (__rqCache_.readRows) delete __rqCache_.readRows[sheetName];
+  if (__rqCache_.sheetMeta) delete __rqCache_.sheetMeta[sheetName];
+  if (__rqCache_.sheetByName) delete __rqCache_.sheetByName[sheetName];
+}
+
+function ensureSnapshotSheetScaffold_(sheetName, englishHeaders, hebrewLabels) {
+  var sheet = getSpreadsheet_().getSheetByName(sheetName);
+  if (!sheet) return false;
+
+  sheet.getRange(CONFIG.HEADER_ROW, 1, 1, englishHeaders.length).setValues([englishHeaders]);
+
+  var labelRange = sheet.getRange(CONFIG.HEADER_ROW + 1, 1, 1, englishHeaders.length);
+  var currentLabelRow = labelRange.getValues()[0];
+  var isLabelRowEmpty = true;
+  for (var i = 0; i < currentLabelRow.length; i++) {
+    if (text_(currentLabelRow[i])) {
+      isLabelRowEmpty = false;
+      break;
+    }
+  }
+  if (isLabelRowEmpty) {
+    labelRange.setValues([hebrewLabels]);
+  }
+
+  invalidateSnapshotSheetCache_(sheetName);
+  return true;
+}
+
+function dashboardSnapshotSummarySheetName_() {
+  return CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT || 'dashboard_summary_snapshot';
+}
+
+function dashboardSnapshotByManagerSheetName_() {
+  return CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT || 'dashboard_by_manager_snapshot';
+}
+
+function dashboardSnapshotRefreshControlSheetName_() {
+  return CONFIG.SHEETS.DASHBOARD_REFRESH_CONTROL || 'dashboard_refresh_control';
+}
+
+function toJsonText_(value, fallback) {
+  try {
+    return JSON.stringify(value || fallback || []);
+  } catch (_e) {
+    return JSON.stringify(fallback || []);
+  }
+}
+
+function parseJsonText_(raw, fallback) {
+  var txt = text_(raw);
+  if (!txt) return fallback;
+  try {
+    return JSON.parse(txt);
+  } catch (_e) {
+    return fallback;
+  }
+}
+
+function intOrZero_(value) {
+  var n = parseInt(text_(value), 10);
+  return isNaN(n) ? 0 : n;
+}
+
+function boolFromCell_(value) {
+  var raw = text_(value).toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+function writeDashboardSummarySnapshotRow_(ym, dashboardData) {
+  var sheetName = dashboardSnapshotSummarySheetName_();
+  if (!ensureSnapshotSheetScaffold_(sheetName, SUMMARY_SNAPSHOT_HEADERS_, SUMMARY_SNAPSHOT_LABELS_HE_)) return false;
+  var totals = dashboardData.totals || {};
+  var summary = dashboardData.summary || {};
+  upsertRowByKey_(sheetName, 'month', {
+    month: ym,
+    can_view_finance: dashboardData.can_view_finance ? 'yes' : 'no',
+    total_short_activities: intOrZero_(totals.total_short_activities || totals.short),
+    total_long_activities: intOrZero_(totals.total_long_activities || totals.long),
+    total_instructors: intOrZero_(totals.total_instructors),
+    total_course_endings_current_month: intOrZero_(totals.total_course_endings_current_month),
+    active_courses_current_month: intOrZero_(summary.active_courses_current_month),
+    ending_courses_current_month: intOrZero_(summary.ending_courses_current_month),
+    active_courses_next_month: intOrZero_(summary.active_courses_next_month),
+    missing_instructor_count: intOrZero_(summary.missing_instructor_count),
+    missing_start_date_count: intOrZero_(summary.missing_start_date_count),
+    late_end_date_count: intOrZero_(summary.late_end_date_count),
+    active_instructors_json: toJsonText_(summary.active_instructors, []),
+    short_activities_json: toJsonText_(summary.short_activities, []),
+    kpi_cards_json: toJsonText_(dashboardData.kpi_cards, []),
+    show_only_nonzero_kpis: dashboardData.show_only_nonzero_kpis ? 'yes' : 'no',
+    updated_at: formatDate_(new Date())
+  });
+  return true;
+}
+
+function replaceDashboardByManagerSnapshotRows_(ym, byManagerRows) {
+  var sheetName = dashboardSnapshotByManagerSheetName_();
+  if (!ensureSnapshotSheetScaffold_(sheetName, BY_MANAGER_SNAPSHOT_HEADERS_, BY_MANAGER_SNAPSHOT_LABELS_HE_)) return false;
+  deleteRowsByKey_(sheetName, 'month', ym);
+  (byManagerRows || []).forEach(function(row) {
+    appendRow_(sheetName, {
+      month: ym,
+      activity_manager: text_(row.activity_manager),
+      total_short: intOrZero_(row.total_short),
+      total_long: intOrZero_(row.total_long),
+      total: intOrZero_(row.total),
+      num_instructors: intOrZero_(row.num_instructors),
+      course_endings: intOrZero_(row.course_endings),
+      finance_open: intOrZero_(row.finance_open),
+      exceptions: intOrZero_(row.exceptions),
+      updated_at: formatDate_(new Date())
+    });
+  });
+  return true;
+}
+
+function updateDashboardRefreshControl_(status, message) {
+  var sheetName = dashboardSnapshotRefreshControlSheetName_();
+  if (!ensureSnapshotSheetScaffold_(sheetName, REFRESH_CONTROL_HEADERS_, REFRESH_CONTROL_LABELS_HE_)) return false;
+  upsertRowByKey_(sheetName, 'key', {
+    key: 'dashboard',
+    last_refresh_at: formatDate_(new Date()),
+    last_status: text_(status),
+    last_message: text_(message)
+  });
+  return true;
+}
+
+function readDashboardSummarySnapshotRow_(ym) {
+  var sheetName = dashboardSnapshotSummarySheetName_();
+  var sheet = getSpreadsheet_().getSheetByName(sheetName);
+  if (!sheet) return null;
+  var rows = readRows_(sheetName);
+  var hit = rows.find(function(row) { return text_(row.month) === text_(ym); });
+  return hit || null;
+}
+
+function readDashboardByManagerSnapshotRows_(ym) {
+  var sheetName = dashboardSnapshotByManagerSheetName_();
+  var sheet = getSpreadsheet_().getSheetByName(sheetName);
+  if (!sheet) return null;
+  return readRows_(sheetName).filter(function(row) {
+    return text_(row.month) === text_(ym);
+  }).map(function(row) {
+    return {
+      activity_manager: text_(row.activity_manager),
+      total_short: intOrZero_(row.total_short),
+      total_long: intOrZero_(row.total_long),
+      total: intOrZero_(row.total),
+      num_instructors: intOrZero_(row.num_instructors),
+      course_endings: intOrZero_(row.course_endings),
+      finance_open: intOrZero_(row.finance_open),
+      exceptions: intOrZero_(row.exceptions)
+    };
+  });
+}
+
+function actionDashboardSnapshot_(user, payload) {
+  var ym = dashboardPayloadYm_(payload || {});
+  var summaryRow = readDashboardSummarySnapshotRow_(ym);
+  var byManagerRows = readDashboardByManagerSnapshotRows_(ym);
+  if (!summaryRow || byManagerRows === null) {
+    var full = actionDashboard_(user, payload || {});
+    full._is_snapshot = false;
+    return full;
+  }
+
+  var canViewFinance = yesNo_(summaryRow.can_view_finance) === 'yes' || boolFromCell_(summaryRow.can_view_finance);
+  var activeInstructors = parseJsonText_(summaryRow.active_instructors_json, []);
+  var shortActivities = parseJsonText_(summaryRow.short_activities_json, []);
+  var kpiCards = parseJsonText_(summaryRow.kpi_cards_json, []);
+  var showOnlyNonzero = yesNo_(summaryRow.show_only_nonzero_kpis) === 'yes' || boolFromCell_(summaryRow.show_only_nonzero_kpis);
+
+  return {
+    month: ym,
+    can_view_finance: canViewFinance,
+    totals: {
+      total_short_activities: intOrZero_(summaryRow.total_short_activities),
+      total_long_activities: intOrZero_(summaryRow.total_long_activities),
+      total_instructors: intOrZero_(summaryRow.total_instructors),
+      total_course_endings_current_month: intOrZero_(summaryRow.total_course_endings_current_month),
+      short: intOrZero_(summaryRow.total_short_activities),
+      long: intOrZero_(summaryRow.total_long_activities)
+    },
+    by_activity_manager: byManagerRows,
+    summary: {
+      active_courses_current_month: intOrZero_(summaryRow.active_courses_current_month),
+      ending_courses_current_month: intOrZero_(summaryRow.ending_courses_current_month),
+      active_courses_next_month: intOrZero_(summaryRow.active_courses_next_month),
+      active_instructors: Array.isArray(activeInstructors) ? activeInstructors : [],
+      missing_instructor_count: intOrZero_(summaryRow.missing_instructor_count),
+      missing_start_date_count: intOrZero_(summaryRow.missing_start_date_count),
+      late_end_date_count: intOrZero_(summaryRow.late_end_date_count),
+      short_activities: Array.isArray(shortActivities) ? shortActivities : []
+    },
+    kpi_cards: Array.isArray(kpiCards) ? kpiCards : [],
+    show_only_nonzero_kpis: showOnlyNonzero,
+    _is_snapshot: true
+  };
+}
+
+function monthsForDashboardSnapshotRefresh_() {
+  var nowYm = dashboardPayloadYm_({});
+  return [shiftYm_(nowYm, -1), nowYm, shiftYm_(nowYm, 1)];
+}
+
+function resolveSnapshotRefreshUser_(user) {
+  if (user && text_(user.user_id)) return user;
+  var rows = readRows_(CONFIG.SHEETS.PERMISSIONS);
+  var match = rows.find(function(row) {
+    if (yesNo_(row.active) === 'no') return false;
+    try {
+      return normalizeRole_(internalRoleFromPermissionRow_(row)) === 'admin';
+    } catch (_e) {
+      return false;
+    }
+  });
+  if (!match) {
+    throw new Error('No active admin user found for snapshot refresh');
+  }
+  return {
+    user_id: text_(match.user_id),
+    display_role: 'admin'
+  };
+}
+
+function refreshDashboardSnapshots_(user) {
+  var actor = resolveSnapshotRefreshUser_(user);
+  var months = monthsForDashboardSnapshotRefresh_();
+  try {
+    months.forEach(function(ym) {
+      var dashboard = actionDashboard_(actor, { month: ym });
+      writeDashboardSummarySnapshotRow_(ym, dashboard);
+      replaceDashboardByManagerSnapshotRows_(ym, dashboard.by_activity_manager || []);
+    });
+    updateDashboardRefreshControl_('ok', 'refresh_completed');
+    bumpDataViewsCacheVersion_();
+    return { ok: true, months: months };
+  } catch (err) {
+    updateDashboardRefreshControl_('error', err && err.message ? err.message : String(err));
+    throw err;
+  }
+}

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -23,6 +23,7 @@ function handlePost_(e) {
       login: function() { return actionLogin_(payload); },
       bootstrap: function() { return actionBootstrap_(user); },
       dashboard: function() { return actionDashboard_(user, payload); },
+      dashboardSnapshot: function() { return actionDashboardSnapshot_(user, payload); },
       activities: function() { return actionActivities_(user, payload); },
       activityDetail: function() { return actionActivityDetail_(user, payload); },
       week: function() { return actionWeek_(user, payload); },
@@ -62,6 +63,7 @@ function handlePost_(e) {
 
     var ACTION_ROUTE_MAP = {
       dashboard: 'dashboard',
+      dashboardSnapshot: 'dashboard',
       activities: 'activities',
       activityDetail: 'activities',
       week: 'week',
@@ -108,6 +110,22 @@ function handlePost_(e) {
 
     markRequestPerf_('action_start');
     var writeData = handlers[action]();
+    if (action === 'addActivity' ||
+        action === 'saveActivity' ||
+        action === 'reviewEditRequest' ||
+        action === 'saveFinanceRow' ||
+        action === 'syncFinance') {
+      try {
+        refreshDashboardSnapshots_(user);
+      } catch (snapshotErr) {
+        try {
+          updateDashboardRefreshControl_(
+            'error',
+            snapshotErr && snapshotErr.message ? snapshotErr.message : String(snapshotErr)
+          );
+        } catch (_e) {}
+      }
+    }
     markRequestPerf_('action_done');
     return jsonResponse_({
       ok: true,
@@ -132,6 +150,7 @@ function isReadActionCacheable_(action, user) {
   var map = {
     bootstrap: true,
     dashboard: true,
+    dashboardSnapshot: true,
     activities: true,
     activityDetail: true,
     week: true,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -38,6 +38,7 @@ const MUTATING_ACTIONS = {
 const READ_ACTIONS = {
   bootstrap: true,
   dashboard: true,
+  dashboardSnapshot: true,
   activities: true,
   activityDetail: true,
   week: true,
@@ -228,6 +229,7 @@ export const api = {
   login: (user_id, entry_code) => request('login', { user_id, entry_code }),
   bootstrap: () => request('bootstrap'),
   dashboard: (filters) => request('dashboard', filters || {}),
+  dashboardSnapshot: (filters) => request('dashboardSnapshot', filters || {}),
   activities: (filters) => request('activities', filters),
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
   week: (params) => request('week', params || {}),

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -125,7 +125,7 @@ export const dashboardScreen = {
       ym = currentMonthYm();
     }
     state.dashboardMonthYm = ym;
-    return api.dashboard({ month: ym });
+    return api.dashboardSnapshot({ month: ym });
   },
   render(data, { state } = {}) {
     const ym = data?.month || currentMonthYm();
@@ -210,6 +210,22 @@ export const dashboardScreen = {
   bind({ root, ui, state, api, rerender, clearScreenDataCache, data }) {
     const DASHBOARD_TTL_MS = 5 * 60 * 1000;
     const ym = data?.month || state.dashboardMonthYm || currentMonthYm();
+    function putDashboardCache(cacheKey, payload) {
+      const existing = state.screenDataCache[cacheKey];
+      if (!existing) {
+        state.screenDataCache[cacheKey] = { data: payload, t: Date.now() };
+        return;
+      }
+      const existingIsSnapshot = !!existing.data?._is_snapshot;
+      const nextIsSnapshot = !!payload?._is_snapshot;
+      if (!nextIsSnapshot) {
+        state.screenDataCache[cacheKey] = { data: payload, t: Date.now() };
+        return;
+      }
+      if (existingIsSnapshot) {
+        state.screenDataCache[cacheKey] = { data: payload, t: Date.now() };
+      }
+    }
 
     function getSummaryBtn(target) {
       return [...root.querySelectorAll('.ds-summary-btn[data-summary-target]')]
@@ -266,10 +282,13 @@ export const dashboardScreen = {
         const adjKey = `dashboard:${adjYm}`;
         const hit = state.screenDataCache[adjKey];
         if (hit && Date.now() - hit.t < DASHBOARD_TTL_MS) return;
-        api.dashboard({ month: adjYm }).then((d) => {
+        api.dashboardSnapshot({ month: adjYm }).then((d) => {
           if (!state.screenDataCache[adjKey] || Date.now() - state.screenDataCache[adjKey].t > DASHBOARD_TTL_MS) {
-            state.screenDataCache[adjKey] = { data: d, t: Date.now() };
+            putDashboardCache(adjKey, d);
           }
+          api.dashboard({ month: adjYm }).then((full) => {
+            putDashboardCache(adjKey, full);
+          }).catch(() => {});
         }).catch(() => {});
       });
     }
@@ -286,12 +305,22 @@ export const dashboardScreen = {
       }
 
       showDataAreaLoading();
+      let snapshotLoaded = false;
       try {
-        const data = await api.dashboard({ month: nextYm });
-        state.screenDataCache[cacheKey] = { data, t: Date.now() };
-        prefetchAdjacentDashboard(nextYm);
+        const snap = await api.dashboardSnapshot({ month: nextYm });
+        putDashboardCache(cacheKey, snap);
+        snapshotLoaded = true;
+        rerender();
+        try {
+          const full = await api.dashboard({ month: nextYm });
+          putDashboardCache(cacheKey, full);
+          prefetchAdjacentDashboard(nextYm);
+        } catch (_hydrateErr) {
+          console.warn('[dashboard] full hydration failed; keeping snapshot');
+          if (!snapshotLoaded) clearScreenDataCache?.();
+        }
       } catch (_err) {
-        clearScreenDataCache?.();
+        if (!snapshotLoaded) clearScreenDataCache?.();
       }
       rerender();
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Stabilized snapshot-first dashboard flow with dedicated snapshot backend action and resilient fallback behavior.
- Added strict scaffold writer for technical snapshot sheets (English headers row 1, Hebrew labels row 2).
- Updated dashboard frontend cache write rules so hydrated full dashboard data always wins over snapshot data.

## Backend

### `backend/dashboard-snapshot.gs`

- Added strict scaffold function:
  - `ensureSnapshotSheetScaffold_(sheetName, englishHeaders, hebrewLabels)`
  - Always writes English headers to row 1 with exact width.
  - Writes Hebrew labels to row 2 only if row 2 is fully empty.
  - Does not append headers and does not touch row 3+ data.
  - Clears request caches for that sheet (`headers`, `readRows`, `sheetMeta`, `sheetByName`).
- Added Hebrew label arrays:
  - `SUMMARY_SNAPSHOT_LABELS_HE_`
  - `BY_MANAGER_SNAPSHOT_LABELS_HE_`
  - `REFRESH_CONTROL_LABELS_HE_`
- Replaced scaffold/header calls in:
  - `writeDashboardSummarySnapshotRow_`
  - `replaceDashboardByManagerSnapshotRows_`
  - `updateDashboardRefreshControl_`
- Added real fallback in `actionDashboardSnapshot_`:
  - If snapshot sheet/row missing for requested month, returns `actionDashboard_(...)` full payload with `_is_snapshot: false`.
  - Returns snapshot payload with `_is_snapshot: true` only when valid snapshot exists.
- In `refreshDashboardSnapshots_` added `bumpDataViewsCacheVersion_()` after successful writes so read-action cache keys rotate.

### `backend/router.gs`

- Registered `dashboardSnapshot` action and mapped it to `dashboard` route.
- Marked `dashboardSnapshot` as read-cacheable.
- For write actions:
  - `addActivity`
  - `saveActivity`
  - `reviewEditRequest`
  - `saveFinanceRow`
  - `syncFinance`
  now runs immediate snapshot refresh:
  - `refreshDashboardSnapshots_()`
  - on failure: writes refresh control status error via `updateDashboardRefreshControl_('error', ...)`.
- No refresh hook was added for:
  - `savePrivateNote`
  - `addUser`
  - `savePermission`
  - `saveContact`
  - `addContact`

### `backend/Code.gs`

- Added manual entrypoint wrapper:
  - `refreshDashboardSnapshots()` -> calls `refreshDashboardSnapshots_()`

## Frontend

### `frontend/src/screens/dashboard.js`

- Kept snapshot-first load: `api.dashboardSnapshot({ month: ym })`.
- Added helper `putDashboardCache(cacheKey, payload)` implementing:
  - Full payload (`_is_snapshot !== true`) always overrides cache.
  - Snapshot payload writes only if cache is empty or already snapshot.
- Replaced direct `state.screenDataCache[cacheKey] = ...` writes in:
  - month apply flow
  - adjacent month prefetch
  - background hydration path
- Kept hydration warning behavior and preserved snapshot on hydration failure (`console.warn`, no error rerender).

### `frontend/src/api.js`

- Ensured only dashboard snapshot wiring:
  - `dashboardSnapshot` in `READ_ACTIONS`
  - `dashboardSnapshot` in exported `api` object
- No unrelated action changes.

## Testing

- `npm test` passes.
- Attempted manual Apps Script execution command for `refreshDashboardSnapshots`; local environment does not have `clasp` installed (`clasp: command not found`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d52c54a-1f5b-4d36-a8a2-b4c80cbd9506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

