### PR TITLE
Activities page: compact layout, toolbar alignment, and dropdown/filter data fixes

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -2930,6 +2930,12 @@ function buildActivityNameOptionsFromListRows_(rows) {
     if (!label) return;
     var parent = text_(row.parent_value || row.activity_type);
     var actNo = text_(row.activity_no);
+    if (!actNo || /[^\d]/.test(actNo)) {
+      var fromType = text_(row.activity_type);
+      var fromValue = text_(row.value);
+      var fromValueMatch = /activity_(\d+)/i.exec(fromValue);
+      actNo = /^\d+$/.test(fromType) ? fromType : (fromValueMatch ? fromValueMatch[1] : '');
+    }
     var sig = label + '\t' + actNo + '\t' + parent;
     if (seen[sig]) return;
     seen[sig] = true;
@@ -2950,7 +2956,7 @@ function buildDropdownOptionsMapFromRows_(rows) {
     var key = listKey_(row.list_name);
     var value = text_(row.value || row.display_value || row.val);
     if (!key) return;
-    if (key === 'activity_name') {
+    if (key === 'activity_name' || key === 'activity') {
       activityNameRows.push(row);
       return;
     }

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -79,6 +79,7 @@ function normalizeRole_(value) {
     case 'domain_manager':    return 'domain_manager';
     case 'manager_instructor':return 'manager_instructor';
     case 'instructor':        return 'instructor';
+    case 'instructor_admin':  return 'instructor';
     default:                  throw new Error('invalid_role');
   }
 }

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -406,13 +406,15 @@ export const activitiesScreen = {
         : `<div class="ds-compact-list">${compactRows}</div>${loadMoreHtml}`;
 
     const mainToolbar = `<div class="ds-activities-main-toolbar">
-      ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--primary ds-btn--sm ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">➕</button>` : ''}
+      <div class="ds-activities-main-toolbar__actions">
+        ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost ds-btn--activities-action" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">➕</button>` : ''}
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost ds-btn--activities-action" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">🔄</button>
+      </div>
       <div class="ds-view-toggle" dir="rtl" role="group" aria-label="בחירת תצוגת רשימה">
         <button type="button" class="ds-view-toggle__btn ${!compactView ? 'is-active' : ''}" data-activity-view="table" ${forceCompact ? 'disabled title="במסך צר מוצגות תיבות קומפקטיות"' : ''} aria-label="טבלה" title="טבלה">☰</button>
         <button type="button" class="ds-view-toggle__btn ${compactView ? 'is-active' : ''}" data-activity-view="compact" aria-label="תיבות" title="תיבות">⊞</button>
       </div>
       <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="🔍" aria-label="חיפוש פעילויות" title="חיפוש לפי פעילות / מדריך / רשות / בית ספר" />
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">🔄</button>
     </div>`;
 
     const titleNavRow = `<div class="ds-activities-title-row">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -5257,6 +5257,7 @@ select.ds-input {
   display: flex;
   flex-direction: column;
   gap: var(--ds-space-3);
+  zoom: 0.9;
 }
 
 .ds-activities-top-panel {
@@ -5346,10 +5347,10 @@ select.ds-input {
 
 .ds-activities-page-title {
   margin: 0 0 var(--ds-space-2);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-weight: 800;
-  color: #344054;
-  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.14);
+  color: #4b2e83;
+  text-shadow: 0 2px 6px rgba(76, 29, 149, 0.18);
 }
 
 .ds-toolbar--filters-inline {
@@ -5366,10 +5367,10 @@ select.ds-input {
 }
 
 .ds-filter-select-inline {
-  width: 74px;
-  min-width: 74px;
-  max-width: 74px;
-  flex: 0 0 74px;
+  width: 84px;
+  min-width: 84px;
+  max-width: 84px;
+  flex: 0 0 84px;
   font-size: 0.7rem;
   padding-top: 3px;
   padding-bottom: 3px;
@@ -7215,16 +7216,18 @@ select.ds-input {
 .ds-activities-title-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  gap: 4px;
 }
 
 .ds-activities-title-row .ds-activities-page-title {
-  flex: 1 1 0;
+  flex: 0 1 auto;
   margin: 0;
   text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: min(72vw, 620px);
 }
 
 /* ——— Activities main toolbar: one-row layout ——— */
@@ -7239,6 +7242,18 @@ select.ds-input {
   border-radius: var(--ds-radius-md);
   box-shadow: var(--ds-shadow-xs);
   overflow-x: auto;
+}
+
+.ds-activities-main-toolbar__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ds-btn--activities-action {
+  min-width: 30px;
+  min-height: 30px !important;
+  padding: 4px 7px;
 }
 
 .ds-activities-main-toolbar .ds-cal-nav__label {


### PR DESCRIPTION
### Motivation
- Reduce the visual density of the Activities screen and tidy top-bar and month-navigation spacing so the page looks more compact and professional. 
- Make the Add Activity control consistent with other toolbar actions and ensure the filters/populated dropdowns use the full lists data from sheets. 

### Description
- UI: compacted the Activities screen by applying a 90% scale and tightened title/month-nav spacing, updated the page title color and subtle shadow, and adjusted filter/select sizing for a denser layout (`frontend/src/styles/main.css`).
- Toolbar: grouped the Add Activity button next to the refresh/clear action and switched it to a compact/ghost icon style so both controls share height and appearance (`frontend/src/screens/activities.js`, `frontend/src/styles/main.css`).
- Dropdowns/lists: expanded dropdown source parsing so activity options are collected from both `activity_name` and `activity` list rows, and added robust extraction for `activity_no` (fallback to `activity_type` or `value` when `activity_no` is missing/malformed) (`backend/actions.gs`).
- Permissions: normalized `Instructor_admin` to the `instructor` role so instructor roster/population includes `Instructor_admin` users for the instructor filter (`backend/helpers.gs`).

### Testing
- Ran the automated test suite with `npm test`, and all tests passed (19 tests, 0 failures). 
- No automated visual tests available in this environment, so visual/acceptance checks for layout and runtime behavior should be validated in a browser build after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee67804cc4832b94b187c1f7be7f88)