### PR TITLE
Ensure immediate post-login render, defer prefetch, lighten dashboard snapshot fallback, bump SW cache

### DIFF
--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -118,8 +118,9 @@ function actionDashboardSnapshot_(user, payload) {
   var byManagerRows = [];
 
   var ss = getSpreadsheet_();
+  var hasSummarySnapshotSheet = !!ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT);
 
-  if (ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT)) {
+  if (hasSummarySnapshotSheet) {
     var summaryRows = readRows_(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT);
     snap = summaryRows.find(function(r) { return text_(r.month_ym) === ym; }) || null;
   }
@@ -129,12 +130,25 @@ function actionDashboardSnapshot_(user, payload) {
     byManagerRows = allByMgr.filter(function(r) { return text_(r.month_ym) === ym; });
   }
 
-  if (!snap || !ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT)) {
-    var fullData = actionDashboard_(user, payload);
-    if (fullData && typeof fullData === 'object') {
-      fullData._is_snapshot = false;
+  if (!snap || !hasSummarySnapshotSheet) {
+    if (payload && payload.force_full === true) {
+      var fullData = actionDashboard_(user, payload);
+      if (fullData && typeof fullData === 'object') {
+        fullData._is_snapshot = false;
+      }
+      return fullData;
     }
-    return fullData;
+    return {
+      month: ym,
+      _is_snapshot: false,
+      _is_snapshot_missing: true,
+      can_view_finance: canViewFinance,
+      totals: {},
+      summary: {},
+      by_activity_manager: [],
+      kpi_cards: [],
+      show_only_nonzero_kpis: true
+    };
   }
 
   var s = snap || {};

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -36,6 +36,75 @@ const PERF_MAX_RENDERS = 150;
 
 /** Timer handle for deferred prefetch — cancelled on every new navigation. */
 let prefetchTimer = null;
+let prefetchIdleId = null;
+let firstAuthenticatedRenderTimerStarted = false;
+let firstLoadTimerStarted = false;
+let firstDashboardSnapshotTimerStarted = false;
+let firstPrefetchTimerStarted = false;
+let fastRerenderVersion = 0;
+const activeConsoleTimers = new Set();
+
+function beginPerfTimer(label) {
+  if (!label || typeof console === 'undefined' || typeof console.time !== 'function') return;
+  if (activeConsoleTimers.has(label)) return;
+  activeConsoleTimers.add(label);
+  console.time(label);
+}
+
+function endPerfTimer(label) {
+  if (!label || typeof console === 'undefined' || typeof console.timeEnd !== 'function') return;
+  if (!activeConsoleTimers.has(label)) return;
+  activeConsoleTimers.delete(label);
+  console.timeEnd(label);
+}
+
+function scheduleRender() {
+  beginPerfTimer('login:scheduleRender');
+  const complete = () => {
+    endPerfTimer('login:scheduleRender');
+    render().catch(() => {});
+  };
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(complete);
+    return;
+  }
+  setTimeout(complete, 0);
+}
+
+function cancelPrefetchSchedule() {
+  clearTimeout(prefetchTimer);
+  prefetchTimer = null;
+  if (typeof window !== 'undefined' && typeof window.cancelIdleCallback === 'function' && prefetchIdleId != null) {
+    window.cancelIdleCallback(prefetchIdleId);
+  }
+  prefetchIdleId = null;
+}
+
+function schedulePostLoginPrefetch() {
+  cancelPrefetchSchedule();
+  const run = () => {
+    prefetchTimer = null;
+    prefetchIdleId = null;
+    if (!state.token) return;
+    if (!firstPrefetchTimerStarted) {
+      firstPrefetchTimerStarted = true;
+      beginPerfTimer('prefetch:firstRun');
+      try {
+        prefetchFromDashboardIfNeeded();
+      } finally {
+        endPerfTimer('prefetch:firstRun');
+      }
+      return;
+    }
+    prefetchFromDashboardIfNeeded();
+  };
+
+  if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+    prefetchIdleId = window.requestIdleCallback(run, { timeout: 5000 });
+    return;
+  }
+  prefetchTimer = setTimeout(run, 5000);
+}
 
 function recordRenderPerf(route, phase, durationMs, extra = {}) {
   if (typeof window === 'undefined') return;
@@ -602,6 +671,7 @@ function updateNavActiveClasses() {
  * (same screen root) to avoid full-shell reload/spinner.
  */
 async function fastRerenderScreen(screen, routeAtBind) {
+  const rerenderVersion = ++fastRerenderVersion;
   const perfStart = performance.now();
   if (state.route !== routeAtBind) { render(); return; }
   const key = screenDataCacheKey();
@@ -614,6 +684,7 @@ async function fastRerenderScreen(screen, routeAtBind) {
     const requestedKey = key;
     try {
       const data = await loadScreenDataWithCache(screen);
+      if (rerenderVersion !== fastRerenderVersion) return;
       if (state.route !== routeAtBind) return;
       if (screenDataCacheKey() !== requestedKey) return;
       screenRoot.innerHTML = screen.render(data, { state });
@@ -768,8 +839,7 @@ async function restoreSession() {
 
 async function mountScreen() {
   const mountStartMs = performance.now();
-  clearTimeout(prefetchTimer);
-  prefetchTimer = null;
+  cancelPrefetchSchedule();
   if (isDesktopViewport()) {
     isMobileNavOpen = false;
     document.body.classList.remove('is-shell-nav-open');
@@ -806,6 +876,11 @@ async function mountScreen() {
   const isStale = rawEntry && Date.now() - rawEntry.t >= screenCacheTtl();
 
   const shellExists = !!(state.token && document.querySelector('.app-shell #screenRoot'));
+  const firstAuthenticatedMount = !!(state.token && !hasMountedAuthenticatedShell);
+  if (firstAuthenticatedMount && !firstAuthenticatedRenderTimerStarted) {
+    firstAuthenticatedRenderTimerStarted = true;
+    beginPerfTimer('login:firstAuthenticatedRender');
+  }
 
   if (!shellExists) {
     // First mount: build shell HTML.
@@ -856,7 +931,18 @@ async function mountScreen() {
   }
 
   try {
+    if (firstAuthenticatedMount && !firstLoadTimerStarted) {
+      firstLoadTimerStarted = true;
+      beginPerfTimer('screen:firstLoad');
+    }
+    if (firstAuthenticatedMount && state.route === 'dashboard' && !firstDashboardSnapshotTimerStarted) {
+      firstDashboardSnapshotTimerStarted = true;
+      beginPerfTimer('dashboardSnapshot:firstLoad');
+    }
     const data = await loadScreenDataWithCache(screen);
+    if (firstAuthenticatedMount && state.route === 'dashboard') {
+      endPerfTimer('dashboardSnapshot:firstLoad');
+    }
     const renderStart = performance.now();
     const screenRoot = document.getElementById('screenRoot');
     if (!screenRoot) throw new Error('אזור התצוגה לא זמין');
@@ -868,6 +954,9 @@ async function mountScreen() {
     if (routeChanged) lastRenderedRoute = state.route;
     maybePrefetchFromDashboard();
   } catch (err) {
+    if (firstAuthenticatedMount && state.route === 'dashboard') {
+      endPerfTimer('dashboardSnapshot:firstLoad');
+    }
     const screenRoot = document.getElementById('screenRoot');
     if (screenRoot) {
       const msg = translateApiErrorForUser(err?.message) || 'אירעה שגיאה בטעינת הדף';
@@ -880,9 +969,9 @@ async function mountScreen() {
   } finally {
     if (!hasMountedAuthenticatedShell) {
       hasMountedAuthenticatedShell = true;
-      setTimeout(() => {
-        if (state.token) prefetchFromDashboardIfNeeded();
-      }, 1200);
+      endPerfTimer('login:firstAuthenticatedRender');
+      endPerfTimer('screen:firstLoad');
+      schedulePostLoginPrefetch();
     }
     setShellNavBusy(false);
     recordRenderPerf(state.route, 'mount-total', performance.now() - mountStartMs, { cache_key: cacheKey });
@@ -954,18 +1043,35 @@ async function render() {
             clearRoutesSnapshot();
             loginInlineError = message;
           };
+          beginPerfTimer('login:total');
           try {
+            beginPerfTimer('login:api.login');
             const data = await api.login(userId, code);
+            endPerfTimer('login:api.login');
             hasMountedAuthenticatedShell = false;
+            firstAuthenticatedRenderTimerStarted = false;
+            firstLoadTimerStarted = false;
+            firstDashboardSnapshotTimerStarted = false;
+            firstPrefetchTimerStarted = false;
+            beginPerfTimer('login:setSession');
             setSession({ token: data.token, user: data.user });
+            endPerfTimer('login:setSession');
+            beginPerfTimer('login:applyBootstrap');
             applyBootstrapFromLoginData(data);
+            endPerfTimer('login:applyBootstrap');
             loginInlineError = '';
-            _pendingRender = true;
+            scheduleRender();
           } catch (error) {
+            endPerfTimer('login:api.login');
+            endPerfTimer('login:setSession');
+            endPerfTimer('login:applyBootstrap');
+            endPerfTimer('login:scheduleRender');
             const msg = translateApiErrorForUser(error?.message);
             if (errorNode) errorNode.textContent = msg;
             rollbackToLogin(msg);
             throw error;
+          } finally {
+            endPerfTimer('login:total');
           }
         }
       });

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 91;
+const CACHE_VERSION = 92;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- ישרר רגרסיה שבה המסך נתקע על "מתחבר..." לאחר `api.login` עקב הסתמכות על `_pendingRender` בלבד במקום קריאת `render` מתוזמנת. 
- להפריד בין שלב ה־login לבין טעינת המסך הכבד הראשון כדי למנוע חסימת משתמש בכניסה ולצמצם עומס ראשוני על backend. 
- להימנע מהפעלת חישוב מלא וכבד של ה־dashboard בזמן כניסה כשה־snapshot חסר ולמנוע שימוש מוקדם מדי ב־prefetch שיצר עומס על Apps Script. 

### Description
- ב־`frontend/src/main.js` הוספתי `scheduleRender()` שמשתמש ב־`requestAnimationFrame` (עם `setTimeout`fallback) ומחליף את ההסתמכות על `_pendingRender` כדי להבטיח מעבר מהיר ל־shell המאומת אחרי login מוצלח. 
- הוספו מדדי ביצועים זמניים (`beginPerfTimer`/`endPerfTimer`) וסימוני `console.time` סביב ה־login וטעינות ראשוניות (`login:total`, `login:api.login`, `login:setSession`, `login:applyBootstrap`, `login:scheduleRender`, `login:firstAuthenticatedRender`, `screen:firstLoad`, `dashboardSnapshot:firstLoad`, `prefetch:firstRun`). 
- שיניתי את דחיית ה־prefetch ל־`schedulePostLoginPrefetch()` שמשתמש ב־`requestIdleCallback` עם `setTimeout(5000)` כ־fallback וכולל ביטול תזמונים קודמים באמצעות `cancelPrefetchSchedule()` כדי למנוע עומס מיד אחרי כניסה. 
- חיזקתי את `fastRerenderScreen` עם guard גרסה למניעת עדכונים ישנים שמחליפים מסך מאוחר/שגוי, ועדכנתי `hasMountedAuthenticatedShell`/flow כדי לשמור את ה־login לא חוסם. 
- ב־`backend/dashboard-snapshot.gs` שיניתי את התנהגות fallback כך שאם ה־snapshot חסר לא יופעל `actionDashboard_` הכבד כברירת מחדל; במקום זאת מוחזר payload קל עם `_is_snapshot_missing: true` והחישוב המלא יבוצע רק אם `payload.force_full === true`. 
- ב־`sw.js` העליתי את `CACHE_VERSION` מ־`91` ל־`92` כדי לשבור cache ולהבטיח שהדפדפנים יקבלו את `main.js` המעודכן. 

### Testing
- הרצתי `npm test` והכל עבר בהצלחה (unit tests עברו — כל הבדיקות ב־`tests/interactions.test.mjs` עוברות). 
- `npm run lint` נכשל כי אין סקריפט `lint` ב־`package.json` בסביבה זו. 
- `npm run build` נכשל כי אין סקריפט `build` ב־`package.json` בסביבה זו.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecec39a438832ba9979de256f5f41e)