### PR TITLE
Add temporary debug function to validate script-cache runtime loading

### DIFF
--- a/backend/script-cache.gs
+++ b/backend/script-cache.gs
@@ -50,6 +50,10 @@ function scriptCacheDebugMark_(eventName, key, bytes, errorText) {
   } catch (e) {}
 }
 
+function debugScriptCacheLoaded_() {
+  Logger.log('typeof scriptCacheDebugMark_ = ' + typeof scriptCacheDebugMark_);
+}
+
 function scriptCacheInvalidateDataViews_() {
   try {
     var c = CacheService.getScriptCache();


### PR DESCRIPTION
### Motivation
- Add a small, safe helper to confirm whether the deployed Apps Script runtime actually includes the `script-cache.gs` implementation (to diagnose source vs runtime/deploy mismatches). 

### Description
- Added `debugScriptCacheLoaded_()` to `backend/script-cache.gs` which logs `typeof scriptCacheDebugMark_` for manual execution in the Apps Script project and is intended as a temporary diagnostic helper. 

### Testing
- Ran `node scripts/check_apps_script_backend_sync.mjs` which exited successfully (no missing files or missing functions detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2640635c832b993a89c3aede403a)