### PR TITLE
Revamp activities list UI, add status chips, update default API URL and styles

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec';
+  'https://script.google.com/macros/s/AKfycbx9ephqrIIN75B-LdtA8DdaEQTD7MALoRF6sjJsXaRujEwFkWibdKGj1MiH-ak8Xrxz/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -7,12 +7,10 @@ import {
 } from './shared/ui-hebrew.js';
 import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bind-activity-edit-form.js';
 import {
-  dsPageHeader,
   dsCard,
   dsScreenStack,
   dsTableWrap,
-  dsEmptyState,
-  dsInteractiveCard
+  dsEmptyState
 } from './shared/layout.js';
 
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
@@ -34,7 +32,6 @@ import {
   cleanUnique
 } from './shared/activity-options.js';
 
-const ACTIVITY_VIEW_LS = 'dashboard_activity_view_v2';
 const inflightActivityDetailRequests = new Map();
 const ACTIVITIES_SCOPE = 'activities';
 const ACTIVITY_FILTER_FIELDS = [
@@ -58,10 +55,14 @@ const ACTIVITY_SEARCH_FIELDS = [
   'activity_type'
 ];
 
-function hasRowException(row) {
-  const noInstructor = !String(row.emp_id || '').trim() && !String(row.emp_id_2 || '').trim();
-  const noStartDate  = !String(row.start_date || '').trim();
-  return noInstructor || noStartDate;
+function activityStatusMeta(row) {
+  const statusText = String(row?.status || '').trim();
+  const hasInstructor = !!String(row?.emp_id || '').trim() || !!String(row?.emp_id_2 || '').trim();
+  const hasDate = !!String(row?.start_date || '').trim();
+  if (!hasInstructor) return { label: 'חסר מדריך', kind: 'warning' };
+  if (!hasDate) return { label: 'חסר תאריך', kind: 'warning' };
+  if (statusText === 'סגור' || statusText === 'חריגה') return { label: statusText || 'חריגה', kind: 'danger' };
+  return { label: statusText || 'תקין', kind: 'success' };
 }
 
 const FAMILY_LABEL_SHORT = 'חד-יומיות';
@@ -299,12 +300,6 @@ function putCachedActivityDetail(summaryRow, row, s) {
 
 export const activitiesScreen = {
   async load({ api, state }) {
-    try {
-      const v = typeof localStorage !== 'undefined' ? localStorage.getItem(ACTIVITY_VIEW_LS) : null;
-      if (v === 'table' || v === 'compact') state.activityView = v;
-    } catch (_e) {
-      /* ignore */
-    }
     return api.activities({ activity_type: 'all' });
   },
 
@@ -318,71 +313,44 @@ export const activitiesScreen = {
     const hideEmpIds    = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const forceCompact  = typeof window !== 'undefined' && window.matchMedia('(max-width: 760px)').matches;
-    const compactView   = forceCompact || state?.activityView === 'compact';
     const canAddActivity = !!state?.user?.can_add_activity;
 
     const tableRows = safeRows
       .map((row) => {
-        const emp1 = hideEmpIds ? '' : `<td>${escapeHtml(row.emp_id || '—')}</td>`;
-        const emp2 = hideEmpIds ? '' : `<td>${escapeHtml(row.emp_id_2 || '—')}</td>`;
+        const instructors = [row?.instructor_name, row?.instructor_name_2].filter(Boolean).join(' · ');
+        const status = activityStatusMeta(row);
         const rowSearch = [
           hideRowId ? '' : row.RowID,
+          visibleActivityCategoryLabel(row.activity_type),
           row.activity_name,
           row.start_date,
           row.end_date,
           row.school,
           row.authority,
+          row.instructor_name,
+          row.instructor_name_2,
           row.activity_manager,
-          visibleActivityCategoryLabel(row.activity_type),
           hideEmpIds ? '' : row.emp_id,
-          hideEmpIds ? '' : row.emp_id_2,
-          canSeePrivateNotes ? row.private_note : ''
+          hideEmpIds ? '' : row.emp_id_2
         ]
           .filter(Boolean)
           .join(' ');
         return `
-      <tr class="ds-data-row" data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="" data-row-id="${escapeHtml(row.RowID)}">
-        <td>${escapeHtml(visibleActivityCategoryLabel(row.activity_type))}</td>
-        <td>${escapeHtml(row.activity_name || '—')}</td>
-        <td>${escapeHtml(row.school || '—')}</td>
+      <tr class="ds-data-row ds-activities-row" data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="" data-row-id="${escapeHtml(row.RowID)}">
+        <td><strong>${escapeHtml(row.activity_name || '—')}</strong><div class="ds-row-subtle">${escapeHtml(visibleActivityCategoryLabel(row.activity_type))}</div></td>
         <td>${escapeHtml(row.authority || '—')}</td>
+        <td>${escapeHtml(row.school || '—')}</td>
+        <td>${escapeHtml(instructors || 'ללא מדריך')}</td>
         <td>${escapeHtml(formatDateHe(row.start_date) || '—')}</td>
-        <td>${escapeHtml(formatDateHe(row.end_date) || '—')}</td>
-        ${emp1}${emp2}
+        <td><span class="ds-chip ds-chip--status ds-chip--status-${status.kind}">${escapeHtml(status.label)}</span></td>
+        <td><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-activity-open="${escapeHtml(row.RowID)}">פתח</button></td>
         ${canSeePrivateNotes ? `<td>${escapeHtml(row.private_note || '')}</td>` : ''}
       </tr>
     `;
       })
       .join('');
 
-    const compactRows = safeRows
-      .map((row) => {
-        const rowSearch = [
-          hideRowId ? '' : row.RowID,
-          row.activity_name,
-          row.school,
-          row.authority,
-          row.start_date,
-          row.end_date
-        ]
-          .filter(Boolean)
-          .join(' ');
-        const excBadge = hasRowException(row) ? '<span class="ds-exc-dot" title="חריגה">⚠️</span>' : '';
-        return `<div data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="">
-        ${excBadge}${dsInteractiveCard({
-          action: `activity:${row.RowID}`,
-          title: row.activity_name || 'פעילות ללא שם',
-          subtitle: row.school || 'ללא בית ספר',
-          meta: row.authority || 'ללא רשות',
-          variant: 'session'
-        })}
-      </div>`;
-      })
-      .join('');
-
     const thPrivate = canSeePrivateNotes ? `<th>${hebrewColumn('private_note')}</th>` : '';
-    const thEmp     = hideEmpIds ? '' : '<th>מדריך/ה 1 (מזהה)</th><th>מדריך/ה 2 (מזהה)</th>';
 
     const fundingOptions = mergeOptions(state?.clientSettings || {}, ['funding', 'fundings']);
     const centralOptions = getFilterOptionOverrides(state?.clientSettings || {});
@@ -399,23 +367,14 @@ export const activitiesScreen = {
       safeRows.length === 0
         ? dsEmptyState('לא נמצאו פעילויות')
         : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--equal-cols">
-                <thead><tr><th>${hebrewColumn('activity_type')}</th><th>שם</th><th>בית ספר</th><th>רשות</th><th>התחלה</th><th>סיום</th>${thEmp}${thPrivate}</tr></thead>
+                <thead><tr><th>תוכנית / סוג</th><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך</th><th>סטטוס</th><th>פעולה</th>${thPrivate}</tr></thead>
                 <tbody>${tableRows}</tbody>
               </table>`) + loadMoreHtml;
-
-    const compactSection =
-      safeRows.length === 0
-        ? dsEmptyState('לא נמצאו פעילויות')
-        : `<div class="ds-compact-list">${compactRows}</div>${loadMoreHtml}`;
 
     const mainToolbar = `<div class="ds-activities-main-toolbar">
       <div class="ds-activities-main-toolbar__actions">
         ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost ds-btn--activities-action" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">➕</button>` : ''}
         <button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost ds-btn--activities-action" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">🔄</button>
-      </div>
-      <div class="ds-view-toggle" dir="rtl" role="group" aria-label="בחירת תצוגת רשימה">
-        <button type="button" class="ds-view-toggle__btn ${!compactView ? 'is-active' : ''}" data-activity-view="table" ${forceCompact ? 'disabled title="במסך צר מוצגות תיבות קומפקטיות"' : ''} aria-label="טבלה" title="טבלה">☰</button>
-        <button type="button" class="ds-view-toggle__btn ${compactView ? 'is-active' : ''}" data-activity-view="compact" aria-label="תיבות" title="תיבות">⊞</button>
       </div>
       <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="🔍" aria-label="חיפוש פעילויות" title="חיפוש לפי פעילות / מדריך / רשות / בית ספר" />
     </div>`;
@@ -430,9 +389,7 @@ export const activitiesScreen = {
       ${titleNavRow}
       ${mainToolbar}
       ${toolbarHtml}
-      ${compactView
-        ? dsCard({ body: compactSection, padded: true })
-        : dsCard({ body: tableSection,   padded: false })}
+      ${dsCard({ title: `פעילויות · ${total} פעילויות נמצאו`, body: tableSection, padded: false })}
     </section>`);
     return html;
   },
@@ -728,22 +685,6 @@ export const activitiesScreen = {
       }, addActivitySig);
     }
 
-    root.querySelectorAll('[data-activity-view]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        if (btn.disabled) return;
-        const next = btn.getAttribute('data-activity-view');
-        if (next !== 'table' && next !== 'compact') return;
-        state.activityView = next;
-        try {
-          localStorage.setItem(ACTIVITY_VIEW_LS, state.activityView);
-        } catch (_e) {
-          /* ignore */
-        }
-        if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
-        else rerender();
-      });
-    });
-
     root.querySelectorAll('.ds-data-row').forEach((n) => {
       n.tabIndex = 0;
       n.setAttribute('role', 'button');
@@ -752,6 +693,10 @@ export const activitiesScreen = {
     root._rowAbort = new AbortController();
     const rowSig = { signal: root._rowAbort.signal };
     root.addEventListener('click', (ev) => {
+      const actionBtn = ev.target.closest('[data-activity-open]');
+      if (actionBtn) {
+        ev.stopPropagation();
+      }
       const rowNode = ev.target.closest('.ds-data-row');
       if (!rowNode) return;
       ev.stopPropagation();

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -27,9 +27,9 @@ function renderInstructorRow(row) {
   const inactiveClass = hasActivity ? '' : ' ci-row--inactive';
 
   const statsHtml = `<span class="instr-stats">
-    <span class="instr-stat"><span class="instr-stat__num">${programs}</span><span class="instr-stat__lbl">תוכניות</span></span>
-    <span class="instr-stat__sep">·</span>
-    <span class="instr-stat"><span class="instr-stat__num">${oneDay}</span><span class="instr-stat__lbl">חד-יומיות</span></span>
+    <span class="instr-stat"><span class="instr-stat__lbl">תוכניות</span><span class="instr-stat__num">${programs}</span></span>
+    <span class="instr-stat"><span class="instr-stat__lbl">חד-יומיות</span><span class="instr-stat__num">${oneDay}</span></span>
+    <span class="instr-stat"><span class="instr-stat__lbl">תאריך אחרון</span><span class="instr-stat__num instr-stat__num--date">${escapeHtml(endDate || '—')}</span></span>
   </span>`;
 
   return `
@@ -37,7 +37,6 @@ function renderInstructorRow(row) {
       <div class="ci-row__main">
         <span class="ci-row__name">${name}</span>
         ${statsHtml}
-        ${endDate ? `<span class="instr-end-date">${escapeHtml(endDate)}</span>` : ''}
       </div>
     </button>`;
 }

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -79,8 +79,9 @@ function weekDrawerHtml(itemOrItems, date, hideEmpIds, hideRowId, hideActivityNo
 
 function weekRangeLabel(days) {
   if (!days || days.length === 0) return '';
-  const first = days[0]?.date || '';
-  const last = days[days.length - 1]?.date || '';
+  const dayDates = days.map((d) => String(d?.date || '')).filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)).sort();
+  const first = dayDates[0] || '';
+  const last = dayDates[dayDates.length - 1] || '';
   if (!first) return '';
   const fmtFirst = formatDateHe(first);
   const fmtLast = formatDateHe(last);

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7408,3 +7408,268 @@ select.ds-activity-add-field .ds-input,
     width: min(94vw, 640px);
   }
 }
+
+/* ===== UI/UX refresh: compact operational system language ===== */
+:root {
+  --ds-surface-subtle: #f4f6f9;
+  --ds-border: #d8dee8;
+  --ds-text: #101828;
+  --ds-text-secondary: #1f2937;
+  --ds-text-muted: #667085;
+  --ds-radius-sm: 8px;
+  --ds-radius-md: 8px;
+  --ds-shadow-xs: 0 1px 2px rgba(16, 24, 40, 0.05);
+  --ds-shadow-sm: 0 1px 3px rgba(16, 24, 40, 0.07);
+}
+
+.shell-sidebar {
+  background: linear-gradient(180deg, #172033 0%, #121a2a 100%);
+}
+.shell-nav__btn {
+  min-height: 36px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border-color: rgba(255, 255, 255, 0.11);
+  font-size: 0.74rem;
+}
+.shell-nav__btn.is-active {
+  background: rgba(26, 51, 88, 0.55);
+  border-color: rgba(255, 255, 255, 0.24);
+  box-shadow: none;
+}
+.shell-nav__btn.is-active::before {
+  width: 2px;
+  top: 7px;
+  bottom: 7px;
+}
+
+.ds-act-nav-grid--header {
+  padding: 0;
+  gap: 4px;
+}
+.ds-act-nav-item--header {
+  min-height: 28px;
+  padding: 3px 6px;
+  border-radius: 8px;
+  font-size: 0.56rem;
+}
+.ds-act-nav-item--header .ds-act-nav-item__icon {
+  font-size: 0.66rem;
+}
+
+.ds-toolbar--filters-inline,
+.ds-filter-panel__grid {
+  gap: 6px;
+  align-items: center;
+}
+.ds-input,
+.ds-input--sm,
+.ds-filter-search-sm,
+.ds-filter-select-inline,
+.ds-btn,
+.ds-chip--tab {
+  min-height: 32px;
+}
+.ds-filter-search-sm {
+  width: 180px;
+  min-width: 140px;
+}
+.ds-filter-select-inline {
+  width: 124px;
+  min-width: 124px;
+  max-width: 124px;
+  padding-inline-end: 24px;
+  box-shadow: none;
+}
+.ds-btn--xs {
+  min-height: 24px;
+  font-size: 0.66rem;
+}
+
+.ci-list--instr-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  padding: 6px;
+}
+@media (max-width: 1180px) {
+  .ci-list--instr-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 860px) {
+  .ci-list--instr-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 520px) {
+  .ci-list--instr-grid { grid-template-columns: 1fr; }
+}
+.instr-summary-row {
+  min-height: 112px;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid var(--ds-border);
+}
+.instr-stats {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 1fr;
+  gap: 4px;
+  margin-inline-start: 0;
+}
+.instr-stat {
+  justify-content: space-between;
+  width: 100%;
+}
+.instr-stat__sep,
+.instr-end-date {
+  display: none;
+}
+.instr-stat__lbl { font-size: 0.68rem; color: var(--ds-text-muted); }
+.instr-stat__num { font-size: 0.8rem; }
+.instr-stat__num--date { font-size: 0.74rem; font-weight: 600; color: var(--ds-text-secondary); }
+
+.ds-activities-screen {
+  zoom: 1;
+}
+.ds-activities-main-toolbar {
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  row-gap: 6px;
+}
+.ds-activities-page-title {
+  font-size: 0.94rem;
+  margin: 0;
+}
+.ds-card__head {
+  min-height: 34px;
+  padding: 6px 10px;
+  border-top: 0;
+}
+.ds-table {
+  min-width: 760px;
+  font-size: 0.76rem;
+}
+.ds-table th {
+  background: #f7f9fc;
+  box-shadow: none;
+}
+.ds-table th,
+.ds-table td {
+  padding: 6px 8px;
+  vertical-align: middle;
+}
+.ds-activities-row .ds-row-subtle {
+  font-size: 0.68rem;
+  color: var(--ds-text-muted);
+  margin-top: 2px;
+}
+.ds-chip--status {
+  min-width: auto;
+  min-height: 22px;
+  padding: 1px 8px;
+  font-size: 0.66rem;
+}
+
+.ds-cal-nav {
+  padding: 4px 6px;
+  border-radius: 8px;
+  box-shadow: none;
+}
+.ds-cal-nav .ds-btn.ds-btn--sm,
+.ds-btn--nav-arrow {
+  min-height: 30px !important;
+  min-width: 30px;
+  padding: 2px 8px !important;
+}
+.ds-cal-nav__label {
+  font-size: 0.84rem;
+}
+
+.ds-cal-wrap {
+  padding: 6px;
+  gap: 6px;
+}
+.ds-cal-weekdays,
+.ds-cal-grid {
+  gap: 6px;
+}
+.ds-cal-wd {
+  font-size: 0.66rem;
+  padding: 0;
+}
+.ds-cal-slot-hit,
+.ds-cal-slot-hit .ds-interactive-card,
+.ds-cal-slot--empty {
+  min-height: 52px;
+}
+.ds-cal-grid .ds-interactive-card--day-cell {
+  padding: 4px 6px;
+  border: 1px solid var(--ds-border);
+  box-shadow: none;
+}
+.ds-interactive-card.has-activities {
+  background: #ecf8f1;
+  border-color: #b8e8cb;
+}
+.ds-interactive-card.is-no-activities {
+  background: #fafbfd;
+  opacity: 1;
+}
+.ds-cal-grid .ds-interactive-card--day-cell .ds-interactive-card__subtitle {
+  background: #f1f4ff;
+  color: #4a4f75;
+}
+.ds-interactive-card.is-cal-today {
+  background: #edf4ff;
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.15);
+}
+
+.ds-week-board {
+  gap: 8px;
+}
+.ds-week-col {
+  border-color: var(--ds-border);
+  border-radius: 8px;
+  box-shadow: none;
+}
+.ds-week-col__head {
+  padding: 6px;
+  gap: 3px;
+  background: #f8fafc;
+}
+.ds-week-col__dow {
+  font-size: 0.72rem;
+  text-transform: none;
+}
+.ds-week-col__date {
+  font-size: 0.73rem;
+}
+.ds-week-col__holiday {
+  font-size: 0.6rem;
+}
+.ds-week-col__count {
+  min-width: 22px;
+  height: 18px;
+  font-size: 0.63rem;
+}
+.ds-week-col__body {
+  padding: 6px;
+  overflow-y: visible;
+  max-height: none !important;
+}
+.ds-week-empty {
+  font-size: 0.68rem;
+}
+.ds-week-col .ds-interactive-card--session {
+  min-height: 40px;
+  padding: 5px 7px;
+  border-inline-start-width: 2px;
+  box-shadow: none;
+}
+.ds-week-col .ds-interactive-card--session .ds-interactive-card__title {
+  font-size: 0.72rem;
+}
+.ds-week-col .ds-interactive-card--session .ds-interactive-card__meta {
+  font-size: 0.66rem;
+}
+.ds-week-group__badge {
+  font-size: 0.56rem;
+  padding: 2px 5px;
+}


### PR DESCRIPTION
### Motivation
- Standardize and modernize the activities list presentation and overall UI language and styles for a more compact operational look. 
- Replace fragile/unclear status/exception handling for activities with explicit status metadata. 
- Centralize deployment target by updating the default `DEFAULT_API_URL` constant.

### Description
- Updated `frontend/src/config.js` to point `DEFAULT_API_URL` to a new Google Apps Script Web App URL. 
- Overhauled `frontend/src/screens/activities.js` to: replace `hasRowException` with `activityStatusMeta` that returns `{label, kind}`; combine instructor names into a single column; add a status chip column and an explicit open action button; simplify row markup for better hierarchy; remove the compact/table view toggle and `localStorage` persistence for activity view; remove unused imports and compact view code paths; add click handling for the action button and retain keyboard-accessible row activation. 
- Adjusted `frontend/src/screens/instructors.js` to reorder instructor stats and show the last activity date inline in the stats block. 
- Hardened `weekRangeLabel` in `frontend/src/screens/week.js` to normalize, validate and sort day date strings before formatting. 
- Large visual refresh in `frontend/src/styles/main.css` introducing new variables and many UI refinements for sidebar, toolbar, activities table, calendar, week board and instructor grid to match the compact operational theme. 

### Testing
- Ran linting via `npm run lint` and the frontend test suite via `npm test`, both completed successfully. 
- Verified a production build with `npm run build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa3625984832b8a1d6b33772486ba)