### PR TITLE
Update Google Apps Script API URL across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec
+- API URL: https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec
 - Samples per screen requested: 20
 
 ## Status

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbwZ8HuV1k4e7xsRGf5A-osywiAWfkJ9G6PriPgeC5zTNvchTegHrZGju4qk8my4rvuI/exec';
+  'https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbyT4OSQLYsbb-12500G1wj7Sd5ECqD0PRsXzb0WvB0aSECDoN3iSnmm67VGfF6Zs9TP/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);


### PR DESCRIPTION
### Motivation

- Replace the old Google Apps Script Web App URL with the new deployment URL so the frontend, scripts and documentation point to the correct API endpoint.

### Description

- Updated the default API URL in `frontend/src/config.js` (`DEFAULT_API_URL`) to the new Apps Script deployment URL.
- Updated the default API URL used by the collection script in `scripts/collect_baseline_stage0_real.mjs` (`API_URL`) to the new deployment URL.
- Updated usage examples and the baseline docs in `README.md` and `docs/architecture/read-models-stage0-real-baseline.md` to reference the new API URL.

### Testing

- Executed the baseline collection script via `node scripts/collect_baseline_stage0_real.mjs`, which attempted to contact the new endpoint but failed with a network error (`ENETUNREACH`) due to outbound network restrictions. No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7d608e34832bad5eea7c3325db86)