### PR TITLE
Update Apps Script API URL to latest deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbyEtSzqarDUJ1VPJy2YvC_H9tCCiRTgIOho_OjrTrSGAEtybeSnLnCX91jfSy-zELvA/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyEtSzqarDUJ1VPJy2YvC_H9tCCiRTgIOho_OjrTrSGAEtybeSnLnCX91jfSy-zELvA/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycby_Pc_eNthHMGiSIKY0Jzt5dbkRwpqo31HvEhF6OSgs2RvLgaYFM1140-oSbx_-vFEr/exec';
+  'https://script.google.com/macros/s/AKfycbyEtSzqarDUJ1VPJy2YvC_H9tCCiRTgIOho_OjrTrSGAEtybeSnLnCX91jfSy-zELvA/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 94;
+const CACHE_VERSION = 95;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- לעדכן את ה־DEFAULT_API_URL לכתובת הפריסה החדשה של Apps Script ולהבטיח שכל הלקוחות יקבלו את הכתובת המעודכנת דרך ה־config ושה־Service Worker יבטל את ה־precache הישן.
- לוודא שאין מופעים ישנים של כתובת ה־Apps Script בקבצים פעילים בתיעוד/קוד.

### Description
- שונה `DEFAULT_API_URL` ב־`frontend/src/config.js` ל־`https://script.google.com/macros/s/AKfycbyEtSzqarDUJ1VPJy2YvC_H9tCCiRTgIOho_OjrTrSGAEtybeSnLnCX91jfSy-zELvA/exec`.
- עודכנו דוגמאות תיעוד ב־`README.md` שציינו את הכתובת הישנה כדי שלא יישארו הפניות פעילות אליה.
- הוגדל `CACHE_VERSION` ב־`sw.js` מ־`94` ל־`95` כדי לגרום ל־cache-bust של ה־precache ולגרום ללקוחות להוריד את `config.js` המעודכן.
- לא שונתה שום לוגיקה עסקית, הרשאות, עיצוב, או זרימות (login/snapshot) — שינוי רק של הכתובת ו־cache bust.

### Testing
- הרץ `npm test` (שהפעיל את `node --test tests/interactions.test.mjs`) וכל הבדיקות עברו בהצלחה (19 passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed028c8078832bbe0525601652f46a)