### PR TITLE
Fix activities UI regression, restore instructor fields, and enforce COURSE-only exceptions

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -115,7 +115,10 @@ function rowExceptionTypes_(row) {
 function collectProgramExceptions_(rows, opts) {
   var options = opts || {};
   var ym = text_(options.month || '');
-  var programTypes = configuredProgramActivityTypes_();
+  var includeActivityTypes = Array.isArray(options.include_activity_types)
+    ? options.include_activity_types.map(function(t) { return text_(t); }).filter(function(t) { return !!t; })
+    : ['course'];
+  if (!includeActivityTypes.length) includeActivityTypes = ['course'];
   var includePerTypeRows = options.include_per_type_rows !== false;
   var sourceRows = Array.isArray(rows) ? rows : [];
   var counts = {
@@ -127,7 +130,7 @@ function collectProgramExceptions_(rows, opts) {
   var rowLevelExceptionCount = 0;
 
   sourceRows.forEach(function(row) {
-    if (programTypes.indexOf(text_(row && row.activity_type)) < 0) return;
+    if (includeActivityTypes.indexOf(text_(row && row.activity_type)) < 0) return;
     if (ym && !activityOverlapsYm_(row, ym)) return;
     var types = rowExceptionTypes_(row);
     if (!types.length) return;
@@ -528,7 +531,11 @@ function actionDashboard_(user, payload) {
     }
     if (exceptionTypes.indexOf('late_end_date') >= 0) lateEndDateCount += 1;
   });
-  var exceptionSummary = collectProgramExceptions_(longRows, { month: ym, include_per_type_rows: false });
+  var exceptionSummary = collectProgramExceptions_(longRows, {
+    month: ym,
+    include_activity_types: ['course'],
+    include_per_type_rows: false
+  });
   missingInstructorCount = exceptionSummary.counts.missing_instructor || 0;
   missingStartDateCount = exceptionSummary.counts.missing_start_date || 0;
   lateEndDateCount = exceptionSummary.counts.late_end_date || 0;
@@ -1424,16 +1431,18 @@ function actionMonth_(user, payload) {
 function actionExceptions_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var month = text_((payload && payload.month) || '');
+  var includeActivityTypes = ['course'];
   var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
   var exceptionPayload = collectProgramExceptions_(rows, {
     month: month,
+    include_activity_types: includeActivityTypes,
     include_per_type_rows: true
   });
   var counts = exceptionPayload.counts || {};
   var result = exceptionPayload.rows || [];
   var relevantRows = rows.filter(function(row) {
     return !isExcludedStatusForControl_(row && row.status) &&
-      configuredProgramActivityTypes_().indexOf(text_(row && row.activity_type)) >= 0 &&
+      includeActivityTypes.indexOf(text_(row && row.activity_type)) >= 0 &&
       (!month || activityOverlapsYm_(row, month));
   });
   var missingInstructorExamples = [];

--- a/backend/activities-snapshot.gs
+++ b/backend/activities-snapshot.gs
@@ -76,10 +76,14 @@ function normalizeActivitiesSnapshotRow_(row) {
   var src = row && typeof row === 'object' ? row : {};
   var normalized = {};
   Object.keys(src).forEach(function(key) { normalized[key] = src[key]; });
-  normalized.instructor_name = text_(src.instructor_name || src.Instructor || src.Employee);
-  normalized.instructor_name_2 = text_(src.instructor_name_2 || src.Instructor2);
-  normalized.emp_id = text_(src.emp_id || src.EmployeeID);
-  normalized.emp_id_2 = text_(src.emp_id_2);
+  var instructor1 = text_(src.instructor_name || src.Instructor || src.Employee || src.employee_name || src.employee);
+  var instructor2 = text_(src.instructor_name_2 || src.Instructor2 || src.Employee2 || src.employee_name_2 || src.employee2_name || src.employee2);
+  var emp1 = text_(src.emp_id || src.EmployeeID || src.employee_id);
+  var emp2 = text_(src.emp_id_2 || src.EmployeeID2 || src.employee_id_2);
+  normalized.instructor_name = instructor1;
+  normalized.instructor_name_2 = instructor2;
+  normalized.emp_id = emp1;
+  normalized.emp_id_2 = emp2;
   if (!normalized.source_sheet) {
     var rowId = text_(src.RowID);
     normalized.source_sheet = rowId.indexOf('LONG-') === 0 ? CONFIG.SHEETS.DATA_LONG : CONFIG.SHEETS.DATA_SHORT;

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -319,7 +319,11 @@ export const activitiesScreen = {
     const tableRows = safeRows
       .map((row) => {
         const instructorLine = activityInstructorLine(row, { hideEmpIds });
-        const instructorDisplay = instructorLine || 'ללא מדריך';
+        const instructorDisplay = instructorLine
+          ? `<span class="ds-activities-instructor-name">${escapeHtml(instructorLine)}</span>`
+          : '<span class="ds-chip ds-chip--status ds-chip--warn ds-chip--instructor-empty">ללא מדריך</span>';
+        const activityTypeLabel = escapeHtml(visibleActivityCategoryLabel(row.activity_type));
+        const activityName = escapeHtml(row.activity_name || '—');
         const startHe = formatDateHe(row.start_date) || '—';
         const endRaw = String(row?.end_date || '').trim() || String(row?.start_date || '').trim();
         const endHe = endRaw ? formatDateHe(endRaw) || '—' : '—';
@@ -341,12 +345,12 @@ export const activitiesScreen = {
           .join(' ');
         return `
       <tr class="ds-data-row ds-activities-row" data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="" data-row-id="${escapeHtml(row.RowID)}">
-        <td><strong>${escapeHtml(row.activity_name || '—')}</strong><div class="ds-row-subtle">${escapeHtml(visibleActivityCategoryLabel(row.activity_type))}</div></td>
-        <td>${escapeHtml(row.authority || '—')}</td>
-        <td>${escapeHtml(row.school || '—')}</td>
-        <td>${escapeHtml(instructorDisplay)}</td>
-        <td>${escapeHtml(startHe)}</td>
-        <td>${escapeHtml(endHe)}</td>
+        <td class="ds-activities-col ds-activities-col--program"><div class="ds-activities-program-cell"><strong class="ds-activities-program-name">${activityName}</strong><span class="ds-chip ds-chip--status ds-chip--neutral ds-activities-type-badge">${activityTypeLabel}</span></div></td>
+        <td class="ds-activities-col ds-activities-col--authority">${escapeHtml(row.authority || '—')}</td>
+        <td class="ds-activities-col ds-activities-col--school">${escapeHtml(row.school || '—')}</td>
+        <td class="ds-activities-col ds-activities-col--instructor">${instructorDisplay}</td>
+        <td class="ds-activities-col ds-activities-col--date">${escapeHtml(startHe)}</td>
+        <td class="ds-activities-col ds-activities-col--date">${escapeHtml(endHe)}</td>
         ${canSeePrivateNotes ? `<td>${escapeHtml(row.private_note || '')}</td>` : ''}
       </tr>
     `;
@@ -359,7 +363,8 @@ export const activitiesScreen = {
     const centralOptions = getFilterOptionOverrides(state?.clientSettings || {});
     const toolbarHtml = filtersToolbarHtml(ACTIVITIES_SCOPE, filteredRows, state, {
       filterFields: ACTIVITY_FILTER_FIELDS,
-      layout: 'panel',
+      search: false,
+      clear: false,
       optionsOverrides: { ...centralOptions, funding: fundingOptions }
     });
     const loadMoreHtml = hasMore
@@ -369,7 +374,16 @@ export const activitiesScreen = {
     const tableSection =
       safeRows.length === 0
         ? dsEmptyState('לא נמצאו פעילויות')
-        : dsTableWrap(`<table class="ds-table ds-table--interactive">
+        : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--activities-list" dir="rtl">
+                <colgroup>
+                  <col class="ds-activities-col--program">
+                  <col class="ds-activities-col--authority">
+                  <col class="ds-activities-col--school">
+                  <col class="ds-activities-col--instructor">
+                  <col class="ds-activities-col--date">
+                  <col class="ds-activities-col--date">
+                  ${canSeePrivateNotes ? '<col>' : ''}
+                </colgroup>
                 <thead><tr><th>תוכנית / סוג</th><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך התחלה</th><th>תאריך סיום</th>${thPrivate}</tr></thead>
                 <tbody>${tableRows}</tbody>
               </table>`) + loadMoreHtml;

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -98,7 +98,7 @@ export const exceptionsScreen = {
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const toolbarHtml = filtersToolbarHtml(EXCEPTIONS_SCOPE, allRows, state, {
       filterFields: EXCEPTION_FILTER_FIELDS,
-      searchPlaceholder: 'חיפוש חריגות…',
+      searchPlaceholder: 'חיפוש חריגות קורסים…',
       optionsOverrides: getFilterOptionOverrides(state?.clientSettings || {})
     });
     const loadMoreHtml = hasMore
@@ -132,7 +132,7 @@ export const exceptionsScreen = {
     return dsScreenStack(`
       ${toolbarHtml}
       ${dsCard({
-        title: `חריגות${data?.month ? ` · ${escapeHtml(data.month)}` : ''} · ${total}`,
+        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(data.month)}` : ''} · ${total}`,
         body: compact,
         padded: visibleRows.length === 0
       })}

--- a/frontend/src/screens/shared/act-nav-grid.js
+++ b/frontend/src/screens/shared/act-nav-grid.js
@@ -62,7 +62,6 @@ export function headerNavGridHtml(state) {
         data-route="${escapeHtml(item.route)}"
         dir="rtl"
       >
-        <span class="ds-act-nav-item__icon" aria-hidden="true">${item.icon}</span>
         <span class="ds-act-nav-item__label">${escapeHtml(item.label)}</span>
       </button>`
     )

--- a/frontend/src/screens/shared/activity-list-filters.js
+++ b/frontend/src/screens/shared/activity-list-filters.js
@@ -121,6 +121,7 @@ export function filtersToolbarHtml(scope, rows, state, config = {}) {
   }
 
   const showSearch = config.search !== false;
+  const showClear = config.clear !== false;
   const searchPlaceholder = config.searchPlaceholder || 'חיפוש…';
 
   const isPanel = config.layout === 'panel';
@@ -135,7 +136,7 @@ export function filtersToolbarHtml(scope, rows, state, config = {}) {
   return `<div class="ds-toolbar ds-toolbar--filters-inline" dir="rtl" data-local-filters="${escapeHtml(scope)}">
     ${showSearch ? `<input type="search" class="ds-input ds-input--sm ds-filter-search-sm" data-filter-search="${escapeHtml(scope)}" value="${escapeHtml(filters.q || '')}" placeholder="${escapeHtml(searchPlaceholder)}" />` : ''}
     ${filterFields.map((field) => selectInlineHtml(scope, field, filters, optionsMap)).join('')}
-    <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-filter-clear="${escapeHtml(scope)}">ניקוי</button>
+    ${showClear ? `<button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-filter-clear="${escapeHtml(scope)}">ניקוי</button>` : ''}
   </div>`;
 }
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7641,6 +7641,99 @@ select.ds-activity-add-field .ds-input,
   padding: 6px;
   gap: 6px;
 }
+
+/* ===== Regression fix: compact activities UI + clean header nav ===== */
+.ds-act-nav-item--header {
+  min-height: 30px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  font-size: 0.65rem;
+}
+
+.ds-act-nav-grid--header .ds-act-nav-item__icon {
+  display: none;
+}
+
+.ds-activities-screen {
+  gap: 8px;
+}
+
+.ds-activities-main-toolbar {
+  flex-wrap: nowrap;
+  gap: 6px;
+  padding: 6px 8px;
+}
+
+.ds-activities-main-toolbar__search-wrap .ds-input,
+.ds-activities-main-toolbar__actions .ds-btn {
+  min-height: 32px;
+}
+
+.ds-toolbar--filters-inline {
+  flex-wrap: nowrap;
+  gap: 6px;
+  padding: 6px 8px;
+  border: 1px solid rgba(26, 51, 88, 0.12);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.ds-filter-select-inline {
+  width: 132px;
+  min-width: 132px;
+  max-width: 132px;
+}
+
+.ds-table--activities-list {
+  table-layout: fixed;
+}
+
+.ds-table--activities-list .ds-activities-col--program {
+  width: 28%;
+}
+.ds-table--activities-list .ds-activities-col--authority,
+.ds-table--activities-list .ds-activities-col--school,
+.ds-table--activities-list .ds-activities-col--instructor {
+  width: 16%;
+}
+.ds-table--activities-list .ds-activities-col--date {
+  width: 12%;
+}
+
+.ds-table--activities-list th {
+  text-align: right;
+  font-size: 0.72rem;
+  font-weight: 800;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.18);
+}
+
+.ds-table--activities-list td {
+  text-align: right;
+  padding-block: 6px;
+}
+
+.ds-activities-program-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.ds-activities-program-name {
+  font-weight: 700;
+}
+
+.ds-activities-type-badge {
+  width: fit-content;
+  min-height: 20px;
+  font-size: 0.63rem;
+  padding: 1px 8px;
+}
+
+.ds-chip--instructor-empty {
+  min-height: 20px;
+  font-size: 0.62rem;
+  padding: 1px 8px;
+}
 .ds-cal-weekdays,
 .ds-cal-grid {
   gap: 6px;


### PR DESCRIPTION
### Motivation
- לתקן רגרסיה שנכנסה לאחר מיזוגים אחרונים שגרמה לחזרת אימוג׳ים בסרגל העליון, לשורת חיפוש/סינונים ישנה ולמראה טבלאי גולמי בעמוד ה־Activities תוך שמירה על נתיב ה־snapshot-first (`actionActivitiesSnapshotFirst_`).
- להחזיר את הצגת המדריכים כך ששמות ו־`emp_id` ישמרו ב‑payload ולא יוחלפו ב־"ללא מדריך" באופן גורף. 
- לאכוף את כללחריגות העסקי: לדווח ולהציג רק חריגות מסוג `course` ברמת ה־backend ולא רק בפרונט.

### Description
- Frontend: עדכון `frontend/src/screens/shared/act-nav-grid.js` להסרת תצוגת האייקון בסרגל העליון כדי להחזיר כפתורים טקסטואליים נקיים, ושדרוג `frontend/src/screens/activities.js` ל‑markup קומפקטי עם `colgroup`, badges למין/תוכנית ו‑badge קטן ל־"ללא מדריך" רק כ‑fallback; שינויים נלווים ב־`frontend/src/screens/shared/activity-list-filters.js` כדי לאפשר `search: false`/`clear: false` ו־`frontend/src/screens/exceptions.js` כדי לשנות את הכותרת/placeholder ל־"חריגות קורסים".
- CSS: הוספת חוקים ב־`frontend/src/styles/main.css` שמחזקים את העיצוב הקומפקטי של שורת החיפוש/פעולות, מאחדים את סינונים, מסתירים אייקונים ב‑header ונותנים רוחבי עמודות קבועים (`table-layout: fixed`) עבור טבלת הפעילויות.
- Backend: ב־`backend/activities-snapshot.gs` הוספתי נרמול alias לשדות מדריך/מזהים (לדוגמה `Employee2`, `EmployeeID2`, `employee_name_*`) כדי להבטיח ש־`instructor_name`, `instructor_name_2`, `emp_id`, `emp_id_2` יהיו קיימים ב‑snapshot גם כש המקור השתמש בשמות ישנים.
- Exceptions rule: ב־`backend/actions.gs` שיניתי את `collectProgramExceptions_` כך שברירת המחדל היא `['course']` ושהיא מקבלת פרמטר `include_activity_types`, ועדכנתי את `actionExceptions_` (וגם נקודות סיכום בדשבורד) לקרוא/לסנן עם `include_activity_types: ['course']` כדי להבטיח שהחריגות הן COURSE בלבד.
- קבצים שעודכנו: `backend/actions.gs`, `backend/activities-snapshot.gs`, `frontend/src/screens/activities.js`, `frontend/src/screens/exceptions.js`, `frontend/src/screens/shared/act-nav-grid.js`, `frontend/src/screens/shared/activity-list-filters.js`, `frontend/src/styles/main.css`.

### Testing
- הרצתי את המבחנים האוטומטיים עם `npm test` והכל עבר בהצלחה (`19 tests`, `0 failed`).
- ניסיתי להריץ `npm run build` אך הריפו אינו מכיל סקריפט `build`, ולכן הבנייה לא רצה (שגיאה עקב היעדר הסקריפט, לא שגיאת קומפילציה מקוד השינויים).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effc5a27e8832bbb82af1e68026579)