### PR TITLE
Improve activity edit flow, calendar detail loading, and contacts/dashboard UX

### DIFF
--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -192,32 +192,39 @@ function renderAuthorityGroup(authority, schoolsMap) {
   let schoolsHtml = '';
   schoolsMap.forEach((rows, schoolName) => { schoolsHtml += renderSchoolCard(schoolName, rows); });
   if (!schoolsHtml) return '';
-  const schoolCount = schoolsMap.size;
-  const countLabel = schoolCount === 1 ? '1 בית ספר' : `${schoolCount} בתי ספר`;
   return `<div class="sc-authority-group">
     <div class="sc-authority-head">
       <span class="sc-authority-icon" aria-hidden="true">🏛️</span>
       <span class="sc-authority-name">${escapeHtml(authority)}</span>
-      <span class="sc-authority-count">${escapeHtml(countLabel)}</span>
     </div>
     <div class="sc-school-grid">${schoolsHtml}</div>
   </div>`;
 }
 
-function instructorFormHtml(row = {}) {
+function selectOptionsHtml(values, selected = '', placeholder = '—') {
+  const safe = String(selected || '');
+  const uniq = [...new Set((Array.isArray(values) ? values : []).map((v) => String(v || '').trim()).filter(Boolean))];
+  const merged = safe && !uniq.includes(safe) ? [safe, ...uniq] : uniq;
+  return [`<option value="">${escapeHtml(placeholder)}</option>`]
+    .concat(merged.map((v) => `<option value="${escapeHtml(v)}"${v === safe ? ' selected' : ''}>${escapeHtml(v)}</option>`))
+    .join('');
+}
+
+function instructorFormHtml(row = {}, managerOptions = []) {
+  const employmentOptions = ['תעשיידע', 'מעוף', 'מנפוואר'];
   return `
-    <div class="ds-perm-edit-form" dir="rtl">
+    <div class="ds-perm-edit-form ds-contact-edit-form" dir="rtl">
       <div class="ds-perm-field"><span class="ds-muted">מזהה מדריך</span><input class="ds-input ds-input--sm" name="emp_id" value="${escapeHtml(String(row.emp_id || ''))}" ${row.emp_id ? 'readonly' : ''}></div>
       <div class="ds-perm-field"><span class="ds-muted">שם מלא</span><input class="ds-input ds-input--sm" name="full_name" value="${escapeHtml(String(row.full_name || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">נייד</span><input class="ds-input ds-input--sm" name="mobile" value="${escapeHtml(String(row.mobile || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">אימייל</span><input class="ds-input ds-input--sm" name="email" value="${escapeHtml(String(row.email || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">כתובת</span><input class="ds-input ds-input--sm" name="address" value="${escapeHtml(String(row.address || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">סוג העסקה</span><select class="ds-input ds-input--sm" name="employment_type">
-        <option value="">—</option>
-        <option value="full_time" ${String(row.employment_type || '') === 'full_time' ? 'selected' : ''}>משרה מלאה</option>
-        <option value="part_time" ${String(row.employment_type || '') === 'part_time' ? 'selected' : ''}>משרה חלקית</option>
+        ${selectOptionsHtml(employmentOptions, String(row.employment_type || ''), 'בחרו סוג העסקה')}
       </select></div>
-      <div class="ds-perm-field"><span class="ds-muted">מנהל ישיר</span><input class="ds-input ds-input--sm" name="direct_manager" value="${escapeHtml(String(row.direct_manager || ''))}"></div>
+      <div class="ds-perm-field"><span class="ds-muted">מנהל ישיר</span><select class="ds-input ds-input--sm" name="direct_manager">
+        ${selectOptionsHtml(managerOptions, String(row.direct_manager || ''), 'בחרו מנהל')}
+      </select></div>
       <div class="ds-perm-field"><span class="ds-muted">פעיל</span><select class="ds-input ds-input--sm" name="active">
         <option value="yes" ${String(row.active || 'yes').toLowerCase() === 'yes' ? 'selected' : ''}>כן</option>
         <option value="no" ${String(row.active || '').toLowerCase() === 'no' ? 'selected' : ''}>לא</option>
@@ -229,7 +236,7 @@ function instructorFormHtml(row = {}) {
 
 function schoolFormHtml(row = {}) {
   return `
-    <div class="ds-perm-edit-form" dir="rtl">
+    <div class="ds-perm-edit-form ds-contact-edit-form" dir="rtl">
       <div class="ds-perm-field"><span class="ds-muted">רשות</span><input class="ds-input ds-input--sm" name="authority" value="${escapeHtml(String(row.authority || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">בית ספר</span><input class="ds-input ds-input--sm" name="school" value="${escapeHtml(String(row.school || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">שם איש קשר</span><input class="ds-input ds-input--sm" name="contact_name" value="${escapeHtml(String(row.contact_name || ''))}"></div>
@@ -304,6 +311,9 @@ export const contactsScreen = {
     const instrRows = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows) ? data.school_rows : [];
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
+    const managerOptions = (Array.isArray(state?.clientSettings?.dropdown_options?.activities_manager_users)
+      ? state.clientSettings.dropdown_options.activities_manager_users.map((u) => String(u?.name || '').trim())
+      : []).filter(Boolean);
 
     root.querySelectorAll('[data-contacts-tab]').forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -312,14 +322,18 @@ export const contactsScreen = {
       });
     });
 
+    let instrSearchTimer;
     root.querySelector('#contacts-instr-search')?.addEventListener('input', (ev) => {
       state.contactsInstrSearch = ev.target.value || '';
-      rerender();
+      clearTimeout(instrSearchTimer);
+      instrSearchTimer = setTimeout(() => rerender(), 180);
     });
 
+    let schoolSearchTimer;
     root.querySelector('#contacts-school-search')?.addEventListener('input', (ev) => {
       state.contactsSchoolSearch = ev.target.value || '';
-      rerender();
+      clearTimeout(schoolSearchTimer);
+      schoolSearchTimer = setTimeout(() => rerender(), 180);
     });
 
     root.querySelectorAll('[data-copy-email]').forEach((btn) => {
@@ -351,7 +365,7 @@ export const contactsScreen = {
       const target = row || {};
       ui.openModal({
         title: isCreate ? 'הוספת איש קשר מדריך' : 'עריכת איש קשר מדריך',
-        content: instructorFormHtml(target),
+        content: instructorFormHtml(target, managerOptions),
         actions: `<button type="button" class="ds-btn ds-btn--primary" data-save-contact="instr">${isCreate ? 'הוספה' : 'שמירה'}</button>
                   <button type="button" class="ds-btn" data-ui-close-modal>ביטול</button>`
       });
@@ -495,4 +509,3 @@ function fallbackCopy(text, cb) {
   document.body.removeChild(ta);
   cb?.();
 }
-

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -77,17 +77,19 @@ function renderStructuredSummary(summary, ym, byManager) {
   return `<div class="ds-summary-panel__structured">
     <h3 class="ds-summary-panel__title">סיכום חודשי – <strong>${escapeHtml(monthTitle)}</strong></h3>
 
-    <p class="ds-summary-panel__text">ב<strong>${escapeHtml(monthTitle)}</strong> יש קורסים פעילים (<strong>${activeCurrent}</strong>).</p>
-    <p class="ds-summary-panel__text">במהלך <strong>${escapeHtml(monthTitle)}</strong> צפויים להסתיים קורסים (<strong>${endingCurrent}</strong>).</p>
-    <p class="ds-summary-panel__text ds-summary-panel__text--districts">מחוז צפון: קורסים פעילים (<strong>${northActive}</strong>) · מחוז דרום: קורסים פעילים (<strong>${southActive}</strong>)</p>
-    <p class="ds-summary-panel__text">ב<strong>${escapeHtml(nextMonthTitle)}</strong> צפויים להיות קורסים פעילים (<strong>${activeNext}</strong>).</p>
+    <p class="ds-summary-panel__text">בחודש <strong>${escapeHtml(monthTitle)}</strong> יש קורסים (<strong>${activeCurrent}</strong>) קורסים פעילים.</p>
+    <p class="ds-summary-panel__text">במהלך החודש צפויים להסתיים (<strong>${endingCurrent}</strong>) קורסי.</p>
+    <p class="ds-summary-panel__text ds-summary-panel__text--districts">מחוז צפון: (<strong>${northActive}</strong>) קורסים פעילים · מחוז דרום: (<strong>${southActive}</strong>) קורסים פעילים</p>
+    <p class="ds-summary-panel__text">בחודש <strong>${escapeHtml(nextMonthTitle)}</strong> צפויים להיות (<strong>${activeNext}</strong>) קורסים פעילים.</p>
 
     <h4 class="ds-summary-panel__inner-title"><strong>המדריכים הפעילים החודש:</strong></h4>
     <p class="ds-summary-panel__text">במחוז צפון: <strong>${escapeHtml(northInstructors || '—')}</strong> · במחוז דרום: <strong>${escapeHtml(southInstructors || '—')}</strong></p>
 
     <div class="ds-summary-panel__block ds-summary-panel__block--exceptions">
-      <h4 class="ds-summary-panel__inner-title"><strong>חריגות החודש</strong></h4>
-      <p class="ds-summary-panel__text">קורסים ללא שיבוץ מדריך (<strong>${missingInstr}</strong>) · קורסים ללא תאריך התחלה (<strong>${missingDate}</strong>) · קורסים בסיכון עקב תאריך סיום מאוחר (<strong>${lateEnd}</strong>)</p>
+      <h4 class="ds-summary-panel__inner-title"><strong>חריגות החודש:</strong></h4>
+      <p class="ds-summary-panel__text">קורסים ללא שיבוץ מדריך (<strong>${missingInstr}</strong>)</p>
+      <p class="ds-summary-panel__text">קורסים ללא תאריך התחלה (<strong>${missingDate}</strong>)</p>
+      <p class="ds-summary-panel__text">קורסים בסיכון עקב תאריך סיום מאוחר (<strong>${lateEnd}</strong>)</p>
     </div>
   </div>`;
 }

--- a/frontend/src/screens/instructor-contacts.js
+++ b/frontend/src/screens/instructor-contacts.js
@@ -135,9 +135,11 @@ export const instructorContactsScreen = {
     const allRows = Array.isArray(data?.rows) ? data.rows : [];
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
 
+    let searchTimer;
     root.querySelector('#instr-contacts-search')?.addEventListener('input', (ev) => {
       state.instrContactsSearch = ev.target.value || '';
-      rerender();
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => rerender(), 180);
     });
 
     root.querySelectorAll('[data-active-filter]').forEach((btn) => {

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -35,16 +35,19 @@ function renderInstructorRow(row) {
   const inactiveClass = hasActivity ? '' : ' ci-row--inactive';
 
   return `
-    <div class="ci-row instr-summary-row${inactiveClass}" dir="rtl">
+    <button type="button" class="ci-row instr-summary-row${inactiveClass}" dir="rtl" data-instructor-card="${escapeHtml(String(row.emp_id || ''))}">
       <div class="ci-row__main">
         <span class="ci-row__name">${name}</span>
         <span class="instr-count-badges">
           ${countBadge(programs, 'תוכניות', 'program')}
           ${countBadge(oneDay, 'חד-יומיות', 'oneday')}
         </span>
+        <span class="instr-count-badges">
+          ${countBadge(total, 'סה״כ פעילות', 'total')}
+        </span>
         ${endDate ? `<span class="instr-end-date">🏁 ${escapeHtml(endDate)}</span>` : ''}
       </div>
-    </div>`;
+    </button>`;
 }
 
 export const instructorsScreen = {
@@ -91,7 +94,7 @@ export const instructorsScreen = {
     `);
   },
 
-  bind({ root, data, state, rerender }) {
+  bind({ root, data, state, rerender, ui, api }) {
     bindActNavGrid(root, { state, rerender });
 
     root.querySelector('#instructors-active-only')?.addEventListener('change', (ev) => {
@@ -104,6 +107,28 @@ export const instructorsScreen = {
       state.instructorsSearch = ev.target.value || '';
       clearTimeout(_searchTimer);
       _searchTimer = setTimeout(() => rerender(), 220);
+    });
+
+    root.querySelectorAll('[data-instructor-card]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const empId = String(btn.dataset.instructorCard || '').trim();
+        if (!empId || !ui) return;
+        ui.openDrawer({ title: 'מדריך', content: '<p class="ds-muted">טוען פעילויות…</p>' });
+        try {
+          const res = await api.activities({ activity_type: 'all' });
+          const allRows = Array.isArray(res?.rows) ? res.rows : [];
+          const rows = allRows.filter((r) => {
+            const active = String(r.status || '').trim() !== 'סגור';
+            return active && (String(r.emp_id || '').trim() === empId || String(r.emp_id_2 || '').trim() === empId);
+          });
+          const list = rows.length
+            ? `<ul class="ds-summary-panel__list">${rows.map((r) => `<li>${escapeHtml(String(r.activity_name || '—'))} · ${escapeHtml(formatDateHe(r.start_date) || '—')}</li>`).join('')}</ul>`
+            : '<p class="ds-muted">אין פעילויות פעילות בחודש הנוכחי.</p>';
+          ui.openDrawer({ title: 'פעילויות מדריך', content: list });
+        } catch (_e) {
+          ui.openDrawer({ title: 'פעילויות מדריך', content: '<p class="ds-muted">טעינת הפעילויות נכשלה.</p>' });
+        }
+      });
     });
   }
 };

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -283,8 +283,15 @@ export const monthScreen = {
     const canEditActivity = state?.user?.display_role !== 'instructor';
     const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
 
+    const detailCache = new Map();
+    const detailKey = (row) => `${String(row?.source_sheet || '')}|${String(row?.RowID || '')}`;
+    const patchDetailCache = ({ sourceSheet, sourceRowId, changes }) => {
+      const key = `${String(sourceSheet || '')}|${String(sourceRowId || '')}`;
+      const hit = detailCache.get(key);
+      if (hit && typeof hit === 'object') Object.assign(hit, changes || {});
+    };
     const bindActivityEditForm = (contentRoot) =>
-      bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender });
+      bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender, onRowSaved: patchDetailCache });
 
     /** Bind the accordion toggles and activity card clicks inside a day drawer. */
     const bindDayDrawer = (contentRoot) => {
@@ -317,19 +324,32 @@ export const monthScreen = {
           ui.openDrawer({ title: 'פעילות', content: '<p class="ds-muted">לא נמצאו נתונים</p>' });
           return;
         }
-        const privateNote = showPrivateNote ? item.private_note || '—' : null;
-        ui.openDrawer({
-          title: item.activity_name || 'פעילות',
-          content: activityWorkDrawerHtml(item, {
-            privateNote,
-            canEdit: canEditActivity,
-            hideEmpIds,
-            hideRowId,
-            hideActivityNo,
-            settings: state?.clientSettings || {}
-          }),
-          onOpen: canEditActivity ? bindActivityEditForm : undefined
-        });
+        const openItem = (row) => {
+          const privateNote = showPrivateNote ? row.private_note || '—' : null;
+          ui.openDrawer({
+            title: row.activity_name || 'פעילות',
+            content: activityWorkDrawerHtml(row, {
+              privateNote,
+              canEdit: canEditActivity,
+              hideEmpIds,
+              hideRowId,
+              hideActivityNo,
+              settings: state?.clientSettings || {}
+            }),
+            onOpen: canEditActivity ? bindActivityEditForm : undefined
+          });
+        };
+        openItem(item);
+        const key = detailKey(item);
+        if (detailCache.has(key)) {
+          openItem(detailCache.get(key));
+          return;
+        }
+        api.activityDetail(item.RowID, item.source_sheet).then((rsp) => {
+          const full = rsp?.row || item;
+          detailCache.set(key, full);
+          openItem(full);
+        }).catch(() => {});
       });
     };
 

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -113,10 +113,13 @@ function textareaHtml({ name, value, klass = 'ds-input', rows = 3, attrs = '' })
 
 function activityNameSelectHtml(name, value, options, activityType) {
   const safeValue = String(value || '').trim();
-  const filtered = (Array.isArray(options) ? options : []).filter((o) => {
+  const normalizedType = String(activityType || '').trim().toLowerCase();
+  let filtered = (Array.isArray(options) ? options : []).filter((o) => {
     const parent = String(o?.parent_value || o?.activity_type || '').trim();
-    return !parent || parent === activityType;
+    if (!parent) return true;
+    return parent.toLowerCase() === normalizedType;
   });
+  if (!filtered.length) filtered = Array.isArray(options) ? options : [];
   const all = filtered.slice();
   if (safeValue && !all.some((o) => String(o?.label || '').trim() === safeValue)) {
     all.unshift({ label: safeValue, activity_no: '', parent_value: activityType });

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -147,7 +147,7 @@ function updateMoreDatesToggle(form) {
   syncMeetingRemoveButtons(form);
 }
 
-export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, rerender }) {
+export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, rerender, onRowSaved }) {
   if (!api || !contentRoot) return;
 
   if (contentRoot._activityEditAbort) {
@@ -181,9 +181,14 @@ export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, r
       await api.saveActivity({ source_sheet: sourceSheet, source_row_id: sourceRowId, changes });
       setStatus(statusEl, 'is-success', '✅ נשמר בהצלחה');
       showToast('✅ נשמר בהצלחה', 'success', 2500);
+      if (typeof onRowSaved === 'function') onRowSaved({ sourceSheet, sourceRowId, changes, form });
       setEditMode(form, false);
       clearScreenDataCache?.();
-      if (typeof rerender === 'function') await rerender();
+      if (typeof rerender === 'function') {
+        requestAnimationFrame(() => {
+          rerender();
+        });
+      }
     } catch (err) {
       setStatus(statusEl, 'is-error', `⚠️ ${translateApiErrorForUser(err?.message)}`);
     } finally {

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -201,8 +201,15 @@ export const weekScreen = {
     const canEditActivity = state?.user?.display_role !== 'instructor';
     const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
 
+    const detailCache = new Map();
+    const detailKey = (row) => `${String(row?.source_sheet || '')}|${String(row?.RowID || '')}`;
+    const patchDetailCache = ({ sourceSheet, sourceRowId, changes }) => {
+      const key = `${String(sourceSheet || '')}|${String(sourceRowId || '')}`;
+      const hit = detailCache.get(key);
+      if (hit && typeof hit === 'object') Object.assign(hit, changes || {});
+    };
     const bindActivityEditForm = (contentRoot) =>
-      bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender });
+      bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender, onRowSaved: patchDetailCache });
 
     let navDebounceTimer = null;
     const queueWeekShift = (delta) => {
@@ -257,21 +264,37 @@ export const weekScreen = {
         group.some((entry) => String(entry.RowID) === String(rowId))
       ) || [item];
       const mode = summaryGroup.length > 1 ? 'summary' : 'single';
-      ui.openDrawer({
-        title: '',
-        content: weekDrawerHtml(
-          mode === 'summary' ? summaryGroup : item,
-          date,
-          hideEmpIds,
-          hideRowId,
-          hideActivityNo,
-          canEditActivity,
-          showPrivateNote,
-          state?.clientSettings || {},
-          mode
-        ),
-        onOpen: canEditActivity ? bindActivityEditForm : undefined
-      });
+      const openDrawerWith = (payload, currMode) => {
+        ui.openDrawer({
+          title: '',
+          content: weekDrawerHtml(
+            currMode === 'summary' ? payload : payload[0],
+            date,
+            hideEmpIds,
+            hideRowId,
+            hideActivityNo,
+            canEditActivity,
+            showPrivateNote,
+            state?.clientSettings || {},
+            currMode
+          ),
+          onOpen: canEditActivity ? bindActivityEditForm : undefined
+        });
+      };
+      openDrawerWith(summaryGroup, mode);
+      const loadDetails = async () => {
+        const rows = mode === 'summary' ? summaryGroup : [item];
+        const detailed = await Promise.all(rows.map(async (row) => {
+          const key = detailKey(row);
+          if (detailCache.has(key)) return detailCache.get(key);
+          const rsp = await api.activityDetail(row.RowID, row.source_sheet);
+          const full = rsp?.row || row;
+          detailCache.set(key, full);
+          return full;
+        }));
+        openDrawerWith(detailed, mode);
+      };
+      loadDetails().catch(() => {});
     });
   }
 };

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4129,8 +4129,17 @@ select.ds-input {
 
 /* ——— Instructor summary rows (מדריכים) ——— */
 .instr-summary-row {
-  cursor: default;
-  pointer-events: none;
+  cursor: pointer;
+  width: 100%;
+  border: 1px solid var(--ds-border);
+  border-radius: 10px;
+  background: var(--ds-surface);
+  padding: 10px 12px;
+  text-align: right;
+}
+
+.instr-summary-row:hover {
+  border-color: color-mix(in srgb, var(--ds-accent) 30%, var(--ds-border));
 }
 
 .instr-count-badges {
@@ -4161,6 +4170,12 @@ select.ds-input {
   background: #fef3c7;
   color: #92400e;
   border: 1px solid #fde68a;
+}
+
+.instr-count-badge--total {
+  background: #e0f2fe;
+  color: #075985;
+  border: 1px solid #bae6fd;
 }
 
 .instr-count-badge__num {
@@ -4455,7 +4470,7 @@ select.ds-input {
 
 .sc-school-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 6px;
   align-items: start;
 }
@@ -4624,7 +4639,7 @@ select.ds-input {
 
 @media (max-width: 760px) {
   .sc-school-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .sc-contact-list {
@@ -4643,9 +4658,18 @@ select.ds-input {
 }
 
 @media (max-width: 560px) {
+  .sc-school-grid {
+    grid-template-columns: 1fr;
+  }
   .ci-person-grid {
     grid-template-columns: repeat(2, 1fr);
   }
+}
+
+.ds-contact-edit-form {
+  width: min(720px, 90vw);
+  margin-inline: auto;
+  gap: var(--ds-space-2);
 }
 
 /* ── Contacts copy toast ── */


### PR DESCRIPTION
### Motivation
- Reduce visible page reloads and make activity edits update immediately while background refreshes run silently. 
- Ensure week/month calendar drawers show full meeting/date details reliably after opening the drawer. 
- Fix several UX issues on contacts and dashboard screens per requested copy/layout and prevent search input stutter. 

### Description
- Make the activity edit binding accept `onRowSaved` and call it after successful `api.saveActivity`, and invoke `rerender()` via `requestAnimationFrame` to push refresh into the background (`frontend/src/screens/shared/bind-activity-edit-form.js`).
- Change week/month drawer flows to open immediately from summary data and then fetch the full `activityDetail` payload (cached per-row) and replace drawer content when ready, preserving meeting schedules (`frontend/src/screens/week.js`, `frontend/src/screens/month.js`).
- Fix activity-name dropdown filtering to normalize activity type comparison and fall back to the full list when filtering yields no options (`frontend/src/screens/shared/activity-detail-html.js`).
- Update dashboard monthly summary wording and split exceptions into separate lines to match the requested Hebrew phrasing (`frontend/src/screens/dashboard.js`), while relying on existing snapshot sheets (`backend/dashboard-snapshot.gs`).
- Revamp contacts edit forms: `employment_type` set to the requested fixed list (`תעשיידע`, `מעוף`, `מנפוואר`), `direct_manager` uses `activities_manager_users` from client settings, and edit forms get a compact width wrapper (`frontend/src/screens/contacts.js`, `frontend/src/styles/main.css`).
- Adjust school-contacts layout to a 3-column grid with responsive fallbacks and remove the authority-level school-count badge text (`frontend/src/screens/contacts.js`, `frontend/src/styles/main.css`).
- Make instructor rows into clickable compact cards that show per-type totals and open a drawer listing that instructor's active activities (plus small UI/CSS tweaks and a new total badge) (`frontend/src/screens/instructors.js`, `frontend/src/styles/main.css`).
- Add debounce to search inputs on contacts and instructor-contacts screens to reduce UI stutter while typing (`frontend/src/screens/contacts.js`, `frontend/src/screens/instructor-contacts.js`).

### Testing
- Ran `npm test` and all tests passed (`19` tests, no failures). 
- Performed a module import sanity check using `node -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec24e7f124832ba5f48d9d42f2e1a4)