### PR TITLE
Normalize week response and harden week screen rendering

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -1037,6 +1037,46 @@ function filterWeekPayloadForInstructor_(weekPayload, empId) {
   };
 }
 
+function normalizeWeekPayloadShape_(payload) {
+  var source = payload || {};
+  var srcItems = source.items_by_id && typeof source.items_by_id === 'object' ? source.items_by_id : {};
+  var itemsById = {};
+  Object.keys(srcItems).forEach(function(rowId) {
+    if (!rowId) return;
+    itemsById[text_(rowId)] = srcItems[rowId];
+  });
+
+  var days = Array.isArray(source.days) ? source.days : [];
+  var normalizedDays = days.map(function(day) {
+    var normalizedDate = text_(day && day.date);
+    var normalizedDow = text_(day && day.weekday_label);
+    var dayItems = Array.isArray(day && day.items) ? day.items.filter(Boolean) : null;
+    var dayItemIds = [];
+    if (Array.isArray(day && day.item_ids)) {
+      dayItemIds = day.item_ids.map(function(id) { return text_(id); }).filter(Boolean);
+    } else if (dayItems && dayItems.length) {
+      dayItemIds = dayItems
+        .map(function(item) { return text_(item && item.RowID); })
+        .filter(Boolean);
+    }
+
+    return {
+      date: normalizedDate,
+      weekday_label: normalizedDow,
+      item_ids: dayItemIds
+    };
+  });
+
+  return {
+    days: normalizedDays,
+    items_by_id: itemsById,
+    week_starts_on: source.week_starts_on,
+    show_shabbat: source.show_shabbat,
+    week_hide_saturday_column: source.week_hide_saturday_column,
+    week_offset: source.week_offset
+  };
+}
+
 function actionWeekLegacy_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
 
@@ -1070,14 +1110,14 @@ function actionWeekLegacy_(user, payload) {
     });
   }
 
-  return {
+  return normalizeWeekPayloadShape_({
     days: days,
     items_by_id: itemsById,
     week_starts_on: startDay,
     show_shabbat: showSat,
     week_hide_saturday_column: hideSatColumn,
     week_offset: weekOffset
-  };
+  });
 }
 
 function actionWeek_(user, payload) {
@@ -1109,7 +1149,7 @@ function actionWeek_(user, payload) {
     setRequestPerfField_('week_filtered_rows', 0);
     markRequestPerf_('week:used_view:false');
     markRequestPerf_('week:fallback_used:true');
-    var legacyWeek = actionWeekLegacy_(user, payload);
+    var legacyWeek = normalizeWeekPayloadShape_(actionWeekLegacy_(user, payload));
     setRequestPerfField_('payload_bytes', JSON.stringify(legacyWeek || {}).length);
     return legacyWeek;
   }
@@ -1118,6 +1158,7 @@ function actionWeek_(user, payload) {
   if (user.display_role === 'instructor') {
     weekPayload = filterWeekPayloadForInstructor_(weekPayload, text_(user.emp_id || user.user_id));
   }
+  weekPayload = normalizeWeekPayloadShape_(weekPayload);
 
   setRequestPerfField_('week_used_view', true);
   setRequestPerfField_('week_used_cache', !!ensured.usedCacheOnly);

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -94,6 +94,19 @@ function weekDayItems(day, itemsById) {
   return ids.map((id) => itemsById?.[id]).filter(Boolean);
 }
 
+function normalizeWeekResponseForRender(data) {
+  const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
+  const days = Array.isArray(data?.days)
+    ? data.days.map((day) => ({
+        date: typeof day?.date === 'string' ? day.date : '',
+        weekday_label: typeof day?.weekday_label === 'string' ? day.weekday_label : '',
+        item_ids: Array.isArray(day?.item_ids) ? day.item_ids : [],
+        items: Array.isArray(day?.items) ? day.items : undefined
+      }))
+    : [];
+  return { days, itemsById };
+}
+
 /**
  * Group items by primary instructor key so multiple activities by the same
  * instructor on the same day can be collapsed into an accordion.
@@ -191,8 +204,7 @@ export const weekScreen = {
     return api.week({ week_offset: offset });
   },
   render(data, { state }) {
-    const safeDays = Array.isArray(data?.days) ? data.days : [];
-    const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
+    const { days: safeDays, itemsById } = normalizeWeekResponseForRender(data);
     const filterState = ensureActivityListFilters(state, WEEK_SCOPE);
     const allItems = Object.values(itemsById || {});
     prepareRowsForSearch(allItems, CALENDAR_SEARCH_FIELDS);
@@ -207,22 +219,24 @@ export const weekScreen = {
     const columns = safeDays
       .map((d, idx) => {
         const items = applyLocalFilters(weekDayItems(d, itemsById), filterState, { filterFields: CALENDAR_FILTER_FIELDS });
-        const isToday = d.date === todayIso;
+        const dayDate = d.date || '';
+        const isToday = dayDate === todayIso;
         const dow = d.weekday_label || '';
         const groups = groupItemsByInstructor(items);
         const sessionBlocks = items.length
           ? groups.map((group) => renderWeekGroup(group, d.date, dow)).join('')
           : '';
-        const holiday = getHolidayLabel(d.date);
+        const holiday = dayDate ? getHolidayLabel(dayDate) : '';
+        const displayDate = /^\d{4}-\d{2}-\d{2}$/.test(dayDate) ? formatDateHe(dayDate) : '—';
         return `
-      <section class="ds-week-col${isToday ? ' is-today' : ''}" data-day-idx="${idx}" aria-label="${escapeHtml(d.date)}">
+      <section class="ds-week-col${isToday ? ' is-today' : ''}" data-day-idx="${idx}" aria-label="${escapeHtml(dayDate || `day-${idx + 1}`)}">
         <header class="ds-week-col__head">
           <div class="ds-week-col__head-top">
             <span class="ds-week-col__dow">${escapeHtml(dow || `יום ${idx + 1}`)}</span>
             ${isToday ? '<span class="ds-week-col__today-badge">היום</span>' : ''}
             <span class="ds-week-col__count">${items.length}</span>
           </div>
-          <span class="ds-week-col__date">${escapeHtml(formatDateHe(d.date))}</span>
+          <span class="ds-week-col__date">${escapeHtml(displayDate)}</span>
           ${holiday ? `<span class="ds-week-col__holiday">${escapeHtml(holiday)}</span>` : ''}
         </header>
         <div class="ds-week-col__body">${sessionBlocks}</div>


### PR DESCRIPTION
### Motivation
- The week screen could show a load error even when the backend reported `errored:false` because the `week` response shape was inconsistent with what `week.js` expects (missing/variant `days` / `items_by_id` shapes). 
- Ensure the `week` payload always contains stable keys and per-day fields (`date`, `weekday_label`, `item_ids`) so the frontend can render the board deterministically.

### Description
- Added `normalizeWeekPayloadShape_` in `backend/actions.gs` to guarantee `days` and `items_by_id` exist and to normalize each day to include `date`, `weekday_label`, and `item_ids` (including fallback from `items` when present). 
- Applied normalization on both normal and fallback paths (`actionWeek_` and `actionWeekLegacy_`) so the same shape is returned regardless of execution route. 
- Added `normalizeWeekResponseForRender` and rendering guards in `frontend/src/screens/week.js` to defensively coerce `days` and `items_by_id`, guard date formatting, and avoid crashes when day entries are partial or malformed. 
- Files changed: `backend/actions.gs` and `frontend/src/screens/week.js`.

### Testing
- Ran the unit tests with `npm test -- --runInBand` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc0c2dc80832b838ae0a61834bb37)