### PR TITLE
Add monthly payload cache for `actionMonth_` with prewarm and perf fields

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -975,6 +975,36 @@ function buildMonthResponseFromMeetingViewRows_(rows, year, month) {
   };
 }
 
+function filterMonthPayloadForInstructor_(monthPayload, empId) {
+  var source = monthPayload || {};
+  var normalizedEmpId = text_(empId);
+  if (!normalizedEmpId) return source;
+  var sourceItems = source.items_by_id || {};
+  var itemsById = {};
+  Object.keys(sourceItems).forEach(function(rowId) {
+    var item = sourceItems[rowId] || {};
+    if (text_(item.emp_id) === normalizedEmpId || text_(item.emp_id_2) === normalizedEmpId) {
+      itemsById[rowId] = item;
+    }
+  });
+  var cells = (source.cells || []).map(function(cell) {
+    var itemIds = (cell.item_ids || []).filter(function(rowId) {
+      return !!itemsById[rowId];
+    });
+    return {
+      day: cell.day,
+      date: cell.date,
+      item_ids: itemIds
+    };
+  });
+  return {
+    month: text_(source.month),
+    cells: cells,
+    items_by_id: itemsById,
+    hide_saturday: !!source.hide_saturday
+  };
+}
+
 function actionMonthLegacy_(user, year, month) {
   var daysInMonth = new Date(year, month + 1, 0).getDate();
   var calRows = visibleActivitiesSummaryForUser_(user);
@@ -1007,8 +1037,6 @@ function actionMonthLegacy_(user, year, month) {
 
 function actionMonth_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
-
-  markRequestPerf_('month:view lookup:start');
   var now = new Date();
   var ym = text_(payload && payload.ym).slice(0, 7);
   var ymMatch = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(ym);
@@ -1022,9 +1050,30 @@ function actionMonth_(user, payload) {
   }
 
   var targetYm = year + '-' + ('0' + (month + 1)).slice(-2);
+  var viewRowsRead = 0;
+  var filteredRows = 0;
+  var buildStartMs = perfNowMs_();
+  var buildMs = 0;
+  var monthCacheHit = false;
+  var usedMonthPayloadCache = false;
   var usedView = false;
-  var viewRows = [];
+  var monthPayload = null;
+
+  markRequestPerf_('month:cache lookup:start');
   try {
+    var payloadCacheKey = monthPayloadCacheKey_(targetYm);
+    var cachedMonthPayload = payloadCacheKey ? scriptCacheGetJson_(payloadCacheKey) : null;
+    if (cachedMonthPayload && typeof cachedMonthPayload === 'object') {
+      monthPayload = cachedMonthPayload;
+      monthCacheHit = true;
+      usedMonthPayloadCache = true;
+      usedView = true;
+    }
+  } catch (_cacheErr) {}
+  markRequestPerf_('month:cache lookup:end');
+
+  markRequestPerf_('month:view lookup:start');
+  if (!monthPayload) {
     var projected = [
       'month_ym', 'meeting_date', 'source_sheet', 'source_row_id',
       'activity_type', 'activity_name', 'activity_manager',
@@ -1033,25 +1082,39 @@ function actionMonth_(user, payload) {
       'status', 'start_time', 'end_time', 'start_date', 'end_date',
       'activity_no', 'private_note'
     ];
-    viewRows = readRowsProjected_(CONFIG.SHEETS.VIEW_ACTIVITY_MEETINGS, projected).filter(function(row) {
-      return normalizeMonthYmFlexible_(row.month_ym) === targetYm;
-    });
-    if (user.display_role === 'instructor') {
-      var empId = text_(user.emp_id || user.user_id);
-      viewRows = viewRows.filter(function(row) {
-        return text_(row.emp_id) === empId || text_(row.emp_id_2) === empId;
+    try {
+      var viewRowsAll = readRowsProjected_(CONFIG.SHEETS.VIEW_ACTIVITY_MEETINGS, projected);
+      viewRowsRead = viewRowsAll.length;
+      var viewRows = viewRowsAll.filter(function(row) {
+        return normalizeMonthYmFlexible_(row.month_ym) === targetYm;
       });
+      filteredRows = viewRows.length;
+      if (viewRows.length > 0) {
+        monthPayload = buildMonthResponseFromMeetingViewRows_(viewRows, year, month);
+        buildMs = Math.max(0, perfNowMs_() - buildStartMs);
+        var cacheKey = monthPayloadCacheKey_(targetYm);
+        if (cacheKey) scriptCachePutJson_(cacheKey, monthPayload, 21600);
+        usedView = true;
+      }
+    } catch (_viewErr) {
+      usedView = false;
+      monthPayload = null;
     }
-    usedView = viewRows.length > 0;
-  } catch (_viewErr) {
-    usedView = false;
-    viewRows = [];
   }
   markRequestPerf_('month:view lookup:end');
 
+  setRequestPerfField_('month_cache_hit', monthCacheHit);
+  setRequestPerfField_('used_month_payload_cache', usedMonthPayloadCache);
+  setRequestPerfField_('view_rows_read', viewRowsRead);
+  setRequestPerfField_('filtered_rows', filteredRows);
+  setRequestPerfField_('build_ms', buildMs);
+
   if (usedView) {
+    if (user.display_role === 'instructor') {
+      monthPayload = filterMonthPayloadForInstructor_(monthPayload, text_(user.emp_id || user.user_id));
+    }
     markRequestPerf_('month:used_view:true');
-    return buildMonthResponseFromMeetingViewRows_(viewRows, year, month);
+    return monthPayload;
   }
   markRequestPerf_('month:fallback_used:true');
   return actionMonthLegacy_(user, year, month);

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -281,7 +281,8 @@ function beginRequestPerf_(action, payload) {
     started_ms: perfNowMs_(),
     marks: [{ label: 'request_start', at_ms: perfNowMs_() }],
     sheet_reads: [],
-    sheets_total_ms: 0
+    sheets_total_ms: 0,
+    custom: {}
   };
 }
 
@@ -304,6 +305,13 @@ function trackSheetReadPerf_(meta) {
   __rqPerf_.sheets_total_ms += item.duration_ms;
 }
 
+function setRequestPerfField_(key, value) {
+  if (!__rqPerf_ || !__rqPerf_.enabled) return;
+  var fieldKey = text_(key);
+  if (!fieldKey) return;
+  __rqPerf_.custom[fieldKey] = value;
+}
+
 function buildPerfPayload_(responsePayload, meta) {
   if (!__rqPerf_ || !__rqPerf_.enabled) return null;
   var endMs = perfNowMs_();
@@ -317,7 +325,7 @@ function buildPerfPayload_(responsePayload, meta) {
     });
   }
   var responseSize = JSON.stringify(responsePayload || {}).length;
-  return {
+  var perfPayload = {
     action: text_((meta && meta.action) || __rqPerf_.action),
     cache_hit: !!(meta && meta.cache_hit),
     errored: !!(meta && meta.errored),
@@ -327,6 +335,10 @@ function buildPerfPayload_(responsePayload, meta) {
     steps: stepDurations,
     response_size_bytes: responseSize
   };
+  Object.keys(__rqPerf_.custom || {}).forEach(function(key) {
+    perfPayload[key] = __rqPerf_.custom[key];
+  });
+  return perfPayload;
 }
 
 function jsonResponse_(payload, perfMeta) {

--- a/backend/script-cache.gs
+++ b/backend/script-cache.gs
@@ -7,6 +7,7 @@ var SCRIPT_CACHE_KEY_DASHBOARD = 'pc:dashboard:v2';
 var SCRIPT_CACHE_KEY_PERMISSIONS_LIST = 'pc:permissions:v2';
 var SCRIPT_CACHE_KEY_DATA_VIEWS_VERSION = 'pc:data-views-version:v1';
 var SCRIPT_CACHE_KEY_DEBUG_STATS = 'pc:cache-debug:stats:v1';
+var SCRIPT_CACHE_KEY_MONTH_PAYLOAD_PREFIX = 'pc:month-payload:v1:';
 
 function scriptCacheGetJson_(key) {
   try {
@@ -88,4 +89,10 @@ function bumpDataViewsCacheVersion_() {
       600
     );
   } catch (e) {}
+}
+
+function monthPayloadCacheKey_(monthYm) {
+  var ym = normalizeMonthYmFlexible_(monthYm);
+  if (!ym) return '';
+  return SCRIPT_CACHE_KEY_MONTH_PAYLOAD_PREFIX + dataViewsCacheVersion_() + ':' + ym;
 }

--- a/backend/views.gs
+++ b/backend/views.gs
@@ -327,6 +327,44 @@ function buildViewDashboardMonthlyRows_(activitiesSummaryRows, meetingsViewRows)
   });
 }
 
+function buildMonthPayloadMapFromMeetingViewRows_(meetingsViewRows) {
+  var grouped = {};
+  (meetingsViewRows || []).forEach(function(row) {
+    var ym = normalizeMonthYmFlexible_(row.month_ym);
+    if (!ym) return;
+    if (!grouped[ym]) grouped[ym] = [];
+    grouped[ym].push(row);
+  });
+  var payloadByMonth = {};
+  Object.keys(grouped).forEach(function(ym) {
+    var parts = ym.split('-');
+    var year = parseInt(parts[0], 10);
+    var month = parseInt(parts[1], 10) - 1;
+    if (isNaN(year) || isNaN(month)) return;
+    payloadByMonth[ym] = buildMonthResponseFromMeetingViewRows_(grouped[ym], year, month);
+  });
+  return payloadByMonth;
+}
+
+function warmMonthPayloadCacheFromMeetingRows_(meetingsViewRows) {
+  var payloadByMonth = buildMonthPayloadMapFromMeetingViewRows_(meetingsViewRows);
+  var months = Object.keys(payloadByMonth);
+  var cachedCount = 0;
+  var skippedCount = 0;
+  months.forEach(function(ym) {
+    var key = monthPayloadCacheKey_(ym);
+    if (!key) return;
+    var writeRes = scriptCachePutJson_(key, payloadByMonth[ym], 21600);
+    if (writeRes && writeRes.ok) cachedCount += 1;
+    else skippedCount += 1;
+  });
+  return {
+    months_total: months.length,
+    months_cached: cachedCount,
+    months_skipped: skippedCount
+  };
+}
+
 function refreshDataViews_() {
   markRequestPerf_('refreshDataViews:read:start');
   var readStartMs = perfNowMs_();
@@ -351,6 +389,7 @@ function refreshDataViews_() {
   writeRowsToViewSheet_(CONFIG.SHEETS.VIEW_ACTIVITIES_SUMMARY, activitiesSummaryRows);
   writeRowsToViewSheet_(CONFIG.SHEETS.VIEW_DASHBOARD_MONTHLY, dashboardMonthlyRows);
   bumpDataViewsCacheVersion_();
+  var monthPayloadCache = warmMonthPayloadCacheFromMeetingRows_(meetingsViewRows);
   markRequestPerf_('refreshDataViews:write:end');
 
   return {
@@ -362,6 +401,7 @@ function refreshDataViews_() {
       view_activities_summary: activitiesSummaryRows.length,
       view_dashboard_monthly: dashboardMonthlyRows.length
     },
+    month_payload_cache: monthPayloadCache,
     used_view: false,
     fallback_used: false
   };


### PR DESCRIPTION
### Motivation
- `actionMonth_` still read the entire `view_activity_meetings` sheet and filtered in memory each request, causing high backend latency for month views. 
- Provide a month-level cache/index so hot months can be served immediately without repeated full-view reads. 

### Description
- Add script-cache key prefix and helper `monthPayloadCacheKey_` and store month payloads keyed by `month_ym` + data-views version in the Script Cache. 
- Update `refreshDataViews_` to prebuild per-month payloads via `buildMonthPayloadMapFromMeetingViewRows_` and `warmMonthPayloadCacheFromMeetingRows_` and return `month_payload_cache` stats. 
- Change `actionMonth_` to attempt a cache lookup first, return cached `month` payload on hit, fall back to reading `view_activity_meetings` on miss, and preserve the legacy fallback (`actionMonthLegacy_`) when the view path is unavailable. 
- Add instructor-safe post-cache filtering via `filterMonthPayloadForInstructor_` and extend perf diagnostics by adding `setRequestPerfField_` and emitting custom `debug_perf` fields: `month_cache_hit`, `used_month_payload_cache`, `view_rows_read`, `filtered_rows`, and `build_ms`. 

### Testing
- Ran the test suite with `npm test` and all tests passed (`19` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb1b41a78832b8429d8ae563c2248)