### PR TITLE
Normalize API responses for snake_case fields and update Apps Script endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbw6xlWfhS32O_y-fUoZSqBjx0HL5oxqXr2uSyR_NTM3TDEFIRJzm4vAAl1ycBtpD47b/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbw6xlWfhS32O_y-fUoZSqBjx0HL5oxqXr2uSyR_NTM3TDEFIRJzm4vAAl1ycBtpD47b/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbx_N-zondGSjlTV4mH2RKEJH8AjgC0y-Wbulf-fd-kQGK5ygOCiAwaex38vPKvJ7AAF/exec
+- API URL: https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec
 - Samples per screen requested: 20
 
 ## Status
@@ -13,4 +13,3 @@ Collection was blocked: Network error while calling login (ENETUNREACH): fetch f
 1. Outbound network access from this environment to Google Apps Script endpoint.
 2. Valid credentials via env vars: `DASHBOARD_USER_ID` and `DASHBOARD_ENTRY_CODE`.
 3. Re-run `node scripts/collect_baseline_stage0_real.mjs`.
-

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -129,6 +129,25 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function normalizeData(data) {
+  if (Array.isArray(data)) return data.map(normalizeData);
+  if (!data || typeof data !== 'object') return data;
+
+  const normalized = Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [key, normalizeData(value)])
+  );
+
+  normalized.StartTime = normalized.StartTime ?? normalized.start_time ?? normalized.startTime ?? '';
+  normalized.EndTime = normalized.EndTime ?? normalized.end_time ?? normalized.endTime ?? '';
+  normalized.End = normalized.End ?? normalized.end_date ?? normalized.endDate ?? normalized.DateEnd ?? '';
+  normalized.EmployeeID = normalized.EmployeeID ?? normalized.emp_id ?? normalized.employee_id ?? '';
+  normalized.Employee = normalized.Employee ?? normalized.instructor_name ?? normalized.employee_name ?? '';
+  normalized.Program = normalized.Program ?? normalized.activity_name ?? '';
+  normalized.ActivityNo = normalized.ActivityNo ?? normalized.activity_no ?? '';
+
+  return normalized;
+}
+
 async function postWithTimeout(action, requestBody) {
   const timeoutMs = READ_ACTIONS[action] ? API_TIMEOUT_MS_READ : API_TIMEOUT_MS_WRITE;
   const controller = new AbortController();
@@ -222,7 +241,7 @@ async function request(action, payload = {}) {
     payload_bytes: lastResponseText.length,
     backend_debug: json.data && json.data.debug_perf ? json.data.debug_perf : null
   });
-  return json.data;
+  return normalizeData(json.data);
 }
 
 export const api = {


### PR DESCRIPTION
### Motivation
- The frontend expected CamelCase fields from the Apps Script response while the Sheets data uses snake_case (e.g. `end_time`, `emp_id`), causing missing values like `EndTime` in the UI. 
- The deployed Apps Script Web App URL changed and docs/config examples needed to be aligned to the new endpoint.

### Description
- Added a recursive normalizer `normalizeData` in `frontend/src/api.js` and applied it to every API response before returning. 
- Implemented explicit fallback mappings for requested fields so both snake_case and camelCase are supported: `StartTime` from `StartTime`/`start_time`/`startTime`, `EndTime` from `EndTime`/`end_time`/`endTime`, `End` from `End`/`end_date`/`endDate`/`DateEnd`, `EmployeeID` from `EmployeeID`/`emp_id`/`employee_id`, `Employee` from `Employee`/`instructor_name`/`employee_name`, `Program` from `Program`/`activity_name`, and `ActivityNo` from `ActivityNo`/`activity_no`. 
- Updated README and `docs/architecture/read-models-stage0-real-baseline.md` to use the new Apps Script Web App URL and left `frontend/src/config.js` default unchanged (now already set to the new URL). 
- No UI, layout or styling changes were made; this is a data-mapping and docs update only.

### Testing
- Ran the automated test suite with `npm test` (`node --test tests/interactions.test.mjs`) and all tests passed (19/19). 
- Performed a repository search for legacy endpoint strings and updated documentation references; no old endpoint occurrences remain after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2c4876a4832b83f46d13c5a04516)