### PR TITLE
Add shared client-side filtering and debounced search across calendars and lists

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -974,6 +974,7 @@ function actionExceptions_(user) {
       activity_no:       row.activity_no,
       authority:         row.authority,
       school:            row.school,
+      funding:           row.funding,
       grade:             text_(row.grade),
       class_group:       text_(row.class_group),
       emp_id:            row.emp_id,

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -16,9 +16,38 @@ import {
 } from './shared/layout.js';
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
 import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  filtersToolbarHtml,
+  bindLocalFilters,
+  splitVisibleRows
+} from './shared/activity-list-filters.js';
 
 const ACTIVITY_VIEW_LS = 'dashboard_activity_view_v2';
 const inflightActivityDetailRequests = new Map();
+const ACTIVITIES_SCOPE = 'activities';
+const ACTIVITY_FILTER_FIELDS = [
+  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
+  { key: 'activity_name', label: 'תוכנית' },
+  { key: 'authority', label: 'רשות' },
+  { key: 'funding', label: 'מימון' },
+  { key: 'school', label: 'בית ספר' }
+];
+const ACTIVITY_SEARCH_FIELDS = [
+  'RowID',
+  'activity_name',
+  'activity_manager',
+  'instructor_name',
+  'instructor_name_2',
+  'authority',
+  'school',
+  'funding',
+  'status',
+  'activity_type'
+];
 
 function hasRowException(row) {
   const noInstructor = !String(row.emp_id || '').trim() && !String(row.emp_id_2 || '').trim();
@@ -205,6 +234,57 @@ function applyClientFilters(rows, state, settings) {
   return out;
 }
 
+function currentYm() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function shiftYm(ym, delta) {
+  const base = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
+  const d = base ? new Date(Number(base[1]), Number(base[2]) - 1, 1) : new Date();
+  d.setMonth(d.getMonth() + delta);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function monthBounds(ym) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
+  if (!m) return null;
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  return {
+    start: `${y}-${String(mo).padStart(2, '0')}-01`,
+    end: `${y}-${String(mo).padStart(2, '0')}-${String(new Date(y, mo, 0).getDate()).padStart(2, '0')}`
+  };
+}
+
+function activityOverlapsMonth(row, ym) {
+  const bounds = monthBounds(ym);
+  if (!bounds) return true;
+  const meetings = Array.from({ length: 35 }, (_, i) => String(row?.[`Date${i + 1}`] || '').trim()).filter(Boolean);
+  if (meetings.length > 0) return meetings.some((date) => String(date).startsWith(ym));
+  const start = String(row?.start_date || '').trim();
+  const end = String(row?.end_date || start).trim();
+  if (!start && !end) return false;
+  const rowStart = start || end;
+  const rowEnd = end || start;
+  return rowStart <= bounds.end && rowEnd >= bounds.start;
+}
+
+function monthLabel(ym) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
+  if (!m) return '';
+  return `${m[1]}-${m[2]}`;
+}
+
+function applyActivitiesLocalFilters(rows, state, settings) {
+  const filters = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
+  if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
+  const familyRows = applyClientFilters(rows, state, settings);
+  const monthRows = familyRows.filter((row) => activityOverlapsMonth(row, state.activitiesMonthYm));
+  prepareRowsForSearch(monthRows, ACTIVITY_SEARCH_FIELDS);
+  return applyLocalFilters(monthRows, filters, { filterFields: ACTIVITY_FILTER_FIELDS });
+}
+
 function activityDrawerContent(row, canSeePrivateNotes, canEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
   const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
   return activityWorkDrawerHtml(row, {
@@ -247,7 +327,10 @@ export const activitiesScreen = {
 
   render(data, { state }) {
     const allRows       = Array.isArray(data?.rows) ? data.rows : [];
-    const safeRows      = applyClientFilters(allRows, state, state?.clientSettings);
+    if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
+    const filteredRows  = applyActivitiesLocalFilters(allRows, state, state?.clientSettings);
+    const listFilters   = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
+    const { visible: safeRows, hasMore, total, nextCount } = splitVisibleRows(filteredRows, listFilters);
     const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';
     const hideEmpIds    = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
@@ -328,18 +411,31 @@ export const activitiesScreen = {
       )
       .join('');
 
+    const toolbarHtml = filtersToolbarHtml(ACTIVITIES_SCOPE, filteredRows, state, {
+      searchPlaceholder: 'חיפוש לפי פעילות / מדריך / רשות / בית ספר…',
+      filterFields: ACTIVITY_FILTER_FIELDS
+    });
+    const monthNavHtml = `<nav class="ds-cal-nav" role="navigation" aria-label="ניווט חודשי פעילויות" dir="rtl">
+      <button type="button" class="ds-btn ds-btn--sm" data-activities-month-prev aria-label="חודש קודם">חודש קודם ▶</button>
+      <span class="ds-cal-nav__label">${escapeHtml(monthLabel(state.activitiesMonthYm))}</span>
+      <button type="button" class="ds-btn ds-btn--sm" data-activities-month-next aria-label="חודש הבא">◀ חודש הבא</button>
+    </nav>`;
+    const loadMoreHtml = hasMore
+      ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${ACTIVITIES_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>`
+      : '';
+
     const tableSection =
       safeRows.length === 0
         ? dsEmptyState('לא נמצאו פעילויות')
         : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--equal-cols">
                 <thead><tr><th>${hebrewColumn('activity_type')}</th><th>שם</th><th>בית ספר</th><th>רשות</th><th>התחלה</th><th>סיום</th>${thEmp}${thPrivate}</tr></thead>
                 <tbody>${tableRows}</tbody>
-              </table>`);
+              </table>`) + loadMoreHtml;
 
     const compactSection =
       safeRows.length === 0
         ? dsEmptyState('לא נמצאו פעילויות')
-        : `<div class="ds-compact-list">${compactRows}</div>`;
+        : `<div class="ds-compact-list">${compactRows}</div>${loadMoreHtml}`;
 
     const html = dsScreenStack(`
       ${actNavGridHtml(state)}
@@ -352,9 +448,11 @@ export const activitiesScreen = {
         </div>
         <div class="ds-chip-group" dir="rtl">${familyChips}</div>
       `)}
+      ${monthNavHtml}
+      ${toolbarHtml}
       ${compactView
-        ? dsCard({ title: 'רשימת פעילויות', body: compactSection, padded: true })
-        : dsCard({ title: 'רשימת פעילויות', body: tableSection,   padded: false })}
+        ? dsCard({ title: `רשימת פעילויות · ${total}`, body: compactSection, padded: true })
+        : dsCard({ title: `רשימת פעילויות · ${total}`, body: tableSection,   padded: false })}
     `);
     return html;
   },
@@ -362,7 +460,7 @@ export const activitiesScreen = {
   bind({ root, data, state, rerender, rerenderActivitiesView, ui, api, clearScreenDataCache }) {
     bindActNavGrid(root, { state, rerender });
 
-    const filteredRows      = applyClientFilters(Array.isArray(data?.rows) ? data.rows : [], state, state?.clientSettings);
+    const filteredRows      = applyActivitiesLocalFilters(Array.isArray(data?.rows) ? data.rows : [], state, state?.clientSettings);
     const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';
     const canEditActivity   = state?.user?.display_role !== 'instructor';
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -446,8 +544,28 @@ export const activitiesScreen = {
     root.querySelectorAll('[data-family]').forEach((node) => {
       node.addEventListener('click', () => {
         state.activityQuickFamily = node.dataset.family || '';
-        rerender();
+        if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
+        else rerender();
       });
+    });
+
+    const rerenderLocal = () => {
+      if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
+      else rerender();
+    };
+    bindLocalFilters(root, state, ACTIVITIES_SCOPE, rerenderLocal, { debounceMs: 300 });
+    root.querySelector('[data-activities-month-prev]')?.addEventListener('click', () => {
+      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), -1);
+      rerenderLocal();
+    });
+    root.querySelector('[data-activities-month-next]')?.addEventListener('click', () => {
+      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), 1);
+      rerenderLocal();
+    });
+    root.querySelector(`[data-list-show-more="${ACTIVITIES_SCOPE}"]`)?.addEventListener('click', (ev) => {
+      const next = Number(ev.currentTarget?.dataset?.nextCount || 200);
+      ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = next;
+      rerenderLocal();
     });
 
     if (root._addActivityAbort) root._addActivityAbort.abort();

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -3,12 +3,20 @@ import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { hebrewColumn, hebrewEmploymentType } from './shared/ui-hebrew.js';
 import { dsScreenStack, dsEmptyState, dsStatusChip } from './shared/layout.js';
 import { showToast } from './shared/toast.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  filtersToolbarHtml,
+  bindLocalFilters
+} from './shared/activity-list-filters.js';
 
 const AVATAR_COLORS = [
   '#ef4444', '#f97316', '#eab308', '#22c55e',
   '#3b82f6', '#8b5cf6', '#ec4899', '#14b8a6',
   '#f43f5e', '#a855f7'
 ];
+const CONTACTS_SCOPE = 'contacts';
 
 /* ─── Copy button ─── */
 
@@ -35,16 +43,6 @@ function avatarInitials(fullName) {
   if (parts.length >= 2) return parts[0][0] + parts[1][0];
   if (parts.length === 1) return parts[0].slice(0, 2);
   return '??';
-}
-
-function applyInstrSearch(rows, q) {
-  if (!q) return rows;
-  const lq = q.toLowerCase();
-  return rows.filter((r) =>
-    String(r.full_name || '').toLowerCase().includes(lq) ||
-    String(r.mobile   || '').toLowerCase().includes(lq) ||
-    String(r.email    || '').toLowerCase().includes(lq)
-  );
 }
 
 function instrDrawerHtml(row, hideEmpIds) {
@@ -101,7 +99,7 @@ function renderInstrCard(row) {
 }
 
 function instrTabHtml(rows, searchQ) {
-  const filtered = applyInstrSearch(rows, searchQ);
+  const filtered = searchQ ? applyLocalFilters(rows, { q: searchQ }, { filterFields: [] }) : rows;
   const body = filtered.length === 0
     ? dsEmptyState('לא נמצאו אנשי קשר')
     : `<div class="ci-person-grid">${filtered.map((r) => renderInstrCard(r)).join('')}</div>`;
@@ -109,16 +107,6 @@ function instrTabHtml(rows, searchQ) {
 }
 
 /* ─── School contacts ─── */
-
-function applySchoolSearch(rows, q) {
-  if (!q) return rows;
-  const lq = q.toLowerCase();
-  return rows.filter((r) =>
-    String(r.school       || '').toLowerCase().includes(lq) ||
-    String(r.authority    || '').toLowerCase().includes(lq) ||
-    String(r.contact_name || '').toLowerCase().includes(lq)
-  );
-}
 
 function schoolPersonHtml(row) {
   const name = row.contact_name ? escapeHtml(String(row.contact_name)) : '';
@@ -251,7 +239,7 @@ function schoolFormHtml(row = {}) {
 }
 
 function schoolTabHtml(rows, searchQ) {
-  const filtered = applySchoolSearch(rows, searchQ);
+  const filtered = searchQ ? applyLocalFilters(rows, { q: searchQ }, { filterFields: [] }) : rows;
   if (filtered.length === 0) return { filtered, body: dsEmptyState('לא נמצאו אנשי קשר') };
   const authorityGroups = groupByAuthorityThenSchool(filtered);
   let html = '';
@@ -267,11 +255,13 @@ export const contactsScreen = {
   render(data, { state } = {}) {
     const instrRows  = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows)     ? data.school_rows     : [];
+    prepareRowsForSearch(instrRows, ['full_name', 'contact_name', 'mobile', 'phone', 'email', 'authority', 'school', 'role', 'contact_role']);
+    prepareRowsForSearch(schoolRows, ['full_name', 'contact_name', 'mobile', 'phone', 'email', 'authority', 'school', 'role', 'contact_role']);
+    const filters = ensureActivityListFilters(state, CONTACTS_SCOPE);
     const canViewInstr  = data?.can_view_instructors !== false;
     const canViewSchool = data?.can_view_schools     !== false;
     const tab     = state?.contactsTab || (canViewInstr ? 'instr' : 'school');
-    const instrQ  = state?.contactsInstrSearch  || '';
-    const schoolQ = state?.contactsSchoolSearch || '';
+    const searchQ = filters.q || '';
 
     const tabBtns = [
       canViewInstr  && { key: 'instr',  label: `אנשי קשר מדריכים (${instrRows.length})`  },
@@ -284,16 +274,17 @@ export const contactsScreen = {
     let listHtml    = '';
 
     if (tab === 'instr' && canViewInstr) {
-      const { body } = instrTabHtml(instrRows, instrQ);
-      searchInput = `<input id="contacts-instr-search" type="search" class="ds-search-input"
-        placeholder="חיפוש לפי שם / טלפון / מייל…" value="${escapeHtml(instrQ)}" dir="rtl" />`;
+      const { body } = instrTabHtml(instrRows, searchQ);
       listHtml = body;
     } else if (tab === 'school' && canViewSchool) {
-      const { body } = schoolTabHtml(schoolRows, schoolQ);
-      searchInput = `<input id="contacts-school-search" type="search" class="ds-search-input"
-        placeholder="חיפוש לפי בית ספר / רשות / איש קשר…" value="${escapeHtml(schoolQ)}" dir="rtl" />`;
+      const { body } = schoolTabHtml(schoolRows, searchQ);
       listHtml = body;
     }
+    searchInput = filtersToolbarHtml(CONTACTS_SCOPE, tab === 'instr' ? instrRows : schoolRows, state, {
+      searchPlaceholder: 'חיפוש לפי שם / תפקיד / טלפון / מייל / רשות / בית ספר…',
+      filterFields: [],
+      search: true
+    });
 
     return dsScreenStack(`
       ${actNavGridHtml(state)}
@@ -321,20 +312,7 @@ export const contactsScreen = {
         rerender();
       });
     });
-
-    let instrSearchTimer;
-    root.querySelector('#contacts-instr-search')?.addEventListener('input', (ev) => {
-      state.contactsInstrSearch = ev.target.value || '';
-      clearTimeout(instrSearchTimer);
-      instrSearchTimer = setTimeout(() => rerender(), 180);
-    });
-
-    let schoolSearchTimer;
-    root.querySelector('#contacts-school-search')?.addEventListener('input', (ev) => {
-      state.contactsSchoolSearch = ev.target.value || '';
-      clearTimeout(schoolSearchTimer);
-      schoolSearchTimer = setTimeout(() => rerender(), 180);
-    });
+    bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, { debounceMs: 300 });
 
     root.querySelectorAll('[data-copy-email]').forEach((btn) => {
       btn.addEventListener('click', (ev) => {

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -10,6 +10,23 @@ import {
   dsEmptyState,
   dsStatusChip
 } from './shared/layout.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  filtersToolbarHtml,
+  bindLocalFilters,
+  splitVisibleRows
+} from './shared/activity-list-filters.js';
+
+const EXCEPTIONS_SCOPE = 'exceptions';
+const EXCEPTION_FILTER_FIELDS = [
+  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'authority', label: 'רשות' },
+  { key: 'funding', label: 'מימון' },
+  { key: 'school', label: 'בית ספר' },
+  { key: 'exception_type', label: 'סוג חריגה', getOptionLabel: (value) => hebrewExceptionType(value) }
+];
 
 function fieldRow(label, value) {
   const display = (value !== undefined && value !== null && value !== '')
@@ -69,12 +86,23 @@ export const exceptionsScreen = {
   load: ({ api }) => api.exceptions(),
   render(data, { state } = {}) {
     const allRows   = Array.isArray(data?.rows) ? data.rows : [];
+    const filterState = ensureActivityListFilters(state, EXCEPTIONS_SCOPE);
+    prepareRowsForSearch(allRows, ['RowID', 'activity_name', 'activity_manager', 'authority', 'school', 'funding', 'exception_type']);
+    const filteredRows = applyLocalFilters(allRows, filterState, { filterFields: EXCEPTION_FILTER_FIELDS });
+    const { visible: visibleRows, hasMore, nextCount, total } = splitVisibleRows(filteredRows, filterState);
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
+    const toolbarHtml = filtersToolbarHtml(EXCEPTIONS_SCOPE, allRows, state, {
+      filterFields: EXCEPTION_FILTER_FIELDS,
+      searchPlaceholder: 'חיפוש חריגות…'
+    });
+    const loadMoreHtml = hasMore
+      ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${EXCEPTIONS_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>`
+      : '';
 
     const compact =
-      allRows.length === 0
+      visibleRows.length === 0
         ? dsEmptyState('לא נמצאו חריגות')
-        : `<div class="ds-compact-list">${allRows
+        : `<div class="ds-compact-list">${visibleRows
             .map((row, idx) => {
               const et = String(row.exception_type || '').trim();
               const subtitleParts = [row.authority, row.school].filter(Boolean);
@@ -86,27 +114,33 @@ export const exceptionsScreen = {
               return `<div data-list-item>
                 <button type="button"
                   class="ds-interactive-card ds-interactive-card--session"
-                  data-card-action="${escapeHtml(`exception:${idx}`)}">
+                  data-card-action="${escapeHtml(`exception:${row.RowID}`)}">
                   <p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p>
                   ${subtitleHtml}
                   ${chipHtml}
                 </button>
               </div>`;
             })
-            .join('')}</div>`;
+            .join('')}</div>${loadMoreHtml}`;
 
     return dsScreenStack(`
       ${actNavGridHtml(state)}
+      ${toolbarHtml}
       ${dsCard({
-        title: `חריגות · ${allRows.length}`,
+        title: `חריגות · ${total}`,
         body: compact,
-        padded: allRows.length === 0
+        padded: visibleRows.length === 0
       })}
     `);
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
     bindActNavGrid(root, { state, rerender });
     const allRows   = Array.isArray(data?.rows) ? data.rows : [];
+    bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 300 });
+    root.querySelector(`[data-list-show-more="${EXCEPTIONS_SCOPE}"]`)?.addEventListener('click', (ev) => {
+      ensureActivityListFilters(state, EXCEPTIONS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
+      rerender();
+    });
     const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';
     const canEditActivity = state?.user?.display_role !== 'instructor';
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -196,7 +230,8 @@ export const exceptionsScreen = {
 
     ui?.bindInteractiveCards(root, (action) => {
       if (!action.startsWith('exception:')) return;
-      const idx = Number(action.slice('exception:'.length));
+      const rowId = action.slice('exception:'.length);
+      const idx = allRows.findIndex((row) => String(row.RowID) === String(rowId));
       openAt(idx);
     });
   }

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -2,15 +2,17 @@ import { escapeHtml } from './shared/html.js';
 import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { dsCard, dsScreenStack, dsEmptyState } from './shared/layout.js';
 import { formatDateHe } from './shared/format-date.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  filtersToolbarHtml,
+  bindLocalFilters,
+  splitVisibleRows
+} from './shared/activity-list-filters.js';
 
-function applySearch(rows, q) {
-  if (!q) return rows;
-  const lq = q.toLowerCase();
-  return rows.filter((r) =>
-    String(r.full_name || '').toLowerCase().includes(lq) ||
-    String(r.emp_id   || '').toLowerCase().includes(lq)
-  );
-}
+const INSTRUCTORS_SCOPE = 'instructors';
+const INSTRUCTOR_FILTER_FIELDS = [{ key: 'activity_manager', label: 'מנהל פעילות' }];
 
 function applyActiveFilter(rows, activeOnly) {
   if (!activeOnly) return rows;
@@ -56,19 +58,27 @@ export const instructorsScreen = {
   render(data, { state } = {}) {
     const allRows  = Array.isArray(data?.rows) ? data.rows : [];
     const ym       = data?.ym || '';
-    const searchQ  = state?.instructorsSearch  || '';
+    prepareRowsForSearch(allRows, ['full_name', 'emp_id', 'activity_manager', 'authority', 'school', 'activity_name']);
+    const filters = ensureActivityListFilters(state, INSTRUCTORS_SCOPE);
     const activeOnly = state?.instructorsActiveOnly !== false;
 
-    const searched  = applySearch(allRows, searchQ);
-    const filtered  = applyActiveFilter(searched, activeOnly);
-    const totalAll  = searched.length;
+    const locallyFiltered = applyLocalFilters(allRows, filters, { filterFields: INSTRUCTOR_FILTER_FIELDS });
+    const filtered  = applyActiveFilter(locallyFiltered, activeOnly);
+    const totalAll  = locallyFiltered.length;
+    const { visible: visibleRows, hasMore, nextCount } = splitVisibleRows(filtered, filters);
+    const toolbarHtml = filtersToolbarHtml(INSTRUCTORS_SCOPE, allRows, state, {
+      filterFields: INSTRUCTOR_FILTER_FIELDS,
+      searchPlaceholder: 'חיפוש לפי שם מדריך / מזהה / מנהל / רשות / בית ספר…'
+    });
 
     const ymLabel = ym ? ym.slice(0, 7) : '';
     const activeChk = activeOnly ? 'checked' : '';
 
-    const bodyHtml = filtered.length === 0
-      ? dsEmptyState(searchQ || activeOnly ? 'לא נמצאו מדריכים לסינון זה' : 'אין נתוני מדריכים')
-      : `<div class="ci-list ci-list--instr-grid">${filtered.map(renderInstructorRow).join('')}</div>`;
+    const bodyHtml = visibleRows.length === 0
+      ? dsEmptyState(filters.q || activeOnly ? 'לא נמצאו מדריכים לסינון זה' : 'אין נתוני מדריכים')
+      : `<div class="ci-list ci-list--instr-grid">${visibleRows.map(renderInstructorRow).join('')}</div>${
+        hasMore ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${INSTRUCTORS_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>` : ''
+      }`;
 
     const subtitle = ymLabel
       ? `מדריכים · ${filtered.length}${activeOnly && totalAll !== filtered.length ? ` (מתוך ${totalAll})` : ''} · חודש ${ymLabel}`
@@ -77,14 +87,7 @@ export const instructorsScreen = {
     return dsScreenStack(`
       ${actNavGridHtml(state)}
       <div class="ds-screen-top-row">
-        <input
-          id="instructors-search"
-          type="search"
-          class="ds-search-input"
-          placeholder="חיפוש לפי שם / מזהה..."
-          value="${escapeHtml(searchQ)}"
-          dir="rtl"
-        />
+        ${toolbarHtml}
         <label class="ds-toggle-label" dir="rtl">
           <input type="checkbox" id="instructors-active-only" ${activeChk} />
           פעילים החודש בלבד
@@ -96,17 +99,15 @@ export const instructorsScreen = {
 
   bind({ root, data, state, rerender, ui, api }) {
     bindActNavGrid(root, { state, rerender });
+    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 300 });
+    root.querySelector(`[data-list-show-more="${INSTRUCTORS_SCOPE}"]`)?.addEventListener('click', (ev) => {
+      ensureActivityListFilters(state, INSTRUCTORS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
+      rerender();
+    });
 
     root.querySelector('#instructors-active-only')?.addEventListener('change', (ev) => {
       state.instructorsActiveOnly = ev.target.checked;
       rerender();
-    });
-
-    let _searchTimer;
-    root.querySelector('#instructors-search')?.addEventListener('input', (ev) => {
-      state.instructorsSearch = ev.target.value || '';
-      clearTimeout(_searchTimer);
-      _searchTimer = setTimeout(() => rerender(), 220);
     });
 
     root.querySelectorAll('[data-instructor-card]').forEach((btn) => {

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -5,8 +5,35 @@ import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bin
 import { formatDateHe } from './shared/format-date.js';
 import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { getHolidayLabel } from './shared/holidays.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  filtersToolbarHtml,
+  bindLocalFilters
+} from './shared/activity-list-filters.js';
 
 const inflightActivityDetailRequests = new Map();
+const MONTH_SCOPE = 'calendar';
+const CALENDAR_FILTER_FIELDS = [
+  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
+  { key: 'activity_name', label: 'תוכנית' },
+  { key: 'authority', label: 'רשות' },
+  { key: 'funding', label: 'מימון' },
+  { key: 'school', label: 'בית ספר' }
+];
+const CALENDAR_SEARCH_FIELDS = [
+  'RowID',
+  'activity_name',
+  'activity_manager',
+  'instructor_name',
+  'instructor_name_2',
+  'authority',
+  'school',
+  'funding',
+  'status'
+];
 
 const HEBREW_MONTHS = [
   'ינואר',
@@ -217,6 +244,13 @@ export const monthScreen = {
 
     const safeCells = Array.isArray(data?.cells) ? data.cells : [];
     const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
+    const filterState = ensureActivityListFilters(state, MONTH_SCOPE);
+    const allItems = Object.values(itemsById || {});
+    prepareRowsForSearch(allItems, CALENDAR_SEARCH_FIELDS);
+    const toolbarHtml = filtersToolbarHtml(MONTH_SCOPE, allItems, state, {
+      filterFields: CALENDAR_FILTER_FIELDS,
+      searchPlaceholder: 'חיפוש פעילויות בלוח החודש…'
+    });
     const byDay = cellMapFromCells(safeCells);
     const todayIso = localYmd();
     const hideSaturday = !!data?.hide_saturday;
@@ -242,7 +276,7 @@ export const monthScreen = {
         date: padDayKey(y, mo, dayNum),
         item_ids: []
       };
-      const cellItems = monthCellItems(cell, itemsById);
+      const cellItems = applyLocalFilters(monthCellItems(cell, itemsById), filterState, { filterFields: CALENDAR_FILTER_FIELDS });
       const n = cellItems.length;
       const isToday = cell.date === todayIso;
       const isShabbat = cellDate.getDay() === 6;
@@ -291,6 +325,7 @@ export const monthScreen = {
         <span class="ds-cal-nav__label">${escapeHtml(monthTitle)}</span>
         <button type="button" class="ds-btn ds-btn--sm" data-month-next aria-label="חודש הבא">◀ חודש הבא</button>
       </nav>
+      ${toolbarHtml}
       ${dsCard({
         body: gridHtml,
         padded: false
@@ -307,6 +342,7 @@ export const monthScreen = {
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = state?.user?.display_role !== 'instructor';
     const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
+    bindLocalFilters(root, state, MONTH_SCOPE, rerender, { debounceMs: 300 });
     const cells = Array.isArray(data?.cells) ? data.cells : [];
     const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
     const allItemsByRowId = new Map();
@@ -435,7 +471,8 @@ export const monthScreen = {
         date: padDayKey(spec.y, spec.mo, d),
         item_ids: []
       };
-      const cellItems = monthCellItems(cell, itemsById);
+      const filterState = ensureActivityListFilters(state, MONTH_SCOPE);
+      const cellItems = applyLocalFilters(monthCellItems(cell, itemsById), filterState, { filterFields: CALENDAR_FILTER_FIELDS });
       if (!cellItems.length) return;
 
       ui.openDrawer({

--- a/frontend/src/screens/shared/activity-list-filters.js
+++ b/frontend/src/screens/shared/activity-list-filters.js
@@ -1,0 +1,157 @@
+import { escapeHtml } from './html.js';
+
+const DEFAULT_SEARCH_DEBOUNCE_MS = 300;
+const DEFAULT_VISIBLE_LIMIT = 200;
+
+export function normalizeText(value) {
+  return String(value == null ? '' : value)
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+export function buildSearchText(row, fields) {
+  const keys = Array.isArray(fields) ? fields : [];
+  return normalizeText(
+    keys
+      .map((field) => {
+        if (typeof field === 'function') return field(row);
+        return row?.[field];
+      })
+      .filter(Boolean)
+      .join(' ')
+  );
+}
+
+export function prepareRowsForSearch(rows, fields) {
+  const list = Array.isArray(rows) ? rows : [];
+  list.forEach((row) => {
+    if (!row || typeof row !== 'object') return;
+    if (!row.__searchText) row.__searchText = buildSearchText(row, fields);
+  });
+  return list;
+}
+
+export function ensureActivityListFilters(state, scope) {
+  state.listFilters = state.listFilters || {};
+  state.listFilters[scope] = state.listFilters[scope] || { q: '', visibleCount: DEFAULT_VISIBLE_LIMIT };
+  if (typeof state.listFilters[scope].visibleCount !== 'number') {
+    state.listFilters[scope].visibleCount = DEFAULT_VISIBLE_LIMIT;
+  }
+  return state.listFilters[scope];
+}
+
+export function collectFilterOptions(rows, fields) {
+  const result = {};
+  const list = Array.isArray(rows) ? rows : [];
+  (Array.isArray(fields) ? fields : []).forEach((field) => {
+    const key = field.key;
+    const values = new Set();
+    list.forEach((row) => {
+      const rawValues = typeof field.getValues === 'function' ? field.getValues(row) : [row?.[key]];
+      (Array.isArray(rawValues) ? rawValues : [rawValues]).forEach((value) => {
+        const text = String(value || '').trim();
+        if (text) values.add(text);
+      });
+    });
+    result[key] = Array.from(values).sort((a, b) => a.localeCompare(b, 'he'));
+  });
+  return result;
+}
+
+export function applyLocalFilters(rows, filters, config = {}) {
+  const list = Array.isArray(rows) ? rows : [];
+  const scoped = filters || {};
+  const search = normalizeText(scoped.q || '');
+  const filterFields = Array.isArray(config.filterFields) ? config.filterFields : [];
+
+  return list.filter((row) => {
+    if (search && !String(row?.__searchText || '').includes(search)) return false;
+    for (const field of filterFields) {
+      const selected = String(scoped[field.key] || '').trim();
+      if (!selected) continue;
+      const values = typeof field.getValues === 'function' ? field.getValues(row) : [row?.[field.key]];
+      const ok = (Array.isArray(values) ? values : [values]).some((value) => String(value || '').trim() === selected);
+      if (!ok) return false;
+    }
+    return true;
+  });
+}
+
+function selectHtml(scope, field, filters, optionsMap) {
+  const selected = String(filters?.[field.key] || '');
+  const options = optionsMap?.[field.key] || [];
+  return `<label class="ds-chip" style="display:flex;align-items:center;gap:6px;">
+    <span>${escapeHtml(field.label)}</span>
+    <select class="ds-input ds-input--sm" data-filter-scope="${escapeHtml(scope)}" data-filter-field="${escapeHtml(field.key)}">
+      <option value="">הכל</option>
+      ${options
+    .map((value) => {
+      const label = typeof field.getOptionLabel === 'function' ? field.getOptionLabel(value) : value;
+      return `<option value="${escapeHtml(value)}"${value === selected ? ' selected' : ''}>${escapeHtml(label)}</option>`;
+    })
+    .join('')}
+    </select>
+  </label>`;
+}
+
+export function filtersToolbarHtml(scope, rows, state, config = {}) {
+  const filters = ensureActivityListFilters(state, scope);
+  const filterFields = Array.isArray(config.filterFields) ? config.filterFields : [];
+  const optionsMap = collectFilterOptions(rows, filterFields);
+  const showSearch = config.search !== false;
+  const searchPlaceholder = config.searchPlaceholder || 'חיפוש…';
+
+  return `<div class="ds-toolbar" dir="rtl" data-local-filters="${escapeHtml(scope)}">
+    ${showSearch ? `<input type="search" class="ds-input" data-filter-search="${escapeHtml(scope)}" value="${escapeHtml(filters.q || '')}" placeholder="${escapeHtml(searchPlaceholder)}" />` : ''}
+    ${filterFields.map((field) => selectHtml(scope, field, filters, optionsMap)).join('')}
+    <button type="button" class="ds-btn ds-btn--sm" data-filter-clear="${escapeHtml(scope)}">ניקוי סינונים</button>
+  </div>`;
+}
+
+export function bindLocalFilters(root, state, scope, rerender, options = {}) {
+  const filters = ensureActivityListFilters(state, scope);
+  const searchInput = root.querySelector(`[data-filter-search="${scope}"]`);
+  const clearBtn = root.querySelector(`[data-filter-clear="${scope}"]`);
+  const debounceMs = Math.max(250, Number(options.debounceMs || DEFAULT_SEARCH_DEBOUNCE_MS));
+
+  let searchTimer;
+  searchInput?.addEventListener('input', (ev) => {
+    const nextValue = ev.target?.value || '';
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      filters.q = nextValue;
+      filters.visibleCount = DEFAULT_VISIBLE_LIMIT;
+      rerender();
+    }, debounceMs);
+  });
+
+  root.querySelectorAll(`[data-filter-scope="${scope}"][data-filter-field]`).forEach((node) => {
+    node.addEventListener('change', (ev) => {
+      const field = ev.target?.dataset?.filterField;
+      if (!field) return;
+      state.listFilters[scope][field] = ev.target?.value || '';
+      state.listFilters[scope].visibleCount = DEFAULT_VISIBLE_LIMIT;
+      rerender();
+    });
+  });
+
+  clearBtn?.addEventListener('click', () => {
+    const prevVisibleCount = state.listFilters?.[scope]?.visibleCount;
+    state.listFilters[scope] = { q: '', visibleCount: typeof prevVisibleCount === 'number' ? prevVisibleCount : DEFAULT_VISIBLE_LIMIT };
+    rerender();
+  });
+}
+
+export function splitVisibleRows(rows, filters, limit = DEFAULT_VISIBLE_LIMIT) {
+  const visibleLimit = Math.max(150, Math.min(200, Number(limit || filters?.visibleCount || DEFAULT_VISIBLE_LIMIT)));
+  const visibleCount = Number(filters?.visibleCount || visibleLimit);
+  const list = Array.isArray(rows) ? rows : [];
+  return {
+    visible: list.slice(0, visibleCount),
+    hasMore: list.length > visibleCount,
+    total: list.length,
+    visibleCount,
+    nextCount: visibleCount + visibleLimit
+  };
+}

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -5,8 +5,35 @@ import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bin
 import { formatDateHe } from './shared/format-date.js';
 import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { getHolidayLabel } from './shared/holidays.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  filtersToolbarHtml,
+  bindLocalFilters
+} from './shared/activity-list-filters.js';
 
 const inflightActivityDetailRequests = new Map();
+const WEEK_SCOPE = 'calendar';
+const CALENDAR_FILTER_FIELDS = [
+  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
+  { key: 'activity_name', label: 'תוכנית' },
+  { key: 'authority', label: 'רשות' },
+  { key: 'funding', label: 'מימון' },
+  { key: 'school', label: 'בית ספר' }
+];
+const CALENDAR_SEARCH_FIELDS = [
+  'RowID',
+  'activity_name',
+  'activity_manager',
+  'instructor_name',
+  'instructor_name_2',
+  'authority',
+  'school',
+  'funding',
+  'status'
+];
 
 function localYmd() {
   const d = new Date();
@@ -163,12 +190,19 @@ export const weekScreen = {
   render(data, { state }) {
     const safeDays = Array.isArray(data?.days) ? data.days : [];
     const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
+    const filterState = ensureActivityListFilters(state, WEEK_SCOPE);
+    const allItems = Object.values(itemsById || {});
+    prepareRowsForSearch(allItems, CALENDAR_SEARCH_FIELDS);
     const todayIso = localYmd();
     const weekOffset = state.weekOffset || 0;
+    const toolbarHtml = filtersToolbarHtml(WEEK_SCOPE, allItems, state, {
+      filterFields: CALENDAR_FILTER_FIELDS,
+      searchPlaceholder: 'חיפוש פעילויות בלוח השבוע…'
+    });
 
     const columns = safeDays
       .map((d, idx) => {
-        const items = weekDayItems(d, itemsById);
+        const items = applyLocalFilters(weekDayItems(d, itemsById), filterState, { filterFields: CALENDAR_FILTER_FIELDS });
         const isToday = d.date === todayIso;
         const dow = d.weekday_label || '';
         const groups = groupItemsByInstructor(items);
@@ -211,6 +245,7 @@ export const weekScreen = {
         <span class="ds-cal-nav__label">${escapeHtml(navLabel)}</span>
         <button type="button" class="ds-btn ds-btn--sm" data-week-next aria-label="שבוע הבא">◀ שבוע הבא</button>
       </nav>
+      ${toolbarHtml}
       <div class="ds-week-board" style="--week-cols:${safeDays.length || 7}" role="region" aria-label="לוח שבוע">${body}</div>
     `);
     return html;
@@ -224,6 +259,7 @@ export const weekScreen = {
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = state?.user?.display_role !== 'instructor';
     const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
+    bindLocalFilters(root, state, WEEK_SCOPE, rerender, { debounceMs: 300 });
 
     const bindActivityEditForm = (contentRoot) =>
       bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender, onRowSaved: (p) => patchCachedActivityDetail(p, state) });

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 96;
+const CACHE_VERSION = 97;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [
@@ -36,6 +36,7 @@ const APP_SHELL = [
   './frontend/src/screens/shared/toast.js',
   './frontend/src/screens/shared/ui-hebrew.js',
   './frontend/src/screens/shared/interactions.js',
+  './frontend/src/screens/shared/activity-list-filters.js',
   './frontend/src/styles/main.css',
   './frontend/public/manifest.json',
   './frontend/assets/logo1.png',


### PR DESCRIPTION
### Motivation
- לשפר ביצועים על ידי העברה של חיפוש וסינון למצב תצוגה מקומי בלבד ולא להפעיל קריאות API על שינויי פילטר/חיפוש.
- למנוע רינדור על כל הקלדה על ידי שימוש ב-debounce (≥250–300ms) ולשפר את חוויית המשתמש במסכים הכבדים.
- לבנות אינדקס חיפוש לכל שורה פעם אחת (`__searchText`) כדי להימנע מבניית מחרוזות חוזרות בכל render.

### Description
- הוספת מודול משותף `frontend/src/screens/shared/activity-list-filters.js` שמספק: `ensureActivityListFilters`, `normalizeText`, `buildSearchText`, `prepareRowsForSearch`, `collectFilterOptions`, `applyLocalFilters`, `filtersToolbarHtml`, `bindLocalFilters` (עם debounce 250–300ms) ו־`splitVisibleRows` לתמיכה ב־"הצג עוד".
- עמוד `activities` (`frontend/src/screens/activities.js`): הוספת ניווט חודש מקומי (`state.activitiesMonthYm`) ללא קריאה ל־API, סינון פעילויות לפי חפיפה לחודש (תומך `Date1..Date35` או `start_date/end_date`), שימוש בכלי ה־toolbar המשותף לחיפוש ופילטרים AND (manager, instructor, program, authority, funding, school), שימוש ב־`rerenderActivitiesView` כשזמין, ותצוגת "הצג עוד" לרשימות גדולות; לא שונתה מפתח הקאש `activities:all` ב־`frontend/src/main.js`.
- עמודי לוח: `week` ו־`month` — הוספת אותו toolbar משותף וחיפוש מקומי, סינון מקומי על `data.days/items_by_id` ו־`data.cells/items_by_id` (עדכון מונים ותוכן תא/יום לפי המסונן) מבלי להפעיל `api.week` או `api.month` על שינויי פילטר.
- עמוד `exceptions` — הוספת פילטרים מקומיים (manager, authority, funding, school, exception type), חיפוש מקומי, "הצג עוד" ושדרוג קריאות פתיחת כרטיסי חריגה כדי לעבוד נכון אחרי סינון; ב־backend הועבר שדה `funding` ל־payload של `exceptions` כדי לאפשר את הסינון בצד לקוח.
- עמוד `instructors` — החלפת החיפוש לרכיב המשותף עם debounce 300ms, הוספת פילטר מנהל, ותמיכה ב־"הצג עוד".
- עמוד `contacts` — הוספת toolbar חיפוש משותף עם debounce 300ms לשתי הלשוניות (instructors / schools) וביצוע החיפוש על `__searchText` המקומי שנבנה על הנתונים שכבר נטענו.
- Service Worker (`sw.js`) — העלאת `CACHE_VERSION` ב־1 והוספת הקובץ החדש לרשימת ה־precache.
- Backend (`backend/actions.gs`) — הוספת `funding` ל־payload של `exceptions` כדי לתמוך בסינון frontend בלי טעינות חוזרות.
- כל שינויים מבוצעים כך שלא להפוך את סינון למצב טעינת נתונים; קריאות API נשמרות רק לטעינה ראשונית של המסך או בניווט חודשי/שבועי אמיתי.

### Testing
- הרצת `npm test` (הרצה של `node --test tests/interactions.test.mjs`) ועברו כל המבחנים אוטומטיים (19/19 passed). 
- בדקתי ש־`npm test` עובר בהצלחה אחרי השינויים ואין שגיאות קומפילציה בסביבות הבדיקה האוטומטיות.
- שימת לב ביצועית: המימוש משתמש ב־debounce (300ms) ב־`bindLocalFilters` והסינון מבוסס על `__searchText` שנבנה ב־`prepareRowsForSearch` — מבנה זה מפחית רינדורים מיותרים ופוגע פחות בביצועים על המסכים הכבדים.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a4c12f0832baefa2a0a16a388cf)