### PR TITLE
Snapshot refresh: add locking, dedupe keys, diagnostics, and ops script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,11 @@ npm test
 - `GAS_SCRIPT_ID`
 - `SPREADSHEET_ID`
 
+אופציונלי לאימות idempotency מורחב:
+
+- `SNAPSHOT_REFRESH_RUNS` (ברירת מחדל: `5`)
+- `SYNC_ACTIVE_PROJECT` (ברירת מחדל: `true`, מסנכרן את קבצי `backend/*.gs` לפרויקט Apps Script הפעיל לפני האימות)
+
 אופציונלי ל-redeploy של Web App פעיל:
 
 - `REDEPLOY_WEBAPP=true`
@@ -398,10 +403,15 @@ node scripts/apps_script_snapshot_ops.mjs
 ```
 
 הסקריפט מבצע:
-1. הרצת `refreshDashboardSnapshots` בפרויקט Apps Script.
-2. קריאת `dashboard_refresh_control`.
-3. בדיקה ששני גיליונות snapshot התמלאו.
-4. redeploy (אם הופעל בדגלים המתאימים).
+1. סנכרון `backend/*.gs` לפרויקט Apps Script הפעיל (אם `SYNC_ACTIVE_PROJECT` לא מכובה).
+2. הרצת `refreshDashboardSnapshots` מספר פעמים רצופות (ברירת מחדל: 5).
+3. אימות שאין כפילויות:
+   - `dashboard_summary_snapshot`: שורה אחת לכל `month_ym`
+   - `dashboard_by_manager_snapshot`: שורה אחת לכל `snapshot_key`
+   - `dashboard_refresh_control`: שורה אחת לכל `key`
+4. אימות שאין גידול שורות בין ריצות.
+5. בדיקה שמספר ה-triggers עבור `refreshDashboardSnapshotsTrigger` אינו גדול מ-1.
+6. redeploy (אם הופעל בדגלים המתאימים).
 
 ## תחזוקה נכונה
 

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -34,3 +34,7 @@ function refreshDashboardSnapshots() {
 function refreshDashboardSnapshotsTrigger() {
   refreshDashboardSnapshots_();
 }
+
+function getSnapshotRefreshDiagnostics() {
+  return getSnapshotRefreshDiagnostics_();
+}

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -27,7 +27,7 @@ var BY_MANAGER_SNAPSHOT_HEADERS_ = [
   'month_ym', 'activity_manager', 'manager_display_name',
   'total_short', 'total_long', 'total', 'num_instructors',
   'course_endings', 'finance_open', 'exceptions',
-  'active_instructors_names', 'updated_at'
+  'active_instructors_names', 'updated_at', 'snapshot_key'
 ];
 
 var REFRESH_CONTROL_HEADERS_ = ['key', 'value', 'label_he'];
@@ -65,7 +65,8 @@ var BY_MANAGER_SNAPSHOT_LABELS_HE_ = [
   'כספים פתוחים',
   'חריגות',
   'שמות מדריכים פעילים',
-  'עודכן בתאריך'
+  'עודכן בתאריך',
+  'מפתח snapshot'
 ];
 var REFRESH_CONTROL_LABELS_HE_ = ['מפתח', 'ערך', 'תווית'];
 
@@ -290,6 +291,11 @@ function buildDashboardSnapshotKpis_(snapshot, canViewFinance) {
 // ─── C. refreshDashboardSnapshots_ ───────────────────────────────────────────
 
 function refreshDashboardSnapshots_() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(1000)) {
+    return { skipped: true, reason: 'snapshot_refresh_already_running' };
+  }
+
   var hadCache = !!__rqCache_;
   if (!hadCache) {
     beginRequestCache_();
@@ -322,6 +328,7 @@ function refreshDashboardSnapshots_() {
     if (!hadCache) {
       __rqCache_ = null;
     }
+    lock.releaseLock();
   }
 }
 
@@ -340,6 +347,7 @@ function markDashboardSnapshotsRefreshNeeded_(reason) {
 function writeDashboardSummarySnapshotRow_(ym, fullData) {
   var sheetName = CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT;
   ensureSnapshotSheetScaffold_(sheetName, SUMMARY_SNAPSHOT_HEADERS_, SUMMARY_SNAPSHOT_LABELS_HE_);
+  dedupeRowsByKeyKeepingLatest_(sheetName, 'month_ym');
 
   var summary = fullData.summary || {};
   var totals  = fullData.totals  || {};
@@ -401,8 +409,7 @@ function canViewFinanceFromKpis_(kpiAll, fullData) {
 function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
   var sheetName = CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT;
   ensureSnapshotSheetScaffold_(sheetName, BY_MANAGER_SNAPSHOT_HEADERS_, BY_MANAGER_SNAPSHOT_LABELS_HE_);
-
-  deleteRowsByKey_(sheetName, 'month_ym', ym);
+  dedupeDashboardByManagerSnapshotByKey_();
 
   var byManager = Array.isArray(fullData.by_activity_manager) ? fullData.by_activity_manager : [];
   var updatedAt = formatDate_(new Date());
@@ -410,6 +417,7 @@ function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
   byManager.forEach(function(row) {
     var manager = text_(row.activity_manager);
     if (!manager || manager === 'unassigned') return;
+    var snapshotKey = buildDashboardByManagerSnapshotKey_(ym, manager);
     var displayName = SNAPSHOT_MANAGER_DISPLAY_NAMES_[manager] || manager;
     var rowObj = {
       month_ym:               ym,
@@ -423,10 +431,13 @@ function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
       finance_open:           row.finance_open   || 0,
       exceptions:             row.exceptions     || 0,
       active_instructors_names: text_(row.active_instructors_names) || '',
-      updated_at:             updatedAt
+      updated_at:             updatedAt,
+      snapshot_key:           snapshotKey
     };
-    appendRow_(sheetName, rowObj);
+    upsertRowByKey_(sheetName, 'snapshot_key', rowObj);
   });
+
+  dedupeDashboardByManagerSnapshotByKey_();
 }
 
 // ─── F. updateDashboardRefreshControl_ ───────────────────────────────────────
@@ -434,6 +445,7 @@ function replaceDashboardByManagerSnapshotRows_(ym, fullData) {
 function updateDashboardRefreshControl_(status, message) {
   var sheetName = CONFIG.SHEETS.DASHBOARD_REFRESH_CONTROL;
   ensureSnapshotSheetScaffold_(sheetName, REFRESH_CONTROL_HEADERS_, REFRESH_CONTROL_LABELS_HE_);
+  dedupeRowsByKeyKeepingLatest_(sheetName, 'key');
 
   var now = new Date().toISOString();
   var entries = [
@@ -445,4 +457,80 @@ function updateDashboardRefreshControl_(status, message) {
   entries.forEach(function(entry) {
     upsertRowByKey_(sheetName, 'key', entry);
   });
+}
+
+function buildDashboardByManagerSnapshotKey_(ym, manager) {
+  return text_(ym) + '|' + text_(manager);
+}
+
+function dedupeRowsByKeyKeepingLatest_(sheetName, keyField) {
+  var sheet = getSheet_(sheetName);
+  var headers = getHeaders_(sheet);
+  var keyIndex = headers.indexOf(keyField);
+  if (keyIndex < 0) return;
+
+  var dataStart = getDataStartRow_();
+  var lastRow = sheet.getLastRow();
+  if (lastRow < dataStart) return;
+
+  var seen = {};
+  for (var rowNum = lastRow; rowNum >= dataStart; rowNum--) {
+    var key = text_(sheet.getRange(rowNum, keyIndex + 1).getValue());
+    if (!key) continue;
+    if (seen[key]) {
+      sheet.deleteRow(rowNum);
+      continue;
+    }
+    seen[key] = true;
+  }
+  invalidateReadRowsCache_(sheetName);
+}
+
+function dedupeDashboardByManagerSnapshotByKey_() {
+  var sheetName = CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT;
+  var sheet = getSheet_(sheetName);
+  var headers = getHeaders_(sheet);
+  var monthIndex = headers.indexOf('month_ym');
+  var managerIndex = headers.indexOf('activity_manager');
+  var snapshotKeyIndex = headers.indexOf('snapshot_key');
+  if (monthIndex < 0 || managerIndex < 0 || snapshotKeyIndex < 0) return;
+
+  var dataStart = getDataStartRow_();
+  var lastRow = sheet.getLastRow();
+  if (lastRow < dataStart) return;
+
+  var seen = {};
+  for (var rowNum = lastRow; rowNum >= dataStart; rowNum--) {
+    var monthYm = text_(sheet.getRange(rowNum, monthIndex + 1).getValue());
+    var manager = text_(sheet.getRange(rowNum, managerIndex + 1).getValue());
+    var snapshotKey = text_(sheet.getRange(rowNum, snapshotKeyIndex + 1).getValue());
+    var computedKey = snapshotKey || buildDashboardByManagerSnapshotKey_(monthYm, manager);
+    if (!computedKey || computedKey === '|') continue;
+
+    if (!snapshotKey) {
+      sheet.getRange(rowNum, snapshotKeyIndex + 1).setValue(computedKey);
+    }
+
+    if (seen[computedKey]) {
+      sheet.deleteRow(rowNum);
+      continue;
+    }
+    seen[computedKey] = true;
+  }
+  invalidateReadRowsCache_(sheetName);
+}
+
+function getSnapshotRefreshDiagnostics_() {
+  var allTriggers = ScriptApp.getProjectTriggers();
+  var snapshotTriggers = allTriggers.filter(function(t) {
+    return t.getHandlerFunction && t.getHandlerFunction() === 'refreshDashboardSnapshotsTrigger';
+  });
+
+  return {
+    project_trigger_count: allTriggers.length,
+    refresh_snapshot_trigger_count: snapshotTriggers.length,
+    refresh_snapshot_trigger_ids: snapshotTriggers.map(function(t) {
+      return t.getUniqueId ? t.getUniqueId() : '';
+    })
+  };
 }

--- a/scripts/apps_script_snapshot_ops.mjs
+++ b/scripts/apps_script_snapshot_ops.mjs
@@ -11,15 +11,23 @@
  * Optional env vars:
  * - REDEPLOY_WEBAPP=true|false
  * - WEBAPP_DEPLOYMENT_ID=<deployment id to update>
+ * - SNAPSHOT_REFRESH_RUNS=<number, default 5>
+ * - SYNC_ACTIVE_PROJECT=true|false (default true)
  */
+import fs from 'fs';
+import path from 'path';
 
 const {
   GOOGLE_OAUTH_ACCESS_TOKEN,
   GAS_SCRIPT_ID,
   SPREADSHEET_ID,
   REDEPLOY_WEBAPP,
-  WEBAPP_DEPLOYMENT_ID
+  WEBAPP_DEPLOYMENT_ID,
+  SNAPSHOT_REFRESH_RUNS,
+  SYNC_ACTIVE_PROJECT
 } = process.env;
+
+const REFRESH_RUNS = Math.max(1, Number(SNAPSHOT_REFRESH_RUNS || 5));
 
 function required(name, value) {
   if (!value) {
@@ -58,6 +66,13 @@ async function runFunction(functionName, parameters = []) {
   });
 }
 
+function executionResult(executionResponse) {
+  if (executionResponse.error) {
+    throw new Error(`Apps Script execution error: ${JSON.stringify(executionResponse.error)}`);
+  }
+  return executionResponse.response?.result ?? null;
+}
+
 async function readRange(rangeA1) {
   const range = encodeURIComponent(rangeA1);
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(SPREADSHEET_ID)}/values/${range}`;
@@ -65,16 +80,119 @@ async function readRange(rangeA1) {
   return data.values || [];
 }
 
-function rowsToObjects(rows) {
+function rowsToObjects(rows, { skipHebrewHeaderRow = true } = {}) {
   if (!rows.length) return [];
   const headers = rows[0].map(String);
-  return rows.slice(1).map((row) => {
+  const startIndex = rows.length > 1 && skipHebrewHeaderRow ? 2 : 1;
+  return rows.slice(startIndex).map((row) => {
     const obj = {};
     headers.forEach((h, i) => {
       obj[h] = row[i] ?? '';
     });
     return obj;
   });
+}
+
+function countByUniqueKey(rows, keySelector) {
+  const counts = new Map();
+  for (const row of rows) {
+    const key = String(keySelector(row) || '').trim();
+    if (!key) continue;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  const duplicates = [...counts.entries()]
+    .filter(([, n]) => n > 1)
+    .map(([key, count]) => ({ key, count }));
+
+  return {
+    rows_with_key: [...counts.values()].reduce((a, b) => a + b, 0),
+    unique_keys: counts.size,
+    duplicate_keys: duplicates,
+    has_duplicates: duplicates.length > 0
+  };
+}
+
+function buildRunMetrics(summaryRows, byManagerRows, controlRows) {
+  const summaryStats = countByUniqueKey(summaryRows, (r) => r.month_ym);
+  const byManagerStats = countByUniqueKey(
+    byManagerRows,
+    (r) => r.snapshot_key || `${r.month_ym || ''}|${r.activity_manager || ''}`
+  );
+  const controlStats = countByUniqueKey(controlRows, (r) => r.key);
+
+  return {
+    summary: {
+      rows: summaryRows.length,
+      ...summaryStats
+    },
+    by_manager: {
+      rows: byManagerRows.length,
+      ...byManagerStats
+    },
+    refresh_control: {
+      rows: controlRows.length,
+      ...controlStats
+    }
+  };
+}
+
+function validateNoGrowthAcrossRuns(runMetrics) {
+  if (runMetrics.length <= 1) {
+    return { ok: true, reason: 'single_run' };
+  }
+
+  const baseline = runMetrics[0];
+  const unchanged = runMetrics.slice(1).every((m) =>
+    m.summary.rows === baseline.summary.rows &&
+    m.by_manager.rows === baseline.by_manager.rows &&
+    m.refresh_control.rows === baseline.refresh_control.rows
+  );
+
+  return {
+    ok: unchanged,
+    baseline_rows: {
+      summary: baseline.summary.rows,
+      by_manager: baseline.by_manager.rows,
+      refresh_control: baseline.refresh_control.rows
+    },
+    per_run_rows: runMetrics.map((m) => ({
+      summary: m.summary.rows,
+      by_manager: m.by_manager.rows,
+      refresh_control: m.refresh_control.rows
+    }))
+  };
+}
+
+async function syncActiveProjectBackendFiles() {
+  const backendDir = path.join(process.cwd(), 'backend');
+  const localBackendFiles = fs.readdirSync(backendDir).filter((f) => f.endsWith('.gs'));
+  const contentUrl = `https://script.googleapis.com/v1/projects/${encodeURIComponent(GAS_SCRIPT_ID)}/content`;
+  const content = await gfetch(contentUrl, { headers: authHeaders() });
+  const files = Array.isArray(content.files) ? content.files : [];
+
+  const updatedFiles = [];
+  for (const rel of localBackendFiles) {
+    const baseName = rel.replace(/\.gs$/i, '');
+    const localSource = fs.readFileSync(path.join(backendDir, rel), 'utf8');
+    const idx = files.findIndex((f) => f.name === baseName && f.type === 'SERVER_JS');
+    if (idx >= 0) {
+      if (files[idx].source !== localSource) {
+        files[idx] = { ...files[idx], source: localSource };
+        updatedFiles.push(rel);
+      }
+      continue;
+    }
+    files.push({ name: baseName, type: 'SERVER_JS', source: localSource });
+    updatedFiles.push(rel);
+  }
+
+  await gfetch(contentUrl, {
+    method: 'PUT',
+    headers: authHeaders(),
+    body: JSON.stringify({ files })
+  });
+
+  return { synced: true, updated_files: updatedFiles };
 }
 
 async function maybeRedeploy() {
@@ -119,38 +237,52 @@ async function main() {
   required('GAS_SCRIPT_ID', GAS_SCRIPT_ID);
   required('SPREADSHEET_ID', SPREADSHEET_ID);
 
-  await runFunction('refreshDashboardSnapshots');
+  const shouldSync = String(SYNC_ACTIVE_PROJECT || 'true').toLowerCase() !== 'false';
+  const syncResult = shouldSync
+    ? await syncActiveProjectBackendFiles()
+    : { synced: false, reason: 'disabled' };
 
-  const controlRows = rowsToObjects(
-    await readRange('dashboard_refresh_control!A1:C')
-  );
+  const runResults = [];
+  const runMetrics = [];
 
-  const controlMap = Object.fromEntries(
-    controlRows.map((r) => [String(r.key || ''), String(r.value || '')])
-  );
+  for (let i = 0; i < REFRESH_RUNS; i += 1) {
+    const refreshResp = await runFunction('refreshDashboardSnapshots');
+    runResults.push(executionResult(refreshResp));
 
-  const lastStatus = controlMap.last_status || '';
-  const lastMessage = controlMap.last_message || '';
+    const summaryRows = rowsToObjects(await readRange('dashboard_summary_snapshot!A1:T'));
+    const byManagerRows = rowsToObjects(await readRange('dashboard_by_manager_snapshot!A1:M'));
+    const controlRows = rowsToObjects(await readRange('dashboard_refresh_control!A1:C'));
+    runMetrics.push(buildRunMetrics(summaryRows, byManagerRows, controlRows));
+  }
 
-  const summaryRows = rowsToObjects(
-    await readRange('dashboard_summary_snapshot!A1:T')
-  );
-  const byManagerRows = rowsToObjects(
-    await readRange('dashboard_by_manager_snapshot!A1:L')
-  );
-
-  const summaryFilled = summaryRows.length > 0;
-  const byManagerFilled = byManagerRows.length > 0;
+  const finalControlRows = rowsToObjects(await readRange('dashboard_refresh_control!A1:C'));
+  const controlMap = Object.fromEntries(finalControlRows.map((r) => [String(r.key || ''), String(r.value || '')]));
+  const triggerDiagnosticsResp = await runFunction('getSnapshotRefreshDiagnostics');
+  const triggerDiagnostics = executionResult(triggerDiagnosticsResp) || {};
 
   const redeploy = await maybeRedeploy();
+  const noGrowthCheck = validateNoGrowthAcrossRuns(runMetrics);
+  const finalMetrics = runMetrics[runMetrics.length - 1] || buildRunMetrics([], [], []);
 
   const result = {
-    last_status: lastStatus,
-    last_message: lastMessage,
-    snapshots: {
-      dashboard_summary_snapshot_filled: summaryFilled,
-      dashboard_by_manager_snapshot_filled: byManagerFilled
+    synced_active_project: syncResult,
+    refresh_runs: REFRESH_RUNS,
+    refresh_run_results: runResults,
+    last_status: controlMap.last_status || '',
+    last_message: controlMap.last_message || '',
+    validations: {
+      summary_single_row_per_month: !finalMetrics.summary.has_duplicates,
+      by_manager_single_row_per_snapshot_key: !finalMetrics.by_manager.has_duplicates,
+      refresh_control_single_row_per_key: !finalMetrics.refresh_control.has_duplicates,
+      no_row_growth_across_runs: noGrowthCheck.ok,
+      refresh_trigger_count_is_one: Number(triggerDiagnostics.refresh_snapshot_trigger_count || 0) <= 1
     },
+    metrics: {
+      final: finalMetrics,
+      per_run: runMetrics,
+      no_growth_check: noGrowthCheck
+    },
+    trigger_diagnostics: triggerDiagnostics,
     redeploy
   };
 


### PR DESCRIPTION
### Motivation

- Prevent concurrent snapshot rebuilds and make snapshot refreshes idempotent and verifiable.  
- Provide operational visibility and tooling to run and validate multiple refresh runs and redeploys.  
- Ensure snapshot sheets do not accumulate duplicate rows and add a stable per-row key for by-manager snapshots.  

### Description

- Add script-level lock to `refreshDashboardSnapshots_` to skip when a refresh is already running and release the lock on completion.  
- Expose a new Apps Script entrypoint `getSnapshotRefreshDiagnostics` (and backing `getSnapshotRefreshDiagnostics_`) to report project trigger counts and trigger ids.  
- Add `snapshot_key` to `dashboard_by_manager_snapshot` headers and labels and persist a stable key via `buildDashboardByManagerSnapshotKey_`.  
- Replace brute-force deletes with dedupe helpers `dedupeRowsByKeyKeepingLatest_` and `dedupeDashboardByManagerSnapshotByKey_`, and switch writes to use `upsertRowByKey_` for summary and by-manager snapshots.  
- Ensure `dashboard_refresh_control` is deduped by `key` when updating via `updateDashboardRefreshControl_`.  
- Update `Code.gs` to export `getSnapshotRefreshDiagnostics`.  
- Enhance `scripts/apps_script_snapshot_ops.mjs` with: multiple refresh runs (`SNAPSHOT_REFRESH_RUNS` / `REFRESH_RUNS`), optional syncing of local `backend/*.gs` into the active Apps Script project (`SYNC_ACTIVE_PROJECT`), execution result handling, improved row parsing (skip Hebrew label row), duplicate-key counting (`countByUniqueKey`), run metrics aggregation (`buildRunMetrics`), growth validation across runs (`validateNoGrowthAcrossRuns`), and integration with the new diagnostic entrypoint.  
- Update `README.md` to document the new env vars and the expanded end-to-end snapshot ops flow and validations.  

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf26c23cc832ba1821136373010be)