### PR TITLE
Implement read-only monthly End Dates screen with accordion details and Excel export

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -1398,7 +1398,7 @@ function actionEndDates_(user) {
       return !!text_(row.end_date);
     })
     .map(function(row) {
-      return {
+      var mapped = {
         RowID: row.RowID,
         activity_name: row.activity_name,
         activity_type: text_(row.activity_type),
@@ -1410,6 +1410,11 @@ function actionEndDates_(user) {
         status: text_(row.status),
         source_sheet: row.source_sheet
       };
+      for (var i = 1; i <= 35; i += 1) {
+        var key = 'Date' + i;
+        mapped[key] = text_(row[key]);
+      }
+      return mapped;
     });
 
   rows.sort(function(a, b) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -64,9 +64,9 @@ const PERF_MAX_REQUESTS = 150;
 
 function invalidateScreenDataByAction(action) {
   const targetedMutations = {
-    saveActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:'],
-    addActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:'],
-    submitEditRequest: ['activities:', 'edit-requests', 'week:', 'month:', 'dashboard:'],
+    saveActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:', 'end-dates'],
+    addActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:', 'end-dates'],
+    submitEditRequest: ['activities:', 'edit-requests', 'week:', 'month:', 'dashboard:', 'end-dates'],
     reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:'],
     saveFinanceRow: ['finance:', 'dashboard:'],
     syncFinance: ['finance:', 'dashboard:'],

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -1,87 +1,154 @@
 import { escapeHtml } from './shared/html.js';
-import { hebrewColumn, visibleActivityCategoryLabel } from './shared/ui-hebrew.js';
-import {
-  dsCard,
-  dsScreenStack,
-  dsTableWrap,
-  dsEmptyState,
-  dsInteractiveCard
-} from './shared/layout.js';
-import { isNarrowViewport } from './shared/responsive.js';
-import { dsPageListToolsBar, bindPageListTools } from './shared/page-list-tools.js';
+import { dsCard, dsScreenStack, dsEmptyState } from './shared/layout.js';
+import { formatDateHe } from './shared/format-date.js';
 
-const COLS = ['RowID', 'activity_name', 'activity_type', 'activity_manager', 'authority', 'school', 'start_date', 'end_date', 'status'];
+const DATE_COLS = Array.from({ length: 35 }, (_, idx) => `Date${idx + 1}`);
+
+function asIso(value) {
+  const text = String(value || '').trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(text) ? text : '';
+}
+
+function extractValidDates(row) {
+  return DATE_COLS
+    .map((col) => asIso(row?.[col]))
+    .filter(Boolean);
+}
+
+function monthLabelFromIso(iso) {
+  const [year, month] = iso.split('-').map((v) => Number(v));
+  const dt = new Date(Date.UTC(year, month - 1, 1));
+  return dt.toLocaleDateString('he-IL', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+}
+
+function normalizeRows(rows) {
+  return rows
+    .filter((row) => String(row?.source_sheet || '').trim() === 'data_long')
+    .map((row) => {
+      const fallbackEndDate = extractValidDates(row).slice(-1)[0] || '';
+      const endDate = asIso(row?.end_date) || fallbackEndDate;
+      return {
+        ...row,
+        end_date: endDate,
+        validDates: extractValidDates(row)
+      };
+    })
+    .filter((row) => !!row.end_date)
+    .sort((a, b) => {
+      if (a.end_date !== b.end_date) return a.end_date.localeCompare(b.end_date);
+      const schoolCmp = String(a.school || '').localeCompare(String(b.school || ''), 'he');
+      if (schoolCmp !== 0) return schoolCmp;
+      return String(a.activity_name || '').localeCompare(String(b.activity_name || ''), 'he');
+    });
+}
+
+function groupByMonth(rows) {
+  const map = new Map();
+  rows.forEach((row) => {
+    const key = row.end_date.slice(0, 7);
+    if (!map.has(key)) {
+      map.set(key, {
+        key,
+        label: monthLabelFromIso(`${key}-01`),
+        rows: []
+      });
+    }
+    map.get(key).rows.push(row);
+  });
+  return [...map.values()].sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function renderActivityCard(row) {
+  const validDates = row.validDates || [];
+  const datesHtml = validDates.length
+    ? `<div class="ds-end-dates__dates-list">${validDates
+        .map((iso) => `<span class="ds-end-dates__date-pill">${escapeHtml(formatDateHe(iso))}</span>`)
+        .join('')}</div>`
+    : '<p class="ds-end-dates__muted">לא נמצאו תאריכים תקינים.</p>';
+
+  return `<details class="ds-activity-accordion ds-end-dates__activity" data-end-dates-accordion>
+    <summary class="ds-activity-accordion__summary ds-end-dates__summary" role="button" aria-label="פתיחת פירוט תאריכים">
+      <span class="ds-activity-accordion__name ds-end-dates__summary-grid">
+        <span>${escapeHtml(String(row.activity_name || '—'))}</span>
+        <span>${escapeHtml(String(row.school || '—'))}</span>
+        <span>${escapeHtml(String(row.authority || '—'))}</span>
+        <span>${escapeHtml(formatDateHe(row.end_date))}</span>
+      </span>
+      <span class="ds-activity-accordion__chevron" aria-hidden="true">›</span>
+    </summary>
+    <div class="ds-activity-accordion__body">
+      <p class="ds-end-dates__dates-title">פירוט תאריכים (${escapeHtml(String(validDates.length))})</p>
+      ${datesHtml}
+    </div>
+  </details>`;
+}
+
+function exportRowsToExcel(rows) {
+  const headers = ['חודש', 'שם פעילות', 'בית ספר', 'רשות', 'תאריך סיום', 'פירוט תאריכים'];
+  const tableRows = rows
+    .map((row) => {
+      const month = monthLabelFromIso(`${row.end_date.slice(0, 7)}-01`);
+      const datesText = (row.validDates || []).map((iso) => formatDateHe(iso)).join(', ');
+      return `<tr>
+        <td>${escapeHtml(month)}</td>
+        <td>${escapeHtml(String(row.activity_name || ''))}</td>
+        <td>${escapeHtml(String(row.school || ''))}</td>
+        <td>${escapeHtml(String(row.authority || ''))}</td>
+        <td>${escapeHtml(formatDateHe(row.end_date))}</td>
+        <td>${escapeHtml(datesText)}</td>
+      </tr>`;
+    })
+    .join('');
+
+  const html = `<!doctype html><html dir="rtl" xmlns:x="urn:schemas-microsoft-com:office:excel"><head><meta charset="UTF-8"></head><body>
+    <table border="1"><thead><tr>${headers.map((h) => `<th>${escapeHtml(h)}</th>`).join('')}</tr></thead><tbody>${tableRows}</tbody></table>
+  </body></html>`;
+
+  const blob = new Blob(['\uFEFF' + html], { type: 'application/vnd.ms-excel;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  const stamp = new Date().toISOString().slice(0, 10);
+  a.href = url;
+  a.download = `תאריכי_סיום_${stamp}.xls`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
 
 export const endDatesScreen = {
   load: ({ api }) => api.endDates(),
-  render(data, { state } = {}) {
-    const rows = Array.isArray(data?.rows) ? data.rows : [];
-    const narrow = isNarrowViewport();
-    const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
-    const cols = hideRowId
-      ? ['activity_name', 'activity_type', 'activity_manager', 'authority', 'school', 'start_date', 'end_date', 'status']
-      : COLS;
+  render(data) {
+    const rawRows = Array.isArray(data?.rows) ? data.rows : [];
+    const rows = normalizeRows(rawRows);
+    const months = groupByMonth(rows);
 
-    const typeFilters = [...new Set(rows.map((r) => String(r.activity_type || '').trim()).filter(Boolean))].map((t) => ({
-      value: t,
-      label: visibleActivityCategoryLabel(t)
-    }));
+    const headerTools = `<div class="ds-end-dates__head-tools">
+      <button type="button" class="ds-icon-btn" data-end-dates-export title="ייצוא לאקסל" aria-label="ייצוא לאקסל">⬇️</button>
+    </div>`;
 
-    const body = rows.map((row) => {
-      const rawType = String(row.activity_type || '').trim();
-      const searchHay = cols.map((c) => {
-        let v = row?.[c] ?? '';
-        if (c === 'activity_type') v = visibleActivityCategoryLabel(v);
-        return String(v || '');
-      }).join(' ');
-      return `
-      <tr class="ds-data-row" data-list-item data-search="${escapeHtml(searchHay)}" data-filter="${escapeHtml(rawType)}">${cols.map((c) => {
-        let v = row?.[c] ?? '';
-        if (c === 'activity_type') v = visibleActivityCategoryLabel(v);
-        return `<td>${escapeHtml(String(v || '—'))}</td>`;
-      }).join('')}</tr>
-    `;
-    });
+    const body = months.length
+      ? `<div class="ds-end-dates__months">${months
+          .map((month) => `<section class="ds-end-dates__month-group" data-end-dates-month="${escapeHtml(month.key)}">
+            <h3 class="ds-end-dates__month-title">${escapeHtml(month.label)}</h3>
+            <div class="ds-end-dates__month-list">${month.rows.map(renderActivityCard).join('')}</div>
+          </section>`)
+          .join('')}</div>`
+      : dsEmptyState('לא נמצאו פעילויות מתמשכות עם תאריך סיום');
 
-    const tableBlock =
-      rows.length === 0
-        ? dsEmptyState('לא נמצאו רשומות עם תאריך סיום')
-        : dsTableWrap(`<table class="ds-table">
-            <thead><tr>${cols.map((c) => `<th>${escapeHtml(hebrewColumn(c))}</th>`).join('')}</tr></thead>
-            <tbody>${body.join('')}</tbody>
-          </table>`);
-
-    const compact =
-      rows.length === 0
-        ? dsEmptyState('לא נמצאו רשומות עם תאריך סיום')
-        : `<div class="ds-compact-list">${rows
-            .map((row) => {
-              const rawType = String(row.activity_type || '').trim();
-              const searchHay = [row.RowID, row.activity_name, row.end_date, visibleActivityCategoryLabel(row.activity_type)]
-                .filter(Boolean)
-                .join(' ');
-              return `<div data-list-item data-search="${escapeHtml(searchHay)}" data-filter="${escapeHtml(rawType)}">
-              ${dsInteractiveCard({
-                variant: 'session',
-                action: `noop:${row.RowID}`,
-                title: hideRowId ? `${row.activity_name || '—'}` : `${row.RowID} · ${row.activity_name || '—'}`,
-                subtitle: `סיום: ${row.end_date || '—'}`,
-                meta: visibleActivityCategoryLabel(row.activity_type)
-              })}
-            </div>`;
-            })
-            .join('')}</div>`;
-
-    return dsScreenStack(`
-      ${rows.length ? dsPageListToolsBar({ searchPlaceholder: 'חיפוש ברשימה…', filterLabel: 'סוג פעילות', filters: typeFilters }) : ''}
-      ${dsCard({
-        title: 'רשימת סיומים',
-        body: narrow ? compact : tableBlock,
-        padded: rows.length === 0 || narrow
-      })}
-    `);
+    return dsScreenStack(
+      dsCard({
+        title: 'תאריכי סיום פעילויות',
+        badge: `${rows.length} פעילויות`,
+        body: `${headerTools}${body}`,
+        padded: true
+      })
+    );
   },
-  bind({ root, state, rerender }) {
-    bindPageListTools(root);
+  bind({ root, data }) {
+    const rows = normalizeRows(Array.isArray(data?.rows) ? data.rows : []);
+    root.querySelector('[data-end-dates-export]')?.addEventListener('click', () => {
+      exportRowsToExcel(rows);
+    });
   }
 };

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -6880,3 +6880,79 @@ select.ds-input {
 .ds-drawer:has(.activity-drawer__header) > .ds-drawer__header {
   display: none;
 }
+
+/* ——— End dates screen ——— */
+.ds-end-dates__head-tools {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 10px;
+}
+
+.ds-end-dates__months {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ds-end-dates__month-title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #1e293b;
+}
+
+.ds-end-dates__month-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ds-end-dates__activity {
+  margin-bottom: 0;
+}
+
+.ds-end-dates__summary {
+  align-items: center;
+}
+
+.ds-end-dates__summary-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.ds-end-dates__dates-title {
+  margin: 0;
+  font-size: 0.86rem;
+  color: #334155;
+  font-weight: 700;
+}
+
+.ds-end-dates__dates-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ds-end-dates__date-pill {
+  font-size: 0.76rem;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #eef4ff;
+  color: #1e3a8a;
+  border: 1px solid #d9e6ff;
+}
+
+.ds-end-dates__muted {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 900px) {
+  .ds-end-dates__summary-grid {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a read-only screen that shows long activities grouped by their end month to make it easy to track activity completions. 
- Allow quick inspection of all valid session dates (Date1–Date35) per activity without additional API calls when expanding an item. 
- Ensure the screen reflects updates to activities by invalidating cache for relevant mutations so users see fresh data after changes elsewhere.

### Description
- Reworked the frontend `end-dates` screen to filter to `data_long` only, group rows by end month, and render each activity as a closed accordion that expands to show only valid `Date1`–`Date35` values; sorting is by end date asc, then school, then activity name. 
- Added a compact icon-only Excel export button (`title`/`aria-label`: "ייצוא לאקסל") that exports the currently displayed rows (month, activity name, school, authority, end date and a consolidated dates column) as an .xls HTML table. 
- Extended the backend `actionEndDates_` payload to include `Date1`–`Date35` for each long activity row so expanded accordions do not require extra API calls. 
- Updated client-side cache invalidation in `frontend/src/api.js` so `end-dates` is cleared after relevant mutations (`saveActivity`, `addActivity`, `submitEditRequest`) and added dedicated CSS rules for the new layout in `main.css`.

### Testing
- Ran the automated test suite with `npm test`, and all tests passed. 
- Visual verification was not captured as a screenshot in this environment, but the UI changes are limited to the read-only screen and styling files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2fb61498832b9cc103c0e18295a5)