### PR TITLE
Sync data_long start/end from activity_meetings and separate short/long date sources

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -103,7 +103,11 @@ function rowExceptionTypes_(row) {
   var hasInstructor1 = !isNormalizedEmptyValue_(row && row.instructor_name) || !isNormalizedEmptyValue_(row && row.emp_id);
   var hasInstructor2 = !isNormalizedEmptyValue_(row && row.instructor_name_2) || !isNormalizedEmptyValue_(row && row.emp_id_2);
   if (!hasInstructor1 && !hasInstructor2) out.push('missing_instructor');
-  if (!activityStartDateFromRow_(row)) out.push('missing_start_date');
+  if (isDataShortRow_(row)) {
+    if (!normalizeDateTextToIso_(row && row.start_date)) out.push('missing_start_date');
+  } else {
+    if (!activityStartDateFromRow_(row)) out.push('missing_start_date');
+  }
   if (text_(row.end_date) > getLateEndDateCutoff_()) out.push('late_end_date');
   return out;
 }
@@ -236,26 +240,25 @@ function activityDateColumnsFromRow_(row) {
   return out;
 }
 
+function isDataShortRow_(row) {
+  var source = text_(row && row.source_sheet);
+  if (source) return source === CONFIG.SHEETS.DATA_SHORT;
+  return text_(row && row.RowID).indexOf('SHORT-') === 0;
+}
+
+function isDataLongRow_(row) {
+  var source = text_(row && row.source_sheet);
+  if (source) return source === CONFIG.SHEETS.DATA_LONG;
+  return text_(row && row.RowID).indexOf('LONG-') === 0;
+}
+
 function activityStartDateFromRow_(row) {
-  var src = getSettingText_('activity_start_date_source', 'Date1');
-  var fromSrc = normalizeDateTextToIso_(row[src]);
-  return fromSrc || normalizeDateTextToIso_(row.start_date) || '';
+  return normalizeDateTextToIso_(row && row.start_date) || '';
 }
 
 function activityEndDateFromRow_(row) {
-  var rule = getSettingText_('activity_end_date_rule', 'last_valid_date_from_date_columns');
-  var dates = activityDateColumnsFromRow_(row);
-  if (rule === 'last_valid_date_from_date_columns') {
-    // לפי ה-settings: תאריך סיום = התאריך האחרון התקין מבין עמודות Date1-Date35.
-    // אין fallback לעמודת end_date — אם אין עמודות תאריך תקינות, תאריך הסיום ריק.
-    if (!dates.length) return '';
-    dates.sort();
-    return dates[dates.length - 1];
-  }
-  // כלל אחר / לאחורה תואם
-  if (!dates.length) return normalizeDateTextToIso_(row.end_date) || '';
-  dates.sort();
-  return dates[dates.length - 1];
+  var start = activityStartDateFromRow_(row);
+  return normalizeDateTextToIso_(row && row.end_date) || start || '';
 }
 
 function appendDateColumnsToMappedRow_(mapped, sourceRow) {
@@ -263,8 +266,14 @@ function appendDateColumnsToMappedRow_(mapped, sourceRow) {
     var key = 'Date' + i;
     mapped[key] = normalizeDateTextToIso_(sourceRow[key]);
   }
-  mapped.start_date = activityStartDateFromRow_(sourceRow);
-  mapped.end_date = activityEndDateFromRow_(sourceRow);
+  if (mapped.source_sheet === CONFIG.SHEETS.DATA_SHORT) {
+    var shortStart = normalizeDateTextToIso_(sourceRow && sourceRow.start_date);
+    mapped.start_date = shortStart;
+    mapped.end_date = normalizeDateTextToIso_(sourceRow && sourceRow.end_date) || shortStart || '';
+  } else {
+    mapped.start_date = normalizeDateTextToIso_(sourceRow && sourceRow.start_date) || '';
+    mapped.end_date = normalizeDateTextToIso_(sourceRow && sourceRow.end_date) || mapped.start_date || '';
+  }
   return mapped;
 }
 
@@ -701,15 +710,19 @@ function actionActivities_(user, payload) {
 function mapActivitySummaryRowForList_(row, user, noteMap, meetingsMap, today) {
   var noteKey = row.source_sheet + '|' + row.RowID;
   var noteRow = noteMap[noteKey];
-  var meetingsFromSheet = meetingsMap[text_(row.RowID)];
-  var meetingDates = (meetingsFromSheet && meetingsFromSheet.length
-    ? meetingsFromSheet.slice()
-    : activityDateColumnsFromRow_(row).filter(function(v, i, arr) {
-      return !!v && arr.indexOf(v) === i;
-    }).sort());
-  var dateRange = meetingDateRangeFromList_(meetingDates);
-  var computedStartDate = dateRange.start || normalizeDateTextToIso_(row.Date1) || normalizeDateTextToIso_(row.start_date);
-  var computedEndDate = dateRange.end || normalizeDateTextToIso_(row.end_date) || computedStartDate;
+  var meetingsFromSheet = meetingsMap[text_(row.RowID)] || [];
+  var meetingDates = meetingsFromSheet.slice();
+  var computedStartDate = '';
+  var computedEndDate = '';
+  if (isDataLongRow_(row)) {
+    var dateRange = meetingDateRangeFromList_(meetingDates);
+    computedStartDate = dateRange.start || normalizeDateTextToIso_(row.start_date) || '';
+    computedEndDate = dateRange.end || normalizeDateTextToIso_(row.end_date) || computedStartDate;
+  } else {
+    computedStartDate = normalizeDateTextToIso_(row.start_date) || '';
+    computedEndDate = normalizeDateTextToIso_(row.end_date) || computedStartDate;
+    meetingDates = [];
+  }
   return {
     RowID: row.RowID,
     source_sheet: row.source_sheet,
@@ -724,6 +737,7 @@ function mapActivitySummaryRowForList_(row, user, noteMap, meetingsMap, today) {
     emp_id_2: row.emp_id_2,
     start_date: computedStartDate,
     end_date: computedEndDate,
+    meeting_dates: meetingDates,
     status: row.status,
     finance_status: row.finance_status,
     meetings_total: meetingDates.length,
@@ -740,12 +754,16 @@ function mapActivityDetailRowForDrawer_(row, user) {
   var meetingsMap = buildMeetingsMap_();
   var today = formatDate_(new Date());
   var summary = mapActivitySummaryRowForList_(row, user, noteMap, meetingsMap, today);
-  var meetingsFromSheet = meetingsMap[text_(row.RowID)];
-  var meetingDates = (meetingsFromSheet && meetingsFromSheet.length
-    ? meetingsFromSheet.slice()
-    : activityDateColumnsFromRow_(row).filter(function(v, i, arr) {
-      return !!v && arr.indexOf(v) === i;
-    }).sort());
+  var meetingDates = [];
+  if (isDataLongRow_(row)) {
+    var meetingsFromSheet = meetingsMap[text_(row.RowID)];
+    meetingDates = (meetingsFromSheet && meetingsFromSheet.length) ? meetingsFromSheet.slice() : [];
+  } else {
+    var shortStart = normalizeDateTextToIso_(summary.start_date);
+    var shortEnd = normalizeDateTextToIso_(summary.end_date);
+    if (shortStart) meetingDates.push(shortStart);
+    if (shortEnd && shortEnd !== shortStart) meetingDates.push(shortEnd);
+  }
   var meetingSchedule = meetingDates.map(function(dateKey) {
     return { date: dateKey, performed: dateKey <= today ? 'yes' : 'no' };
   });
@@ -948,9 +966,7 @@ function actionMonth_(user, payload) {
 function actionExceptions_(user) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
 
-  // enrichRowsWithMeetings_ מעדכן end_date לתאריך המפגש האחרון האמיתי מגיליון activity_meetings,
-  // כך שבדיקת late_end_date תזהה נכון קורסים עם מפגשים מעבר ל-late_end_date_cutoff.
-  var rows = enrichRowsWithMeetings_(buildLongRows_().slice());
+  var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
   var counts = {
     missing_instructor: 0,
     missing_start_date: 0,
@@ -1414,25 +1430,20 @@ function actionEndDates_(user) {
   }
 
   var meetingsMap = buildMeetingsMap_();
-  var longRows = enrichRowsWithMeetings_(buildLongRows_().slice());
-  var rows = longRows
+  var activityRows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
+  var rows = activityRows
     .filter(function(row) {
       return !!text_(row.end_date);
     })
     .map(function(row) {
       var rowId = text_(row.RowID);
 
-      // תאריכי מפגשים מגיליון activity_meetings (מקור עיקרי)
-      var fromMeetings = meetingsMap[rowId];
-      var meetingDates = (fromMeetings && fromMeetings.length)
-        ? fromMeetings.map(function(d) { return text_(d); }).filter(Boolean).sort()
-        : [];
-
-      // תאריכים מ-Date1-Date35 (fallback)
-      var dateCols = [];
-      for (var i = 1; i <= 35; i++) {
-        var d = text_(row['Date' + i]);
-        if (d) dateCols.push(d);
+      var meetingDates = [];
+      if (isDataLongRow_(row)) {
+        var fromMeetings = meetingsMap[rowId];
+        meetingDates = (fromMeetings && fromMeetings.length)
+          ? fromMeetings.map(function(d) { return text_(d); }).filter(Boolean).sort()
+          : [];
       }
 
       return {
@@ -1447,7 +1458,7 @@ function actionEndDates_(user) {
         status: text_(row.status),
         source_sheet: row.source_sheet,
         meeting_dates: meetingDates,
-        date_cols: dateCols
+        date_cols: []
       };
     });
 
@@ -1772,6 +1783,8 @@ function actionAddActivity_(user, payload) {
       instructor_name: common.instructor_name,
       emp_id_2: text_(derivedEmpId2 || activity.emp_id_2),
       instructor_name_2: instructorName2,
+      start_date: firstStartDate || '',
+      end_date: (autoEndDate || firstStartDate || ''),
       Date1: firstStartDate || dateCols.Date1 || '',
       Date2: (isOneDay ? '' : (autoEndDate || dateCols.Date2 || '')),
       status: common.status,
@@ -1876,6 +1889,8 @@ function actionAddActivity_(user, payload) {
 
   if (plannedMeetings.length) {
     setMeetings_(rowId, plannedMeetings);
+  } else if (targetSheet === CONFIG.SHEETS.DATA_LONG) {
+    syncDataLongDatesForRowFromMeetings_(rowId);
   }
 
   scriptCacheInvalidateDataViews_();
@@ -1905,14 +1920,19 @@ function actionSaveActivity_(user, payload) {
     var rawStatus = text_(changes.status).toLowerCase();
     changes.status = (rawStatus === 'closed' || rawStatus === 'סגור') ? 'סגור' : 'פעיל';
   }
-  // עדכון start_date / end_date בגיליון data_long כשיש שינוי בעמודות תאריך
-  if (sourceSheet === CONFIG.SHEETS.DATA_LONG && Object.keys(datePatch).length > 0) {
-    var currentLongRow = getRowByKey_(sourceSheet, 'RowID', sourceRowId);
-    var mergedForDates = {};
-    Object.keys(currentLongRow).forEach(function(k) { mergedForDates[k] = currentLongRow[k]; });
-    Object.keys(changes).forEach(function(k) { mergedForDates[k] = changes[k]; });
-    changes.start_date = activityStartDateFromRow_(mergedForDates);
-    changes.end_date   = activityEndDateFromRow_(mergedForDates);
+  if (sourceSheet === CONFIG.SHEETS.DATA_SHORT) {
+    if (Object.prototype.hasOwnProperty.call(changes, 'start_date')) {
+      changes.start_date = normalizeDateTextToIso_(changes.start_date);
+      if (!Object.prototype.hasOwnProperty.call(changes, 'end_date')) {
+        changes.end_date = normalizeDateTextToIso_(changes.end_date) || changes.start_date;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(changes, 'end_date')) {
+      changes.end_date = normalizeDateTextToIso_(changes.end_date) || normalizeDateTextToIso_(changes.start_date) || '';
+    }
+    if (!Object.prototype.hasOwnProperty.call(changes, 'end_date') && Object.prototype.hasOwnProperty.call(changes, 'start_date')) {
+      changes.end_date = changes.start_date || '';
+    }
   }
   if (!effectiveCanEditDirect_(permission, user.display_role)) {
     if (!effectiveCanRequestEdit_(permission, user.display_role)) {
@@ -1926,6 +1946,9 @@ function actionSaveActivity_(user, payload) {
   }
 
   updateRowByKey_(sourceSheet, 'RowID', sourceRowId, changes);
+  if (sourceSheet === CONFIG.SHEETS.DATA_LONG) {
+    syncDataLongDatesForRowFromMeetings_(sourceRowId);
+  }
 
   scriptCacheInvalidateDataViews_();
   return {
@@ -2319,22 +2342,30 @@ function actionSavePrivateNote_(user, payload) {
 function enrichRowsWithMeetings_(rows) {
   var meetingsMap = buildMeetingsMap_();
   rows.forEach(function(row) {
-    var dates = meetingsMap[text_(row.RowID)];
+    var rowId = text_(row.RowID);
+    if (isDataShortRow_(row)) {
+      row.start_date = normalizeDateTextToIso_(row.start_date) || '';
+      row.end_date = normalizeDateTextToIso_(row.end_date) || row.start_date || '';
+      row.meeting_dates = [];
+      return;
+    }
+    var dates = meetingsMap[rowId];
     if (dates && dates.length) {
       var range = meetingDateRangeFromList_(dates);
       row.start_date = range.start;
-      // שימור ה-end_date המקורי אם הוא מאוחר יותר מהמפגש האחרון,
-      // כדי שקורס עם תאריך סיום מאוחר לא יאבד את החריגה late_end_date
-      // רק בגלל שהמפגשים הרשומים עדיין לא הגיעו לאותו תאריך.
-      var origEnd = text_(row.end_date);
-      row.end_date = (range.end > origEnd) ? range.end : origEnd;
+      row.end_date = range.end || range.start;
+      row.meeting_dates = dates.slice();
+      return;
     }
+    row.start_date = normalizeDateTextToIso_(row.start_date) || '';
+    row.end_date = normalizeDateTextToIso_(row.end_date) || row.start_date || '';
+    row.meeting_dates = [];
   });
   return rows;
 }
 
 function meetingDateRangeFromList_(dates) {
-  var list = (dates || []).map(function(v) { return text_(v); }).filter(Boolean);
+  var list = (dates || []).map(function(v) { return normalizeDateTextToIso_(v); }).filter(Boolean).sort();
   if (!list.length) return { start: '', end: '' };
   var start = list[0];
   var end = list[0];
@@ -2412,6 +2443,8 @@ function projectedActivityColumnsForDetail_() {
 }
 
 function mapProjectedActivityDetailRow_(sheetName, row) {
+  var startIso = normalizeDateTextToIso_(row.start_date) || '';
+  var endIso = normalizeDateTextToIso_(row.end_date) || startIso || '';
   var out = {
     source_sheet: sheetName,
     RowID: text_(row.RowID),
@@ -2432,8 +2465,8 @@ function mapProjectedActivityDetailRow_(sheetName, row) {
     instructor_name: text_(row.instructor_name),
     emp_id_2: text_(row.emp_id_2),
     instructor_name_2: text_(row.instructor_name_2),
-    start_date: normalizeDateTextToIso_(row.start_date) || normalizeDateTextToIso_(row.Date1),
-    end_date: normalizeDateTextToIso_(row.end_date) || normalizeDateTextToIso_(row.start_date) || normalizeDateTextToIso_(row.Date1),
+    start_date: startIso,
+    end_date: endIso,
     status: text_(row.status),
     notes: text_(row.notes),
     finance_status: normalizeFinance_(row.finance_status),
@@ -2515,6 +2548,8 @@ function allActivitiesSummary_() {
       return;
     }
     var rows = readRowsProjected_(sheetName, cols).map(function(row) {
+      var startIso = normalizeDateTextToIso_(row.start_date) || '';
+      var endIso = normalizeDateTextToIso_(row.end_date) || startIso || '';
       return {
         source_sheet: sheetName,
         RowID: text_(row.RowID),
@@ -2535,8 +2570,8 @@ function allActivitiesSummary_() {
         instructor_name: text_(row.instructor_name),
         emp_id_2: text_(row.emp_id_2),
         instructor_name_2: text_(row.instructor_name_2),
-        start_date: normalizeDateTextToIso_(row.start_date) || normalizeDateTextToIso_(row.Date1),
-        end_date: normalizeDateTextToIso_(row.end_date) || normalizeDateTextToIso_(row.start_date) || normalizeDateTextToIso_(row.Date1),
+        start_date: startIso,
+        end_date: endIso,
         status: text_(row.status),
         notes: text_(row.notes),
         finance_status: normalizeFinance_(row.finance_status),
@@ -2820,7 +2855,7 @@ function buildMeetingsMap_() {
   var byMeetingNo = {};
   rows.forEach(function(row) {
     var key = text_(row.source_row_id);
-    var date = text_(row.meeting_date);
+    var date = normalizeDateTextToIso_(row.meeting_date);
     var meetingNo = parseInt(text_(row.meeting_no), 10);
     if (!key || !date) return;
     if (!map[key]) map[key] = [];
@@ -3160,19 +3195,15 @@ function buildCalendarIndexForDateRange_(rows, meetingsMap, fromDate, toDate) {
     };
 
     var meetingDates = meetingsMap && meetingsMap[rowId];
-    if (meetingDates && meetingDates.length) {
-      meetingDates.forEach(addRowToDate);
-      return;
+    if (isDataLongRow_(row)) {
+      if (meetingDates && meetingDates.length) {
+        meetingDates.forEach(addRowToDate);
+        return;
+      }
     }
 
-    var dlist = activityDateColumnsFromRow_(row);
-    if (dlist.length) {
-      dlist.forEach(addRowToDate);
-      return;
-    }
-
-    var startIso = text_(row.start_date) || normalizeDateTextToIso_(row.Date1);
-    var endIso = text_(row.end_date) || activityEndDateFromRow_(row);
+    var startIso = normalizeDateTextToIso_(row.start_date);
+    var endIso = normalizeDateTextToIso_(row.end_date) || startIso;
     eachIsoDateInIntersection_(startIso, endIso, fromIso, toIso, addRowToDate);
   });
 
@@ -3263,7 +3294,7 @@ function actionSyncFinance_(user, payload) {
 /* ── Sync End Dates (admin-only manual full sync) ─────────────────────────── */
 function actionSyncEndDates_(user, payload) {
   requireAnyRole_(user, ['admin']);
-  var result = syncLongDataEndDates_();
+  var result = syncDataLongDatesFromMeetings_();
   scriptCacheInvalidateDataViews_();
   return {
     synced: true,

--- a/backend/sync-end-dates.gs
+++ b/backend/sync-end-dates.gs
@@ -1,200 +1,159 @@
 /**
  * sync-end-dates.gs
  *
- * מסנכרן את עמודת end_date בגיליון data_long עם תאריך המפגש האחרון מגיליון activity_meetings.
- *
- * לוגיקה לכל שורה ב-data_long:
- *   end_date = max( תאריכים ב-activity_meetings לאותו RowID , תאריכים ב-Date1-Date35 )
- *
- * נקודות כניסה:
- *   • syncLongDataEndDates_()          — סנכרון מלא של כל השורות (הפעלה ידנית / trigger)
- *   • syncEndDateForRow_(sourceRowId)  — עדכון שורה אחת (נקרא מ-setMeetings_ אוטומטית)
- *   • onEditSyncEndDates_(e)           — installable trigger לעריכות ישירות בגיליון activity_meetings
- *   • installEndDateSyncTrigger_()     — התקנת ה-trigger (הפעל פעם אחת מ-Apps Script Editor)
- *   • uninstallEndDateSyncTrigger_()   — הסרת ה-trigger
+ * מקור אמת לתאריכי data_long הוא activity_meetings (רק active=yes).
+ * הקובץ מסנכרן בפועל את העמודות start_date + end_date בגיליון data_long.
  */
 
-// ─── A. מפה source_row_id → תאריך סיום מגיליון activity_meetings ─────────────
+function buildActiveMeetingDatesMap_() {
+  var rows = readRows_(CONFIG.SHEETS.MEETINGS);
+  var out = {};
+  rows.forEach(function(row) {
+    if (yesNo_(row.active) !== 'yes') return;
+    var sourceRowId = text_(row.source_row_id);
+    var meetingDate = normalizeDateTextToIso_(row.meeting_date);
+    if (!sourceRowId || !meetingDate) return;
+    if (!out[sourceRowId]) out[sourceRowId] = [];
+    out[sourceRowId].push(meetingDate);
+  });
 
-function buildMeetingEndDateMap_() {
+  Object.keys(out).forEach(function(sourceRowId) {
+    var uniq = {};
+    out[sourceRowId].forEach(function(d) { uniq[d] = true; });
+    out[sourceRowId] = Object.keys(uniq).sort();
+  });
+
+  return out;
+}
+
+/**
+ * סנכרון מרכזי: ממלא/מעדכן data_long.start_date + data_long.end_date
+ * לפי min/max של meeting_date הפעילים ב-activity_meetings.
+ */
+function syncDataLongDatesFromMeetings_() {
   var ss = getSpreadsheet_();
-  var sheet = ss.getSheetByName(CONFIG.SHEETS.MEETINGS);
-  if (!sheet) return {};
+  var sheet = ss.getSheetByName(CONFIG.SHEETS.DATA_LONG);
+  if (!sheet) return { updated: 0, error: 'missing_data_long' };
 
   var lastRow = sheet.getLastRow();
   var lastCol = sheet.getLastColumn();
-  var dataStart = CONFIG.DATA_START_ROW;
-  if (lastRow < dataStart || !lastCol) return {};
-
-  var headers = sheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
-  var srcIdx    = headers.indexOf('source_row_id');
-  var dateIdx   = headers.indexOf('meeting_date');
-  var activeIdx = headers.indexOf('active');
-  if (srcIdx < 0 || dateIdx < 0) return {};
-
-  var values = sheet.getRange(dataStart, 1, lastRow - dataStart + 1, lastCol).getValues();
-  var endMap = {};
-  values.forEach(function(row) {
-    if (activeIdx >= 0 && yesNo_(row[activeIdx]) === 'no') return;
-    var srcId   = text_(row[srcIdx]);
-    var dateStr = normalizeDateTextToIso_(row[dateIdx]);
-    if (!srcId || !dateStr) return;
-    if (!endMap[srcId] || dateStr > endMap[srcId]) {
-      endMap[srcId] = dateStr;
-    }
-  });
-  return endMap;
-}
-
-// ─── B. סנכרון מלא ───────────────────────────────────────────────────────────
-
-/**
- * עובר על כל שורות data_long ומעדכן end_date לפי:
- *   max( activity_meetings , Date1-Date35 )
- * מחזיר { updated: N }.
- */
-function syncLongDataEndDates_() {
-  var ss = getSpreadsheet_();
-
-  var meetingEndMap = buildMeetingEndDateMap_();
-
-  var longSheet = ss.getSheetByName(CONFIG.SHEETS.DATA_LONG);
-  if (!longSheet) return { updated: 0, error: 'missing_data_long' };
-
-  var lastRow  = longSheet.getLastRow();
-  var lastCol  = longSheet.getLastColumn();
-  var dataStart = CONFIG.DATA_START_ROW;
+  var dataStart = getDataStartRow_();
   if (lastRow < dataStart || !lastCol) return { updated: 0 };
 
-  var headers    = longSheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
-  var rowIdIdx   = headers.indexOf('RowID');
+  var headers = sheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
+  var rowIdIdx = headers.indexOf('RowID');
+  var startDateIdx = headers.indexOf('start_date');
   var endDateIdx = headers.indexOf('end_date');
-  if (rowIdIdx < 0 || endDateIdx < 0) {
-    return { updated: 0, error: 'missing_RowID_or_end_date_column' };
+  if (rowIdIdx < 0 || startDateIdx < 0 || endDateIdx < 0) {
+    return { updated: 0, error: 'missing_RowID_or_start_date_or_end_date_column' };
   }
 
-  var dateColIndexes = [];
-  for (var i = 1; i <= 35; i++) {
-    var idx = headers.indexOf('Date' + i);
-    if (idx >= 0) dateColIndexes.push(idx);
-  }
-
+  var meetingDatesMap = buildActiveMeetingDatesMap_();
   var numRows = lastRow - dataStart + 1;
-  var values  = longSheet.getRange(dataStart, 1, numRows, lastCol).getValues();
-  var updatedCount = 0;
+  var values = sheet.getRange(dataStart, 1, numRows, lastCol).getValues();
+  var startWrites = [];
+  var endWrites = [];
 
   values.forEach(function(row, offset) {
     var rowId = text_(row[rowIdIdx]);
     if (!rowId) return;
+    var meetingDates = meetingDatesMap[rowId] || [];
+    if (!meetingDates.length) return;
 
-    var maxFromDateCols = '';
-    dateColIndexes.forEach(function(ci) {
-      var d = normalizeDateTextToIso_(row[ci]);
-      if (d && d > maxFromDateCols) maxFromDateCols = d;
-    });
+    var nextStart = meetingDates[0];
+    var nextEnd = meetingDates[meetingDates.length - 1];
+    var currentStart = normalizeDateTextToIso_(row[startDateIdx]);
+    var currentEnd = normalizeDateTextToIso_(row[endDateIdx]);
 
-    var fromMeetings = meetingEndMap[rowId] || '';
-    var newEndDate   = fromMeetings > maxFromDateCols ? fromMeetings : maxFromDateCols;
-    if (!newEndDate) return;
-
-    var currentEndDate = normalizeDateTextToIso_(row[endDateIdx]);
-    if (newEndDate === currentEndDate) return;
-
-    longSheet.getRange(dataStart + offset, endDateIdx + 1).setValue(newEndDate);
-    updatedCount++;
+    if (nextStart !== currentStart) {
+      startWrites.push({ row: dataStart + offset, value: nextStart });
+    }
+    if (nextEnd !== currentEnd) {
+      endWrites.push({ row: dataStart + offset, value: nextEnd });
+    }
   });
 
-  if (updatedCount > 0) {
+  startWrites.forEach(function(item) {
+    sheet.getRange(item.row, startDateIdx + 1).setValue(item.value);
+  });
+  endWrites.forEach(function(item) {
+    sheet.getRange(item.row, endDateIdx + 1).setValue(item.value);
+  });
+
+  var updated = startWrites.length + endWrites.length;
+  if (updated > 0) {
+    invalidateReadRowsCache_(CONFIG.SHEETS.DATA_LONG);
     bumpDataViewsCacheVersion_();
   }
 
-  return { updated: updatedCount };
+  return {
+    updated: updated,
+    updated_start_date_cells: startWrites.length,
+    updated_end_date_cells: endWrites.length
+  };
 }
 
-// ─── C. עדכון שורה בודדת ─────────────────────────────────────────────────────
+function syncDataLongDatesForRowFromMeetings_(sourceRowId) {
+  var wanted = text_(sourceRowId);
+  if (!wanted) return { updated: 0 };
 
-/**
- * מעדכן end_date עבור שורה יחידה ב-data_long לאחר שמירת מפגשים.
- * נקרא מ-setMeetings_() אוטומטית.
- */
-function syncEndDateForRow_(sourceRowId) {
-  if (!sourceRowId) return;
   var ss = getSpreadsheet_();
+  var sheet = ss.getSheetByName(CONFIG.SHEETS.DATA_LONG);
+  if (!sheet) return { updated: 0, error: 'missing_data_long' };
 
-  var meetingsSheet = ss.getSheetByName(CONFIG.SHEETS.MEETINGS);
-  var fromMeetings  = '';
-  if (meetingsSheet) {
-    var mLastRow  = meetingsSheet.getLastRow();
-    var mLastCol  = meetingsSheet.getLastColumn();
-    var mDataStart = CONFIG.DATA_START_ROW;
-    if (mLastRow >= mDataStart && mLastCol > 0) {
-      var mHeaders  = meetingsSheet.getRange(CONFIG.HEADER_ROW, 1, 1, mLastCol).getValues()[0].map(text_);
-      var srcIdx    = mHeaders.indexOf('source_row_id');
-      var dateIdx   = mHeaders.indexOf('meeting_date');
-      var activeIdx = mHeaders.indexOf('active');
-      if (srcIdx >= 0 && dateIdx >= 0) {
-        var mValues = meetingsSheet.getRange(mDataStart, 1, mLastRow - mDataStart + 1, mLastCol).getValues();
-        mValues.forEach(function(row) {
-          if (text_(row[srcIdx]) !== text_(sourceRowId)) return;
-          if (activeIdx >= 0 && yesNo_(row[activeIdx]) === 'no') return;
-          var d = normalizeDateTextToIso_(row[dateIdx]);
-          if (d && d > fromMeetings) fromMeetings = d;
-        });
-      }
-    }
-  }
+  var lastRow = sheet.getLastRow();
+  var lastCol = sheet.getLastColumn();
+  var dataStart = getDataStartRow_();
+  if (lastRow < dataStart || !lastCol) return { updated: 0 };
 
-  var longSheet = ss.getSheetByName(CONFIG.SHEETS.DATA_LONG);
-  if (!longSheet) return;
-
-  var lastRow  = longSheet.getLastRow();
-  var lastCol  = longSheet.getLastColumn();
-  var dataStart = CONFIG.DATA_START_ROW;
-  if (lastRow < dataStart || !lastCol) return;
-
-  var headers    = longSheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
-  var rowIdIdx   = headers.indexOf('RowID');
+  var headers = sheet.getRange(CONFIG.HEADER_ROW, 1, 1, lastCol).getValues()[0].map(text_);
+  var rowIdIdx = headers.indexOf('RowID');
+  var startDateIdx = headers.indexOf('start_date');
   var endDateIdx = headers.indexOf('end_date');
-  if (rowIdIdx < 0 || endDateIdx < 0) return;
+  if (rowIdIdx < 0 || startDateIdx < 0 || endDateIdx < 0) return { updated: 0 };
 
-  var dateColIndexes = [];
-  for (var i = 1; i <= 35; i++) {
-    var ci = headers.indexOf('Date' + i);
-    if (ci >= 0) dateColIndexes.push(ci);
-  }
+  var meetingDates = buildActiveMeetingDatesMap_()[wanted] || [];
+  if (!meetingDates.length) return { updated: 0 };
 
-  var numRows = lastRow - dataStart + 1;
-  var values  = longSheet.getRange(dataStart, 1, numRows, lastCol).getValues();
-
+  var values = sheet.getRange(dataStart, 1, lastRow - dataStart + 1, lastCol).getValues();
   for (var offset = 0; offset < values.length; offset++) {
     var row = values[offset];
-    if (text_(row[rowIdIdx]) !== text_(sourceRowId)) continue;
+    if (text_(row[rowIdIdx]) !== wanted) continue;
 
-    var maxFromDateCols = '';
-    dateColIndexes.forEach(function(ci) {
-      var d = normalizeDateTextToIso_(row[ci]);
-      if (d && d > maxFromDateCols) maxFromDateCols = d;
-    });
+    var nextStart = meetingDates[0];
+    var nextEnd = meetingDates[meetingDates.length - 1];
+    var currentStart = normalizeDateTextToIso_(row[startDateIdx]);
+    var currentEnd = normalizeDateTextToIso_(row[endDateIdx]);
+    var updated = 0;
 
-    var newEndDate = fromMeetings > maxFromDateCols ? fromMeetings : maxFromDateCols;
-    if (!newEndDate) break;
+    if (nextStart !== currentStart) {
+      sheet.getRange(dataStart + offset, startDateIdx + 1).setValue(nextStart);
+      updated++;
+    }
+    if (nextEnd !== currentEnd) {
+      sheet.getRange(dataStart + offset, endDateIdx + 1).setValue(nextEnd);
+      updated++;
+    }
 
-    var currentEndDate = normalizeDateTextToIso_(row[endDateIdx]);
-    if (newEndDate !== currentEndDate) {
-      longSheet.getRange(dataStart + offset, endDateIdx + 1).setValue(newEndDate);
+    if (updated > 0) {
+      invalidateReadRowsCache_(CONFIG.SHEETS.DATA_LONG);
       bumpDataViewsCacheVersion_();
     }
-    break;
+    return { updated: updated };
   }
+
+  return { updated: 0 };
 }
 
-// ─── D. Trigger – עריכה ישירה בגיליון activity_meetings ──────────────────────
+// תאימות לאחור
+function syncLongDataEndDates_() {
+  return syncDataLongDatesFromMeetings_();
+}
 
-/**
- * Installable onEdit trigger.
- * מופעל אוטומטית כשהמשתמש עורך ישירות את גיליון activity_meetings.
- * דורש הרשאות — הפעל installEndDateSyncTrigger_() פעם אחת להתקנה.
- */
+function syncEndDateForRow_(sourceRowId) {
+  return syncDataLongDatesForRowFromMeetings_(sourceRowId);
+}
+
 function onEditSyncEndDates_(e) {
   var sheet = e && e.range && e.range.getSheet();
   if (!sheet || sheet.getName() !== CONFIG.SHEETS.MEETINGS) return;
@@ -203,22 +162,15 @@ function onEditSyncEndDates_(e) {
   if (!lock.tryLock(8000)) return;
   try {
     beginRequestCache_();
-    syncLongDataEndDates_();
+    syncDataLongDatesFromMeetings_();
   } catch (_err) {
-    // שמור שגיאות בשקט
+    // no-op
   } finally {
     __rqCache_ = null;
     lock.releaseLock();
   }
 }
 
-// ─── E. התקנה / הסרה של ה-trigger ───────────────────────────────────────────
-
-/**
- * מתקין installable onEdit trigger עבור onEditSyncEndDates_.
- * הפעל פעם אחת:
- *   Apps Script Editor → Run → installEndDateSyncTrigger_
- */
 function installEndDateSyncTrigger_() {
   var triggers = ScriptApp.getProjectTriggers();
   var exists = triggers.some(function(t) {
@@ -234,9 +186,6 @@ function installEndDateSyncTrigger_() {
   return { status: 'installed' };
 }
 
-/**
- * מסיר את ה-trigger של onEditSyncEndDates_.
- */
 function uninstallEndDateSyncTrigger_() {
   var removed = 0;
   ScriptApp.getProjectTriggers().forEach(function(t) {

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -232,8 +232,11 @@ function monthBounds(ym) {
 function activityOverlapsMonth(row, ym) {
   const bounds = monthBounds(ym);
   if (!bounds) return true;
-  const meetings = Array.from({ length: 35 }, (_, i) => String(row?.[`Date${i + 1}`] || '').trim()).filter(Boolean);
-  if (meetings.length > 0) return meetings.some((date) => String(date).startsWith(ym));
+  const sourceSheet = String(row?.source_sheet || '').trim();
+  const meetings = Array.isArray(row?.meeting_dates)
+    ? row.meeting_dates.map((d) => String(d || '').trim()).filter(Boolean)
+    : [];
+  if (sourceSheet === 'data_long' && meetings.length > 0) return meetings.some((date) => date.startsWith(ym));
   const start = String(row?.start_date || '').trim();
   const end = String(row?.end_date || start).trim();
   if (!start && !end) return false;


### PR DESCRIPTION
### Motivation
- לתקן את מקור האמת של תאריכי פעילויות: `data_short` חייב להשתמש בתאריכים מהשורה עצמה, ו־`data_long` חייב להשתמש ב־`activity_meetings` (רק שורות `active = yes`) ולמלא בפועל את העמודות `start_date`/`end_date` בגיליון.
- להבטיח שכל מסכי השרת והלקוח משתמשים באותה לוגיקה (fallback בזיכרון רק כאשר אין מפגשים) ולמנוע שימוש ב־`Date1-Date35` כמקור עיקרי כשיש מפגשים.

### Description
- הוספתי סנכרון מרכזי חדש ב־`backend/sync-end-dates.gs` עם פונקציות `buildActiveMeetingDatesMap_()`, `syncDataLongDatesFromMeetings_()` ו־`syncDataLongDatesForRowFromMeetings_()` שמחשבות `start_date = min(active meeting_date)` ו־`end_date = max(active meeting_date)` ומעדכנות תאים ב־`data_long` רק כשהערך משתנה.
- שיניתי לוגיקה ב־`backend/actions.gs`: הוספת `isDataShortRow_()`/`isDataLongRow_()` והפרדה ברורה של מקורות תאריכים כך ש־`data_short` קורא מ־`start_date`/`end_date` ו־`data_long` מעושר מ־`activity_meetings` (עם fallback בזיכרון לשדות השורה אם אין מפגשים). וגם העברתי ופישטתי normalization של תאריכים (`normalizeDateTextToIso_`) במקומות רלוונטיים.
- העשרתי את payloads כך שעמודת `meeting_dates` מועברת ל־frontend עבור שורות `data_long` ולשימוש בסינון ותצוגה (מספר מפגשים, פירוט מפגשים, חישובי start/end בזמן קריאה).
- חיברתי הרצה של הסנכרון לנקודות שינוי: אחרי `setMeetings_()`, אחרי יצירת פעילות ארוכה ללא מפגשים, ואחרי `actionSaveActivity_()` עבור `data_long` כדי לעדכן שורה בודדת מיד.
- עדכנתי לוגיקה שקיימת במסכים/אקשנים (`activities`, `week`, `month`, `exceptions`, `endDates`) כדי להשתמש ב־`enrichRowsWithMeetings_()` וליישם את ההבחנה בין `data_short` ו־`data_long` באופן עקבי.
- שיניתי את ה־frontend_month filter ב־`frontend/src/screens/activities.js` כך שבראש ובראשונה עבור `data_long` יוודא קיום מפגש בחודש דרך `meeting_dates`, ואילו `data_short` ממשיך להסתמך על `start_date`/`end_date`.
- שיפורים נלווים: נורמליזציית תאריכים כשנבנים מפות המפגשים, התעלמות מתאריכים לא תקינים, והימנעות מכתיבה מיותרת לגיליון (כותבים רק כאשר הערך שונה).

### Testing
- הרצתי את המבחנים האוטומטיים עם `npm test` (הרצה של `node --test tests/interactions.test.mjs`) והכל עבר בהצלחה; 19 בדיקות עוברות (`# pass 19`).
- נוספו בדיקות אינטגרציה ידניות חלקיות בזמן פיתוח (הרצת סקריפטים ובדיקת diff), והקוד נבדק מול קריאות פנימיות בשרת/לקוח כדי לוודא שה־payloads החדשים וקריאות הסנכרון מופעלות בנקודות החיתוך.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2fc92da4832baea8edbfb031bc36)