### PR TITLE
יישור חישוב חריגות בדשבורד ושיפור UX + חיווי טעינה ב־activities/week/month

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -408,7 +408,8 @@ function actionDashboard_(user, payload) {
     }
 
     if (programTypes.indexOf(t) >= 0) {
-      if (primaryExceptionForRow_(row)) managerExceptions[manager] += 1;
+      var rowExceptionsCount = rowExceptionTypes_(row).length;
+      if (rowExceptionsCount > 0) managerExceptions[manager] += rowExceptionsCount;
       if (t === 'course' && text_(row.end_date).slice(0, 7) === ym) managerCourseEndings[manager] += 1;
     }
 
@@ -439,11 +440,6 @@ function actionDashboard_(user, payload) {
   var financeOpenCount = canViewFinance ? combined.filter(function(row) {
     return normalizeFinance_(row.finance_status) === 'open';
   }).length : 0;
-
-  var exceptionSum = 0;
-  longRows.forEach(function(row) {
-    if (primaryExceptionForRow_(row)) exceptionSum += 1;
-  });
 
   var missingInstructorCount = 0;
   var missingStartDateCount = 0;
@@ -488,6 +484,7 @@ function actionDashboard_(user, payload) {
     }
     if (exceptionTypes.indexOf('late_end_date') >= 0) lateEndDateCount += 1;
   });
+  var exceptionSum = missingInstructorCount + missingStartDateCount + lateEndDateCount;
 
 
   var shortActivitiesByType = {};
@@ -614,6 +611,7 @@ function actionDashboard_(user, payload) {
       active_courses_current_month: activeTypeCountsCurrent.course,
       ending_courses_current_month: courseEndings,
       active_courses_next_month: countActiveByTypeInYm_(allSummary, nextYm, 'course'),
+      exceptions_count: exceptionSum,
       active_instructors: collectUniqueInstructorNames_(combined),
       active_instructors_by_manager: activeInstructorsByManager,
       missing_instructor_count: missingInstructorCount,

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -211,6 +211,18 @@ function parseJsonArraySafeForDashboard_(raw, fallback) {
   return fallback;
 }
 
+function resolveExceptionsCountForDashboard_(summaryObj, rawExceptions) {
+  var summary = summaryObj && typeof summaryObj === 'object' ? summaryObj : {};
+  var missingInstr = parseInt(text_(summary.missing_instructor_count), 10) || 0;
+  var missingStart = parseInt(text_(summary.missing_start_date_count), 10) || 0;
+  var lateEnd = parseInt(text_(summary.late_end_date_count), 10) || 0;
+  var fromSummaryParts = missingInstr + missingStart + lateEnd;
+  var fromRaw = parseInt(text_(rawExceptions), 10);
+  if (isNaN(fromRaw) || fromRaw < 0) return fromSummaryParts;
+  if (fromSummaryParts > 0 && fromRaw !== fromSummaryParts) return fromSummaryParts;
+  return fromRaw;
+}
+
 function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, canViewFinance) {
   var summary = parseJsonObjectSafeForDashboard_(primaryRow.summary_json, {});
   if (!Array.isArray(summary.active_instructors) || !summary.active_instructors.length) {
@@ -224,7 +236,10 @@ function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, can
   } else if (summary.active_courses_next_month === undefined || summary.active_courses_next_month === null) {
     summary.active_courses_next_month = 0;
   }
-  summary.exceptions_count = parseInt(text_(primaryRow.exceptions_count), 10) || summary.exceptions_count || 0;
+  summary.exceptions_count = resolveExceptionsCountForDashboard_(
+    summary,
+    primaryRow.exceptions_count || summary.exceptions_count
+  );
   var finRaw = summary.finance_open_count;
   summary.finance_open_count = typeof finRaw === 'number' && !isNaN(finRaw)
     ? finRaw
@@ -261,7 +276,7 @@ function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, can
   var totalInstr = parseInt(text_(primaryRow.total_instructors), 10) || 0;
   var courseEndings = parseInt(text_(primaryRow.course_endings), 10) || 0;
   var financeOpen = canViewFinance ? (summary.finance_open_count || 0) : 0;
-  var exceptCount = parseInt(text_(primaryRow.exceptions_count), 10) || summary.exceptions_count || 0;
+  var exceptCount = resolveExceptionsCountForDashboard_(summary, primaryRow.exceptions_count);
   var activeCurrent = parseInt(text_(primaryRow.active_courses), 10) || 0;
 
   var snapshotData = {
@@ -448,12 +463,16 @@ function actionDashboardSnapshot_(user, payload) {
   var totalInstr     = parseInt(text_(s.active_instructors_count), 10) || 0;
   var courseEndings  = parseInt(text_(s.course_endings_current_month), 10) || 0;
   var financeOpen    = parseInt(text_(s.finance_open_count),       10) || 0;
-  var exceptCount    = parseInt(text_(s.exceptions_count),         10) || 0;
-  var activeCurrent  = parseInt(text_(s.active_courses_current_month), 10) || 0;
-  var activeNext     = parseInt(text_(s.active_courses_next_month), 10) || 0;
   var missingInstr   = parseInt(text_(s.missing_instructor_count), 10) || 0;
   var missingDate    = parseInt(text_(s.missing_start_date_count), 10) || 0;
   var lateEnd        = parseInt(text_(s.late_end_date_count),      10) || 0;
+  var exceptCount    = resolveExceptionsCountForDashboard_({
+    missing_instructor_count: missingInstr,
+    missing_start_date_count: missingDate,
+    late_end_date_count: lateEnd
+  }, s.exceptions_count);
+  var activeCurrent  = parseInt(text_(s.active_courses_current_month), 10) || 0;
+  var activeNext     = parseInt(text_(s.active_courses_next_month), 10) || 0;
 
   var combinedStr = text_(s.active_instructors_names);
   var allInstructorNames = combinedStr
@@ -672,7 +691,10 @@ function writeDashboardSummarySnapshotRow_(ym, fullData) {
   kpiAll.forEach(function(card) { counts[card.id] = card.value || 0; });
 
   var financeOpen = canViewFinanceFromKpis_(kpiAll, fullData);
-  var exceptions  = counts['exceptions'] || 0;
+  var exceptions  = (counts['exceptions'] || 0);
+  if (!exceptions) {
+    exceptions = resolveExceptionsCountForDashboard_(summary, summary.exceptions_count);
+  }
 
   var rowObj = {
     month_ym:                          "'" + normalizeSnapshotMonthYm_(ym),

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -378,19 +378,23 @@ export const activitiesScreen = {
                 <tbody>${tableRows}</tbody>
               </table>`) + loadMoreHtml;
 
+    const isNavLoading = !!state.activitiesNavLoading;
+    const navLoadingChip = isNavLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : '';
     const mainToolbar = `<div class="ds-activities-main-toolbar">
-      <div class="ds-activities-main-toolbar__actions">
-        ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost ds-btn--activities-action" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">➕</button>` : ''}
-        <button type="button" class="ds-btn ds-btn--sm ds-btn--icon-only ds-btn--ghost ds-btn--activities-action" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">🔄</button>
+      <div class="ds-activities-main-toolbar__search-wrap">
+        <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="חיפוש" aria-label="חיפוש פעילויות" title="חיפוש לפי פעילות / מדריך / רשות / בית ספר" />
       </div>
-      <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="🔍" aria-label="חיפוש פעילויות" title="חיפוש לפי פעילות / מדריך / רשות / בית ספר" />
+      <div class="ds-activities-main-toolbar__actions">
+        ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--activities-action" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">הוספה</button>` : ''}
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--activities-action" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">ניקוי</button>
+      </div>
     </div>`;
 
-    const titleNavRow = `<div class="ds-activities-title-row">
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-prev aria-label="חודש קודם">▶</button>
-      <h2 class="ds-activities-page-title">ניהול פעילויות לחודש ${escapeHtml(heMonthLabel(state.activitiesMonthYm))} (${total} פעילויות)</h2>
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-next aria-label="חודש הבא">◀</button>
-    </div>`;
+    const titleNavRow = `<nav class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" aria-label="ניווט חודשי לפעילויות" dir="rtl">
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-prev aria-label="חודש קודם" title="חודש קודם" ${isNavLoading ? 'disabled' : ''}>▶</button>
+      <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(heMonthLabel(state.activitiesMonthYm))} · ${total} פעילויות ${navLoadingChip}</h2>
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-next aria-label="חודש הבא" title="חודש הבא" ${isNavLoading ? 'disabled' : ''}>◀</button>
+    </nav>`;
 
     const html = dsScreenStack(`<section class="ds-activities-screen">
       ${titleNavRow}
@@ -403,7 +407,8 @@ export const activitiesScreen = {
 
   bind({ root, data, state, rerender, rerenderActivitiesView, ui, api, clearScreenDataCache }) {
 
-    const filteredRows      = applyActivitiesLocalFilters(Array.isArray(data?.rows) ? data.rows : [], state, state?.clientSettings);
+    const activitiesRows = Array.isArray(data?.rows) ? data.rows : [];
+    const filteredRows      = applyActivitiesLocalFilters(activitiesRows, state, state?.clientSettings);
     const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
     const canEditActivity   = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -411,8 +416,54 @@ export const activitiesScreen = {
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canAddActivity = !!state?.user?.can_add_activity;
 
+    const rerenderLocal = () => {
+      if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
+      else rerender();
+    };
+
+    const upsertLocalRow = (rowId, patch) => {
+      const hit = activitiesRows.find((row) => String(row?.RowID || '') === String(rowId || ''));
+      if (!hit) return false;
+      Object.assign(hit, patch || {});
+      return true;
+    };
+    const patchLocalRowFromSave = ({ sourceRowId, changes }) => {
+      if (!upsertLocalRow(sourceRowId, changes || {})) return;
+      const summaryHit = filteredRows.find((row) => String(row?.RowID || '') === String(sourceRowId || ''));
+      if (summaryHit) Object.assign(summaryHit, changes || {});
+    };
+    const scheduleQuietRefresh = async () => {
+      try {
+        const fresh = await api.activities({ activity_type: 'all' });
+        const freshRows = Array.isArray(fresh?.rows) ? fresh.rows : [];
+        activitiesRows.splice(0, activitiesRows.length, ...freshRows);
+        state.screenDataCache['activities:all'] = { data: { ...fresh, rows: activitiesRows }, t: Date.now() };
+      } catch {
+        // keep local optimistic view on failure
+      }
+    };
+
     const bindActivityEditForm = (contentRoot) =>
-      bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender });
+      bindActivityEditFormShared(contentRoot, {
+        api,
+        ui,
+        clearScreenDataCache,
+        rerender,
+        onRowSaved: ({ sourceSheet, sourceRowId, changes }) => {
+          patchLocalRowFromSave({ sourceRowId, changes });
+          const key = `activityDetail:${sourceSheet || ''}:${sourceRowId || ''}`;
+          const entry = state?.screenDataCache?.[key];
+          if (entry?.data && typeof entry.data === 'object') Object.assign(entry.data, changes || {});
+        },
+        onSaveSuccess: async ({ sourceRowId }) => {
+          rerenderLocal();
+          void scheduleQuietRefresh();
+          const rowNode = Array.from(root.querySelectorAll('.ds-data-row'))
+            .find((node) => String(node?.dataset?.rowId || '') === String(sourceRowId || ''));
+          rowNode?.classList.add('is-just-saved');
+          setTimeout(() => rowNode?.classList.remove('is-just-saved'), 1200);
+        }
+      });
 
     async function loadDetailRow(summaryRow) {
       const key = activityDetailCacheKey(summaryRow);
@@ -486,19 +537,21 @@ export const activitiesScreen = {
       } catch {}
     }
 
-    const rerenderLocal = () => {
-      if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
-      else rerender();
-    };
     bindLocalFilters(root, state, ACTIVITIES_SCOPE, rerenderLocal, { debounceMs: 280 });
-    root.querySelector('[data-activities-month-prev]')?.addEventListener('click', () => {
-      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), -1);
+    const runMonthShift = (delta) => {
+      if (state.activitiesNavLoading) return;
+      const startedAt = Date.now();
+      state.activitiesNavLoading = true;
+      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), delta);
       rerenderLocal();
-    });
-    root.querySelector('[data-activities-month-next]')?.addEventListener('click', () => {
-      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), 1);
-      rerenderLocal();
-    });
+      const minMs = 420;
+      setTimeout(() => {
+        state.activitiesNavLoading = false;
+        rerenderLocal();
+      }, Math.max(0, minMs - (Date.now() - startedAt)));
+    };
+    root.querySelector('[data-activities-month-prev]')?.addEventListener('click', () => runMonthShift(-1));
+    root.querySelector('[data-activities-month-next]')?.addEventListener('click', () => runMonthShift(1));
     root.querySelector(`[data-list-show-more="${ACTIVITIES_SCOPE}"]`)?.addEventListener('click', (ev) => {
       const next = Number(ev.currentTarget?.dataset?.nextCount || 200);
       ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = next;
@@ -665,11 +718,30 @@ export const activitiesScreen = {
       try {
         submit.disabled = true;
         if (statusEl) statusEl.textContent = 'שומר...';
-        await api.addActivity(payload);
+        const rsp = await api.addActivity(payload);
         if (statusEl) statusEl.textContent = 'נשמר בהצלחה';
-        clearScreenDataCache?.();
+        const localRow = {
+          RowID: rsp?.RowID || '',
+          source_sheet: rsp?.source_sheet || (payload.source === 'long' ? 'data_long' : 'data_short'),
+          activity_manager: payload.activity_manager,
+          authority: payload.authority,
+          school: payload.school,
+          activity_type: payload.activity_type,
+          activity_name: payload.activity_name,
+          instructor_name: payload.instructor_name,
+          instructor_name_2: payload.instructor_name_2,
+          emp_id: payload.emp_id,
+          emp_id_2: payload.emp_id_2,
+          start_date: payload.start_date,
+          end_date: payload.Date2 || payload.start_date,
+          status: 'פעיל',
+          private_note: '',
+          meeting_dates: dateInputs.map((input) => String(input.value || '').trim()).filter(Boolean)
+        };
+        if (localRow.RowID) activitiesRows.unshift(localRow);
+        rerenderLocal();
         ui?.closeModal?.();
-        rerender?.();
+        void scheduleQuietRefresh();
       } catch (err) {
         if (statusEl) statusEl.textContent = `שגיאה: ${String(err?.message || '')}`;
       } finally {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -52,6 +52,13 @@ function getStrictNumericField(obj, fieldName) {
   return { ok: true, value: asNumber, fieldName };
 }
 
+function pickNumericFallback(obj, fieldName, fallbackValue = 0) {
+  const strict = getStrictNumericField(obj, fieldName);
+  if (strict.ok) return strict.value;
+  const fromFallback = Number(fallbackValue);
+  return Number.isFinite(fromFallback) ? fromFallback : 0;
+}
+
 const MANAGER_DISPLAY_NAMES = {
   'גיל נאמן':               'מחוז צפון',
   'לינוי שמואל מזרחי':      'מחוז דרום',
@@ -67,7 +74,11 @@ function renderStructuredSummary(summary, ym, byManager) {
   const missingInstrField = getStrictNumericField(summary, 'missing_instructor_count');
   const missingDateField = getStrictNumericField(summary, 'missing_start_date_count');
   const lateEndField = getStrictNumericField(summary, 'late_end_date_count');
+  const exceptionsFromParts = pickNumericFallback(summary, 'missing_instructor_count')
+    + pickNumericFallback(summary, 'missing_start_date_count')
+    + pickNumericFallback(summary, 'late_end_date_count');
   const exceptionsTotalField = getStrictNumericField(summary, 'exceptions_count');
+  const exceptionsTotalResolved = exceptionsTotalField.ok ? exceptionsTotalField.value : exceptionsFromParts;
 
   const activeCurrent = escapeHtml(String(activeCurrentField.ok ? activeCurrentField.value : 'שגיאת מיפוי'));
   const endingCurrent = escapeHtml(String(endingCurrentField.ok ? endingCurrentField.value : 'שגיאת מיפוי'));
@@ -75,7 +86,7 @@ function renderStructuredSummary(summary, ym, byManager) {
   const missingInstr = escapeHtml(String(missingInstrField.ok ? missingInstrField.value : 'שגיאת מיפוי'));
   const missingDate = escapeHtml(String(missingDateField.ok ? missingDateField.value : 'שגיאת מיפוי'));
   const lateEnd = escapeHtml(String(lateEndField.ok ? lateEndField.value : 'שגיאת מיפוי'));
-  const exceptionsTotal = escapeHtml(String(exceptionsTotalField.ok ? exceptionsTotalField.value : 'שגיאת מיפוי'));
+  const exceptionsTotal = escapeHtml(String(exceptionsTotalResolved));
 
   const mappingErrors = [
     activeCurrentField,
@@ -83,8 +94,7 @@ function renderStructuredSummary(summary, ym, byManager) {
     activeNextField,
     missingInstrField,
     missingDateField,
-    lateEndField,
-    exceptionsTotalField
+    lateEndField
   ].filter((field) => !field.ok);
 
   const districtRows = (Array.isArray(byManager) ? byManager : []).filter(
@@ -218,10 +228,11 @@ export const dashboardScreen = {
           .join('')
       : '<p class="ds-muted">אין כרטיסי KPI להצגה.</p>';
 
-    const monthNav = `<div class="ds-dash-month-nav" dir="rtl" aria-label="בחירת חודש לתצוגה">
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-dash-month-prev aria-label="חודש קודם">▶</button>
-      <span class="ds-dash-month-nav__label">${escapeHtml(hebrewMonthTitle(ym))}</span>
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-dash-month-next aria-label="חודש הבא">◀</button>
+    const navLoading = !!state?.dashboardNavLoading;
+    const monthNav = `<div class="ds-dash-month-nav${navLoading ? ' is-nav-loading' : ''}" dir="rtl" aria-label="בחירת חודש לתצוגה">
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-dash-month-prev aria-label="חודש קודם" title="חודש קודם" ${navLoading ? 'disabled' : ''}>▶</button>
+      <span class="ds-dash-month-nav__label">${escapeHtml(hebrewMonthTitle(ym))} ${navLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-dash-month-next aria-label="חודש הבא" title="חודש הבא" ${navLoading ? 'disabled' : ''}>◀</button>
     </div>`;
 
     return dsScreenStack(`
@@ -317,25 +328,32 @@ export const dashboardScreen = {
     }
 
     const applyYm = async (nextYm) => {
+      if (state.dashboardNavLoading) return;
+      const startedAt = Date.now();
+      state.dashboardNavLoading = true;
       state.dashboardMonthYm = nextYm;
       const cacheKey = `dashboard:${/^\d{4}-\d{2}$/.test(nextYm) ? nextYm : 'default'}`;
 
       const cached = state.screenDataCache[cacheKey];
       if (cached?.data && Date.now() - cached.t < DASHBOARD_TTL_MS) {
         rerender();
-        return;
+      } else {
+        showDataAreaLoading();
+        let snapshotLoaded = false;
+        try {
+          const snapshotData = await api.dashboardSnapshot({ month: nextYm });
+          putDashboardCache(cacheKey, snapshotData);
+          snapshotLoaded = true;
+        } catch (_err) {
+          if (!snapshotLoaded) clearScreenDataCache?.();
+        }
+        rerender();
       }
-
-      showDataAreaLoading();
-      let snapshotLoaded = false;
-      try {
-        const snapshotData = await api.dashboardSnapshot({ month: nextYm });
-        putDashboardCache(cacheKey, snapshotData);
-        snapshotLoaded = true;
-      } catch (_err) {
-        if (!snapshotLoaded) clearScreenDataCache?.();
-      }
-      rerender();
+      const minMs = 420;
+      setTimeout(() => {
+        state.dashboardNavLoading = false;
+        rerender();
+      }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
 
     root.querySelector('[data-dash-month-prev]')?.addEventListener('click', () => {

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -319,11 +319,12 @@ export const monthScreen = {
     const currentYm = data?.month || `${y}-${String(mo).padStart(2, '0')}`;
     const monthTitle = monthTitleHebrew(spec);
 
+    const navLoading = !!state.monthNavLoading;
     const html = dsScreenStack(`
-      <nav class="ds-cal-nav" role="navigation" aria-label="ניווט חודשי" dir="rtl">
-        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-month-prev aria-label="חודש קודם">▶</button>
-        <span class="ds-cal-nav__label">${escapeHtml(monthTitle)}</span>
-        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-month-next aria-label="חודש הבא">◀</button>
+      <nav class="ds-cal-nav${navLoading ? ' is-nav-loading' : ''}" role="navigation" aria-label="ניווט חודשי" dir="rtl">
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-month-prev aria-label="חודש קודם" title="חודש קודם" ${navLoading ? 'disabled' : ''}>▶</button>
+        <span class="ds-cal-nav__label">${escapeHtml(monthTitle)} ${navLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-month-next aria-label="חודש הבא" title="חודש הבא" ${navLoading ? 'disabled' : ''}>◀</button>
       </nav>
       ${toolbarHtml}
       ${dsCard({
@@ -430,27 +431,29 @@ export const monthScreen = {
     };
     const prevBtn = root.querySelector('[data-month-prev]');
     const nextBtn = root.querySelector('[data-month-next]');
-    const setMonthAreaLoading = (isLoading) => {
-      root.classList.toggle('is-month-loading', !!isLoading);
-      root.setAttribute('aria-busy', isLoading ? 'true' : 'false');
-      if (prevBtn) prevBtn.disabled = !!isLoading;
-      if (nextBtn) nextBtn.disabled = !!isLoading;
-    };
     const doMonthShift = (delta) => {
+      if (state.monthNavLoading) return;
       const targetYm = shiftMonthYm(resolveBaseYm(), delta);
       const targetKey = monthCacheKey(targetYm);
       const hasCachedTarget = !!state?.screenDataCache?.[targetKey];
+      const startedAt = Date.now();
 
       state.monthYm = targetYm;
+      state.monthNavLoading = true;
       try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
 
       if (hasCachedTarget) {
         rerender?.();
-        return;
+      } else {
+        root.classList.add('is-month-loading');
+        root.setAttribute('aria-busy', 'true');
+        rerender?.();
       }
-
-      setMonthAreaLoading(true);
-      rerender?.();
+      const minMs = 420;
+      setTimeout(() => {
+        state.monthNavLoading = false;
+        rerender?.();
+      }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
     prevBtn?.addEventListener('click', () => { doMonthShift(-1); });
     nextBtn?.addEventListener('click', () => { doMonthShift(1); });

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -147,7 +147,14 @@ function updateMoreDatesToggle(form) {
   syncMeetingRemoveButtons(form);
 }
 
-export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, rerender, onRowSaved }) {
+export function bindActivityEditForm(contentRoot, {
+  api,
+  clearScreenDataCache,
+  rerender,
+  onRowSaved,
+  onSaveSuccess,
+  quietRefresh
+}) {
   if (!api || !contentRoot) return;
 
   if (contentRoot._activityEditAbort) {
@@ -184,8 +191,11 @@ export function bindActivityEditForm(contentRoot, { api, clearScreenDataCache, r
       showToast(canDirectEdit ? '✅ נשמר בהצלחה' : '✅ בקשת העריכה נשלחה לאישור', 'success', 2500);
       if (typeof onRowSaved === 'function') onRowSaved({ sourceSheet, sourceRowId, changes, form });
       setEditMode(form, false);
-      clearScreenDataCache?.();
-      if (typeof rerender === 'function') {
+      if (typeof onSaveSuccess === 'function') {
+        await onSaveSuccess({ sourceSheet, sourceRowId, changes, form });
+      } else if (typeof quietRefresh === 'function') {
+        quietRefresh({ sourceSheet, sourceRowId, changes, form });
+      } else if (typeof rerender === 'function') {
         requestAnimationFrame(() => {
           rerender();
         });

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -257,11 +257,12 @@ export const weekScreen = {
         ? `${Math.abs(weekOffset)} שבועות אחורה${rangeLabel ? ` · ${rangeLabel}` : ''}`
         : `${rangeLabel || 'שבוע'}`;
 
+    const navLoading = !!state.weekNavLoading;
     const html = dsScreenStack(`
-      <nav class="ds-cal-nav" role="navigation" aria-label="ניווט שבועי" dir="rtl">
-        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-prev aria-label="שבוע קודם">▶</button>
-        <span class="ds-cal-nav__label">${escapeHtml(navLabel)}</span>
-        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-next aria-label="שבוע הבא">◀</button>
+      <nav class="ds-cal-nav${navLoading ? ' is-nav-loading' : ''}" role="navigation" aria-label="ניווט שבועי" dir="rtl">
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-prev aria-label="שבוע קודם" title="שבוע קודם" ${navLoading ? 'disabled' : ''}>▶</button>
+        <span class="ds-cal-nav__label">${escapeHtml(navLabel)} ${navLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-next aria-label="שבוע הבא" title="שבוע הבא" ${navLoading ? 'disabled' : ''}>◀</button>
       </nav>
       ${toolbarHtml}
       <div class="ds-week-board" style="--week-cols:${safeDays.length || 7}" role="region" aria-label="לוח שבוע">${body}</div>
@@ -300,12 +301,16 @@ export const weekScreen = {
     const prevBtn = root.querySelector('[data-week-prev]');
     const nextBtn = root.querySelector('[data-week-next]');
     const doWeekShift = (delta) => {
-      if (prevBtn) prevBtn.disabled = true;
-      if (nextBtn) nextBtn.disabled = true;
-      root.classList.add('is-week-loading');
-      root.setAttribute('aria-busy', 'true');
+      if (state.weekNavLoading) return;
+      const startedAt = Date.now();
+      state.weekNavLoading = true;
       state.weekOffset = (state.weekOffset || 0) + delta;
       rerender?.();
+      const minMs = 420;
+      setTimeout(() => {
+        state.weekNavLoading = false;
+        rerender?.();
+      }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
     bindListener(prevBtn, 'click', () => doWeekShift(-1));
     bindListener(nextBtn, 'click', () => doWeekShift(1));

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2350,12 +2350,12 @@ span.ds-chip {
 .ds-cal-nav {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  padding: 6px 8px;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 10px;
   background: #fff;
   border: 1px solid rgba(26, 51, 88, 0.11);
-  border-radius: 12px;
+  border-radius: 14px;
   box-shadow: 0 1px 2px rgba(26, 51, 88, 0.05);
 }
 
@@ -2378,6 +2378,29 @@ span.ds-chip {
   text-overflow: ellipsis;
   white-space: nowrap;
   letter-spacing: 0.01em;
+}
+
+.is-nav-loading .ds-btn--nav-arrow {
+  opacity: 0.72;
+}
+
+.ds-inline-loading-dot {
+  display: inline-block;
+  inline-size: 10px;
+  block-size: 10px;
+  border-radius: 999px;
+  margin-inline-start: 8px;
+  background: rgba(26, 51, 88, 0.22);
+  vertical-align: middle;
+}
+
+.is-inline-loading {
+  animation: dsInlinePulse 0.9s ease-in-out infinite;
+}
+
+@keyframes dsInlinePulse {
+  0%, 100% { transform: scale(0.8); opacity: 0.5; }
+  50% { transform: scale(1); opacity: 1; }
 }
 
 .ds-cal-nav .ds-btn.ds-btn--sm {
@@ -5435,16 +5458,34 @@ select.ds-input {
 
 .ds-activities-screen .ds-table th,
 .ds-activities-screen .ds-table td {
-  padding: 8px 10px;
-  vertical-align: top;
+  padding: 8px 9px;
+  vertical-align: middle;
+  line-height: 1.25;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .ds-activities-screen .ds-table tbody tr:nth-child(even) td {
-  background: #fbfdff;
+  background: #fcfdff;
 }
 
 .ds-activities-screen .ds-table tbody tr:hover td {
-  background: #eef5ff;
+  background: #eef4ff;
+}
+
+.ds-activities-screen .ds-table th {
+  background: #f7f9fc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: #334155;
+  white-space: nowrap;
+}
+
+.ds-activities-row {
+  transition: background-color 0.16s ease;
+}
+
+.ds-activities-row.is-just-saved td {
+  background: #e8f8ec !important;
 }
 
 @media (max-width: 1024px) {
@@ -7241,43 +7282,57 @@ select.ds-input {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(26, 51, 88, 0.12);
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: var(--ds-shadow-xs);
 }
 
 .ds-activities-title-row .ds-activities-page-title {
-  flex: 0 1 auto;
+  flex: 1;
   margin: 0;
   text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: min(72vw, 620px);
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: var(--ds-accent);
 }
 
 /* ——— Activities main toolbar: one-row layout ——— */
 .ds-activities-main-toolbar {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 4px;
-  padding: 5px 8px;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
   background: var(--ds-surface);
-  border: 1px solid var(--ds-border);
-  border-radius: var(--ds-radius-md);
+  border: 1px solid rgba(26, 51, 88, 0.12);
+  border-radius: 14px;
   box-shadow: var(--ds-shadow-xs);
-  overflow-x: auto;
 }
 
 .ds-activities-main-toolbar__actions {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
+}
+
+.ds-activities-main-toolbar__search-wrap {
+  flex: 1 1 260px;
+  min-width: 220px;
+}
+
+.ds-activities-main-toolbar__search-wrap .ds-input {
+  width: 100%;
 }
 
 .ds-btn--activities-action {
-  min-width: 30px;
-  min-height: 30px !important;
-  padding: 4px 7px;
+  min-width: 84px;
+  min-height: 34px !important;
+  padding: 6px 12px;
+  font-weight: 700;
 }
 
 .ds-activities-main-toolbar .ds-cal-nav__label {
@@ -7305,12 +7360,12 @@ select.ds-input {
 
 /* narrow search in main toolbar (35% smaller than base) */
 .ds-activities-search-sm {
-  width: 96px;
-  min-width: 74px;
-  max-width: 120px;
-  flex: 0 0 auto;
-  font-size: 0.74rem;
-  padding: 3px 7px;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+  flex: 1 1 auto;
+  font-size: 0.82rem;
+  padding: 6px 10px;
 }
 
 /* ——— Filter panel: grid-only (no search row) ——— */


### PR DESCRIPTION
### Motivation
- לתקן חוסר התאמה בין המספר המוצג בכרטיס "חריגות" לבין הסיכום החודשי ולהבטיח מקור אמת עקבי לחריגות. 
- לשפר את העיצוב והפריסה של עמוד ה־activities כך שיהיה קומפקטי, קריא ו־RTL‑friendly עם כלי חיפוש/סינון מאורגן. 
- למנוע ריענון מסך מלא ומטריד אחרי שמירה/הוספה ולספק חיווי ניווט קצר וברור בעת מעבר חודש/שבוע/דשבורד. 

### Description
- אחידות חריגות: שיניתי את חישוב החריגות ב־backend כך ש־KPI וה־summary משתמשים בבסיס אחד (sum של `missing_instructor_count + missing_start_date_count + late_end_date_count`) ו'הוספתי שדה `exceptions_count` מפורש ב־`actionDashboard_` כדי לשמור עקביות בכל המקומות (קבצים: `backend/actions.gs`, `backend/dashboard-snapshot.gs`).
- snapshot‑robustness: הוספתי פונקציית fallback `resolveExceptionsCountForDashboard_` ב־snapshot כדי לטפל ב‑snapshots ישנים/חסרים ללא שגיאות מיפוי למשתמש ולוודא מקור אמת יציב בעת קריאה וכתיבה של snapshot (`backend/dashboard-snapshot.gs`).
- UX ופריסה Activities: פרסתי את סרגל החיפוש והפעולות לאזור אחד, הפכתי את כפתור ההוספה לנגיש/קריא, וקיבצתי את הניווט החודשי סביב הכותרת כך שהחיצים קרובים ושייכים לכותרת; עדכנתי סגנונות לטבלה (שורות אחידות, hover עדין, כותרות ברור) (`frontend/src/screens/activities.js`, `frontend/src/styles/main.css`).
- חיווי ניווט אחיד: הוספת תמיכה ב־flags ו־CSS לחיווי קטן בזמן ניווט (`is-nav-loading` / `is-inline-loading`) במסכי dashboard/week/month/activities כולל השהיה מינימלית חזותית 300–700ms כדי לתת פידבק גם מעבורת cache (`frontend/src/screens/dashboard.js`, `frontend/src/screens/week.js`, `frontend/src/screens/month.js`, `frontend/src/styles/main.css`).
- שמירה/הוספה שקטה: השינוי ב־`bind-activity-edit-form` מאפשר callback `onSaveSuccess`/`quietRefresh` כך שאחרי `saveActivity` עושים patch מקומי לשורה ו־UX מיידי (סימון קצר של שורה נשמרה) וביצוע background refresh שקט; לאחר `addActivity` מוסיפים באופן אופטימיסטי שורה מקומית, סוגרים modal רק בהצלחה ומעבירים רענון שקט ברקע במקום rerender כבד (`frontend/src/screens/shared/bind-activity-edit-form.js`, `frontend/src/screens/activities.js`).
- שמירת RTL ותאימות: שמרתי על כיווניות RTL בכל השינויים, הוספתי aria/tooltip/labels לכפתורי ניווט וחיקיתי את המסלולים הקיימים; בדקתי ש־router עדיין מפנה `activities` ל־`actionActivitiesSnapshotFirst_` (לא הוחזר ל־actionActivities_ הישן).

Files changed (עיקריים):
- backend/actions.gs
- backend/dashboard-snapshot.gs
- frontend/src/screens/activities.js
- frontend/src/screens/dashboard.js
- frontend/src/screens/week.js
- frontend/src/screens/month.js
- frontend/src/screens/shared/bind-activity-edit-form.js
- frontend/src/styles/main.css

### Testing
- הרצת יחידות/אינטגרציה: `npm test` — כל הבדיקות עברו בהצלחה (TAP tests green). 
- בדיקות סינטקס: `node --check` על הקבצים ששונו (`activities.js`, `week.js`, `month.js`, `dashboard.js`, `bind-activity-edit-form.js`) — ללא שגיאות. 
- אימות תזרים API/router: וודאתי שה‑router מפנה `activities` ל־`actionActivitiesSnapshotFirst_` (pass).

אם יש צורך אפשר להריץ בדיקות נוספות ידניות מול Google Sheets snapshot רצה כדי לוודא ערכי snapshot ישנים/חדשים בתנאי אמת (הגישה ל־runtime של Sheets נחוצה לבדיקת edge cases ספציפיים של snapshot ישן).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe28f925c832b81fab86483de4b58)