### PR TITLE
Update Apps Script API URL to new deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbyRgPaytGRBYT2_6p-qvXsU5oZYV-mV9FPd6uNhWifBOlKFDnWdJd2aVB4GQIoeH00H/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyRgPaytGRBYT2_6p-qvXsU5oZYV-mV9FPd6uNhWifBOlKFDnWdJd2aVB4GQIoeH00H/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbx9ephqrIIN75B-LdtA8DdaEQTD7MALoRF6sjJsXaRujEwFkWibdKGj1MiH-ak8Xrxz/exec';
+  'https://script.google.com/macros/s/AKfycbyRgPaytGRBYT2_6p-qvXsU5oZYV-mV9FPd6uNhWifBOlKFDnWdJd2aVB4GQIoeH00H/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
### Motivation
- Replace the default Apps Script Web App endpoint used by the frontend with the new deployment URL provided.

### Description
- Updated the `DEFAULT_API_URL` in `frontend/src/config.js` and updated the `window.__DASHBOARD_CONFIG__.apiUrl` / `?apiUrl=` examples in `README.md` to the new Apps Script deployment URL.

### Testing
- Ran `npm test -- --runInBand` and all automated tests passed (19/19).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaec905d0832bab9545516ae7f191)