### PR TITLE
Fix Hebrew mojibake and UTF-8 JWT decoding; preserve full_name and display_role2 in state

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -424,15 +424,32 @@ function systemNameDisplay() {
   return raw;
 }
 
+function repairHebrewMojibake(value) {
+  const raw = value == null ? '' : String(value);
+  if (!raw) return '';
+  const hasHebrew = /[\u0590-\u05FF]/.test(raw);
+  const looksBroken = /[×�□]/.test(raw);
+  if (hasHebrew && !looksBroken) return raw;
+  if (!looksBroken) return raw;
+  try {
+    const latin1Bytes = Uint8Array.from(Array.from(raw), (ch) => ch.charCodeAt(0) & 0xff);
+    const repaired = new TextDecoder('utf-8', { fatal: true }).decode(latin1Bytes).trim();
+    if (/[\u0590-\u05FF]/.test(repaired)) return repaired;
+  } catch (_) {
+    // Keep original value if decoding fails.
+  }
+  return raw.replace(/[�□]/g, '').trim();
+}
+
 function shellUserDisplayName() {
-  const fn = state.user?.full_name != null ? String(state.user.full_name).trim() : '';
+  const fn = repairHebrewMojibake(state.user?.full_name).trim();
   return escapeHtml(fn || 'משתמש');
 }
 
 function shellUserRoleLine() {
-  const r2 = state.user?.display_role2 != null ? String(state.user.display_role2).trim() : '';
+  const r2 = repairHebrewMojibake(state.user?.display_role2).trim();
   if (r2) return escapeHtml(r2);
-  return escapeHtml(hebrewRole(state.user?.display_role || state.user?.role));
+  return escapeHtml(repairHebrewMojibake(hebrewRole(state.user?.display_role || state.user?.role)));
 }
 
 // מסכים אלו מגיעים מניווט גריד בלבד — לא מוצגים בסרגל הצד

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -63,8 +63,12 @@ function parseTokenPayloadClaims(token) {
     const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
     const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
     let json = '';
-    if (typeof atob === 'function') {
-      json = atob(padded);
+    if (typeof atob === 'function' && typeof TextDecoder === 'function') {
+      const binary = atob(padded);
+      const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+      json = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } else if (typeof atob === 'function') {
+      json = decodeURIComponent(escape(atob(padded)));
     } else if (typeof globalThis !== 'undefined' && globalThis.Buffer) {
       json = globalThis.Buffer.from(padded, 'base64').toString('utf8');
     } else {
@@ -120,7 +124,9 @@ export function setSession(session) {
     ...(claims || {}),
     user_id: String((session.user && session.user.user_id) || (claims && claims.user_id) || '').trim(),
     display_role: String((session.user && session.user.display_role) || (claims && claims.display_role) || '').trim(),
-    emp_id: String((session.user && session.user.emp_id) || (claims && claims.emp_id) || '').trim()
+    emp_id: String((session.user && session.user.emp_id) || (claims && claims.emp_id) || '').trim(),
+    full_name: String((session.user && session.user.full_name) || (claims && claims.full_name) || '').trim(),
+    display_role2: String((session.user && session.user.display_role2) || (claims && claims.display_role2) || '').trim()
   };
   state.screenDataCache = {};
   localStorage.setItem('dashboard_token', session.token);


### PR DESCRIPTION
### Motivation
- Improve display of Hebrew strings by repairing common mojibake and ensuring JWT payloads decode as UTF-8. 
- Preserve `full_name` and secondary role (`display_role2`) in the client `state` so UI can show correct user info.

### Description
- Added a `repairHebrewMojibake` helper that attempts to recover Hebrew text from common mojibake or strip replacement characters. 
- Updated `shellUserDisplayName` and `shellUserRoleLine` to run values through `repairHebrewMojibake` before escaping and rendering. 
- Changed JWT payload decoding in `parseTokenPayloadClaims` to prefer `TextDecoder('utf-8')` for proper UTF-8 handling with an older fallback using `atob` and `decodeURIComponent(escape(...))`. 
- Updated `setSession` to copy `full_name` and `display_role2` from the session or parsed claims into `state.user` and persist `dashboard_user` to `localStorage`.

### Testing
- Ran the frontend build check and static linting and they completed successfully. 
- Executed the existing frontend unit test suite (`npm test`) and all tests passed. 
- Performed a quick automated login token decode smoke test to verify non-ASCII (Hebrew) names are decoded and shown in state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef851cb65c832b80c093bcb902f24e)