### PR TITLE
Add end-to-end Apps Script snapshot ops script and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,37 @@ npm test
 - `syncFinance`
 - `listSheets`
 
+
+## תפעול snapshot מקצה לקצה (Apps Script + Sheets)
+
+נוסף סקריפט תפעולי להרצה ידנית מקצה לקצה: `scripts/apps_script_snapshot_ops.mjs`.
+
+### דרישות
+
+- `GOOGLE_OAUTH_ACCESS_TOKEN`
+- `GAS_SCRIPT_ID`
+- `SPREADSHEET_ID`
+
+אופציונלי ל-redeploy של Web App פעיל:
+
+- `REDEPLOY_WEBAPP=true`
+- `WEBAPP_DEPLOYMENT_ID=<deployment id>`
+
+### הרצה
+
+```bash
+GOOGLE_OAUTH_ACCESS_TOKEN=... \
+GAS_SCRIPT_ID=... \
+SPREADSHEET_ID=... \
+node scripts/apps_script_snapshot_ops.mjs
+```
+
+הסקריפט מבצע:
+1. הרצת `refreshDashboardSnapshots` בפרויקט Apps Script.
+2. קריאת `dashboard_refresh_control`.
+3. בדיקה ששני גיליונות snapshot התמלאו.
+4. redeploy (אם הופעל בדגלים המתאימים).
+
 ## תחזוקה נכונה
 
 ### כשמחליפים URL של Apps Script

--- a/scripts/apps_script_snapshot_ops.mjs
+++ b/scripts/apps_script_snapshot_ops.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+/**
+ * End-to-end operational helper for dashboard snapshots on Google Apps Script.
+ *
+ * Required env vars:
+ * - GOOGLE_OAUTH_ACCESS_TOKEN
+ * - GAS_SCRIPT_ID
+ * - SPREADSHEET_ID
+ *
+ * Optional env vars:
+ * - REDEPLOY_WEBAPP=true|false
+ * - WEBAPP_DEPLOYMENT_ID=<deployment id to update>
+ */
+
+const {
+  GOOGLE_OAUTH_ACCESS_TOKEN,
+  GAS_SCRIPT_ID,
+  SPREADSHEET_ID,
+  REDEPLOY_WEBAPP,
+  WEBAPP_DEPLOYMENT_ID
+} = process.env;
+
+function required(name, value) {
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}`,
+    'Content-Type': 'application/json'
+  };
+}
+
+async function gfetch(url, options = {}) {
+  const res = await fetch(url, options);
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text };
+  }
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText}: ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function runFunction(functionName, parameters = []) {
+  const url = `https://script.googleapis.com/v1/scripts/${encodeURIComponent(GAS_SCRIPT_ID)}:run`;
+  return gfetch(url, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ function: functionName, parameters })
+  });
+}
+
+async function readRange(rangeA1) {
+  const range = encodeURIComponent(rangeA1);
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(SPREADSHEET_ID)}/values/${range}`;
+  const data = await gfetch(url, { headers: { Authorization: `Bearer ${GOOGLE_OAUTH_ACCESS_TOKEN}` } });
+  return data.values || [];
+}
+
+function rowsToObjects(rows) {
+  if (!rows.length) return [];
+  const headers = rows[0].map(String);
+  return rows.slice(1).map((row) => {
+    const obj = {};
+    headers.forEach((h, i) => {
+      obj[h] = row[i] ?? '';
+    });
+    return obj;
+  });
+}
+
+async function maybeRedeploy() {
+  if (String(REDEPLOY_WEBAPP).toLowerCase() !== 'true') {
+    return { redeployed: false, reason: 'skipped' };
+  }
+
+  if (!WEBAPP_DEPLOYMENT_ID) {
+    return { redeployed: false, reason: 'missing WEBAPP_DEPLOYMENT_ID' };
+  }
+
+  const versionResp = await gfetch(
+    `https://script.googleapis.com/v1/projects/${encodeURIComponent(GAS_SCRIPT_ID)}/versions`,
+    {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ description: `ops refresh ${new Date().toISOString()}` })
+    }
+  );
+
+  const versionNumber = versionResp.versionNumber;
+  await gfetch(
+    `https://script.googleapis.com/v1/projects/${encodeURIComponent(GAS_SCRIPT_ID)}/deployments/${encodeURIComponent(WEBAPP_DEPLOYMENT_ID)}`,
+    {
+      method: 'PUT',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        deploymentConfig: {
+          versionNumber,
+          manifestFileName: 'appsscript',
+          description: `ops redeploy ${new Date().toISOString()}`
+        }
+      })
+    }
+  );
+
+  return { redeployed: true, versionNumber };
+}
+
+async function main() {
+  required('GOOGLE_OAUTH_ACCESS_TOKEN', GOOGLE_OAUTH_ACCESS_TOKEN);
+  required('GAS_SCRIPT_ID', GAS_SCRIPT_ID);
+  required('SPREADSHEET_ID', SPREADSHEET_ID);
+
+  await runFunction('refreshDashboardSnapshots');
+
+  const controlRows = rowsToObjects(
+    await readRange('dashboard_refresh_control!A1:C')
+  );
+
+  const controlMap = Object.fromEntries(
+    controlRows.map((r) => [String(r.key || ''), String(r.value || '')])
+  );
+
+  const lastStatus = controlMap.last_status || '';
+  const lastMessage = controlMap.last_message || '';
+
+  const summaryRows = rowsToObjects(
+    await readRange('dashboard_summary_snapshot!A1:T')
+  );
+  const byManagerRows = rowsToObjects(
+    await readRange('dashboard_by_manager_snapshot!A1:L')
+  );
+
+  const summaryFilled = summaryRows.length > 0;
+  const byManagerFilled = byManagerRows.length > 0;
+
+  const redeploy = await maybeRedeploy();
+
+  const result = {
+    last_status: lastStatus,
+    last_message: lastMessage,
+    snapshots: {
+      dashboard_summary_snapshot_filled: summaryFilled,
+      dashboard_by_manager_snapshot_filled: byManagerFilled
+    },
+    redeploy
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err.message || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide an operational, repo-contained way to run `refreshDashboardSnapshots` against the Apps Script project, verify the `dashboard_refresh_control` status and that snapshot sheets populated, and optionally redeploy the Web App. 
- Enable safe automation / troubleshooting for the snapshot issue (snapshot sheets not filling) without requiring manual Apps Script UI steps.

### Description
- Added `scripts/apps_script_snapshot_ops.mjs`, an executable Node helper that calls the Apps Script API to run the `refreshDashboardSnapshots` function, reads `dashboard_refresh_control` and the snapshot sheets, and can optionally redeploy a specified Web App deployment. 
- Documented the end-to-end ops flow and required environment variables (`GOOGLE_OAUTH_ACCESS_TOKEN`, `GAS_SCRIPT_ID`, `SPREADSHEET_ID`, and optional `REDEPLOY_WEBAPP` / `WEBAPP_DEPLOYMENT_ID`) in `README.md` and showed a one-line run example. 
- The script converts sheet ranges to objects, returns `last_status` / `last_message`, reports whether the two snapshot sheets contain rows, and performs a redeploy flow when requested. 

### Testing
- Ran the repository unit tests with `npm test`, all tests passed (`19` tests, `0` failures). 
- Executed `node scripts/apps_script_snapshot_ops.mjs` in this environment which failed fast with the expected guard (`Missing required env var: GOOGLE_OAUTH_ACCESS_TOKEN`) because no Google credentials were provided, demonstrating the script’s safety checks. 
- No live Apps Script / Sheets calls were performed in this environment due to missing OAuth credentials, so snapshot status on the production spreadsheet was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec290ae828832bb451589d2714b492)