### PR TITLE
Unify shell header navigation and polish contacts UI feedback

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,6 +4,7 @@ import { SCREEN_CACHE_STORAGE_PREFIX, persistCacheEntry } from './cache-persist.
 import { escapeHtml } from './screens/shared/html.js';
 import { hebrewRole, translateApiErrorForUser } from './screens/shared/ui-hebrew.js';
 import { createSharedInteractionLayer } from './screens/shared/interactions.js';
+import { headerNavGridHtml } from './screens/shared/act-nav-grid.js';
 import { loginScreen } from './screens/login.js';
 import { dashboardScreen } from './screens/dashboard.js';
 import { activitiesScreen } from './screens/activities.js';
@@ -445,18 +446,10 @@ function shell(content) {
 
   const systemName = escapeHtml(systemNameDisplay());
 
-  const HEADER_NAV_ROUTES = ['dashboard', 'activities', 'finance', 'permissions'];
-  const HEADER_NAV_ICONS  = { dashboard: '📊', activities: '📋', finance: '💰', permissions: '🔑' };
-  const isAdmin = state?.user?.display_role === 'admin' || state?.user?.display_role === 'operations_reviewer';
-  const availableRoutes = effectiveRoutes();
-  const headerNavHtml = isAdmin
-    ? HEADER_NAV_ROUTES
-        .filter((r) => availableRoutes.includes(r))
-        .map((r) => `<button type="button" class="shell-header-nav__btn${r === state.route ? ' is-active' : ''}" data-route="${r}" aria-label="${screenLabels[r] || r}" title="${screenLabels[r] || r}">
-          <span aria-hidden="true">${HEADER_NAV_ICONS[r] || '▶'}</span>
-        </button>`)
-        .join('')
-    : '';
+  const headerNavHtml = headerNavGridHtml({
+    route: state.route,
+    routes: effectiveRoutes()
+  });
 
   return `
     <div class="app-shell${drawerClass} route-${escapeHtml(String(state.route || ''))}" data-current-route="${escapeHtml(String(state.route || ''))}" dir="rtl">
@@ -491,7 +484,7 @@ function shell(content) {
             </button>
             <p class="shell-top__mobile-brand">${screenLabels[state.route] || systemName}</p>
           </div>
-          ${headerNavHtml ? `<nav class="shell-header-nav" aria-label="ניווט מהיר">${headerNavHtml}</nav>` : ''}
+          ${headerNavHtml}
           <div class="shell-top__end">
             <button type="button" class="shell-logout-btn" id="logoutBtn" aria-label="התנתקות" title="התנתקות">
               <span aria-hidden="true">⏻</span>

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -15,7 +15,6 @@ import {
   dsInteractiveCard
 } from './shared/layout.js';
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import {
   ensureActivityListFilters,
   prepareRowsForSearch,
@@ -438,7 +437,6 @@ export const activitiesScreen = {
         : `<div class="ds-compact-list">${compactRows}</div>${loadMoreHtml}`;
 
     const html = dsScreenStack(`
-      ${actNavGridHtml(state)}
       ${dsToolbar(`
         <div class="ds-view-toggle" dir="rtl" role="group" aria-label="בחירת תצוגת רשימה">
           <button type="button" class="ds-view-toggle__btn ${!compactView ? 'is-active' : ''}" data-activity-view="table" ${
@@ -458,7 +456,6 @@ export const activitiesScreen = {
   },
 
   bind({ root, data, state, rerender, rerenderActivitiesView, ui, api, clearScreenDataCache }) {
-    bindActNavGrid(root, { state, rerender });
 
     const filteredRows      = applyActivitiesLocalFilters(Array.isArray(data?.rows) ? data.rows : [], state, state?.clientSettings);
     const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -1,5 +1,4 @@
 import { escapeHtml } from './shared/html.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { hebrewColumn, hebrewEmploymentType } from './shared/ui-hebrew.js';
 import { dsScreenStack, dsEmptyState, dsStatusChip } from './shared/layout.js';
 import { showToast } from './shared/toast.js';
@@ -287,18 +286,16 @@ export const contactsScreen = {
     });
 
     return dsScreenStack(`
-      ${actNavGridHtml(state)}
       <div class="ds-chip-group" dir="rtl">${tabBtns}</div>
       <div class="ds-screen-top-row">
         ${searchInput}
-        <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-contact-action="add-${tab === 'instr' ? 'instr' : 'school'}">➕ הוספה</button>
+        <button type="button" class="ds-btn ds-btn--primary ds-btn--sm ds-btn--contact-add" data-contact-action="add-${tab === 'instr' ? 'instr' : 'school'}">+ הוסף</button>
       </div>
       <div class="contacts-list-wrap" dir="rtl">${listHtml}</div>
     `);
   },
 
   bind({ root, data, state, ui, rerender, api }) {
-    bindActNavGrid(root, { state, rerender });
     const instrRows = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows) ? data.school_rows : [];
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -318,13 +315,14 @@ export const contactsScreen = {
       btn.addEventListener('click', (ev) => {
         ev.preventDefault();
         ev.stopPropagation();
-        const email = btn.dataset.copyEmail;
-        const doToast = () => showToast('המייל הועתק ✓', 'success', 1200);
-        if (navigator.clipboard?.writeText) {
-          navigator.clipboard.writeText(email).then(doToast).catch(() => fallbackCopy(email, doToast));
-        } else {
-          fallbackCopy(email, doToast);
+        const email = String(btn.dataset.copyEmail || '').trim();
+        if (!email) {
+          showToast('לא ניתן היה להעתיק', 'error', 1800);
+          return;
         }
+        copyEmailToClipboard(email)
+          .then(() => showToast('המייל הועתק', 'success', 1500))
+          .catch(() => showToast('לא ניתן היה להעתיק', 'error', 1800));
       });
     });
 
@@ -476,14 +474,31 @@ export const contactsScreen = {
   }
 };
 
-function fallbackCopy(text, cb) {
+function fallbackCopy(text) {
   const ta = document.createElement('textarea');
   ta.value = text;
   Object.assign(ta.style, { position: 'fixed', opacity: '0', top: '0', left: '0' });
   document.body.appendChild(ta);
   ta.focus();
   ta.select();
-  try { document.execCommand('copy'); } catch (_) { /* ignore */ }
-  document.body.removeChild(ta);
-  cb?.();
+  try {
+    const copied = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return !!copied;
+  } catch (_) {
+    document.body.removeChild(ta);
+    return false;
+  }
+}
+
+async function copyEmailToClipboard(email) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(email);
+      return;
+    } catch (_) {
+      // fallback below
+    }
+  }
+  if (!fallbackCopy(email)) throw new Error('copy-failed');
 }

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -1,5 +1,4 @@
 import { escapeHtml } from './shared/html.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { hebrewColumn, visibleActivityCategoryLabel } from './shared/ui-hebrew.js';
 import {
   dsCard,
@@ -74,7 +73,6 @@ export const endDatesScreen = {
             .join('')}</div>`;
 
     return dsScreenStack(`
-      ${actNavGridHtml(state)}
       ${rows.length ? dsPageListToolsBar({ searchPlaceholder: 'חיפוש ברשימה…', filterLabel: 'סוג פעילות', filters: typeFilters }) : ''}
       ${dsCard({
         title: 'רשימת סיומים',
@@ -84,7 +82,6 @@ export const endDatesScreen = {
     `);
   },
   bind({ root, state, rerender }) {
-    bindActNavGrid(root, { state, rerender });
     bindPageListTools(root);
   }
 };

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -1,5 +1,4 @@
 import { escapeHtml } from './shared/html.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { formatDateHe } from './shared/format-date.js';
 import { hebrewExceptionType, hebrewColumn } from './shared/ui-hebrew.js';
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
@@ -124,7 +123,6 @@ export const exceptionsScreen = {
             .join('')}</div>${loadMoreHtml}`;
 
     return dsScreenStack(`
-      ${actNavGridHtml(state)}
       ${toolbarHtml}
       ${dsCard({
         title: `חריגות · ${total}`,
@@ -134,7 +132,6 @@ export const exceptionsScreen = {
     `);
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
-    bindActNavGrid(root, { state, rerender });
     const allRows   = Array.isArray(data?.rows) ? data.rows : [];
     bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 300 });
     root.querySelector(`[data-list-show-more="${EXCEPTIONS_SCOPE}"]`)?.addEventListener('click', (ev) => {

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -1,5 +1,4 @@
 import { escapeHtml } from './shared/html.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { dsCard, dsScreenStack, dsEmptyState } from './shared/layout.js';
 import { formatDateHe } from './shared/format-date.js';
 import {
@@ -85,7 +84,6 @@ export const instructorsScreen = {
       : `מדריכים · ${filtered.length}`;
 
     return dsScreenStack(`
-      ${actNavGridHtml(state)}
       <div class="ds-screen-top-row">
         ${toolbarHtml}
         <label class="ds-toggle-label" dir="rtl">
@@ -98,7 +96,6 @@ export const instructorsScreen = {
   },
 
   bind({ root, data, state, rerender, ui, api }) {
-    bindActNavGrid(root, { state, rerender });
     bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 300 });
     root.querySelector(`[data-list-show-more="${INSTRUCTORS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, INSTRUCTORS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -3,7 +3,6 @@ import { dsScreenStack, dsCard, dsInteractiveCard } from './shared/layout.js';
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
 import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bind-activity-edit-form.js';
 import { formatDateHe } from './shared/format-date.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { getHolidayLabel } from './shared/holidays.js';
 import {
   ensureActivityListFilters,
@@ -319,7 +318,6 @@ export const monthScreen = {
     const monthTitle = monthTitleHebrew(spec);
 
     const html = dsScreenStack(`
-      ${actNavGridHtml(state)}
       <nav class="ds-cal-nav" role="navigation" aria-label="ניווט חודשי" dir="rtl">
         <button type="button" class="ds-btn ds-btn--sm" data-month-prev aria-label="חודש קודם">חודש קודם ▶</button>
         <span class="ds-cal-nav__label">${escapeHtml(monthTitle)}</span>
@@ -334,7 +332,6 @@ export const monthScreen = {
     return html;
   },
   bind({ root, ui, data, state, rerender, clearScreenDataCache, api }) {
-    bindActNavGrid(root, { state, rerender });
     root.classList.remove('is-month-loading');
     root.setAttribute('aria-busy', 'false');
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;

--- a/frontend/src/screens/shared/act-nav-grid.js
+++ b/frontend/src/screens/shared/act-nav-grid.js
@@ -1,12 +1,20 @@
 import { escapeHtml } from './html.js';
 
 export const ACT_SUBNAV_ITEMS = [
-  { route: 'week',        label: 'שבוע',        icon: '📅' },
-  { route: 'month',       label: 'חודש',         icon: '🗓️' },
-  { route: 'end-dates',   label: 'תאריכי סיום', icon: '🏁' },
-  { route: 'exceptions',  label: 'חריגות',       icon: '⚠️' },
-  { route: 'instructors', label: 'מדריכים',      icon: '👥' },
-  { route: 'contacts',    label: 'אנשי קשר',     icon: '📇' },
+  { route: 'dashboard',           label: 'לוח בקרה',             icon: '📊' },
+  { route: 'activities',          label: 'פעילויות',             icon: '📋' },
+  { route: 'week',                label: 'שבוע',                 icon: '📅' },
+  { route: 'month',               label: 'חודש',                 icon: '🗓️' },
+  { route: 'end-dates',           label: 'תאריכי סיום',          icon: '🏁' },
+  { route: 'exceptions',          label: 'חריגות',               icon: '⚠️' },
+  { route: 'instructors',         label: 'מדריכים',              icon: '👥' },
+  { route: 'contacts',            label: 'אנשי קשר',             icon: '📇' },
+  { route: 'instructor-contacts', label: 'אנשי קשר מדריכים',     icon: '🧑‍🏫' },
+  { route: 'finance',             label: 'כספים',                icon: '💰' },
+  { route: 'permissions',         label: 'הרשאות',               icon: '🔑' },
+  { route: 'operations',          label: 'תפעול',                icon: '⚙️' },
+  { route: 'edit-requests',       label: 'אישורים',              icon: '✅' },
+  { route: 'my-data',             label: 'הנתונים שלי',          icon: '👤' }
 ];
 
 /**
@@ -34,6 +42,33 @@ export function actNavGridHtml(state) {
     )
     .join('');
   return `<div class="ds-act-nav-grid" dir="rtl">${buttons}</div>`;
+}
+
+/**
+ * מחזיר HTML של סרגל ניווט אחיד עבור ההידר (עם הרשאות בלבד).
+ * @param {object} state - state.routes, state.route
+ * @returns {string}
+ */
+export function headerNavGridHtml(state) {
+  const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
+  const currentRoute = state?.route || '';
+  const items = ACT_SUBNAV_ITEMS.filter((item) => availableRoutes.has(item.route));
+  if (!items.length) return '';
+  const buttons = items
+    .map(
+      (item) => `
+      <button
+        type="button"
+        class="ds-act-nav-item ds-act-nav-item--header${item.route === currentRoute ? ' is-active' : ''}"
+        data-route="${escapeHtml(item.route)}"
+        dir="rtl"
+      >
+        <span class="ds-act-nav-item__icon" aria-hidden="true">${item.icon}</span>
+        <span class="ds-act-nav-item__label">${escapeHtml(item.label)}</span>
+      </button>`
+    )
+    .join('');
+  return `<nav class="shell-header-nav ds-act-nav-grid ds-act-nav-grid--header" aria-label="ניווט מהיר" dir="rtl">${buttons}</nav>`;
 }
 
 /**

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -3,7 +3,6 @@ import { dsScreenStack, dsInteractiveCard } from './shared/layout.js';
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
 import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bind-activity-edit-form.js';
 import { formatDateHe } from './shared/format-date.js';
-import { actNavGridHtml, bindActNavGrid } from './shared/act-nav-grid.js';
 import { getHolidayLabel } from './shared/holidays.js';
 import {
   ensureActivityListFilters,
@@ -239,7 +238,6 @@ export const weekScreen = {
         : `${rangeLabel || 'שבוע'}`;
 
     const html = dsScreenStack(`
-      ${actNavGridHtml(state)}
       <nav class="ds-cal-nav" role="navigation" aria-label="ניווט שבועי" dir="rtl">
         <button type="button" class="ds-btn ds-btn--sm" data-week-prev aria-label="שבוע קודם">שבוע קודם ▶</button>
         <span class="ds-cal-nav__label">${escapeHtml(navLabel)}</span>
@@ -251,7 +249,6 @@ export const weekScreen = {
     return html;
   },
   bind({ root, ui, data, state, rerender, clearScreenDataCache, api }) {
-    bindActNavGrid(root, { state, rerender });
     root.classList.remove('is-week-loading');
     root.setAttribute('aria-busy', 'false');
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -482,78 +482,8 @@ select {
 
 /* ——— Header quick-nav (admin) ——— */
 .shell-header-nav {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-space-2);
   flex: 1;
-  justify-content: center;
-  overflow: visible;
-  padding: 4px;
-  background: rgba(255, 255, 255, 0.62);
-  border: 1px solid rgba(26, 51, 88, 0.1);
-  border-radius: 12px;
-}
-
-.shell-header-nav__btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  border: 1px solid rgba(26, 51, 88, 0.14);
-  background: #fff;
-  box-shadow: 0 1px 2px rgba(26, 51, 88, 0.08);
-  font-size: 1rem;
-  color: var(--ds-text-muted);
-  position: relative;
-  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease,
-    box-shadow 0.18s ease, transform 0.08s ease;
-  cursor: pointer;
-}
-
-.shell-header-nav__btn::after {
-  content: '';
-  position: absolute;
-  bottom: -7px;
-  left: 50%;
-  transform: translateX(-50%) scaleX(0);
-  width: 60%;
-  height: 2.5px;
-  border-radius: 2px;
-  background: var(--ds-accent);
-  transition: transform 0.18s ease, opacity 0.18s ease;
-  opacity: 0;
-}
-
-.shell-header-nav__btn:hover {
-  background: #f8fbff;
-  border-color: rgba(26, 51, 88, 0.2);
-  color: var(--ds-text);
-  box-shadow: 0 1px 3px rgba(26, 51, 88, 0.1);
-}
-
-.shell-header-nav__btn.is-active {
-  background: var(--ds-accent);
-  border-color: var(--ds-accent);
-  color: #fff;
-  box-shadow: 0 2px 6px rgba(26, 51, 88, 0.2);
-  font-weight: 600;
-}
-
-.shell-header-nav__btn.is-active::after {
-  transform: translateX(-50%) scaleX(1);
-  opacity: 1;
-}
-
-.shell-header-nav__btn:active:not(.is-active) {
-  transform: translateY(1px);
-  box-shadow: 0 1px 2px rgba(26, 51, 88, 0.10), inset 0 1px 3px rgba(26, 51, 88, 0.12);
-}
-
-.shell-header-nav__btn:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(26, 51, 88, 0.22), 0 1px 3px rgba(26, 51, 88, 0.10);
+  min-width: 0;
 }
 
 /* ——— Apple-style logout button ——— */
@@ -1470,6 +1400,37 @@ span.ds-chip {
   border: 1px solid rgba(26, 51, 88, 0.1);
   border-radius: 12px;
   box-shadow: 0 1px 2px rgba(26, 51, 88, 0.06);
+}
+
+.ds-act-nav-grid--header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  align-items: stretch;
+  width: 100%;
+  margin: 0 var(--ds-space-2);
+  padding: 3px;
+}
+
+.ds-act-nav-item--header {
+  min-height: 34px;
+  padding: 5px 8px;
+  font-size: 0.73rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 960px) {
+  .ds-act-nav-grid--header {
+    display: flex;
+    overflow-x: auto;
+    gap: 6px;
+    justify-content: flex-start;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
+  }
+  .ds-act-nav-item--header {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
 }
 
 @media (max-width: 900px) {
@@ -4531,6 +4492,15 @@ select.ds-input {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  padding-bottom: 14px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ds-border) 80%, transparent);
+}
+
+.sc-authority-group:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 .sc-authority-head {
@@ -4767,6 +4737,14 @@ select.ds-input {
   width: min(720px, 90vw);
   margin-inline: auto;
   gap: var(--ds-space-2);
+}
+
+.ds-btn--contact-add {
+  min-height: 30px;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  border-radius: 999px;
+  line-height: 1.1;
 }
 
 /* ── Contacts copy toast ── */

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 97;
+const CACHE_VERSION = 98;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- Reduce duplicate navigation UI by moving activity/admin/operations links into a single header bar driven by allowed routes (`state.routes`/effective routes). 
- Small UX polish for contacts screens: make the add button less dominant and provide clear clipboard feedback without changing backend logic. 
- Improve visual grouping of school-authority blocks and ensure cached frontend assets are invalidated after the change.

### Description
- Added/expanded route list and new header nav generator in `frontend/src/screens/shared/act-nav-grid.js` (`ACT_SUBNAV_ITEMS`, `headerNavGridHtml`) and kept the existing activity grid (`actNavGridHtml`).
- Render the unified header nav from the shell by importing and calling `headerNavGridHtml` in `frontend/src/main.js` (navigation is still governed by `effectiveRoutes()`/`state.routes`).
- Removed in-screen duplicate activity nav grid and related binding calls from activity-related screens so navigation appears only in the header (`frontend/src/screens/activities.js`, `week.js`, `month.js`, `exceptions.js`, `end-dates.js`, `instructors.js`, `contacts.js`).
- Contacts UX changes in `frontend/src/screens/contacts.js`: compacted the add button to a small pill (`+ הוסף`), replaced the previous copy flow with `copyEmailToClipboard` + robust `fallbackCopy` and added explicit success (`המייל הועתק`) and failure (`לא ניתן היה להעתיק`) toasts (uses existing `showToast`).
- CSS updates in `frontend/src/styles/main.css` to reuse the activity grid visual language in the header (`.ds-act-nav-grid--header`, `.ds-act-nav-item--header`), add mobile horizontal scrolling, compact add-button styles (`.ds-btn--contact-add`), and clearer vertical separators for authority groups (`.sc-authority-group`).
- Bumped service worker cache version in `sw.js` (`CACHE_VERSION` from `97` to `98`) to invalidate stale frontend assets.
- No backend/API changes or new permissions/routes were introduced; visibility remains controlled by the existing `effectiveRoutes`.

### Testing
- Ran the frontend test suite with `npm test`, all tests passed (`19/19`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2d1d2e10832bbf5a78143187f7e6)