### PR TITLE
עדכון כתובת Apps Script והעלאת גרסת cache של Service Worker

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyc0ddYcHyLhF57Z2fzS3guEGPOOKxitrmuHLTWAnfem_Z-h4zq9Zb0n8BthZ9HLDM/exec';
+  'https://script.google.com/macros/s/AKfycbx3kwHi6nPMplBkYswPLrmn4Tym2cA2MNwbT8V_54E6W1-nIrUGUncTke7vV-8gZQS0/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 90;
+const CACHE_VERSION = 91;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- לתקן את כתובת ה־Apps Script שהאפליקציה משתמשת בה כדי להצביע ל־Web App החדש בלי לשנות לוגיקה, טקסטים או הרשאות. 
- לוודא שהדפדפן ימשוך את `frontend/src/config.js` המעודכן על ידי invalidation של ה־cache כשה־SW עושה precache. 

### Description
- עודכנה הכתובת `DEFAULT_API_URL` ב־`frontend/src/config.js` מהכתובת הישנה לכתובת החדשה: `https://script.google.com/macros/s/AKfycbx3kwHi6nPMplBkYswPLrmn4Tym2cA2MNwbT8V_54E6W1-nIrUGUncTke7vV-8gZQS0/exec`. 
- הכתובת הישנה היתה `https://script.google.com/macros/s/AKfycbyc0ddYcHyLhF57Z2fzS3guEGPOOKxitrmuHLTWAnfem_Z-h4zq9Zb0n8BthZ9HLDM/exec`. 
- הוגברה `CACHE_VERSION` ב־`sw.js` מ־`90` ל־`91` כיוון ש־`sw.js` עושה precache של `./frontend/src/config.js`, ולכן נדרש cache-bust כדי לאלץ דפדפנים לקבל את הקונפיג המעודכן. 
- שונו רק שני קבצים: `frontend/src/config.js` ו־`sw.js`, ללא שינויים בעיצוב/טקסט/הרשאות/לוגיקה עסקית. 

### Testing
- ביצעתי חיפוש repo-wide בעזרת `rg` על המחרוזת הישן/כל מופעי `script.google.com/macros/s/` כדי לאתר מופעים נוספים והחיפוש חזר ללא מופעים של הכתובת הישנה לאחר העדכון. (הצלחה). 
- ווידאתי ש־`sw.js` כולל את `./frontend/src/config.js` ב־`APP_SHELL` ולכן ביצעתי bump של `CACHE_VERSION` מ־`90` ל־`91` כדי לאפגן את ה־cache; העדכון בוצע בהצלחה. 
- הריצות האוטומטיות של `git diff -- frontend/src/config.js sw.js` ו־הקומיט בוצעו והראו את שתי השורות ששונו בלבד; הפקודות הסתיימו בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4e7c5d7c832baa92a5ab51431729)