### PR TITLE
עדכון כתובת Google Apps Script והעלאת גרסאות cache

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec';
+  'https://script.google.com/macros/s/AKfycbwZ8HuV1k4e7xsRGf5A-osywiAWfkJ9G6PriPgeC5zTNvchTegHrZGju4qk8my4rvuI/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   <link rel="manifest" href="./frontend/public/manifest.json" />
   <link rel="icon" href="./frontend/assets/favicon.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./frontend/assets/apple-touch-icon.png" />
-  <link rel="preload" href="./frontend/src/styles/main.css?v=2604271" as="style" />
-  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2604271" />
+  <link rel="preload" href="./frontend/src/styles/main.css?v=2604272" as="style" />
+  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2604272" />
   <title>Dashboard-Taasiyeda</title>
 </head>
 <body>
   <main id="app"></main>
-  <script type="module" src="./frontend/src/main.js?v=2604271"></script>
+  <script type="module" src="./frontend/src/main.js?v=2604272"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 216;
+const CACHE_VERSION = 217;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation
- להחליף את כתובת הפריסה הוותיקה של Google Apps Script לכתובת הפעילה החדשה ולהבטיח שכל הקריאות בריצה משתמשות ב`config.apiUrl` במקום בכתובת hardcoded. 
- למנוע טעינת קבצי frontend ישנים על ידי עדכון מנגנון ה־cache-busting והשגת גרסת service worker חדשה.

### Description
- עדכון `DEFAULT_API_URL` ב־`frontend/src/config.js` ל`https://script.google.com/macros/s/AKfycbwZ8HuV1k4e7xsRGf5A-osywiAWfkJ9G6PriPgeC5zTNvchTegHrZGju4qk8my4rvuI/exec`.
- העלאת גרסת query ב־`index.html` עבור `main.css` ו־`main.js` מ־`v=2604271` ל־`v=2604272` כדי לבצע cache-bust.
- העלאת `CACHE_VERSION` ב־`sw.js` מ־`216` ל־`217` כדי לרענן ה־app shell עבור ה־service worker.
- ווידוא שקריאות ה־API ברuntime משתמשות ב־`config.apiUrl` (`frontend/src/api.js`) ולא בכתובת hardcoded.

### Testing
- ביצעתי חיפושים אוטומטיים עם `rg` לאיתור `script.google.com/macros/s`, `DEFAULT_API_URL`, ו־`CACHE_VERSION` והרשומות התקבלו והאמצעים הרלוונטיים עודכנו בהצלחה.
- ווידאתי באמצעות בדיקה של קבצי ה־runtime ש־`frontend/src/api.js` קורא ל־`config.apiUrl` ולא מינף URL ישיר, והבדיקה עברה בהצלחה.
- בדקתי את ההבדלים (`git diff`) וקבצים שונו כמצוין; הבדיקות האוטומטיות הללו עברו בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6b0d0220832bb620bf1d9509f984)