### PR TITLE
נירמול תאריכים ושעות ב־Views והגדרת Plain Text לפני כתיבה

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -127,42 +127,7 @@ function primaryExceptionForRow_(row) {
 }
 
 function normalizeDateTextToIso_(value) {
-  if (isNormalizedEmptyValue_(value)) return '';
-  if (Object.prototype.toString.call(value) === '[object Number]' && !isNaN(value)) {
-    var serialDate = new Date(1899, 11, 30);
-    serialDate.setDate(serialDate.getDate() + Number(value));
-    return isNaN(serialDate.getTime()) ? '' : formatDate_(serialDate);
-  }
-  var t = text_(value);
-  if (!t) return '';
-  t = t.replace(/[T\s]\d{1,2}:\d{2}(:\d{2})?.*$/, '');
-  if (isValidIsoDateString_(t)) return t;
-  var ymd = /^(\d{4})[\/.-](\d{1,2})[\/.-](\d{1,2})$/.exec(t);
-  if (ymd) {
-    var yy = ymd[1];
-    var mmo = ('0' + parseInt(ymd[2], 10)).slice(-2);
-    var dd = ('0' + parseInt(ymd[3], 10)).slice(-2);
-    var ymdIso = yy + '-' + mmo + '-' + dd;
-    if (isValidIsoDateString_(ymdIso)) return ymdIso;
-  }
-  var m = /^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})$/.exec(t);
-  if (m) {
-    var d = ('0' + parseInt(m[1], 10)).slice(-2);
-    var mo = ('0' + parseInt(m[2], 10)).slice(-2);
-    var y = m[3];
-    var iso = y + '-' + mo + '-' + d;
-    if (isValidIsoDateString_(iso)) return iso;
-  }
-  var dmy2 = /^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{2})$/.exec(t);
-  if (dmy2) {
-    var d2 = ('0' + parseInt(dmy2[1], 10)).slice(-2);
-    var mo2 = ('0' + parseInt(dmy2[2], 10)).slice(-2);
-    var yy2 = parseInt(dmy2[3], 10);
-    var y2 = String(yy2 >= 70 ? 1900 + yy2 : 2000 + yy2);
-    var iso2 = y2 + '-' + mo2 + '-' + d2;
-    if (isValidIsoDateString_(iso2)) return iso2;
-  }
-  return '';
+  return normalizeDateToIsoFlexible_(value);
 }
 
 function resolveMappedTimeField_(row, aliases) {
@@ -171,7 +136,7 @@ function resolveMappedTimeField_(row, aliases) {
     var key = aliases[i];
     if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
     if (isNormalizedEmptyValue_(src[key])) continue;
-    return text_(src[key]);
+    return normalizeTimeToTextFlexible_(src[key]);
   }
   return '';
 }
@@ -1069,7 +1034,7 @@ function actionMonth_(user, payload) {
       'activity_no', 'private_note'
     ];
     viewRows = readRowsProjected_(CONFIG.SHEETS.VIEW_ACTIVITY_MEETINGS, projected).filter(function(row) {
-      return text_(row.month_ym) === targetYm;
+      return normalizeMonthYmFlexible_(row.month_ym) === targetYm;
     });
     if (user.display_role === 'instructor') {
       var empId = text_(user.emp_id || user.user_id);

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -118,6 +118,122 @@ function formatDate_(date) {
   return Utilities.formatDate(date, Session.getScriptTimeZone(), 'yyyy-MM-dd');
 }
 
+function googleSheetsSerialToDate_(serial) {
+  var n = Number(serial);
+  if (isNaN(n)) return null;
+  var wholeDays = Math.floor(n);
+  var dayFraction = n - wholeDays;
+  var ms = Math.round(dayFraction * 24 * 60 * 60 * 1000);
+  var dt = new Date(1899, 11, 30);
+  dt.setDate(dt.getDate() + wholeDays);
+  dt = new Date(dt.getTime() + ms);
+  return isNaN(dt.getTime()) ? null : dt;
+}
+
+function normalizeDateToIsoFlexible_(value) {
+  if (isNormalizedEmptyValue_(value)) return '';
+  if (Object.prototype.toString.call(value) === '[object Date]') {
+    return isNaN(value.getTime()) ? '' : formatDate_(value);
+  }
+  if (Object.prototype.toString.call(value) === '[object Number]' && !isNaN(value)) {
+    var serialDate = googleSheetsSerialToDate_(value);
+    return serialDate ? formatDate_(serialDate) : '';
+  }
+
+  var t = text_(value);
+  if (!t) return '';
+  var trimmed = t.replace(/\u00A0/g, ' ').trim();
+
+  if (/^\d{5}(\.\d+)?$/.test(trimmed)) {
+    var serialDateFromText = googleSheetsSerialToDate_(Number(trimmed));
+    if (serialDateFromText) return formatDate_(serialDateFromText);
+  }
+
+  var normalized = trimmed.replace(/[T\s]\d{1,2}:\d{2}(:\d{2})?.*$/, '');
+  if (isValidIsoDateString_(normalized)) return normalized;
+
+  var ym = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(normalized);
+  if (ym) return ym[1] + '-' + ym[2] + '-01';
+
+  var ymd = /^(\d{4})[\/.-](\d{1,2})[\/.-](\d{1,2})$/.exec(normalized);
+  if (ymd) {
+    var yy = ymd[1];
+    var mmo = ('0' + parseInt(ymd[2], 10)).slice(-2);
+    var dd = ('0' + parseInt(ymd[3], 10)).slice(-2);
+    var ymdIso = yy + '-' + mmo + '-' + dd;
+    if (isValidIsoDateString_(ymdIso)) return ymdIso;
+  }
+
+  var dmy = /^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})$/.exec(normalized);
+  if (dmy) {
+    var d = ('0' + parseInt(dmy[1], 10)).slice(-2);
+    var mo = ('0' + parseInt(dmy[2], 10)).slice(-2);
+    var y = dmy[3];
+    var iso = y + '-' + mo + '-' + d;
+    if (isValidIsoDateString_(iso)) return iso;
+  }
+
+  var dmy2 = /^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{2})$/.exec(normalized);
+  if (dmy2) {
+    var d2 = ('0' + parseInt(dmy2[1], 10)).slice(-2);
+    var mo2 = ('0' + parseInt(dmy2[2], 10)).slice(-2);
+    var yy2 = parseInt(dmy2[3], 10);
+    var y2 = String(yy2 >= 70 ? 1900 + yy2 : 2000 + yy2);
+    var iso2 = y2 + '-' + mo2 + '-' + d2;
+    if (isValidIsoDateString_(iso2)) return iso2;
+  }
+
+  var parsed = new Date(trimmed);
+  return isNaN(parsed.getTime()) ? '' : formatDate_(parsed);
+}
+
+function normalizeMonthYmFlexible_(value) {
+  if (isNormalizedEmptyValue_(value)) return '';
+  var t = text_(value);
+  var directYm = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(t);
+  if (directYm) return directYm[1] + '-' + directYm[2];
+  var iso = normalizeDateToIsoFlexible_(value);
+  return iso ? iso.slice(0, 7) : '';
+}
+
+function normalizeTimeToTextFlexible_(value) {
+  if (isNormalizedEmptyValue_(value)) return '';
+
+  if (Object.prototype.toString.call(value) === '[object Date]') {
+    return isNaN(value.getTime()) ? '' : Utilities.formatDate(value, Session.getScriptTimeZone(), 'HH:mm');
+  }
+
+  if (Object.prototype.toString.call(value) === '[object Number]' && !isNaN(value)) {
+    var serialTime = googleSheetsSerialToDate_(value);
+    return serialTime ? Utilities.formatDate(serialTime, Session.getScriptTimeZone(), 'HH:mm') : '';
+  }
+
+  var t = text_(value);
+  if (!t) return '';
+  var trimmed = t.replace(/\u00A0/g, ' ').trim();
+
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    var numeric = Number(trimmed);
+    if (!isNaN(numeric)) {
+      var fromNumeric = googleSheetsSerialToDate_(numeric);
+      if (fromNumeric) return Utilities.formatDate(fromNumeric, Session.getScriptTimeZone(), 'HH:mm');
+    }
+  }
+
+  var hm = /^(\d{1,2}):(\d{1,2})(?::\d{1,2})?$/.exec(trimmed);
+  if (hm) {
+    var h = parseInt(hm[1], 10);
+    var m = parseInt(hm[2], 10);
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+      return ('0' + h).slice(-2) + ':' + ('0' + m).slice(-2);
+    }
+  }
+
+  var parsed = new Date(trimmed);
+  if (isNaN(parsed.getTime())) return '';
+  return Utilities.formatDate(parsed, Session.getScriptTimeZone(), 'HH:mm');
+}
+
 function mondayOfWeek_(date) {
   var d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   var day = d.getDay();

--- a/backend/views.gs
+++ b/backend/views.gs
@@ -50,6 +50,19 @@ function writeRowsToViewSheet_(sheetName, rows) {
   var sheet = getSheet_(sheetName);
   var headers = getHeaders_(sheet);
   var dataStart = getDataStartRow_();
+  var plainTextColumns = {
+    month_ym: true,
+    meeting_date: true,
+    start_date: true,
+    end_date: true,
+    week_start_date: true,
+    start_time: true,
+    end_time: true
+  };
+  headers.forEach(function(header, idx) {
+    if (!plainTextColumns[text_(header)]) return;
+    sheet.getRange(dataStart, idx + 1, Math.max(sheet.getMaxRows() - dataStart + 1, 1), 1).setNumberFormat('@');
+  });
   var lastRow = sheet.getLastRow();
   if (lastRow >= dataStart) {
     sheet.getRange(dataStart, 1, lastRow - dataStart + 1, headers.length).clearContent();
@@ -69,7 +82,7 @@ function buildViewActivityMeetingsRows_(meetingsRows, sourceMap, privateNotesMap
   var out = [];
   (meetingsRows || []).forEach(function(meeting) {
     if (yesNo_(meeting.active || 'yes') === 'no') return;
-    var meetingDate = normalizeDateTextToIso_(meeting.meeting_date);
+    var meetingDate = normalizeDateToIsoFlexible_(meeting.meeting_date);
     if (!meetingDate) return;
 
     var sourceRowId = text_(meeting.source_row_id || meeting.RowID);
@@ -83,7 +96,7 @@ function buildViewActivityMeetingsRows_(meetingsRows, sourceMap, privateNotesMap
     var privateNote = text_(privateNotesMap[noteKey] || sourceRow.private_note || '');
 
     out.push({
-      month_ym: meetingDate.slice(0, 7),
+      month_ym: normalizeMonthYmFlexible_(meetingDate),
       meeting_date: meetingDate,
       source_sheet: sourceSheet,
       source_row_id: sourceRowId,
@@ -100,10 +113,10 @@ function buildViewActivityMeetingsRows_(meetingsRows, sourceMap, privateNotesMap
       emp_id: text_(meeting.emp_id || sourceRow.emp_id),
       emp_id_2: text_(meeting.emp_id_2 || sourceRow.emp_id_2),
       status: text_(meeting.status || sourceRow.status),
-      start_time: text_(meeting.start_time || sourceRow.start_time),
-      end_time: text_(meeting.end_time || sourceRow.end_time),
-      start_date: normalizeDateTextToIso_(meeting.start_date || sourceRow.start_date),
-      end_date: normalizeDateTextToIso_(meeting.end_date || sourceRow.end_date || sourceRow.start_date),
+      start_time: normalizeTimeToTextFlexible_(meeting.start_time || sourceRow.start_time),
+      end_time: normalizeTimeToTextFlexible_(meeting.end_time || sourceRow.end_time),
+      start_date: normalizeDateToIsoFlexible_(meeting.start_date || sourceRow.start_date),
+      end_date: normalizeDateToIsoFlexible_(meeting.end_date || sourceRow.end_date || sourceRow.start_date),
       activity_no: text_(meeting.activity_no || sourceRow.activity_no),
       private_note: privateNote
     });
@@ -121,7 +134,7 @@ function buildMeetingsByActivityMapFromView_(meetingViewRows) {
   var map = {};
   (meetingViewRows || []).forEach(function(row) {
     var rowId = text_(row.source_row_id);
-    var d = normalizeDateTextToIso_(row.meeting_date);
+    var d = normalizeDateToIsoFlexible_(row.meeting_date);
     if (!rowId || !d) return;
     if (!map[rowId]) map[rowId] = [];
     map[rowId].push(d);
@@ -196,20 +209,20 @@ function buildViewDashboardMonthlyRows_(activitiesSummaryRows, meetingsViewRows)
   var nowIso = new Date().toISOString();
   var months = {};
   (activitiesSummaryRows || []).forEach(function(row) {
-    var ym = text_(row.month_ym);
+    var ym = normalizeMonthYmFlexible_(row.month_ym);
     if (ym) months[ym] = true;
   });
   (meetingsViewRows || []).forEach(function(row) {
-    var ym2 = text_(row.month_ym);
+    var ym2 = normalizeMonthYmFlexible_(row.month_ym);
     if (ym2) months[ym2] = true;
   });
 
   return Object.keys(months).sort().map(function(ym) {
     var monthActivities = (activitiesSummaryRows || []).filter(function(row) {
-      return text_(row.month_ym) === ym && text_(row.status) !== 'סגור';
+      return normalizeMonthYmFlexible_(row.month_ym) === ym && text_(row.status) !== 'סגור';
     });
     var monthMeetings = (meetingsViewRows || []).filter(function(row) {
-      return text_(row.month_ym) === ym;
+      return normalizeMonthYmFlexible_(row.month_ym) === ym;
     });
 
     var byManager = {};


### PR DESCRIPTION
### Motivation
- לתקן מצב שבו `view_activity_meetings` קיבל וכתב לתוך הגיליון ערכי תאריך לא אחידים (Date objects או מספרים סידוריים כמו `45962`) במקום מחרוזות סטנדרטיות.
- להבטיח שהמערכת תזהה תאריכים/שעות ממקורות שונים ותכתוב ל־Views פורמטים יציבים שימנעו המרות אוטומטיות של Google Sheets.

### Description
- הוספת פונקציות נירמול מרכזיות ב־`backend/helpers.gs`: `normalizeDateToIsoFlexible_`, `normalizeMonthYmFlexible_`, `normalizeTimeToTextFlexible_` ותמיכה בהמרת serial של Google Sheets עם `googleSheetsSerialToDate_`.
- החלפת `normalizeDateTextToIso_` כך שיפנה ל־`normalizeDateToIsoFlexible_`, ועדכון קריאות זמן (`resolveMappedTimeField_`) לשימוש ב־`normalizeTimeToTextFlexible_` כדי להחזיר תמיד `HH:mm`.
- שינויים בבניית ה־Views (`backend/views.gs`) כדי לנרמל לפני הכתיבה את השדות: `month_ym` → `YYYY-MM`, `meeting_date`/`start_date`/`end_date` → `YYYY-MM-DD`, ו־`start_time`/`end_time` → `HH:mm`.
- לפני `setValues` הוספתי קביעת פורמט עמודות רלוונטיות ל־Plain Text (`setNumberFormat('@')`) כדי למנוע המרות אוטומטיות של Google Sheets; ועדכנתי סינון `actionMonth_` והאגרגציות להשתמש בנירמול החודשי (`normalizeMonthYmFlexible_`).

### Testing
- הרצת בדיקת פורמט diff עם `git diff --check` שנעברה בהצלחה.
- בדקתי סטטוס העץ עם `git status --short` ואישור שהקבצים שונו כצפוי.
- בוצע `git commit -m "Normalize view dates/times to stable text formats"` והפעולה הצליחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efad4497f8832bb6b96349c68ccd55)