### PR TITLE
Redesign activities screen UI for compact enterprise RTL layout

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -7,6 +7,7 @@ import {
 } from './shared/ui-hebrew.js';
 import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bind-activity-edit-form.js';
 import {
+  dsPageHeader,
   dsToolbar,
   dsCard,
   dsScreenStack,
@@ -413,7 +414,9 @@ export const activitiesScreen = {
 
     const toolbarHtml = filtersToolbarHtml(ACTIVITIES_SCOPE, filteredRows, state, {
       searchPlaceholder: 'חיפוש לפי פעילות / מדריך / רשות / בית ספר…',
-      filterFields: ACTIVITY_FILTER_FIELDS
+      filterFields: ACTIVITY_FILTER_FIELDS,
+      layout: 'panel',
+      title: 'סינון מתקדם'
     });
     const monthNavHtml = `<nav class="ds-cal-nav" role="navigation" aria-label="ניווט חודשי פעילויות" dir="rtl">
       <button type="button" class="ds-btn ds-btn--sm" data-activities-month-prev aria-label="חודש קודם">חודש קודם ▶</button>
@@ -437,7 +440,9 @@ export const activitiesScreen = {
         ? dsEmptyState('לא נמצאו פעילויות')
         : `<div class="ds-compact-list">${compactRows}</div>${loadMoreHtml}`;
 
-    const html = dsScreenStack(`
+    const html = dsScreenStack(`<section class="ds-activities-screen">
+      ${dsPageHeader('פעילויות', `ניהול פעילויות לחודש ${monthLabel(state.activitiesMonthYm)}`)}
+      <section class="ds-activities-top-panel">
       ${dsToolbar(`
         <div class="ds-view-toggle" dir="rtl" role="group" aria-label="בחירת תצוגת רשימה">
           <button type="button" class="ds-view-toggle__btn ${!compactView ? 'is-active' : ''}" data-activity-view="table" ${
@@ -448,11 +453,12 @@ export const activitiesScreen = {
         <div class="ds-chip-group" dir="rtl">${familyChips}</div>
       `)}
       ${monthNavHtml}
+      </section>
       ${toolbarHtml}
       ${compactView
         ? dsCard({ title: `רשימת פעילויות · ${total}`, body: compactSection, padded: true })
         : dsCard({ title: `רשימת פעילויות · ${total}`, body: tableSection,   padded: false })}
-    `);
+    </section>`);
     return html;
   },
 

--- a/frontend/src/screens/shared/activity-list-filters.js
+++ b/frontend/src/screens/shared/activity-list-filters.js
@@ -81,8 +81,8 @@ export function applyLocalFilters(rows, filters, config = {}) {
 function selectHtml(scope, field, filters, optionsMap) {
   const selected = String(filters?.[field.key] || '');
   const options = optionsMap?.[field.key] || [];
-  return `<label class="ds-chip" style="display:flex;align-items:center;gap:6px;">
-    <span>${escapeHtml(field.label)}</span>
+  return `<label class="ds-filter-field">
+    <span class="ds-filter-field__label">${escapeHtml(field.label)}</span>
     <select class="ds-input ds-input--sm" data-filter-scope="${escapeHtml(scope)}" data-filter-field="${escapeHtml(field.key)}">
       <option value="">הכל</option>
       ${options
@@ -101,6 +101,21 @@ export function filtersToolbarHtml(scope, rows, state, config = {}) {
   const optionsMap = collectFilterOptions(rows, filterFields);
   const showSearch = config.search !== false;
   const searchPlaceholder = config.searchPlaceholder || 'חיפוש…';
+
+  const isPanel = config.layout === 'panel';
+  if (isPanel) {
+    const title = config.title ? `<p class="ds-filter-panel__title">${escapeHtml(config.title)}</p>` : '';
+    return `<section class="ds-filter-panel" dir="rtl" data-local-filters="${escapeHtml(scope)}">
+      ${title}
+      <div class="ds-filter-panel__grid">
+        ${showSearch ? `<label class="ds-filter-field ds-filter-field--search"><span class="ds-filter-field__label">חיפוש</span><input type="search" class="ds-input ds-input--sm" data-filter-search="${escapeHtml(scope)}" value="${escapeHtml(filters.q || '')}" placeholder="${escapeHtml(searchPlaceholder)}" /></label>` : ''}
+        ${filterFields.map((field) => selectHtml(scope, field, filters, optionsMap)).join('')}
+        <div class="ds-filter-panel__actions">
+          <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-filter-clear="${escapeHtml(scope)}">ניקוי סינונים</button>
+        </div>
+      </div>
+    </section>`;
+  }
 
   return `<div class="ds-toolbar" dir="rtl" data-local-filters="${escapeHtml(scope)}">
     ${showSearch ? `<input type="search" class="ds-input" data-filter-search="${escapeHtml(scope)}" value="${escapeHtml(filters.q || '')}" placeholder="${escapeHtml(searchPlaceholder)}" />` : ''}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -5247,6 +5247,148 @@ select.ds-input {
   font-weight: 700;
 }
 
+/* ——— Activities screen refresh (compact enterprise RTL) ——— */
+.ds-activities-screen {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-3);
+}
+
+.ds-activities-top-panel {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--ds-space-2);
+  padding: var(--ds-space-2) var(--ds-space-3);
+  background: #f8fbff;
+  border: 1px solid rgba(26, 51, 88, 0.1);
+  border-radius: var(--ds-radius-md);
+  box-shadow: var(--ds-shadow-xs);
+}
+
+.ds-activities-screen > .ds-toolbar {
+  justify-content: space-between;
+  gap: var(--ds-space-2);
+}
+
+.ds-activities-screen .ds-chip-group {
+  gap: var(--ds-space-1);
+}
+
+.ds-activities-screen .ds-chip--tab {
+  min-height: 34px;
+  padding-inline: var(--ds-space-2);
+  border-radius: var(--ds-radius-sm);
+  border: 1px solid transparent;
+  border-bottom-width: 1px;
+}
+
+.ds-activities-screen .ds-chip--tab.is-active {
+  background: #e9f0fa;
+  border-color: rgba(26, 51, 88, 0.2);
+}
+
+.ds-filter-panel {
+  background: #fff;
+  border: 1px solid rgba(26, 51, 88, 0.12);
+  border-radius: var(--ds-radius-md);
+  box-shadow: var(--ds-shadow-xs);
+  padding: var(--ds-space-3);
+}
+
+.ds-filter-panel__title {
+  margin: 0 0 var(--ds-space-2);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--ds-text-secondary);
+}
+
+.ds-filter-panel__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--ds-space-2);
+  align-items: end;
+}
+
+.ds-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ds-filter-field__label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--ds-text-muted);
+  white-space: nowrap;
+}
+
+.ds-filter-field--search {
+  grid-column: span 2;
+}
+
+.ds-filter-field .ds-input {
+  width: 100%;
+  max-width: none;
+  min-height: 36px;
+}
+
+.ds-filter-panel__actions {
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+}
+
+.ds-activities-screen .ds-card {
+  background: #fff;
+  border-color: rgba(26, 51, 88, 0.1);
+  box-shadow: var(--ds-shadow-sm);
+}
+
+.ds-activities-screen .ds-card__head {
+  background: #f5f8fc;
+  min-height: 38px;
+}
+
+.ds-activities-screen .ds-table th,
+.ds-activities-screen .ds-table td {
+  padding: 8px 10px;
+  vertical-align: middle;
+}
+
+.ds-activities-screen .ds-table tbody tr:nth-child(even) td {
+  background: #fbfdff;
+}
+
+.ds-activities-screen .ds-table tbody tr:hover td {
+  background: #eef5ff;
+}
+
+@media (max-width: 1024px) {
+  .ds-filter-panel__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .ds-filter-field--search {
+    grid-column: span 3;
+  }
+}
+
+@media (max-width: 760px) {
+  .ds-filter-panel__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .ds-filter-field--search {
+    grid-column: span 2;
+  }
+  .ds-filter-panel__actions {
+    grid-column: span 2;
+    justify-content: stretch;
+  }
+  .ds-filter-panel__actions .ds-btn {
+    width: 100%;
+  }
+}
+
 /* ——— Finance inline edit row ——— */
 .ds-finance-inline-edit-cell {
   padding: 0 !important;


### PR DESCRIPTION
### Motivation
- Improve the visual design and information hierarchy of the Activities screen so it feels like a compact, consistent internal enterprise UI while preserving all existing logic and behavior. 
- Provide a clean, RTL-first layout for filters, controls and the table area to increase density, consistency and usability without touching APIs or data.

### Description
- Added a dedicated page header and a compact top control panel that groups the view toggle, family tabs and month navigation to create a clearer visual hierarchy and reduce visual clutter. 
- Reworked the filters toolbar to support a `panel` layout variant that renders a structured RTL card with labels-above-fields, a search field, grid-aligned selects and an integrated clear action. 
- Introduced scoped activities CSS for compact enterprise styling: unified control heights, subtle layered cards and shadows, consistent spacing grid for filters, refined table paddings, light zebra rows and hover treatments, and responsive wrapping for smaller viewports. 
- Files modified: `frontend/src/screens/activities.js`, `frontend/src/screens/shared/activity-list-filters.js`, `frontend/src/styles/main.css` (UI/layout/CSS only). 

### Testing
- Ran unit/integration test suite with `npm test`, which completed successfully (all tests passed). 
- No functional changes to API calls, data models or event bindings were made, so runtime behavior and existing bindings remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3e94e480832b87c1b4de9711abd6)