### PR TITLE
Fetch missing cache during fast rerender and add month-screen loading UI/caching

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -598,18 +598,33 @@ function updateNavActiveClasses() {
 
 /**
  * Fast re-render for same-route filter/search changes.
- * Bypasses the full mount cycle when data is already cached.
- * Falls back to full render() if cache is missing or route has changed.
+ * Uses cached data immediately; if cache is missing, fetches in place
+ * (same screen root) to avoid full-shell reload/spinner.
  */
-function fastRerenderScreen(screen, routeAtBind) {
+async function fastRerenderScreen(screen, routeAtBind) {
   const perfStart = performance.now();
   if (state.route !== routeAtBind) { render(); return; }
   const key = screenDataCacheKey();
   const raw = state.screenDataCache[key];
   const hit = raw && Date.now() - raw.t < screenCacheTtl() ? raw : null;
-  if (!hit) { render(); return; }
   const screenRoot = document.getElementById('screenRoot');
   if (!screenRoot) { render(); return; }
+  if (!hit) {
+    if (!screen.load) { render(); return; }
+    const requestedKey = key;
+    try {
+      const data = await loadScreenDataWithCache(screen);
+      if (state.route !== routeAtBind) return;
+      if (screenDataCacheKey() !== requestedKey) return;
+      screenRoot.innerHTML = screen.render(data, { state });
+      bindScreen(screen, screenRoot, data);
+      recordRenderPerf(routeAtBind, 'fast-rerender-fetch', performance.now() - perfStart, { cache_key: requestedKey });
+      maybePrefetchFromDashboard();
+    } catch {
+      render();
+    }
+    return;
+  }
   screenRoot.innerHTML = screen.render(hit.data, { state });
   bindScreen(screen, screenRoot, hit.data);
   recordRenderPerf(routeAtBind, 'fast-rerender', performance.now() - perfStart, { cache_key: key });

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -176,6 +176,10 @@ function shiftMonthYm(ym, delta) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
 }
 
+function monthCacheKey(ym) {
+  return `month:${ym && /^\d{4}-\d{2}$/.test(String(ym)) ? ym : 'current'}`;
+}
+
 function activityDetailCacheKey(row) {
   return `activityDetail:${row.source_sheet || ''}:${row.RowID || ''}`;
 }
@@ -294,11 +298,21 @@ export const monthScreen = {
   },
   bind({ root, ui, data, state, rerender, clearScreenDataCache, api }) {
     bindActNavGrid(root, { state, rerender });
+    root.classList.remove('is-month-loading');
+    root.setAttribute('aria-busy', 'false');
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = state?.user?.display_role !== 'instructor';
     const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
+    const cells = Array.isArray(data?.cells) ? data.cells : [];
+    const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
+    const allItemsByRowId = new Map();
+    cells.forEach((cell) => {
+      monthCellItems(cell, itemsById).forEach((item) => {
+        allItemsByRowId.set(String(item?.RowID || ''), item);
+      });
+    });
 
     const bindActivityEditForm = (contentRoot) =>
       bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender, onRowSaved: (p) => patchCachedActivityDetail(p, state) });
@@ -326,10 +340,7 @@ export const monthScreen = {
         const parts = action.split('|');
         const date = decodeURIComponent(parts[1] || '');
         const rowId = decodeURIComponent(parts[2] || '');
-        const cells = Array.isArray(data?.cells) ? data.cells : [];
-        const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
-        const allItems = cells.flatMap((c) => monthCellItems(c, itemsById));
-        const item = allItems.find((it) => String(it.RowID) === String(rowId));
+        const item = allItemsByRowId.get(String(rowId));
         if (!item) {
           ui.openDrawer({ title: 'פעילות', content: '<p class="ds-muted">לא נמצאו נתונים</p>' });
           return;
@@ -372,15 +383,30 @@ export const monthScreen = {
     };
     const prevBtn = root.querySelector('[data-month-prev]');
     const nextBtn = root.querySelector('[data-month-next]');
+    const setMonthAreaLoading = (isLoading) => {
+      root.classList.toggle('is-month-loading', !!isLoading);
+      root.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+      if (prevBtn) prevBtn.disabled = !!isLoading;
+      if (nextBtn) nextBtn.disabled = !!isLoading;
+    };
     const doMonthShift = (delta) => {
-      if (prevBtn) prevBtn.disabled = true;
-      if (nextBtn) nextBtn.disabled = true;
-      state.monthYm = shiftMonthYm(resolveBaseYm(), delta);
+      const targetYm = shiftMonthYm(resolveBaseYm(), delta);
+      const targetKey = monthCacheKey(targetYm);
+      const hasCachedTarget = !!state?.screenDataCache?.[targetKey];
+
+      state.monthYm = targetYm;
       try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
+
+      if (hasCachedTarget) {
+        rerender?.();
+        return;
+      }
+
+      setMonthAreaLoading(true);
       rerender?.();
     };
-    prevBtn?.addEventListener('click', () => doMonthShift(-1));
-    nextBtn?.addEventListener('click', () => doMonthShift(1));
+    prevBtn?.addEventListener('click', () => { doMonthShift(-1); });
+    nextBtn?.addEventListener('click', () => { doMonthShift(1); });
 
     ui?.bindInteractiveCards(root, (action) => {
       if (!action.startsWith('monthcell|')) return;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2422,10 +2422,30 @@ span.ds-chip {
 }
 
 .ds-cal-wrap {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--ds-space-1);
   padding: var(--ds-space-2);
+}
+
+.screen-root.is-month-loading .ds-cal-wrap {
+  opacity: 0.72;
+  transition: opacity 0.14s ease;
+}
+
+.screen-root.is-month-loading .ds-cal-wrap::after {
+  content: 'טוען חודש…';
+  position: absolute;
+  inset: auto 10px 10px auto;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(26, 51, 88, 0.16);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--ds-accent);
+  box-shadow: 0 2px 8px rgba(26, 51, 88, 0.1);
 }
 
 .ds-cal-weekdays {


### PR DESCRIPTION
### Motivation
- Avoid full-shell reload/spinner when a fast rerender finds the screen data cache missing by fetching data in-place and updating the same screen root.
- Improve month screen UX when navigating months by showing a localized inline loading state and avoiding redundant fetches for already-cached months.

### Description
- Update `fastRerenderScreen` to `await` a data fetch using the screen loader on cache miss and render into the current `screenRoot` instead of falling back to a full `render()`; preserve route and cache-key checks and record separate perf event `fast-rerender-fetch`.
- Add `monthCacheKey` helper and use it when shifting months to detect cached targets and skip extra fetches, while still persisting `state.monthYm` to `localStorage`.
- Improve the month screen `bind` flow by building an `allItemsByRowId` map for fast lookup, marking the month area loading state with `root.classList` and `aria-busy`, disabling nav buttons while loading, and removing the `.is-month-loading` flag when binding completes.
- Add CSS for `.is-month-loading` to dim the calendar and show an inline "loading month" badge, plus minor event-listener/formatting cleanups and small accessibility updates.

### Testing
- Ran the frontend test suite with `npm test` and unit tests passed.
- Ran linting with `npm run lint` and found no lint errors.
- Built the frontend with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5aa7d4c8832bb6d0c1b266bf710c)