### PR TITLE
Enforce role-based edit & approval workflow (instructors read-only; admin/operation_manager direct edits)

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -9,6 +9,8 @@ function actionBootstrap_(user) {
     default_route: defaultRoute,
     routes: routes,
     can_add_activity: effectiveCanAddActivity_(permission, user.display_role),
+    can_edit_direct: effectiveCanEditDirect_(permission, user.display_role),
+    can_request_edit: effectiveCanRequestEdit_(permission, user.display_role),
     profile: {
       full_name: text_(permission.full_name),
       display_role2: text_(permission.display_role2)
@@ -282,7 +284,7 @@ function dateColumnsPatchFromChanges_(changes) {
 }
 
 function actionDashboard_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
 
   var permission = getPermissionRow_(user.user_id);
   var canViewFinance = user.display_role === 'admin' ||
@@ -604,7 +606,7 @@ function actionDashboard_(user, payload) {
 }
 
 function actionActivities_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   var canAddActivity = effectiveCanAddActivity_(permission, user.display_role);
 
@@ -708,7 +710,7 @@ function mapActivitySummaryRowForList_(row, user, noteMap, meetingsMap, today) {
     meetings_total: meetingDates.length,
     meetings_done: meetingDates.filter(function(dateKey) { return dateKey <= today; }).length,
     meetings_remaining: meetingDates.filter(function(dateKey) { return dateKey > today; }).length,
-    private_note: user.display_role === 'operations_reviewer' && noteRow && yesNo_(noteRow.active) === 'yes'
+    private_note: user.display_role === 'operation_manager' && noteRow && yesNo_(noteRow.active) === 'yes'
       ? text_(noteRow.note_text)
       : ''
   };
@@ -791,7 +793,7 @@ function findActivityRowById_(sourceRowId, sourceSheet) {
 }
 
 function actionActivityDetail_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var sourceRowId = text_((payload || {}).source_row_id || (payload || {}).RowID);
   var sourceSheet = text_((payload || {}).source_sheet);
   var row = findActivityRowById_(sourceRowId, sourceSheet);
@@ -799,7 +801,7 @@ function actionActivityDetail_(user, payload) {
 }
 
 function actionAddActivityOptions_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   if (!effectiveCanAddActivity_(permission, user.display_role)) {
     throw new Error('Forbidden');
@@ -822,7 +824,7 @@ function actionAddActivityOptions_(user) {
 }
 
 function actionActivityDraftOptions_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   if (!effectiveCanAddActivity_(permission, user.display_role)) {
     throw new Error('Forbidden');
@@ -839,7 +841,7 @@ function actionActivityDraftOptions_(user, payload) {
 }
 
 function actionWeek_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user', 'instructor']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
 
   var today = new Date();
   var startDay = getWeekStartDay_();
@@ -882,7 +884,7 @@ function actionWeek_(user, payload) {
 }
 
 function actionMonth_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user', 'instructor']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
 
   var now = new Date();
   var ym = text_(payload && payload.ym).slice(0, 7);
@@ -925,7 +927,7 @@ function actionMonth_(user, payload) {
 }
 
 function actionExceptions_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
 
   // enrichRowsWithMeetings_ מעדכן end_date לתאריך המפגש האחרון האמיתי מגיליון activity_meetings,
   // כך שבדיקת late_end_date תזהה נכון קורסים עם מפגשים מעבר ל-late_end_date_cutoff.
@@ -1000,7 +1002,7 @@ function actionExceptions_(user) {
 }
 
 function actionFinance_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
 
   var today = formatDate_(new Date());
   var rule = getSettingText_('finance_display_rule', CONFIG.DEFAULT_FINANCE_DISPLAY_RULE || 'ended_until_today');
@@ -1138,7 +1140,7 @@ function actionFinance_(user, payload) {
 }
 
 function actionFinanceDetail_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var sourceRowId = text_((payload || {}).source_row_id || (payload || {}).RowID);
   var sourceSheet = text_((payload || {}).source_sheet);
   var row = findActivityRowById_(sourceRowId, sourceSheet);
@@ -1148,7 +1150,7 @@ function actionFinanceDetail_(user, payload) {
 }
 
 function actionInstructors_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
 
   var all = allActivitiesSummary_();
   var ym = formatDate_(new Date()).slice(0, 7);
@@ -1212,7 +1214,7 @@ function actionInstructors_(user) {
 }
 
 function actionContacts_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   var canViewInstructors = instructorContactsViewYes_(permission);
   var canViewSchools     = schoolContactsViewYes_(permission);
@@ -1263,7 +1265,7 @@ function actionContacts_(user) {
 
 function canManageContacts_(user, kind) {
   if (!user) return false;
-  if (user.display_role === 'admin' || user.display_role === 'operations_reviewer') return true;
+  if (user.display_role === 'admin' || user.display_role === 'operation_manager') return true;
   var permission = getPermissionRow_(user.user_id);
   if (kind === 'instructor') return instructorContactsViewYes_(permission);
   if (kind === 'school') return schoolContactsViewYes_(permission);
@@ -1363,7 +1365,7 @@ function actionSaveContact_(user, payload) {
 }
 
 function actionInstructorContacts_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   if (!instructorContactsViewYes_(permission)) {
     throw new Error('Forbidden');
@@ -1386,7 +1388,7 @@ function actionInstructorContacts_(user) {
 }
 
 function actionEndDates_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   if (!endDatesViewYes_(permission)) {
     throw new Error('Forbidden');
@@ -1425,7 +1427,7 @@ function actionEndDates_(user) {
 }
 
 function actionMyData_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user', 'instructor']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
   var permission = getPermissionRow_(user.user_id);
   if (user.display_role !== 'instructor' && !myDataViewYes_(permission)) {
     throw new Error('Forbidden');
@@ -1444,7 +1446,7 @@ function actionMyData_(user) {
 }
 
 function actionOperations_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   if (yesNo_(permission.view_operations_data) !== 'yes' && user.display_role !== 'admin') {
     throw new Error('Forbidden');
@@ -1474,7 +1476,7 @@ function actionOperations_(user, payload) {
 }
 
 function actionOperationsDetail_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var permission = getPermissionRow_(user.user_id);
   if (yesNo_(permission.view_operations_data) !== 'yes' && user.display_role !== 'admin') {
     throw new Error('Forbidden');
@@ -1486,10 +1488,8 @@ function actionOperationsDetail_(user, payload) {
 }
 
 function actionEditRequests_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
-  var permission = getPermissionRow_(user.user_id);
-  var canReview = user.display_role === 'admin' ||
-    (user.display_role === 'operations_reviewer' && yesNo_(permission.can_review_requests) === 'yes');
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
+  var canReview = canDirectWriteRole_(user.display_role);
 
   var rows = readRows_(CONFIG.SHEETS.EDIT_REQUESTS).filter(function(r) {
     return yesNo_(r.active) === 'yes';
@@ -1502,34 +1502,43 @@ function actionEditRequests_(user) {
     });
   }
 
-  var groups = {};
-  var order = [];
-  rows.forEach(function(r) {
-    var rid = text_(r.request_id);
-    if (!groups[rid]) {
-      groups[rid] = {
-        request_id: rid,
-        source_sheet: text_(r.source_sheet),
-        source_row_id: text_(r.source_row_id),
-        requested_by_user_id: text_(r.requested_by_user_id),
-        requested_by_name: text_(r.requested_by_name),
-        requested_at: text_(r.requested_at),
-        status: text_(r.status),
-        reviewed_at: text_(r.reviewed_at),
-        reviewed_by: text_(r.reviewed_by),
-        reviewer_notes: text_(r.reviewer_notes),
-        fields: []
-      };
-      order.push(rid);
+  var result = rows.map(function(r) {
+    var changedFields = parseJsonObject_(r.changed_fields, []);
+    if (!Array.isArray(changedFields)) changedFields = [];
+    var originalValues = parseJsonObject_(r.original_values, {});
+    var requestedValues = parseJsonObject_(r.requested_values, {});
+    if (!changedFields.length && text_(r.field_name)) {
+      changedFields = [text_(r.field_name)];
+      originalValues[text_(r.field_name)] = text_(r.old_value);
+      requestedValues[text_(r.field_name)] = text_(r.new_value);
     }
-    groups[rid].fields.push({
-      field_name: text_(r.field_name),
-      old_value: text_(r.old_value),
-      new_value: text_(r.new_value)
-    });
+    return {
+      request_id: text_(r.request_id),
+      RowID: text_(r.RowID || r.source_row_id),
+      source_sheet: text_(r.source_sheet),
+      source_row_id: text_(r.source_row_id || r.RowID),
+      activity_name: text_(r.activity_name),
+      school: text_(r.school),
+      authority: text_(r.authority),
+      requested_by_user_id: text_(r.requested_by_user_id),
+      requested_by_name: text_(r.requested_by_name),
+      requested_at: text_(r.requested_at),
+      status: text_(r.status),
+      changed_fields: changedFields,
+      original_values: originalValues,
+      requested_values: requestedValues,
+      reviewer_user_id: text_(r.reviewer_user_id || r.reviewed_by),
+      reviewed_at: text_(r.reviewed_at),
+      review_note: text_(r.review_note || r.reviewer_notes),
+      fields: changedFields.map(function(fieldName) {
+        return {
+          field_name: fieldName,
+          old_value: text_(originalValues[fieldName]),
+          new_value: text_(requestedValues[fieldName])
+        };
+      })
+    };
   });
-
-  var result = order.map(function(rid) { return groups[rid]; });
   result.sort(function(a, b) {
     return (b.requested_at || '').localeCompare(a.requested_at || '');
   });
@@ -1543,12 +1552,12 @@ function actionEditRequests_(user) {
 /**
  * Computes effective non-admin role defaults, merging hardcoded baseline with
  * any active overrides in the settings sheet (role_defaults.<role>.<flag>).
- * Returns { operations_reviewer: {...}, authorized_user: {...}, instructor: {} }
+ * Returns { operation_manager: {...}, authorized_user: {...}, instructor: {} }
  * where each value is a flag-name → 'yes'/'no' object.
  */
 function computeNonAdminRoleDefaults_() {
   var defaults = {
-    operations_reviewer: {
+    operation_manager: {
       view_dashboard: 'yes', view_activities: 'yes', view_week: 'yes', view_month: 'yes',
       view_instructors: 'yes', view_exceptions: 'yes', view_finance: 'yes',
       view_edit_requests: 'yes', view_final_approvals: 'yes',
@@ -1564,7 +1573,7 @@ function computeNonAdminRoleDefaults_() {
     }
   };
   var settingsMap = readActiveSettingsMap_();
-  var nonAdminRoles = ['operations_reviewer', 'authorized_user', 'instructor'];
+  var nonAdminRoles = ['operation_manager', 'authorized_user', 'instructor'];
   nonAdminRoles.forEach(function(role) {
     var base = defaults[role] || {};
     var prefix = 'role_defaults.' + role + '.';
@@ -1580,9 +1589,9 @@ function computeNonAdminRoleDefaults_() {
 }
 
 function actionPermissions_(user) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer']);
+  requireAnyRole_(user, ['admin', 'operation_manager']);
   var permission = getPermissionRow_(user.user_id);
-  // Admin always has access; for operations_reviewer require explicit flag
+  // Admin always has access; for operation_manager require explicit flag
   if (user.display_role !== 'admin' && yesNo_(permission.view_permissions) !== 'yes') {
     throw new Error('Forbidden');
   }
@@ -1863,6 +1872,9 @@ function actionSaveActivity_(user, payload) {
     changes.status = (rawStatus === 'closed' || rawStatus === 'סגור') ? 'סגור' : 'פעיל';
   }
   if (!effectiveCanEditDirect_(permission, user.display_role)) {
+    if (!effectiveCanRequestEdit_(permission, user.display_role)) {
+      throw new Error('Forbidden');
+    }
     return actionSubmitEditRequest_(user, {
       source_sheet: sourceSheet,
       source_row_id: sourceRowId,
@@ -1881,8 +1893,9 @@ function actionSaveActivity_(user, payload) {
 }
 
 function actionSubmitEditRequest_(user, payload) {
-  requireAnyRole_(user, ['authorized_user']);
-  if (user.display_role === 'instructor') {
+  requireAnyRole_(user, ['authorized_user', 'admin', 'operation_manager']);
+  var permission = getPermissionRow_(user.user_id);
+  if (user.display_role === 'instructor' || !effectiveCanRequestEdit_(permission, user.display_role)) {
     throw new Error('Forbidden');
   }
 
@@ -1902,23 +1915,41 @@ function actionSubmitEditRequest_(user, payload) {
   var currentRow = getRowByKey_(sourceSheet, 'RowID', sourceRowId);
   var requestId = 'REQ-' + new Date().getTime();
 
+  var changedFields = [];
+  var originalValues = {};
+  var requestedValues = {};
   Object.keys(changes).forEach(function(fieldName) {
-    appendRow_(CONFIG.SHEETS.EDIT_REQUESTS, {
-      request_id: requestId,
-      source_sheet: sourceSheet,
-      source_row_id: sourceRowId,
-      field_name: fieldName,
-      old_value: text_(currentRow[fieldName]),
-      new_value: text_(changes[fieldName]),
-      requested_by_user_id: text_(user.user_id),
-      requested_by_name: text_(user.full_name),
-      requested_at: new Date().toISOString(),
-      status: 'pending',
-      reviewed_at: '',
-      reviewed_by: '',
-      reviewer_notes: '',
-      active: 'yes'
-    });
+    var oldValue = text_(currentRow[fieldName]);
+    var newValue = text_(changes[fieldName]);
+    if (oldValue === newValue) return;
+    changedFields.push(fieldName);
+    originalValues[fieldName] = oldValue;
+    requestedValues[fieldName] = newValue;
+  });
+  if (!changedFields.length) {
+    throw new Error('No changes to submit');
+  }
+  appendRow_(CONFIG.SHEETS.EDIT_REQUESTS, {
+    request_id: requestId,
+    RowID: sourceRowId,
+    source_sheet: sourceSheet,
+    source_row_id: sourceRowId,
+    activity_name: text_(currentRow.activity_name),
+    school: text_(currentRow.school),
+    authority: text_(currentRow.authority),
+    requested_by_user_id: text_(user.user_id),
+    requested_by_name: text_(user.full_name),
+    requested_at: new Date().toISOString(),
+    status: 'pending',
+    changed_fields: JSON.stringify(changedFields),
+    original_values: JSON.stringify(originalValues),
+    requested_values: JSON.stringify(requestedValues),
+    reviewer_user_id: '',
+    reviewed_by: '',
+    reviewed_at: '',
+    review_note: '',
+    reviewer_notes: '',
+    active: 'yes'
   });
 
   return {
@@ -1928,12 +1959,7 @@ function actionSubmitEditRequest_(user, payload) {
 }
 
 function actionReviewEditRequest_(user, payload) {
-  var permission = getPermissionRow_(user.user_id);
-  var approvalTarget = getSettingText_('approval_target_role', 'operations_reviewer');
-  if (approvalTarget && text_(user.display_role) !== approvalTarget) {
-    throw new Error('Forbidden');
-  }
-  if (yesNo_(permission.can_review_requests) !== 'yes') {
+  if (!canDirectWriteRole_(user.display_role)) {
     throw new Error('Forbidden');
   }
 
@@ -1952,31 +1978,62 @@ function actionReviewEditRequest_(user, payload) {
   });
 
   if (!requestRows.length) throw new Error('Request not found');
+  if (text_(requestRows[0].status) !== 'pending') throw new Error('Request already reviewed');
 
   if (status === 'approved') {
     var sourceSheet = text_(requestRows[0].source_sheet);
-    var sourceRowId = text_(requestRows[0].source_row_id);
+    var sourceRowId = text_(requestRows[0].RowID || requestRows[0].source_row_id);
+    var currentRow = getRowByKey_(sourceSheet, 'RowID', sourceRowId);
+    var changedFields = parseJsonObject_(requestRows[0].changed_fields, []);
+    if (!Array.isArray(changedFields)) changedFields = [];
+    var originalValues = parseJsonObject_(requestRows[0].original_values, {});
+    var requestedValues = parseJsonObject_(requestRows[0].requested_values, {});
     var changes = {};
+    var hasConflict = false;
+    if (!changedFields.length) {
+      requestRows.forEach(function(row) {
+        var field = text_(row.field_name);
+        if (!field) return;
+        changedFields.push(field);
+        originalValues[field] = text_(row.old_value);
+        requestedValues[field] = text_(row.new_value);
+      });
+    }
 
-    requestRows.forEach(function(row) {
-      changes[text_(row.field_name)] = text_(row.new_value);
+    changedFields.forEach(function(fieldName) {
+      var expectedValue = text_(originalValues[fieldName]);
+      var currentValue = text_(currentRow[fieldName]);
+      if (expectedValue !== currentValue) {
+        hasConflict = true;
+        return;
+      }
+      if (!Object.prototype.hasOwnProperty.call(requestedValues, fieldName)) return;
+      changes[fieldName] = text_(requestedValues[fieldName]);
     });
 
-    updateRowByKey_(sourceSheet, 'RowID', sourceRowId, changes);
+    if (hasConflict) {
+      status = 'conflict';
+    } else {
+      updateRowByKey_(sourceSheet, 'RowID', sourceRowId, changes);
 
-    if (sourceSheet === CONFIG.SHEETS.DATA_LONG && (changes.start_date || changes.end_date)) {
-      setMeetingsFromRange_(sourceRowId, text_(changes.start_date), text_(changes.end_date));
+      if (sourceSheet === CONFIG.SHEETS.DATA_LONG && (changes.start_date || changes.end_date)) {
+        setMeetingsFromRange_(sourceRowId, text_(changes.start_date), text_(changes.end_date));
+      }
     }
   }
 
   updateEditRequestRows_(requestId, {
     status: status,
     reviewed_at: new Date().toISOString(),
+    reviewer_user_id: text_(user.user_id),
     reviewed_by: text_(user.user_id),
+    review_note: reviewerNotes,
     reviewer_notes: reviewerNotes
   });
 
-  scriptCacheInvalidateDataViews_();
+  if (status === 'approved') {
+    scriptCacheInvalidateDataViews_();
+  }
   return {
     reviewed: true,
     request_id: requestId,
@@ -1985,7 +2042,7 @@ function actionReviewEditRequest_(user, payload) {
 }
 
 function actionSavePermission_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer']);
+  requireAnyRole_(user, ['admin', 'operation_manager']);
 
   var row = payload.permission || payload.row || {};
   var userId = text_(row.user_id);
@@ -2179,7 +2236,7 @@ function actionDeleteUser_(user, payload) {
 
 function actionSavePrivateNote_(user, payload) {
   var permission = getPermissionRow_(user.user_id);
-  if (yesNo_(permission.can_review_requests) !== 'yes' || user.display_role !== 'operations_reviewer') {
+  if (yesNo_(permission.can_review_requests) !== 'yes' || user.display_role !== 'operation_manager') {
     throw new Error('Forbidden');
   }
 
@@ -2947,9 +3004,9 @@ function buildClientSettingsPayload_() {
   var navigation = buildNavigationSettings_();
   var roleDefaults = computeNonAdminRoleDefaults_();
   var roleDefaultsBool = {
-    operations_reviewer: {
-      can_edit_direct: (roleDefaults.operations_reviewer || {}).can_edit_direct === 'yes',
-      can_add_activity: (roleDefaults.operations_reviewer || {}).can_add_activity === 'yes'
+    operation_manager: {
+      can_edit_direct: (roleDefaults.operation_manager || {}).can_edit_direct === 'yes',
+      can_add_activity: (roleDefaults.operation_manager || {}).can_add_activity === 'yes'
     },
     authorized_user: {
       can_edit_direct: (roleDefaults.authorized_user || {}).can_edit_direct === 'yes',
@@ -2993,7 +3050,7 @@ function buildClientSettingsPayload_() {
     admin_can_add_rows: getSettingBool_('admin_can_add_rows', true),
     operations_can_add_rows: getSettingBool_('operations_can_add_rows', true),
     non_admin_edits_require_approval: getSettingBool_('non_admin_edits_require_approval', true),
-    approval_target_role: getSettingText_('approval_target_role', 'operations_reviewer'),
+    approval_target_role: getSettingText_('approval_target_role', 'operation_manager'),
     operations_default_view_key: getSettingText_('operations_default_view_key', 'view_operations_data'),
     admin_default_view_key: getSettingText_('admin_default_view_key', 'view_admin'),
     navigation: navigation,
@@ -3103,7 +3160,7 @@ function countActiveByType_(rows, todayIso, activityType) {
 
 /* ── Admin Settings ────────────────────────────────────────────────────────── */
 function actionAdminSettings_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer']);
+  requireAnyRole_(user, ['admin', 'operation_manager']);
   var rows = [];
   try {
     var sheet = getSpreadsheet_().getSheetByName(CONFIG.SHEETS.SETTINGS);
@@ -3116,7 +3173,7 @@ function actionAdminSettings_(user, payload) {
 
 /* ── Save Finance Row (status + notes) ─────────────────────────────────────── */
 function actionSaveFinanceRow_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer']);
+  requireAnyRole_(user, ['admin', 'operation_manager']);
   var sourceRowId = text_(payload.source_row_id || payload.RowID);
   var sourceSheet = text_(payload.source_sheet || (sourceRowId.indexOf('LONG-') === 0 ? CONFIG.SHEETS.DATA_LONG : CONFIG.SHEETS.DATA_SHORT));
   if (!sourceRowId) throw new Error('source_row_id is required');
@@ -3131,7 +3188,7 @@ function actionSaveFinanceRow_(user, payload) {
 
 /* ── Sync Finance (refresh cache + return timestamp) ───────────────────────── */
 function actionSyncFinance_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer']);
+  requireAnyRole_(user, ['admin', 'operation_manager']);
   scriptCacheInvalidateDataViews_();
   return { synced: true, timestamp: new Date().toISOString() };
 }

--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -15,6 +15,8 @@ function actionLogin_(payload) {
 
   var role = normalizeRole_(internalRoleFromPermissionRow_(matchByUser));
   var canAddActivity = effectiveCanAddActivity_(matchByUser, role);
+  var canEditDirect = effectiveCanEditDirect_(matchByUser, role);
+  var canRequestEdit = effectiveCanRequestEdit_(matchByUser, role);
   var user = {
     user_id: text_(matchByUser.user_id),
     full_name: text_(matchByUser.full_name),
@@ -23,6 +25,8 @@ function actionLogin_(payload) {
     default_view: text_(matchByUser.default_view),
     emp_id: text_(matchByUser.user_id),
     can_add_activity: !!canAddActivity,
+    can_edit_direct: !!canEditDirect,
+    can_request_edit: !!canRequestEdit,
     can_view_finance: role === 'admin' || yesNo_(matchByUser.view_finance) === 'yes'
   };
 
@@ -144,7 +148,7 @@ function buildRoutesFromPermission_(permission, role) {
 
   return allRoutes.filter(function(route) {
     if (route === 'permissions') {
-      if (!(role === 'admin' || role === 'operations_reviewer')) return false;
+      if (!canDirectWriteRole_(role)) return false;
       return permYes_(permission, 'view_permissions');
     }
     if (route === 'my-data') {
@@ -180,7 +184,7 @@ function effectiveRoutesForUser_(permission, role) {
 
 function defaultRouteForRole_(role) {
   if (role === 'instructor') return 'my-data';
-  if (role === 'operations_reviewer') {
+  if (isOperationManagerRole_(role)) {
     return viewKeyToRouteId_(getSettingText_('operations_default_view_key', 'view_operations_data')) || 'dashboard';
   }
   if (role === 'admin') {
@@ -294,23 +298,24 @@ function hasWorkViewForEdit_(permission) {
 function effectiveCanEditDirect_(permission, role) {
   if (role === 'instructor') return false;
   if (role === 'admin') return getSettingBool_('admin_direct_edit', true);
-  if (role === 'operations_reviewer') {
+  if (isOperationManagerRole_(role)) {
     return getSettingBool_('operations_direct_edit', true);
   }
-  if (getSettingBool_('non_admin_edits_require_approval', true)) return false;
-  var explicit = text_(permission.can_edit_direct).toLowerCase();
+  return false;
+}
+
+function effectiveCanRequestEdit_(permission, role) {
+  if (role === 'instructor') return false;
+  if (canDirectWriteRole_(role)) return true;
+  var explicit = text_(permission.can_request_edit).toLowerCase();
   if (explicit === 'yes') return true;
   if (explicit === 'no') return false;
-  return false;
+  return hasWorkViewForEdit_(permission);
 }
 
 function effectiveCanAddActivity_(permission, role) {
   if (role === 'instructor') return false;
   if (role === 'admin') return getSettingBool_('admin_can_add_rows', true);
-  if (role === 'operations_reviewer') return getSettingBool_('operations_can_add_rows', true);
-  if (getSettingBool_('non_admin_edits_require_approval', true)) return false;
-  var explicit = text_(permission.can_add_activity).toLowerCase();
-  if (explicit === 'yes') return true;
-  if (explicit === 'no') return false;
+  if (isOperationManagerRole_(role)) return getSettingBool_('operations_can_add_rows', true);
   return false;
 }

--- a/backend/config.gs
+++ b/backend/config.gs
@@ -32,5 +32,5 @@ const CONFIG = {
   DEFAULT_FINANCE_GROUPING_RULE: 'gafen_by_school_else_funding',
   ACTIVITY_TYPES: ['all', 'course', 'after_school', 'workshop', 'tour', 'escape_room'],
   FINANCE_STATUSES: ['open', 'closed'],
-  EDIT_REQUEST_STATUSES: ['pending', 'approved', 'rejected']
+  EDIT_REQUEST_STATUSES: ['pending', 'approved', 'rejected', 'conflict']
 };

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -189,7 +189,7 @@ function getDashboardSnapshotFlags_() {
 }
 
 function actionDashboardSnapshot_(user, payload) {
-  requireAnyRole_(user, ['admin', 'operations_reviewer', 'authorized_user']);
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
 
   markRequestPerf_('dashboardSnapshot:permission lookup:start');
   var permission = getDashboardSnapshotPermission_(user);

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -73,6 +73,7 @@ function normalizeRole_(value) {
   switch (role) {
     case 'admin':             return 'admin';
     case 'finance':           return 'finance';
+    case 'operations_reviewer':
     case 'operation_manager': return 'operation_manager';
     case 'activities_manager':return 'activities_manager';
     case 'domain_manager':    return 'domain_manager';
@@ -80,6 +81,16 @@ function normalizeRole_(value) {
     case 'instructor':        return 'instructor';
     default:                  throw new Error('invalid_role');
   }
+}
+
+function isOperationManagerRole_(role) {
+  var normalized = text_(role).toLowerCase().trim();
+  return normalized === 'operation_manager' || normalized === 'operations_reviewer';
+}
+
+function canDirectWriteRole_(role) {
+  var normalized = normalizeRole_(role);
+  return normalized === 'admin' || normalized === 'operation_manager';
 }
 
 function isAuthorizedUserTier_(role) {
@@ -123,6 +134,16 @@ function shiftDate_(date, days) {
 function parsePayload_(e) {
   var raw = e && e.postData && e.postData.contents ? e.postData.contents : '{}';
   return JSON.parse(raw || '{}');
+}
+
+function parseJsonObject_(raw, fallback) {
+  if (raw === null || raw === undefined || raw === '') return fallback;
+  if (typeof raw === 'object') return raw;
+  try {
+    return JSON.parse(String(raw));
+  } catch (_e) {
+    return fallback;
+  }
 }
 
 var __rqPerf_ = null;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -422,7 +422,7 @@ const ACTIVITIES_CHILD_ROUTES = new Set(['week', 'month', 'instructors', 'end-da
 function shell(content) {
   const hiddenSet = navSidebarHiddenRoutesSet();
   const contextualSet = navContextualRoutesSet();
-  const isAdminUser = state?.user?.display_role === 'admin' || state?.user?.display_role === 'operations_reviewer';
+  const isAdminUser = state?.user?.display_role === 'admin' || state?.user?.display_role === 'operation_manager';
   // לאדמין: הרשאות — מהכותרת בלבד; הנתונים שלי — מוסתר לחלוטין
   const adminSidebarExclude = isAdminUser ? new Set(['permissions', 'my-data']) : new Set();
   const nav = effectiveRoutes()
@@ -851,6 +851,8 @@ function backgroundSyncBootstrap() {
       state.user.display_role2 =
         bootstrap.profile.display_role2 != null ? String(bootstrap.profile.display_role2) : '';
       state.user.can_add_activity = !!bootstrap.can_add_activity;
+      state.user.can_edit_direct = !!bootstrap.can_edit_direct;
+      state.user.can_request_edit = !!bootstrap.can_request_edit;
       localStorage.setItem('dashboard_user', JSON.stringify(state.user));
     }
     if (!isAllowedRoute(state.route)) {
@@ -882,6 +884,8 @@ async function restoreSession() {
     state.user.display_role2 =
       bootstrap.profile.display_role2 != null ? String(bootstrap.profile.display_role2) : '';
     state.user.can_add_activity = !!bootstrap.can_add_activity;
+    state.user.can_edit_direct = !!bootstrap.can_edit_direct;
+    state.user.can_request_edit = !!bootstrap.can_request_edit;
     localStorage.setItem('dashboard_user', JSON.stringify(state.user));
   }
 }

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -284,11 +284,12 @@ function applyActivitiesLocalFilters(rows, state, settings) {
   return applyLocalFilters(monthRows, filters, { filterFields: ACTIVITY_FILTER_FIELDS });
 }
 
-function activityDrawerContent(row, canSeePrivateNotes, canEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
+function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
   const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
   return activityWorkDrawerHtml(row, {
     privateNote,
     canEdit,
+    canDirectEdit,
     hideEmpIds: !!hideEmpIds,
     hideRowId,
     hideActivityNo,
@@ -330,7 +331,7 @@ export const activitiesScreen = {
     const filteredRows  = applyActivitiesLocalFilters(allRows, state, state?.clientSettings);
     const listFilters   = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
     const { visible: safeRows, hasMore, total, nextCount } = splitVisibleRows(filteredRows, listFilters);
-    const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';
+    const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
     const hideEmpIds    = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
@@ -458,8 +459,8 @@ export const activitiesScreen = {
   bind({ root, data, state, rerender, rerenderActivitiesView, ui, api, clearScreenDataCache }) {
 
     const filteredRows      = applyActivitiesLocalFilters(Array.isArray(data?.rows) ? data.rows : [], state, state?.clientSettings);
-    const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';
-    const canEditActivity   = state?.user?.display_role !== 'instructor';
+    const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
+    const canEditActivity   = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
@@ -504,6 +505,7 @@ export const activitiesScreen = {
           initialRow,
           canSeePrivateNotes,
           canEditActivity,
+          !!state?.user?.can_edit_direct,
           hideEmpIds,
           hideRowId,
           hideActivityNo,
@@ -524,6 +526,7 @@ export const activitiesScreen = {
             row,
             canSeePrivateNotes,
             canEditActivity,
+            !!state?.user?.can_edit_direct,
             hideEmpIds,
             hideRowId,
             hideActivityNo,

--- a/frontend/src/screens/edit-requests.js
+++ b/frontend/src/screens/edit-requests.js
@@ -18,12 +18,14 @@ function statusLabel(status) {
   if (status === 'pending') return 'ממתין';
   if (status === 'approved') return 'אושר';
   if (status === 'rejected') return 'נדחה';
+  if (status === 'conflict') return 'קונפליקט';
   return status || '—';
 }
 
 function statusVariant(status) {
   if (status === 'approved') return 'success';
   if (status === 'rejected') return 'danger';
+  if (status === 'conflict') return 'danger';
   if (status === 'pending') return 'warning';
   return 'neutral';
 }
@@ -52,8 +54,8 @@ function renderGroup(group, canReview) {
     </div>
   ` : '';
 
-  const reviewerNoteHtml = group.reviewer_notes ? `
-    <p class="ds-er-reviewer-note"><span class="ds-muted">הערת סוקר:</span> ${escapeHtml(group.reviewer_notes)}</p>
+  const reviewerNoteHtml = group.review_note ? `
+    <p class="ds-er-reviewer-note"><span class="ds-muted">הערת סוקר:</span> ${escapeHtml(group.review_note)}</p>
   ` : '';
 
   return `
@@ -62,6 +64,7 @@ function renderGroup(group, canReview) {
         <div class="ds-er-group-meta">
           <span class="ds-er-requester">${escapeHtml(group.requested_by_name || group.requested_by_user_id || '—')}</span>
           <span class="ds-muted ds-er-date">${formatDate(group.requested_at)}</span>
+          <span class="ds-er-row-id ds-muted">${escapeHtml(group.activity_name || '')}</span>
           <span class="ds-er-row-id ds-muted">${escapeHtml(group.source_row_id || '')}</span>
         </div>
         <div>${dsStatusChip(statusLabel(group.status), statusVariant(group.status))}</div>
@@ -95,7 +98,8 @@ export const editRequestsScreen = {
       { value: '', label: 'הכול' },
       { value: 'pending', label: 'ממתינים' },
       { value: 'approved', label: 'מאושרים' },
-      { value: 'rejected', label: 'נדחו' }
+      { value: 'rejected', label: 'נדחו' },
+      { value: 'conflict', label: 'קונפליקט' }
     ];
 
     const filterChips = statusFilters.map((f) => `

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -34,11 +34,12 @@ function fieldRow(label, value) {
   return `<p><strong>${escapeHtml(label)}:</strong> ${display}</p>`;
 }
 
-function activityDrawerContent(row, canSeePrivateNotes, canEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
+function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
   const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
   return activityWorkDrawerHtml(row, {
     privateNote,
     canEdit,
+    canDirectEdit,
     hideEmpIds: !!hideEmpIds,
     hideRowId,
     hideActivityNo,
@@ -138,8 +139,8 @@ export const exceptionsScreen = {
       ensureActivityListFilters(state, EXCEPTIONS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
       rerender();
     });
-    const canSeePrivateNotes = state?.user?.display_role === 'operations_reviewer';
-    const canEditActivity = state?.user?.display_role !== 'instructor';
+    const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
+    const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
@@ -178,6 +179,7 @@ export const exceptionsScreen = {
           initialRow,
           canSeePrivateNotes,
           canEditActivity,
+          !!state?.user?.can_edit_direct,
           hideEmpIds,
           hideRowId,
           hideActivityNo,
@@ -198,6 +200,7 @@ export const exceptionsScreen = {
             row,
             canSeePrivateNotes,
             canEditActivity,
+            !!state?.user?.can_edit_direct,
             hideEmpIds,
             hideRowId,
             hideActivityNo,

--- a/frontend/src/screens/finance.js
+++ b/frontend/src/screens/finance.js
@@ -803,7 +803,7 @@ export const financeScreen = {
     const activeTab = state?.financeTab || 'active';
     const monthYm = state?.financeMonthYm || '';
     const viewMode = state?.financeViewMode || (narrow ? 'cards' : 'groups');
-    const canEdit = ['admin', 'operations_reviewer'].includes(state?.user?.display_role);
+    const canEdit = ['admin', 'operation_manager'].includes(state?.user?.display_role);
     const canView = state?.user?.display_role !== 'instructor';
     const isAdmin = state?.user?.display_role === 'admin';
     const groupingRule = state?.clientSettings?.finance_grouping_rule || data?.finance_grouping_rule || 'gafen_by_school_else_funding';
@@ -977,7 +977,7 @@ export const financeScreen = {
 
   bind({ root, data, ui, api, state, rerender, clearScreenDataCache = () => {} }) {
     const allRows = Array.isArray(data?.rows) ? data.rows : [];
-    const canEdit = ['admin', 'operations_reviewer'].includes(state?.user?.display_role);
+    const canEdit = ['admin', 'operation_manager'].includes(state?.user?.display_role);
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
@@ -1321,11 +1321,12 @@ export const financeScreen = {
 
     const openDrawerWithRow = (hit) => {
       const meetingsHtml = buildMeetingsDatesHtml(hit);
-      const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
+      const showPrivateNote = state?.user?.display_role === 'operation_manager';
       const privateNote = showPrivateNote ? hit.private_note || '—' : null;
       const baseHtml = activityWorkDrawerHtml(hit, {
         privateNote,
         canEdit,
+        canDirectEdit: canEdit,
         hideEmpIds,
         hideRowId,
         hideActivityNo,

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -337,8 +337,8 @@ export const monthScreen = {
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const canEditActivity = state?.user?.display_role !== 'instructor';
-    const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
+    const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
+    const showPrivateNote = state?.user?.display_role === 'operation_manager';
     bindLocalFilters(root, state, MONTH_SCOPE, rerender, { debounceMs: 300 });
     const cells = Array.isArray(data?.cells) ? data.cells : [];
     const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
@@ -387,6 +387,7 @@ export const monthScreen = {
             content: activityWorkDrawerHtml(row, {
               privateNote,
               canEdit: canEditActivity,
+              canDirectEdit: !!state?.user?.can_edit_direct,
               hideEmpIds,
               hideRowId,
               hideActivityNo,

--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -65,7 +65,7 @@ function sortedPermissionEditorKeys(row) {
 
 function roleChipKind(role) {
   if (role === 'admin') return 'danger';
-  if (role === 'operations_reviewer') return 'warning';
+  if (role === 'operation_manager') return 'warning';
   return 'neutral';
 }
 
@@ -105,7 +105,7 @@ function buildAddUserDrawerHtml(roleDefaults) {
         <select class="ds-input ds-input--sm" id="new-display-role">
           <option value="instructor">מדריך/ה</option>
           <option value="authorized_user">משתמש/ת מורשה</option>
-          <option value="operations_reviewer">בקר/ת תפעול</option>
+          <option value="operation_manager">בקר/ת תפעול</option>
           <option value="admin">מנהל/ת</option>
         </select>
       </div>
@@ -160,7 +160,7 @@ function buildEditDrawerHtml(row) {
         <span class="ds-muted">${escapeHtml(hebrewColumn('display_role'))}</span>
         <select data-role-select data-user-id="${uid}" class="ds-input ds-input--sm">
           <option value="admin" ${row.display_role === 'admin' ? 'selected' : ''}>מנהל/ת</option>
-          <option value="operations_reviewer" ${row.display_role === 'operations_reviewer' ? 'selected' : ''}>בקר/ת תפעול</option>
+          <option value="operation_manager" ${row.display_role === 'operation_manager' ? 'selected' : ''}>בקר/ת תפעול</option>
           <option value="authorized_user" ${row.display_role === 'authorized_user' ? 'selected' : ''}>משתמש/ת מורשה</option>
           <option value="instructor" ${row.display_role === 'instructor' ? 'selected' : ''}>מדריך/ה</option>
         </select>
@@ -246,13 +246,13 @@ export const permissionsScreen = {
   load: ({ api }) => api.permissions(),
   render(data, { state }) {
     const canEdit =
-      state?.user?.display_role === 'admin' || state?.user?.display_role === 'operations_reviewer';
+      state?.user?.display_role === 'admin' || state?.user?.display_role === 'operation_manager';
     const isAdmin = state?.user?.display_role === 'admin';
     const safeRows = Array.isArray(data?.rows) ? data.rows : [];
 
     const activeCount = safeRows.filter((r) => String(r.active || '').toLowerCase() === 'yes').length;
     const adminCount = safeRows.filter((r) => r.display_role === 'admin').length;
-    const reviewerCount = safeRows.filter((r) => r.display_role === 'operations_reviewer').length;
+    const reviewerCount = safeRows.filter((r) => r.display_role === 'operation_manager').length;
     const authorizedCount = safeRows.filter((r) => r.display_role === 'authorized_user').length;
     const instructorCount = safeRows.filter((r) => r.display_role === 'instructor').length;
 

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -353,7 +353,7 @@ function blockContent(row, { settings = {} } = {}) {
   `;
 }
 
-function blockDates(row, { canEdit = false } = {}) {
+function blockDates(row, { canEdit = false, canDirectEdit = false } = {}) {
   const schedule = Array.isArray(row?.meeting_schedule) ? row.meeting_schedule : [];
   const activityType = String(row.activity_type || '').trim();
   const isOnce = ONCE_TYPES.includes(activityType);
@@ -435,7 +435,7 @@ function blockDates(row, { canEdit = false } = {}) {
       ${chainToggle}
       ${addMeetingBtn}
       <div class="activity-drawer__edit-actions" data-mode="edit" hidden>
-        <button type="button" class="activity-drawer__action activity-drawer__action--primary" data-action="save-edit">שמור</button>
+        <button type="button" class="activity-drawer__action activity-drawer__action--primary" data-action="save-edit">${canDirectEdit ? 'שמור' : 'שליחה לאישור'}</button>
         <button type="button" class="activity-drawer__action" data-action="cancel-edit">ביטול</button>
         <p class="ds-activity-edit-status ds-muted" role="status"></p>
       </div>
@@ -473,20 +473,21 @@ function blockNotes(row, { privateNote = null, showPrivateNote = false } = {}) {
   `;
 }
 
-function singleForm(row, { settings = {}, privateNote = null, canEdit = false, showPrivateNote = false, idx = 0 } = {}) {
+function singleForm(row, { settings = {}, privateNote = null, canEdit = false, canDirectEdit = false, showPrivateNote = false, idx = 0 } = {}) {
   const computedEnd = autoEndDate(row);
   const activityType = String(row.activity_type || '').trim();
   return `
     <form class="activity-drawer__form" data-drawer-form data-editing="no"
       data-source-sheet="${escapeHtml(String(row.source_sheet || ''))}"
       data-row-id="${escapeHtml(String(row.RowID || ''))}"
+      data-can-direct-edit="${canDirectEdit ? 'yes' : 'no'}"
       data-auto-end-date="${escapeHtml(computedEnd)}"
       data-is-once="${ONCE_TYPES.includes(activityType) ? 'yes' : 'no'}">
       <input type="hidden" name="activity_no" value="${escapeHtml(String(row.activity_no || ''))}" data-activity-no>
       <input type="hidden" name="_activity_idx" value="${idx}">
       ${blockPeople(row, { settings })}
       ${blockContent(row, { settings })}
-      ${blockDates(row, { canEdit })}
+      ${blockDates(row, { canEdit, canDirectEdit })}
       ${blockNotes(row, { privateNote, showPrivateNote })}
     </form>
   `;
@@ -505,7 +506,7 @@ export function activityRowDetailHtml(row, { privateNote = null, hideActivityNo 
 }
 
 export function activityWorkDrawerHtml(row, opts = {}) {
-  const { mode = 'single', summaryDate = '', privateNote = null, canEdit = false, settings = {} } = opts;
+  const { mode = 'single', summaryDate = '', privateNote = null, canEdit = false, canDirectEdit = false, settings = {} } = opts;
   if (mode === 'summary') {
     const rows = Array.isArray(row) ? row : [];
     const body = rows
@@ -522,6 +523,7 @@ export function activityWorkDrawerHtml(row, opts = {}) {
             settings,
             privateNote,
             canEdit,
+            canDirectEdit,
             showPrivateNote: privateNote !== null,
             idx,
           })}
@@ -543,6 +545,7 @@ export function activityWorkDrawerHtml(row, opts = {}) {
         settings,
         privateNote,
         canEdit,
+        canDirectEdit,
         showPrivateNote: privateNote !== null,
         idx: 0,
       })}

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -162,6 +162,7 @@ export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, r
     const submitBtn = form.querySelector('[data-action="save-edit"]');
     const sourceSheet = form.getAttribute('data-source-sheet') || '';
     const sourceRowId = form.getAttribute('data-row-id') || '';
+    const canDirectEdit = String(form.dataset.canDirectEdit || '') === 'yes';
     const changes = {};
 
     form.querySelectorAll('[name]').forEach((el) => {
@@ -172,15 +173,15 @@ export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, r
     });
 
     try {
-      setStatus(statusEl, 'is-pending', 'שומר...');
+      setStatus(statusEl, 'is-pending', canDirectEdit ? 'שומר...' : 'שולח לאישור...');
       if (submitBtn) {
         submitBtn.disabled = true;
         submitBtn.classList.add('is-loading');
       }
 
       await api.saveActivity({ source_sheet: sourceSheet, source_row_id: sourceRowId, changes });
-      setStatus(statusEl, 'is-success', '✅ נשמר בהצלחה');
-      showToast('✅ נשמר בהצלחה', 'success', 2500);
+      setStatus(statusEl, 'is-success', canDirectEdit ? '✅ נשמר בהצלחה' : '✅ בקשת העריכה נשלחה לאישור');
+      showToast(canDirectEdit ? '✅ נשמר בהצלחה' : '✅ בקשת העריכה נשלחה לאישור', 'success', 2500);
       if (typeof onRowSaved === 'function') onRowSaved({ sourceSheet, sourceRowId, changes, form });
       setEditMode(form, false);
       clearScreenDataCache?.();

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -6,7 +6,7 @@ export const UI_ACTIVITY_FAMILY_LONG = 'תוכניות';
 
 export const HEBREW_ROLE = {
   admin: 'מנהל/ת',
-  operations_reviewer: 'בקר/ת תפעול',
+  operation_manager: 'בקר/ת תפעול',
   authorized_user: 'משתמש/ת מורשה',
   instructor: 'מדריך/ה',
   finance: 'כספים',

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -47,7 +47,7 @@ function weekItemMeta(item) {
   return names || 'ללא מדריך';
 }
 
-function weekDrawerHtml(itemOrItems, date, hideEmpIds, hideRowId, hideActivityNo, canEdit, showPrivateNote, settings, mode = 'single') {
+function weekDrawerHtml(itemOrItems, date, hideEmpIds, hideRowId, hideActivityNo, canEdit, canDirectEdit, showPrivateNote, settings, mode = 'single') {
   if (mode === 'summary') {
     const rows = Array.isArray(itemOrItems) ? itemOrItems : [];
     return activityWorkDrawerHtml(rows, {
@@ -55,6 +55,7 @@ function weekDrawerHtml(itemOrItems, date, hideEmpIds, hideRowId, hideActivityNo
       summaryDate: date,
       privateNote: showPrivateNote ? '—' : null,
       canEdit: !!canEdit,
+      canDirectEdit: !!canDirectEdit,
       hideEmpIds: !!hideEmpIds,
       hideRowId: !!hideRowId,
       hideActivityNo: !!hideActivityNo,
@@ -67,6 +68,7 @@ function weekDrawerHtml(itemOrItems, date, hideEmpIds, hideRowId, hideActivityNo
     mode: 'single',
     privateNote,
     canEdit: !!canEdit,
+    canDirectEdit: !!canDirectEdit,
     hideEmpIds: !!hideEmpIds,
     hideRowId: !!hideRowId,
     hideActivityNo: !!hideActivityNo,
@@ -254,8 +256,8 @@ export const weekScreen = {
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const canEditActivity = state?.user?.display_role !== 'instructor';
-    const showPrivateNote = state?.user?.display_role === 'operations_reviewer';
+    const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
+    const showPrivateNote = state?.user?.display_role === 'operation_manager';
     bindLocalFilters(root, state, WEEK_SCOPE, rerender, { debounceMs: 300 });
 
     const bindActivityEditForm = (contentRoot) =>
@@ -320,7 +322,8 @@ export const weekScreen = {
             hideEmpIds,
             hideRowId,
             hideActivityNo,
-            canEditActivity,
+              canEditActivity,
+              !!state?.user?.can_edit_direct,
             showPrivateNote,
             state?.clientSettings || {},
             currMode


### PR DESCRIPTION
### Motivation
- Make the edit/approval policy authoritative and enforced server-side so UI hiding is not the only protection.
- Prevent instructors from editing and require non-privileged staff to submit edit requests that must be reviewed before merging.
- Keep direct write capability limited to `admin` and the operations role (standardized as `operation_manager`) while preserving backward compatibility for legacy values.

### Description
- Backend: added role helpers (`normalizeRole_`, `isOperationManagerRole_`, `canDirectWriteRole_`) and a request parser `parseJsonObject_` in `backend/helpers.gs` to normalize `operations_reviewer` → `operation_manager` and centralize write/approval checks.
- Backend: expose `can_edit_direct` / `can_request_edit` in `actionBootstrap_` / `actionLogin_` and enforce them in `actionSaveActivity_`, `actionSubmitEditRequest_` and `actionReviewEditRequest_` to block unauthorized direct writes and submissions; updated many `requireAnyRole_` calls to include `operation_manager` where appropriate (`backend/actions.gs`, `backend/auth.gs`, `backend/dashboard-snapshot.gs`).
- Edit-requests model: changed persistence from per-field appended rows to a single richer request row that stores `request_id`, `RowID`, `source_sheet`, `activity_name`, `school`, `authority`, `changed_fields`, `original_values`, `requested_values`, requester metadata and reviewer metadata; kept fallback parsing for legacy per-field rows so older entries remain readable.
- Approval & conflict handling: added `conflict` status to `CONFIG.EDIT_REQUEST_STATUSES`, compare stored `original_values` to the current source row during approve and mark `conflict` instead of auto-merge when values diverge; only `admin` or `operation_manager` can review/merge.
- Frontend: switch edit affordances to rely on `can_edit_direct` / `can_request_edit` (exposed on bootstrap) instead of just role != `instructor`; drawer/form text and behavior updated so direct editors see `שמור` while requesters see `שליחה לאישור` and matching success toasts; `edit-requests` screen updated to render new request fields and show `conflict` state; various screens updated to use `operation_manager` naming.
- Backcompat: code contains logic to read legacy edit-request rows (field-per-row) and convert them to the new representation when listing/reviewing requests.

### Testing
- Ran unit/integration test suite with `npm test -- --runInBand` and all tests passed (19/19 in `tests/interactions.test.mjs`).
- No additional automated backend tests were added in this change; existing test suite remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed31764cf4832bb7e9fc0703a6a444)