### PR TITLE
Add Apps Script backend sync verification utility

### DIFF
--- a/scripts/check_apps_script_backend_sync.mjs
+++ b/scripts/check_apps_script_backend_sync.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const repoRoot = process.cwd();
+const repoBackend = path.join(repoRoot, 'backend');
+const criticalFiles = [
+  'config.gs',
+  'helpers.gs',
+  'sheets.gs',
+  'settings.gs',
+  'router.gs',
+  'actions.gs',
+  'auth.gs',
+  'dashboard-snapshot.gs',
+  'script-cache.gs',
+  'Code.gs'
+];
+
+const requiredScriptCacheFunctions = [
+  'scriptCacheGetJson_',
+  'scriptCachePutJson_',
+  'scriptCacheDebugMark_',
+  'scriptCacheInvalidateDataViews_',
+  'dataViewsCacheVersion_',
+  'bumpDataViewsCacheVersion_'
+];
+
+const arg = process.argv.find(a => a.startsWith('--active-dir='));
+const activeDir = arg ? path.resolve(arg.split('=')[1]) : null;
+
+function fileHash(filePath) {
+  const data = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function hasFunction(fileContents, fnName) {
+  const re = new RegExp(`function\\s+${fnName}\\s*\\(`);
+  return re.test(fileContents);
+}
+
+const report = {
+  missingInRepo: [],
+  scriptCacheMissingFunctions: [],
+  activeComparison: {
+    enabled: Boolean(activeDir),
+    missingInActive: [],
+    mismatched: [],
+    matched: []
+  }
+};
+
+for (const rel of criticalFiles) {
+  const filePath = path.join(repoBackend, rel);
+  if (!fs.existsSync(filePath)) {
+    report.missingInRepo.push(`backend/${rel}`);
+  }
+}
+
+const scriptCachePath = path.join(repoBackend, 'script-cache.gs');
+if (fs.existsSync(scriptCachePath)) {
+  const content = fs.readFileSync(scriptCachePath, 'utf8');
+  for (const fn of requiredScriptCacheFunctions) {
+    if (!hasFunction(content, fn)) {
+      report.scriptCacheMissingFunctions.push(fn);
+    }
+  }
+}
+
+if (activeDir) {
+  for (const rel of criticalFiles) {
+    const repoFile = path.join(repoBackend, rel);
+    const activeFile = path.join(activeDir, rel);
+
+    if (!fs.existsSync(activeFile)) {
+      report.activeComparison.missingInActive.push(`backend/${rel}`);
+      continue;
+    }
+
+    const same = fileHash(repoFile) === fileHash(activeFile);
+    if (same) {
+      report.activeComparison.matched.push(`backend/${rel}`);
+    } else {
+      report.activeComparison.mismatched.push(`backend/${rel}`);
+    }
+  }
+}
+
+console.log(JSON.stringify(report, null, 2));
+
+const hasIssues =
+  report.missingInRepo.length > 0 ||
+  report.scriptCacheMissingFunctions.length > 0 ||
+  (report.activeComparison.enabled &&
+    (report.activeComparison.missingInActive.length > 0 || report.activeComparison.mismatched.length > 0));
+
+process.exit(hasIssues ? 1 : 0);


### PR DESCRIPTION
### Motivation
- Provide a fast, local verification tool to detect missing or out-of-sync Apps Script backend files before/after deployments.
- Ensure critical `script-cache.gs` functions exist so cache-related failures (e.g. `scriptCacheDebugMark_` undefined) can be detected early.

### Description
- Add `scripts/check_apps_script_backend_sync.mjs`, a small Node utility that validates the existence of critical backend `.gs` files and the presence of required `script-cache` functions (`scriptCacheGetJson_`, `scriptCachePutJson_`, `scriptCacheDebugMark_`, `scriptCacheInvalidateDataViews_`, `dataViewsCacheVersion_`, `bumpDataViewsCacheVersion_`).
- The script supports an optional `--active-dir=/path/to/backend` flag to compare repo files against an exported active Apps Script backend by SHA256 hash and emits a JSON report.
- The script prints a structured JSON report and exits with a non-zero status when mismatches or missing files are detected.

### Testing
- Executed `node scripts/check_apps_script_backend_sync.mjs` which printed a JSON report with no missing critical files and no missing `script-cache` functions and exited with code `0`.
- Active-side comparison was not performed in this environment because no `--active-dir` was supplied, so the active-deployment comparison was disabled during the test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1456fc6c832bb29d90d356360a36)