### PR TITLE
Support alternative start/end time field names for activities

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -161,6 +161,25 @@ function normalizeDateTextToIso_(value) {
   return '';
 }
 
+function resolveMappedTimeField_(row, aliases) {
+  var src = row || {};
+  for (var i = 0; i < aliases.length; i++) {
+    var key = aliases[i];
+    if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
+    if (isNormalizedEmptyValue_(src[key])) continue;
+    return text_(src[key]);
+  }
+  return '';
+}
+
+function mappedStartTime_(row) {
+  return resolveMappedTimeField_(row, ['start_time', 'StartTime', 'startTime', 'שעת התחלה']);
+}
+
+function mappedEndTime_(row) {
+  return resolveMappedTimeField_(row, ['end_time', 'EndTime', 'endTime', 'שעת סיום']);
+}
+
 function activityLastValidDateColumnFromRow_(row) {
   var latest = '';
   var latestCol = '';
@@ -2407,8 +2426,8 @@ function mapProjectedActivityDetailRow_(sheetName, row) {
     sessions: text_(row.sessions),
     price: text_(row.price),
     funding: text_(row.funding),
-    start_time: text_(row.start_time),
-    end_time: text_(row.end_time),
+    start_time: mappedStartTime_(row),
+    end_time: mappedEndTime_(row),
     emp_id: text_(row.emp_id),
     instructor_name: text_(row.instructor_name),
     emp_id_2: text_(row.emp_id_2),
@@ -2609,8 +2628,8 @@ function mapShortRow_(row) {
     sessions: text_(row.sessions),
     price: text_(row.price),
     funding: text_(row.funding),
-    start_time: text_(row.start_time),
-    end_time: text_(row.end_time),
+    start_time: mappedStartTime_(row),
+    end_time: mappedEndTime_(row),
     emp_id: text_(row.emp_id),
     instructor_name: text_(row.instructor_name),
     emp_id_2: text_(row.emp_id_2),
@@ -2637,8 +2656,8 @@ function mapLongRow_(row) {
     sessions: text_(row.sessions),
     price: text_(row.price),
     funding: text_(row.funding),
-    start_time: text_(row.start_time),
-    end_time: text_(row.end_time),
+    start_time: mappedStartTime_(row),
+    end_time: mappedEndTime_(row),
     emp_id: text_(row.emp_id),
     instructor_name: text_(row.instructor_name),
     emp_id_2: text_(row.emp_id_2),


### PR DESCRIPTION
### Motivation
- Activities imported from different sources sometimes use `end_time` / `EndTime` / `endTime` (or Hebrew labels) instead of the existing mapped field, so the UI could show no end/start time when data arrives from an API/JSON with alternate names.

### Description
- Added helpers `resolveMappedTimeField_`, `mappedStartTime_` and `mappedEndTime_` in `backend/actions.gs` to read time values from multiple aliases. 
- Updated activity row mappers to use the new helpers in `mapProjectedActivityDetailRow_`, `mapShortRow_` and `mapLongRow_` so start/end time is normalized for all read paths. 
- Supported aliases are: start time `start_time`, `StartTime`, `startTime`, `שעת התחלה` and end time `end_time`, `EndTime`, `endTime`, `שעת סיום`.

### Testing
- Ran the repository test suite with `npm test` and all tests passed (19/19 passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef174523bc832bbbbd50884d6f68dc)