### PR TITLE
Update Google Apps Script endpoint to latest deployment URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbxClLawcmTq3sWlzPG0tstsh0tRUyLsmbGqom8ijtiGIC5sTU9WpxBC8XfyiX26eOXW/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbxClLawcmTq3sWlzPG0tstsh0tRUyLsmbGqom8ijtiGIC5sTU9WpxBC8XfyiX26eOXW/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec
+- API URL: https://script.google.com/macros/s/AKfycbxClLawcmTq3sWlzPG0tstsh0tRUyLsmbGqom8ijtiGIC5sTU9WpxBC8XfyiX26eOXW/exec
 - Samples per screen requested: 20
 
 ## Status

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbwZ8HuV1k4e7xsRGf5A-osywiAWfkJ9G6PriPgeC5zTNvchTegHrZGju4qk8my4rvuI/exec';
+  'https://script.google.com/macros/s/AKfycbxClLawcmTq3sWlzPG0tstsh0tRUyLsmbGqom8ijtiGIC5sTU9WpxBC8XfyiX26eOXW/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbxClLawcmTq3sWlzPG0tstsh0tRUyLsmbGqom8ijtiGIC5sTU9WpxBC8XfyiX26eOXW/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);


### PR DESCRIPTION
### Motivation
- Replace hardcoded Google Apps Script Web App URL with the newly deployed endpoint so frontend, baseline collection script, and docs point at the current production Web App.

### Description
- Updated `DEFAULT_API_URL` in `frontend/src/config.js` to `https://script.google.com/macros/s/AKfycbxClLawcmTq3sWlzPG0tstsh0tRUyLsmbGqom8ijtiGIC5sTU9WpxBC8XfyiX26eOXW/exec`.
- Updated the fallback `API_URL` in `scripts/collect_baseline_stage0_real.mjs` to the same new endpoint.
- Synchronized documentation examples and references in `README.md` and `docs/architecture/read-models-stage0-real-baseline.md` to the new URL.
- Committed changes and prepared the PR with the consolidated endpoint updates across files.

### Testing
- Ran a repository search with `rg` to verify all tracked occurrences of the previous deployment URLs were replaced and the new URL appears in `frontend/src/config.js`, `scripts/collect_baseline_stage0_real.mjs`, `README.md`, and `docs/architecture/read-models-stage0-real-baseline.md`, which succeeded.
- Created a commit (seen via `git show --stat`) confirming the four files were modified, which succeeded.
- No runtime or integration tests were executed against the new endpoint in this change (config/docs-only update).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7d608e34832bad5eea7c3325db86)