### PR TITLE
Fix week screen binding to preserve card click handlers

### DIFF
--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -12,6 +12,7 @@ import {
   bindLocalFilters
 } from './shared/activity-list-filters.js';
 import { getFilterOptionOverrides } from './shared/activity-options.js';
+import { bindActNavGrid } from './shared/act-nav-grid.js';
 
 const inflightActivityDetailRequests = new Map();
 const WEEK_SCOPE = 'calendar';
@@ -281,7 +282,9 @@ export const weekScreen = {
       }
     };
 
-    bindActNavGrid(root, { state, rerender });
+    if (typeof bindActNavGrid === 'function') {
+      bindActNavGrid(root, { state, rerender });
+    }
     root.classList.remove('is-week-loading');
     root.setAttribute('aria-busy', 'false');
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -391,5 +394,7 @@ export const weekScreen = {
         loadDetails().catch(() => {});
       }
     });
+    root.dataset.weeksessionBound = '1';
+    console.debug?.('[week] weeksession interactive cards bound');
   }
 };


### PR DESCRIPTION
### Motivation
- The week screen binding could fail early with a `ReferenceError` (missing `bindActNavGrid`) which prevented `ui.bindInteractiveCards` from executing and left `weeksession` card clicks unhandled.

### Description
- Imported `bindActNavGrid` into `frontend/src/screens/week.js` and wrapped its invocation in a runtime guard `if (typeof bindActNavGrid === 'function') { ... }` to avoid throwing when the function is unavailable.
- Preserved the interactive card wiring by ensuring `ui.bindInteractiveCards(...)` always runs and added a lightweight verification hook `root.dataset.weeksessionBound = '1'` plus `console.debug` after binding to make it easy to confirm handlers are attached.
- Only `frontend/src/screens/week.js` was modified and there are no changes to backend code or UI markup.

### Testing
- Ran `npm test` which executed the test suite (`node --test tests/interactions.test.mjs`) and all tests passed (19/19).
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc393b17c832bb4f7aecf1a7ac649)