### PR TITLE
chore: update Apps Script API URL to new deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbwxY2NwL2eU161Nzzfy4ylS2lxH7Tdf1sCidpeI7EWmEakNZEXsLfsxyYt1FnO7Cvdg/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbzlyCU4R28-UYED_2JFx7O9Crrdd13YjFENmnEyYcuMfAaId2ir3REnMpchvdP-91I/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbwxY2NwL2eU161Nzzfy4ylS2lxH7Tdf1sCidpeI7EWmEakNZEXsLfsxyYt1FnO7Cvdg/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbzlyCU4R28-UYED_2JFx7O9Crrdd13YjFENmnEyYcuMfAaId2ir3REnMpchvdP-91I/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbxvJTV_v3rvEcbgqBjqn-nxsyzShpUZqroadsG_3OdO8v4XCKmZ2EJfIAsSEwEX7NXV/exec';
+  'https://script.google.com/macros/s/AKfycbzlyCU4R28-UYED_2JFx7O9Crrdd13YjFENmnEyYcuMfAaId2ir3REnMpchvdP-91I/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
### Motivation

- Replace the outdated Apps Script Web App endpoint used by the frontend and docs with the new deployment URL and verify that the service worker does not need changes.

### Description

- Updated `DEFAULT_API_URL` in `frontend/src/config.js` to point to the new Apps Script deployment URL.
- Updated README examples for the `window.__DASHBOARD_CONFIG__.apiUrl` snippet and the `?apiUrl=` query example to match the new URL.
- Reviewed `sw.js` behavior and confirmed the Service Worker only caches same-origin app shell assets, so no SW changes are required for this external endpoint swap.
- Modified files: `frontend/src/config.js` and `README.md`.

### Testing

- Ran a repository search to confirm the new URL appears in `frontend/src/config.js` and `README.md` and the old URLs were removed.
- Ran `npm test --silent` which completed successfully with all tests passing (`19` tests, `0` failures).
- Verified the service worker logic in `sw.js` and confirmed no functional changes were necessary for this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee65711f0c832bb397d1eceaa78975)