### PR TITLE
Stabilize dashboard snapshot scaffold and fallback behavior

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -26,6 +26,7 @@ function keepWarm() {
 
 function refreshDashboardSnapshots() {
   return refreshDashboardSnapshots_();
+}
 /**
  * Time-driven trigger entrypoint for rebuilding dashboard snapshots.
  * Set up as a separate trigger — do not add snapshot logic inside keepWarm.

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -31,6 +31,43 @@ var BY_MANAGER_SNAPSHOT_HEADERS_ = [
 ];
 
 var REFRESH_CONTROL_HEADERS_ = ['key', 'value', 'label_he'];
+var SUMMARY_SNAPSHOT_LABELS_HE_ = [
+  'חודש',
+  'תווית חודש',
+  'עודכן בתאריך',
+  'סך פעילויות חד-יומיות',
+  'סך תוכניות',
+  'קורסים פעילים בחודש נוכחי',
+  'סדנאות פעילות בחודש נוכחי',
+  'סיורים פעילים בחודש נוכחי',
+  'צהרונים פעילים בחודש נוכחי',
+  'חדרי בריחה פעילים בחודש נוכחי',
+  'כספים פתוחים',
+  'חריגות',
+  'מדריכים פעילים',
+  'סיומי קורסים בחודש נוכחי',
+  'קורסים פעילים בחודש הבא',
+  'ללא מדריך',
+  'ללא תאריך התחלה',
+  'תאריך סיום מאוחר',
+  'שמות מדריכים פעילים צפון',
+  'שמות מדריכים פעילים דרום'
+];
+var BY_MANAGER_SNAPSHOT_LABELS_HE_ = [
+  'חודש',
+  'מנהל פעילות',
+  'שם תצוגה מנהל',
+  'חד-יומי',
+  'תוכניות',
+  'סך הכול',
+  'מספר מדריכים',
+  'סיומי קורסים',
+  'כספים פתוחים',
+  'חריגות',
+  'שמות מדריכים פעילים',
+  'עודכן בתאריך'
+];
+var REFRESH_CONTROL_LABELS_HE_ = ['מפתח', 'ערך', 'תווית'];
 
 var SNAPSHOT_MANAGER_DISPLAY_NAMES_ = {
   'גיל נאמן':          'מחוז צפון',
@@ -39,30 +76,22 @@ var SNAPSHOT_MANAGER_DISPLAY_NAMES_ = {
 
 // ─── header helpers ───────────────────────────────────────────────────────────
 
-function ensureSnapshotSheetHeaders_(sheetName, requiredHeaders) {
+function ensureSnapshotSheetScaffold_(sheetName, englishHeaders, hebrewLabels) {
   var ss = getSpreadsheet_();
   var sheet = ss.getSheetByName(sheetName);
   if (!sheet) return false;
 
-  var lastCol = sheet.getLastColumn();
-  var existingHeaders = [];
-  if (lastCol > 0) {
-    existingHeaders = sheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
+  var headerLen = englishHeaders.length;
+  var maxCol = Math.max(sheet.getLastColumn(), headerLen);
+  if (maxCol > headerLen) {
+    sheet.getRange(CONFIG.HEADER_ROW, headerLen + 1, 1, maxCol - headerLen).clearContent();
   }
+  sheet.getRange(CONFIG.HEADER_ROW, 1, 1, headerLen).setValues([englishHeaders]);
 
-  var nonEmpty = existingHeaders.filter(Boolean);
-  var missingHeaders = requiredHeaders.filter(function(h) {
-    return nonEmpty.indexOf(h) < 0;
-  });
-  if (missingHeaders.length === 0) return true;
-
-  if (nonEmpty.length === 0) {
-    sheet.getRange(CONFIG.HEADER_ROW, 1, 1, requiredHeaders.length).setValues([requiredHeaders]);
-  } else {
-    var nextCol = nonEmpty.length + 1;
-    missingHeaders.forEach(function(h, i) {
-      sheet.getRange(CONFIG.HEADER_ROW, nextCol + i).setValue(h);
-    });
+  var row2 = sheet.getRange(CONFIG.HEADER_ROW + 1, 1, 1, maxCol).getValues()[0];
+  var row2IsEmpty = row2.every(function(v) { return text_(v) === ''; });
+  if (row2IsEmpty) {
+    sheet.getRange(CONFIG.HEADER_ROW + 1, 1, 1, hebrewLabels.length).setValues([hebrewLabels]);
   }
 
   if (__rqCache_) {
@@ -98,6 +127,14 @@ function actionDashboardSnapshot_(user, payload) {
   if (ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT)) {
     var allByMgr = readRows_(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT);
     byManagerRows = allByMgr.filter(function(r) { return text_(r.month_ym) === ym; });
+  }
+
+  if (!snap || !ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT)) {
+    var fullData = actionDashboard_(user, payload);
+    if (fullData && typeof fullData === 'object') {
+      fullData._is_snapshot = false;
+    }
+    return fullData;
   }
 
   var s = snap || {};
@@ -262,7 +299,11 @@ function refreshDashboardSnapshots_() {
 
     var status  = errors.length === 0 ? 'ok' : 'partial';
     var message = errors.length === 0 ? 'all months updated' : errors.join('; ');
-    updateDashboardRefreshControl_(status, message);
+    try {
+      updateDashboardRefreshControl_(status, message);
+    } finally {
+      bumpDataViewsCacheVersion_();
+    }
   } finally {
     if (!hadCache) {
       __rqCache_ = null;
@@ -274,7 +315,7 @@ function refreshDashboardSnapshots_() {
 
 function writeDashboardSummarySnapshotRow_(ym, fullData) {
   var sheetName = CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT;
-  ensureSnapshotSheetHeaders_(sheetName, SUMMARY_SNAPSHOT_HEADERS_);
+  ensureSnapshotSheetScaffold_(sheetName, SUMMARY_SNAPSHOT_HEADERS_, SUMMARY_SNAPSHOT_LABELS_HE_);
 
   var summary = fullData.summary || {};
   var totals  = fullData.totals  || {};
@@ -335,7 +376,7 @@ function canViewFinanceFromKpis_(kpiAll, fullData) {
 
 function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
   var sheetName = CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT;
-  ensureSnapshotSheetHeaders_(sheetName, BY_MANAGER_SNAPSHOT_HEADERS_);
+  ensureSnapshotSheetScaffold_(sheetName, BY_MANAGER_SNAPSHOT_HEADERS_, BY_MANAGER_SNAPSHOT_LABELS_HE_);
 
   deleteRowsByKey_(sheetName, 'month_ym', ym);
 
@@ -368,7 +409,7 @@ function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
 
 function updateDashboardRefreshControl_(status, message) {
   var sheetName = CONFIG.SHEETS.DASHBOARD_REFRESH_CONTROL;
-  ensureSnapshotSheetHeaders_(sheetName, REFRESH_CONTROL_HEADERS_);
+  ensureSnapshotSheetScaffold_(sheetName, REFRESH_CONTROL_HEADERS_, REFRESH_CONTROL_LABELS_HE_);
 
   var now = new Date().toISOString();
   var entries = [

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -116,7 +116,7 @@ function handlePost_(e) {
         action === 'saveFinanceRow' ||
         action === 'syncFinance') {
       try {
-        refreshDashboardSnapshots_(user);
+        refreshDashboardSnapshots_();
       } catch (snapshotErr) {
         try {
           updateDashboardRefreshControl_(
@@ -127,17 +127,6 @@ function handlePost_(e) {
       }
     }
     markRequestPerf_('action_done');
-
-    var SNAPSHOT_INVALIDATING_ACTIONS_ = {
-      addActivity: true,
-      saveActivity: true,
-      reviewEditRequest: true,
-      saveFinanceRow: true,
-      syncFinance: true
-    };
-    if (SNAPSHOT_INVALIDATING_ACTIONS_[action]) {
-      try { updateDashboardRefreshControl_('pending', 'refresh_needed'); } catch (_e) {}
-    }
 
     return jsonResponse_({
       ok: true,

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -288,7 +288,7 @@ export const dashboardScreen = {
           }
           if (d._is_snapshot) {
             api.dashboard({ month: adjYm }).then((full) => {
-              state.screenDataCache[adjKey] = { data: full, t: Date.now() };
+              putDashboardCache(adjKey, full);
             }).catch(() => {});
           }
         }).catch(() => {});
@@ -310,11 +310,12 @@ export const dashboardScreen = {
       let snapshotLoaded = false;
       try {
         const snapshotData = await api.dashboardSnapshot({ month: nextYm });
-        state.screenDataCache[cacheKey] = { data: snapshotData, t: Date.now() };
+        putDashboardCache(cacheKey, snapshotData);
+        snapshotLoaded = true;
         prefetchAdjacentDashboard(nextYm);
         if (snapshotData._is_snapshot) {
           api.dashboard({ month: nextYm }).then((fullData) => {
-            state.screenDataCache[cacheKey] = { data: fullData, t: Date.now() };
+            putDashboardCache(cacheKey, fullData);
             if ((state.dashboardMonthYm || currentMonthYm()) === nextYm) {
               rerender();
             }
@@ -345,7 +346,7 @@ export const dashboardScreen = {
       const hydrateYm = ym;
       const hydrateCacheKey = `dashboard:${/^\d{4}-\d{2}$/.test(hydrateYm) ? hydrateYm : 'default'}`;
       api.dashboard({ month: hydrateYm }).then((fullData) => {
-        state.screenDataCache[hydrateCacheKey] = { data: fullData, t: Date.now() };
+        putDashboardCache(hydrateCacheKey, fullData);
         if (state.route === 'dashboard' && (state.dashboardMonthYm || currentMonthYm()) === hydrateYm) {
           rerender();
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replaced snapshot header append logic with strict scaffold writes for row 1 English headers and conditional row 2 Hebrew labels
- switched snapshot writers to use the new scaffold helper and clear request caches for affected sheets
- added snapshot-read fallback to `actionDashboard_` when summary snapshot row/sheet is missing, returning `_is_snapshot: false`
- bumped read-action cache version after snapshot refresh completion
- updated write-action router flow to prefer immediate snapshot refresh and only write refresh-control error on failure
- hardened dashboard screen cache writes so full data always wins over snapshot in apply/prefetch/hydration paths
- fixed missing closing brace in `backend/Code.gs` for `refreshDashboardSnapshots` entrypoint

## Validation
- `npm test` passes (19/19)
- manual Google Sheets acceptance checks require Apps Script runtime / bound spreadsheet access and could not be executed in this local environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29402e8b-453d-49d6-99d9-b7d5d150b021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29402e8b-453d-49d6-99d9-b7d5d150b021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

