### PR TITLE
Update Apps Script API URL and bump service worker cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/.../exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/.../exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbx3kwHi6nPMplBkYswPLrmn4Tym2cA2MNwbT8V_54E6W1-nIrUGUncTke7vV-8gZQS0/exec';
+  'https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 92;
+const CACHE_VERSION = 93;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- Replace the production Apps Script Web App URL used by the frontend and ensure the service worker precache is invalidated so clients pick up the new `config.js`.
- Keep runtime configuration override and query-param behavior intact and do not change any business logic, auth, or UI flow.

### Description
- Updated `DEFAULT_API_URL` in `frontend/src/config.js` to the new Web App URL `https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec`.
- Bumped the service worker cache version in `sw.js` from `92` to `93` to force precache refresh of `frontend/src/config.js`.
- Updated runtime/query examples in `README.md` to reference the new URL for current operational documentation.

### Testing
- Ran a repo-wide search `rg "script.google.com/macros/s/"` to verify no old concrete deployment URL remains in active runtime files (result: references updated).
- Ran `npm test` which executed the test suite and passed (19 tests, 0 failures).
- Verified that only `frontend/src/config.js`, `sw.js`, and `README.md` were modified and no unrelated files changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfc037360832b97b4b39aae846178)