### PR TITLE
Update default Google Apps Script API URL across project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbw6xlWfhS32O_y-fUoZSqBjx0HL5oxqXr2uSyR_NTM3TDEFIRJzm4vAAl1ycBtpD47b/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbw6xlWfhS32O_y-fUoZSqBjx0HL5oxqXr2uSyR_NTM3TDEFIRJzm4vAAl1ycBtpD47b/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbx_N-zondGSjlTV4mH2RKEJH8AjgC0y-Wbulf-fd-kQGK5ygOCiAwaex38vPKvJ7AAF/exec
+- API URL: https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec
 - Samples per screen requested: 20
 
 ## Status

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbxbmFA6ADNDcvvZ7xZUgblld4dOKHgZrr2ixWys0sDfvPC5v9BJ3XHQ0gwE9UeB3UZc/exec';
+  'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbx_N-zondGSjlTV4mH2RKEJH8AjgC0y-Wbulf-fd-kQGK5ygOCiAwaex38vPKvJ7AAF/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);


### PR DESCRIPTION
### Motivation
- Rotate the Google Apps Script Web App endpoint used by the frontend, scripts, and documentation to a new API URL.
- Ensure examples in `README.md` and the generated baseline document reflect the deployed endpoint so local runs and diagnostics point to the correct target.

### Description
- Updated the `DEFAULT_API_URL` constant in `frontend/src/config.js` to the new Google Apps Script URL.
- Replaced the runtime `window.__DASHBOARD_CONFIG__` example and the `?apiUrl=` example in `README.md` to use the new endpoint.
- Updated the `API_URL` fallback in `scripts/collect_baseline_stage0_real.mjs` to the new endpoint.
- Updated the generated baseline document `docs/architecture/read-models-stage0-real-baseline.md` to reference the new API URL.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef27824d70832bb8a6c3ec08204f94)