### PR TITLE
Add admin API action to trigger end_date sync and harden meetings save

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -2825,6 +2825,9 @@ function buildMeetingsMap_() {
 }
 
 function setMeetings_(sourceRowId, meetings) {
+  sourceRowId = text_(sourceRowId);
+  if (!sourceRowId) return;
+
   var cleaned = (meetings || []).map(function(item, idx) {
     if (typeof item === 'string') {
       return {
@@ -3210,6 +3213,19 @@ function actionSyncFinance_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager']);
   scriptCacheInvalidateDataViews_();
   return { synced: true, timestamp: new Date().toISOString() };
+}
+
+/* ── Sync End Dates (admin-only manual full sync) ─────────────────────────── */
+function actionSyncEndDates_(user, payload) {
+  requireAnyRole_(user, ['admin']);
+  var result = syncLongDataEndDates_();
+  scriptCacheInvalidateDataViews_();
+  return {
+    synced: true,
+    updated: Number(result && result.updated) || 0,
+    error: text_(result && result.error),
+    timestamp: new Date().toISOString()
+  };
 }
 
 /* ── List Sheets — diagnostic for admin ─────────────────────────────────────── */

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -54,6 +54,7 @@ function handlePost_(e) {
       savePrivateNote: function() { return actionSavePrivateNote_(user, payload); },
       saveFinanceRow: function() { return actionSaveFinanceRow_(user, payload); },
       syncFinance: function() { return actionSyncFinance_(user, payload); },
+      syncEndDates: function() { return actionSyncEndDates_(user, payload); },
       listSheets: function() { return actionListSheets_(user); }
     };
 
@@ -114,7 +115,8 @@ function handlePost_(e) {
         action === 'saveActivity' ||
         action === 'reviewEditRequest' ||
         action === 'saveFinanceRow' ||
-        action === 'syncFinance') {
+        action === 'syncFinance' ||
+        action === 'syncEndDates') {
       try {
         markDashboardSnapshotsRefreshNeeded_('mutation:' + action);
       } catch (snapshotErr) {


### PR DESCRIPTION
### Motivation
- Ensure `end_date` in `data_long` can be reliably synchronized from `activity_meetings` both automatically and via an explicit admin-initiated API call. 
- Prevent invalid/empty `sourceRowId` from causing missing or incorrect sync attempts when saving meetings. 
- Provide a safe admin entrypoint to run a full sync from API/tests without changing UI or other permissions logic.

### Description
- Added a new router handler `syncEndDates` that maps to a new admin-only action `actionSyncEndDates_` in `backend/router.gs` and `backend/actions.gs`. 
- Implemented `actionSyncEndDates_` to call `syncLongDataEndDates_()`, invalidate the data-views cache via `scriptCacheInvalidateDataViews_()`, and return structured metadata (`updated`, `error`, `timestamp`). 
- Hardened `setMeetings_()` in `backend/actions.gs` by normalizing `sourceRowId` with `text_()` and returning early if it is empty before deleting/appending meeting rows and before calling `syncEndDateForRow_()`.
- Marked `syncEndDates` as a mutation in the router so it triggers dashboard snapshot refresh logic like other write actions.

### Testing
- Ran the repository test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee64351c14832baf770c207806b859)