### PR TITLE
Fix background refresh cache persistence guard

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -226,7 +226,7 @@ function restoreScreenCacheFromStorage() {
     let changed = false;
     Object.entries(stored).forEach(([k, v]) => {
       if (!v || !v.t) return;
-        if (MEMORY_ONLY_CACHE_PREFIXES.some((prefix) => k.startsWith(prefix))) {
+      if (MEMORY_ONLY_CACHE_PREFIXES.some((prefix) => k.startsWith(prefix))) {
         delete stored[k];
         changed = true;
         return;
@@ -656,7 +656,7 @@ async function backgroundRefreshScreen(screen, cacheKey) {
     inflightRequests.delete(cacheKey);
     const entry = { data, t: Date.now() };
     state.screenDataCache[cacheKey] = entry;
-    persistCacheEntry(cacheKey, entry);
+    maybePersistScreenCacheEntry(cacheKey, entry);
     if (
       activeNavigationToken === guardedToken &&
       state.route === guardedRoute &&


### PR DESCRIPTION
### Motivation
- Prevent background refreshes from unconditionally persisting heavy memory-only screen caches to `localStorage` and tidy the restore logic formatting.

### Description
- Replace `persistCacheEntry(cacheKey, entry);` with `maybePersistScreenCacheEntry(cacheKey, entry);` inside `backgroundRefreshScreen` and fix indentation of the `MEMORY_ONLY_CACHE_PREFIXES` pruning block in `restoreScreenCacheFromStorage` in `frontend/src/main.js`.

### Testing
- Verified the targeted replacements and file state with `rg` and `sed` checks (`rg -n "maybePersistScreenCacheEntry\(cacheKey, entry\);|if \(!v \|\| !v\.t\) return;|if \(route === 'activities'\)" frontend/src/main.js` and `sed -n '222,236p;654,664p' frontend/src/main.js`) and committed the change, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed122a7974832ba2e621aeff4e1a83)