### PR TITLE
Update DEFAULT_API_URL and add Apps Script backend sync checker

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbzrB5a47FVi6Z2yj-LYcPevYiM5a9vLeybOtbnWKyrX-1Mz7FGnAc07Z5MbXh5TFgk8/exec';
+  'https://script.google.com/macros/s/AKfycbyc0ddYcHyLhF57Z2fzS3guEGPOOKxitrmuHLTWAnfem_Z-h4zq9Zb0n8BthZ9HLDM/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/scripts/check_apps_script_backend_sync.mjs
+++ b/scripts/check_apps_script_backend_sync.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const repoRoot = process.cwd();
+const repoBackend = path.join(repoRoot, 'backend');
+const criticalFiles = [
+  'config.gs',
+  'helpers.gs',
+  'sheets.gs',
+  'settings.gs',
+  'router.gs',
+  'actions.gs',
+  'auth.gs',
+  'dashboard-snapshot.gs',
+  'script-cache.gs',
+  'Code.gs'
+];
+
+const requiredScriptCacheFunctions = [
+  'scriptCacheGetJson_',
+  'scriptCachePutJson_',
+  'scriptCacheDebugMark_',
+  'scriptCacheInvalidateDataViews_',
+  'dataViewsCacheVersion_',
+  'bumpDataViewsCacheVersion_'
+];
+
+const arg = process.argv.find(a => a.startsWith('--active-dir='));
+const activeDir = arg ? path.resolve(arg.split('=')[1]) : null;
+
+function fileHash(filePath) {
+  const data = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function hasFunction(fileContents, fnName) {
+  const re = new RegExp(`function\\s+${fnName}\\s*\\(`);
+  return re.test(fileContents);
+}
+
+const report = {
+  missingInRepo: [],
+  scriptCacheMissingFunctions: [],
+  activeComparison: {
+    enabled: Boolean(activeDir),
+    missingInActive: [],
+    mismatched: [],
+    matched: []
+  }
+};
+
+for (const rel of criticalFiles) {
+  const filePath = path.join(repoBackend, rel);
+  if (!fs.existsSync(filePath)) {
+    report.missingInRepo.push(`backend/${rel}`);
+  }
+}
+
+const scriptCachePath = path.join(repoBackend, 'script-cache.gs');
+if (fs.existsSync(scriptCachePath)) {
+  const content = fs.readFileSync(scriptCachePath, 'utf8');
+  for (const fn of requiredScriptCacheFunctions) {
+    if (!hasFunction(content, fn)) {
+      report.scriptCacheMissingFunctions.push(fn);
+    }
+  }
+}
+
+if (activeDir) {
+  for (const rel of criticalFiles) {
+    const repoFile = path.join(repoBackend, rel);
+    const activeFile = path.join(activeDir, rel);
+
+    if (!fs.existsSync(activeFile)) {
+      report.activeComparison.missingInActive.push(`backend/${rel}`);
+      continue;
+    }
+
+    const same = fileHash(repoFile) === fileHash(activeFile);
+    if (same) {
+      report.activeComparison.matched.push(`backend/${rel}`);
+    } else {
+      report.activeComparison.mismatched.push(`backend/${rel}`);
+    }
+  }
+}
+
+console.log(JSON.stringify(report, null, 2));
+
+const hasIssues =
+  report.missingInRepo.length > 0 ||
+  report.scriptCacheMissingFunctions.length > 0 ||
+  (report.activeComparison.enabled &&
+    (report.activeComparison.missingInActive.length > 0 || report.activeComparison.mismatched.length > 0));
+
+process.exit(hasIssues ? 1 : 0);


### PR DESCRIPTION
### Motivation

- Replace the default Google Apps Script Web App URL used by the frontend to point to the new deployment.
- Add an automated check to ensure critical backend Apps Script files are present and in sync with an active deployment, and to verify required `script-cache` functions exist.

### Description

- Updated `DEFAULT_API_URL` in `frontend/src/config.js` to the new Apps Script Web App URL.
- Added `scripts/check_apps_script_backend_sync.mjs`, a Node script that checks for the presence of a list of critical `backend/` files, verifies required functions in `backend/script-cache.gs`, optionally compares file hashes against an active directory passed via `--active-dir=...`, emits a JSON report, and exits with a non-zero code on issues.
- The script computes SHA-256 hashes with `crypto`, detects functions using a regex for `function <name>(`, and reports `missingInRepo`, `scriptCacheMissingFunctions`, and active-comparison results.

### Testing

- Ran `node scripts/check_apps_script_backend_sync.mjs` locally without `--active-dir` to validate JSON output and exit behavior, and it completed successfully (exit code 0).
- Ran `node scripts/check_apps_script_backend_sync.mjs --active-dir=backend` to compare the repo backend to itself and confirmed all files matched (exit code 0).
- Built the frontend bundle (`yarn build`) to ensure the `config.js` change does not break the build, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1456fc6c832bb29d90d356360a36)