### PR TITLE
Update Google Apps Script deployment URL and invalidate cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycby8WzJP_g-EHWYT7_N7NYdOqEo8Nfm6f5P7escIOPeZgHqIvZbRqBSVLeTLb88sLwRv/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycby8WzJP_g-EHWYT7_N7NYdOqEo8Nfm6f5P7escIOPeZgHqIvZbRqBSVLeTLb88sLwRv/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec
+- API URL: https://script.google.com/macros/s/AKfycby8WzJP_g-EHWYT7_N7NYdOqEo8Nfm6f5P7escIOPeZgHqIvZbRqBSVLeTLb88sLwRv/exec
 - Samples per screen requested: 20
 
 ## Status

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec';
+  'https://script.google.com/macros/s/AKfycby8WzJP_g-EHWYT7_N7NYdOqEo8Nfm6f5P7escIOPeZgHqIvZbRqBSVLeTLb88sLwRv/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   <link rel="manifest" href="./frontend/public/manifest.json" />
   <link rel="icon" href="./frontend/assets/favicon.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./frontend/assets/apple-touch-icon.png" />
-  <link rel="preload" href="./frontend/src/styles/main.css?v=2504276" as="style" />
-  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2504276" />
+  <link rel="preload" href="./frontend/src/styles/main.css?v=2604271" as="style" />
+  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2604271" />
   <title>Dashboard-Taasiyeda</title>
 </head>
 <body>
   <main id="app"></main>
-  <script type="module" src="./frontend/src/main.js?v=2504276"></script>
+  <script type="module" src="./frontend/src/main.js?v=2604271"></script>
 </body>
 </html>

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbySGyM0zSi-4hZTgEc4lHk29-S_GQFWNpGN2eTTnDcdX0l0hjBfPd8q8xyrFHbsK6RB/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycby8WzJP_g-EHWYT7_N7NYdOqEo8Nfm6f5P7escIOPeZgHqIvZbRqBSVLeTLb88sLwRv/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 215;
+const CACHE_VERSION = 216;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- Replace the old Google Apps Script Web App endpoint with the new deployed URL across the project to point runtime traffic to the new deployment.
- Remove any hardcoded legacy endpoints from docs/scripts and ensure the frontend uses a single source of truth for the API URL.
- Force browser/GitHub Pages to serve updated assets by bumping cache-busting versions and the service worker cache version.

### Description
- Updated `DEFAULT_API_URL` in `frontend/src/config.js` to the new Apps Script endpoint `https://script.google.com/macros/s/AKfycby8WzJP_g-EHWYT7_N7NYdOqEo8Nfm6f5P7escIOPeZgHqIvZbRqBSVLeTLb88sLwRv/exec`.
- Replaced legacy endpoint occurrences in `README.md`, `scripts/collect_baseline_stage0_real.mjs`, and `docs/architecture/read-models-stage0-real-baseline.md` with the new URL.
- Bumped cache-busting query versions in `index.html` from `v=2504276` to `v=2604271` for CSS/JS assets and incremented `CACHE_VERSION` in `sw.js` from `215` to `216` to invalidate cached shell.
- Verified that frontend API calls still use `config.apiUrl` (in `frontend/src/api.js`) and did not introduce hardcoded fetch URLs.

### Testing
- Ran repository searches with `rg` to find old/new endpoints and related tokens, which confirmed the old deployment string is no longer present and the new URL is present in the updated files (searches succeeded).
- Confirmed there is a single frontend occurrence of the Apps Script host in `frontend/src/config.js` via `rg` (succeeded).
- Verified `frontend/src/api.js` uses `config.apiUrl` for `fetch` calls via file inspection (succeeded).
- Performed a `git commit` which completed successfully and included the modified files (succeeded).
- Note: interactive browser `DevTools → Network` verification was not executed in this environment due to lack of an interactive browser session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef32d6c888832b95ad44ddae5fc599)