### PR TITLE
chore: update Google Apps Script API endpoint

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbxbmFA6ADNDcvvZ7xZUgblld4dOKHgZrr2ixWys0sDfvPC5v9BJ3XHQ0gwE9UeB3UZc/exec';
+  'https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbx_N-zondGSjlTV4mH2RKEJH8AjgC0y-Wbulf-fd-kQGK5ygOCiAwaex38vPKvJ7AAF/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);


### PR DESCRIPTION
### Motivation
- לעדכן את כתובת ה־Google Apps Script המשמשת בפועל במערכת לכתובת החדשה שנמסרה כדי לוודא שכל הקריאות פונות ל־endpoint אחד.
- לא לשנות UI, הרשאות, מבני נתונים או לוגיקה אחרת — רק עדכון כתובת פריסה.

### Description
- הוחלפה הכתובת ב־`DEFAULT_API_URL` בקובץ `frontend/src/config.js` לכתובת החדשה.
- הוחלפה הכתובת ב־`API_URL` בסקריפט המדידה `scripts/collect_baseline_stage0_real.mjs` לכתובת החדשה.
- ווידאתי שזרימת הרשת בריצה משתמשת בערכים הללו (`frontend/src/api.js` קורא ל-`config.apiUrl`, והסקריפט קורא ל-`fetch(API_URL)`).
- לא שונה כל דבר אחר בקוד הריצה, בעיצוב או בלוגיקה של האפליקציה.

### Testing
- הופעל חיפוש בריפו עם `rg -n "https://script\.google\.com/macros/s/"` כדי לאתר מופעים וקיבלתי את המקומות הרלוונטיים; הפקודה הצליחה.
- הופעל חיפוש ממוקד (מבלי לכלול `docs`, `attached_assets`, `README.md`) כדי לוודא שאין מופעים ישנים בקוד הפעיל והפקודה אישרה שהקבצים הקודיים היחידים היו המעודכנים; הפקודה הצליחה.
- נבדק שהקריאות משתמשות ב־`config.apiUrl`/`API_URL` ושום fetch איןירות לא פונה לכתובת ישנה; בדיקות החיפוש והסקירה המקומית עברו בהצלחה.
- בוצע `git status --short` וקומיט עם ההודעה `chore: update Google Apps Script API endpoint` ונמצא שהקומיט נערך בהצלחה; אין שגיאות אוטומטיות בדיקות אוטומטיות לרוץ כאן.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef27824d70832bb8a6c3ec08204f94)