### PR TITLE
Fix control KPI detection for missing instructor and start date

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -97,8 +97,11 @@ function countActiveByTypeInYm_(rows, ym, activityType) {
 
 function rowExceptionTypes_(row) {
   var out = [];
-  if (!text_(row.emp_id) && !text_(row.emp_id_2)) out.push('missing_instructor');
-  if (!text_(row.start_date)) out.push('missing_start_date');
+  if (isExcludedStatusForControl_(row && row.status)) return out;
+  var hasInstructor1 = !isNormalizedEmptyValue_(row && row.instructor_name) || !isNormalizedEmptyValue_(row && row.emp_id);
+  var hasInstructor2 = !isNormalizedEmptyValue_(row && row.instructor_name_2) || !isNormalizedEmptyValue_(row && row.emp_id_2);
+  if (!hasInstructor1 && !hasInstructor2) out.push('missing_instructor');
+  if (!normalizeDateTextToIso_(row && row.start_date)) out.push('missing_start_date');
   if (text_(row.end_date) > getLateEndDateCutoff_()) out.push('late_end_date');
   return out;
 }
@@ -118,17 +121,17 @@ function primaryExceptionForRow_(row) {
 }
 
 function normalizeDateTextToIso_(value) {
-  if (value === null || value === undefined || value === '') return '';
+  if (isNormalizedEmptyValue_(value)) return '';
   var t = text_(value);
   if (!t) return '';
-  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) return t;
+  if (isValidIsoDateString_(t)) return t;
   var m = /^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})$/.exec(t);
   if (m) {
     var d = ('0' + parseInt(m[1], 10)).slice(-2);
     var mo = ('0' + parseInt(m[2], 10)).slice(-2);
     var y = m[3];
     var iso = y + '-' + mo + '-' + d;
-    if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
+    if (isValidIsoDateString_(iso)) return iso;
   }
   return '';
 }
@@ -353,12 +356,47 @@ function actionDashboard_(user, payload) {
   var missingInstructorCount = 0;
   var missingStartDateCount = 0;
   var lateEndDateCount = 0;
-  longRows.forEach(function(row) {
+  var totalLongRows = longRows.length;
+  var relevantLongRows = longRows.filter(function(row) {
+    return !isExcludedStatusForControl_(row && row.status);
+  });
+  var missingInstructorExamples = [];
+  var missingStartDateExamples = [];
+  relevantLongRows.forEach(function(row) {
     var exceptionTypes = rowExceptionTypes_(row);
-    if (exceptionTypes.indexOf('missing_instructor') >= 0) missingInstructorCount += 1;
-    if (exceptionTypes.indexOf('missing_start_date') >= 0) missingStartDateCount += 1;
+    if (exceptionTypes.indexOf('missing_instructor') >= 0) {
+      missingInstructorCount += 1;
+      if (missingInstructorExamples.length < 5) {
+        missingInstructorExamples.push({
+          RowID: text_(row.RowID),
+          instructor_name: row.instructor_name,
+          instructor_name_2: row.instructor_name_2,
+          emp_id: row.emp_id,
+          emp_id_2: row.emp_id_2,
+          status: row.status
+        });
+      }
+    }
+    if (exceptionTypes.indexOf('missing_start_date') >= 0) {
+      missingStartDateCount += 1;
+      if (missingStartDateExamples.length < 5) {
+        missingStartDateExamples.push({
+          RowID: text_(row.RowID),
+          start_date: row.start_date,
+          status: row.status
+        });
+      }
+    }
     if (exceptionTypes.indexOf('late_end_date') >= 0) lateEndDateCount += 1;
   });
+  console.log('[dashboard][control-metrics-debug]', JSON.stringify({
+    total_records: totalLongRows,
+    relevant_records: relevantLongRows.length,
+    missing_instructor_records: missingInstructorCount,
+    missing_start_date_records: missingStartDateCount,
+    missing_instructor_examples: missingInstructorExamples,
+    missing_start_date_examples: missingStartDateExamples
+  }));
 
   var shortActivitiesByType = {};
   shortRowsBySource.forEach(function(row) {
@@ -831,11 +869,34 @@ function actionExceptions_(user) {
   };
   var result = [];
 
-  rows.forEach(function(row) {
+  var relevantRows = rows.filter(function(row) {
+    return !isExcludedStatusForControl_(row && row.status);
+  });
+  var missingInstructorExamples = [];
+  var missingStartDateExamples = [];
+
+  relevantRows.forEach(function(row) {
     var exceptionType = primaryExceptionForRow_(row);
     if (!exceptionType) return;
 
     counts[exceptionType] += 1;
+    if (exceptionType === 'missing_instructor' && missingInstructorExamples.length < 5) {
+      missingInstructorExamples.push({
+        RowID: text_(row.RowID),
+        instructor_name: row.instructor_name,
+        instructor_name_2: row.instructor_name_2,
+        emp_id: row.emp_id,
+        emp_id_2: row.emp_id_2,
+        status: row.status
+      });
+    }
+    if (exceptionType === 'missing_start_date' && missingStartDateExamples.length < 5) {
+      missingStartDateExamples.push({
+        RowID: text_(row.RowID),
+        start_date: row.start_date,
+        status: row.status
+      });
+    }
     result.push({
       RowID:              row.RowID,
       source_sheet:       text_(row.source_sheet || CONFIG.SHEETS.DATA_LONG),
@@ -859,6 +920,15 @@ function actionExceptions_(user) {
       exception_type:    exceptionType
     });
   });
+
+  console.log('[exceptions][control-metrics-debug]', JSON.stringify({
+    total_records: rows.length,
+    relevant_records: relevantRows.length,
+    missing_instructor_records: counts.missing_instructor,
+    missing_start_date_records: counts.missing_start_date,
+    missing_instructor_examples: missingInstructorExamples,
+    missing_start_date_examples: missingStartDateExamples
+  }));
 
   return {
     rows: result,

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -11,6 +11,50 @@ function text_(value) {
   return String(value).trim();
 }
 
+/**
+ * Unified empty-value normalization for control metrics.
+ * Values such as null/undefined/blank/whitespace/"-"/"—"/"לא שובץ"/"טרם שובץ"/"לא נקבע"
+ * are treated as empty.
+ */
+function isNormalizedEmptyValue_(value) {
+  if (value === null || value === undefined) return true;
+  var raw = text_(value);
+  if (!raw) return true;
+  var norm = raw.replace(/\u00A0/g, ' ').trim();
+  if (!norm) return true;
+  var compact = norm.replace(/\s+/g, ' ').toLowerCase();
+  return compact === '-' ||
+    compact === '—' ||
+    compact === 'לא שובץ' ||
+    compact === 'טרם שובץ' ||
+    compact === 'לא נקבע';
+}
+
+function isValidIsoDateString_(value) {
+  var iso = text_(value);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return false;
+  var parts = iso.split('-');
+  var y = parseInt(parts[0], 10);
+  var m = parseInt(parts[1], 10);
+  var d = parseInt(parts[2], 10);
+  if (!y || m < 1 || m > 12 || d < 1 || d > 31) return false;
+  var dt = new Date(y, m - 1, d);
+  return dt.getFullYear() === y && (dt.getMonth() + 1) === m && dt.getDate() === d;
+}
+
+function normalizeStatusForControl_(status) {
+  return text_(status).replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function isExcludedStatusForControl_(status) {
+  var s = normalizeStatusForControl_(status);
+  return s === 'מבוטל' ||
+    s === 'בוטל' ||
+    s === 'הסתיים' ||
+    s === 'לא פעיל' ||
+    s === 'טיוטה';
+}
+
 function yesNo_(value) {
   return text_(value).toLowerCase() === 'no' ? 'no' : 'yes';
 }


### PR DESCRIPTION
### Motivation
- לתקן את זיהוי מדדי הבקרה שבהם קורסים עם שדות מדריך/תאריך התחלה לא מזוהים נכון, וליישם נרמול ערכים חסרים וסינון סטטוסים לא־רלוונטיים.

### Description
- הוספו עזרי נרמול וולידציה ב-`backend/helpers.gs`: `isNormalizedEmptyValue_`, `isValidIsoDateString_`, `normalizeStatusForControl_` ו-`isExcludedStatusForControl_` עבור התנהגות אחידה של ערכים "ריקים" וסטטוסים שמוחרגים מכל מדדי הבקרה.
- שונתה הלוגיקה ב-`rowExceptionTypes_` כך ש"קורס ללא מדריך" ייספר רק אם כל שדות המדריך (`instructor_name`, `instructor_name_2`, `emp_id`, `emp_id_2`) ריקים לפי הנרמול, ו"אין תאריך התחלה" ייספר גם כאשר `start_date` לא ניתן לפענוח כתאריך תקין באמצעות `normalizeDateTextToIso_`.
- שודרגה `normalizeDateTextToIso_` לשימוש בולידציה של פורמט ISO באמצעות `isValidIsoDateString_` וברור ערכים נורמליים כחלשים.
- נוספו בדיקות דיבאג זמניות ב-`actionDashboard_` ו-`actionExceptions_` שמדפיסות לקונסול את מספר הרשומות הכולל, מספר הרשומות הרלוונטיות אחרי סינון `status`, ספירת חסרי מדריך וחסרי תאריך התחלה, ועוד עד 5 דוגמאות לכל קטגוריה.

### Testing
- בוצעו בדיקות חשיפה וקונסולציה של הקוד באמצעות `rg`, `sed -n '...'`, `nl -ba ...`, `git status --short` ו-`git diff` כדי לאמת שהשינויים הוכנסו לקבצים הרלוונטיים והפקודות השלימו בהצלחה.
- לא הוספו או הורצו מבחנים אוטומטיים יחידתיים במסגרת השינוי; יש להפעיל בדיקות אינטגרציה/סביבת סטייג' כדי לאמת שהספירות בדשבורד משתקפות כמצופה לאחר פריסה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5390b14c832ba084673145f9f434)