### PR TITLE
Fix activities instructor resolution and tighten activities table/nav layout

### DIFF
--- a/backend/activities-snapshot.gs
+++ b/backend/activities-snapshot.gs
@@ -77,9 +77,9 @@ function normalizeActivitiesSnapshotRow_(row) {
   var normalized = {};
   Object.keys(src).forEach(function(key) { normalized[key] = src[key]; });
   var instructor1 = text_(src.instructor_name || src.Instructor || src.Employee || src.employee_name || src.employee);
-  var instructor2 = text_(src.instructor_name_2 || src.Instructor2 || src.Employee2 || src.employee_name_2 || src.employee2_name || src.employee2);
-  var emp1 = text_(src.emp_id || src.EmployeeID || src.employee_id);
-  var emp2 = text_(src.emp_id_2 || src.EmployeeID2 || src.employee_id_2);
+  var instructor2 = text_(src.instructor_name_2 || src.Instructor2 || src.Employee2 || src.employee_name_2 || src.employee2_name || src.employee2 || src.employee_2 || src.instructor2);
+  var emp1 = text_(src.emp_id || src.EmployeeID || src.employee_id || src.employeeId || src.empId);
+  var emp2 = text_(src.emp_id_2 || src.EmployeeID2 || src.EmployeeID_2 || src.employee_id_2 || src.employee_id2 || src.employeeId2 || src.empId2);
   normalized.instructor_name = instructor1;
   normalized.instructor_name_2 = instructor2;
   normalized.emp_id = emp1;
@@ -89,6 +89,29 @@ function normalizeActivitiesSnapshotRow_(row) {
     normalized.source_sheet = rowId.indexOf('LONG-') === 0 ? CONFIG.SHEETS.DATA_LONG : CONFIG.SHEETS.DATA_SHORT;
   }
   return normalized;
+}
+
+
+
+function activitiesInstructorCoverageStats_(rows) {
+  var list = Array.isArray(rows) ? rows : [];
+  var total = list.length;
+  var withInstructorName = 0;
+  var withEmpId = 0;
+  var missingInstructor = 0;
+  list.forEach(function(row) {
+    var hasName = !!(text_(row && row.instructor_name) || text_(row && row.instructor_name_2));
+    var hasEmp = !!(text_(row && row.emp_id) || text_(row && row.emp_id_2));
+    if (hasName) withInstructorName++;
+    if (hasEmp) withEmpId++;
+    if (!hasName && !hasEmp) missingInstructor++;
+  });
+  return {
+    total: total,
+    with_instructor_name: withInstructorName,
+    with_emp_id: withEmpId,
+    missing_instructor: missingInstructor
+  };
 }
 
 function filterActivitiesSnapshotRows_(rows, payload) {
@@ -154,13 +177,33 @@ function actionActivitiesSnapshotFirst_(user, payload) {
   var counts = parseActivitiesSnapshotJson_(snap.activity_type_counts_json, {});
   var rows = parseActivitiesSnapshotJson_(snap.rows_json, []).map(normalizeActivitiesSnapshotRow_);
   var filtered = filterActivitiesSnapshotRows_(rows, payload || {});
+  var snapStats = activitiesInstructorCoverageStats_(filtered);
+
+  if (filtered.length && snapStats.missing_instructor === filtered.length) {
+    var fallbackAllMissing = actionActivitiesLegacy_(user, payload || {});
+    var fallbackRowsMissing = Array.isArray(fallbackAllMissing.rows) ? fallbackAllMissing.rows : [];
+    var fallbackStatsMissing = activitiesInstructorCoverageStats_(fallbackRowsMissing);
+    if (fallbackStatsMissing.missing_instructor < snapStats.missing_instructor) {
+      try { refreshActivitiesSnapshot_(); } catch (_refreshErrAllMissing) {}
+      fallbackAllMissing._is_snapshot = false;
+      fallbackAllMissing._activities_fallback_used = true;
+      fallbackAllMissing._snapshot_fallback_reason = 'snapshot_missing_instructor';
+      fallbackAllMissing._snapshot_instructor_stats = {
+        snapshot: snapStats,
+        fallback: fallbackStatsMissing
+      };
+      return fallbackAllMissing;
+    }
+  }
+
   return {
     activity_type_counts: counts,
     rows: filtered,
     can_add_activity: true,
     _is_snapshot: true,
     _activities_fallback_used: false,
-    _snapshot_updated_at: text_(snap.updated_at)
+    _snapshot_updated_at: text_(snap.updated_at),
+    _snapshot_instructor_stats: { snapshot: snapStats }
   };
 }
 

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -56,19 +56,26 @@ const ACTIVITY_SEARCH_FIELDS = [
 ];
 
 /** שם תצוגה למדריך/ים — כולל כינויים מה־API ומ־normalizeData (Employee וכו'). */
-function activityInstructorLine(row, opts = {}) {
+function activityInstructorMeta(row, opts = {}) {
   const hideEmpIds = !!opts.hideEmpIds;
   const n1 = String(row?.instructor_name ?? row?.Instructor ?? row?.Employee ?? '').trim();
-  const n2 = String(row?.instructor_name_2 ?? row?.Instructor2 ?? '').trim();
-  const parts = [n1, n2].filter(Boolean);
-  if (parts.length) return parts.join(' · ');
-  if (!hideEmpIds) {
-    const e1 = String(row?.emp_id ?? row?.EmployeeID ?? '').trim();
-    const e2 = String(row?.emp_id_2 ?? '').trim();
-    const empParts = [e1, e2].filter(Boolean);
-    if (empParts.length) return empParts.join(' · ');
+  const n2 = String(row?.instructor_name_2 ?? row?.Instructor2 ?? row?.Employee2 ?? '').trim();
+  const names = [n1, n2].filter(Boolean);
+  const e1 = String(row?.emp_id ?? row?.EmployeeID ?? row?.employee_id ?? '').trim();
+  const e2 = String(row?.emp_id_2 ?? row?.EmployeeID2 ?? row?.employee_id_2 ?? '').trim();
+  const empIds = [e1, e2].filter(Boolean);
+  if (names.length) {
+    return { text: names.join(' · '), hasInstructor: true, hasName: true, hasEmpId: empIds.length > 0 };
   }
-  return '';
+  if (empIds.length) {
+    return {
+      text: hideEmpIds ? 'מדריך משויך' : empIds.join(' · '),
+      hasInstructor: true,
+      hasName: false,
+      hasEmpId: true
+    };
+  }
+  return { text: '', hasInstructor: false, hasName: false, hasEmpId: false };
 }
 
 const FAMILY_LABEL_SHORT = 'חד-יומיות';
@@ -318,9 +325,9 @@ export const activitiesScreen = {
 
     const tableRows = safeRows
       .map((row) => {
-        const instructorLine = activityInstructorLine(row, { hideEmpIds });
-        const instructorDisplay = instructorLine
-          ? `<span class="ds-activities-instructor-name">${escapeHtml(instructorLine)}</span>`
+        const instructorMeta = activityInstructorMeta(row, { hideEmpIds });
+        const instructorDisplay = instructorMeta.hasInstructor
+          ? `<span class="ds-activities-instructor-name${instructorMeta.hasName ? '' : ' is-derived'}">${escapeHtml(instructorMeta.text)}</span>`
           : '<span class="ds-chip ds-chip--status ds-chip--warn ds-chip--instructor-empty">ללא מדריך</span>';
         const activityTypeLabel = escapeHtml(visibleActivityCategoryLabel(row.activity_type));
         const activityName = escapeHtml(row.activity_name || '—');
@@ -345,12 +352,12 @@ export const activitiesScreen = {
           .join(' ');
         return `
       <tr class="ds-data-row ds-activities-row" data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="" data-row-id="${escapeHtml(row.RowID)}">
-        <td class="ds-activities-col ds-activities-col--program"><div class="ds-activities-program-cell"><strong class="ds-activities-program-name">${activityName}</strong><span class="ds-chip ds-chip--status ds-chip--neutral ds-activities-type-badge">${activityTypeLabel}</span></div></td>
-        <td class="ds-activities-col ds-activities-col--authority">${escapeHtml(row.authority || '—')}</td>
-        <td class="ds-activities-col ds-activities-col--school">${escapeHtml(row.school || '—')}</td>
-        <td class="ds-activities-col ds-activities-col--instructor">${instructorDisplay}</td>
-        <td class="ds-activities-col ds-activities-col--date">${escapeHtml(startHe)}</td>
-        <td class="ds-activities-col ds-activities-col--date">${escapeHtml(endHe)}</td>
+        <td class="ds-activities-col ds-activities-col--program"><div class="ds-activities-program-cell"><strong class="ds-activities-program-name" title="${activityName}">${activityName}</strong><span class="ds-activities-program-type" title="${activityTypeLabel}">${activityTypeLabel}</span></div></td>
+        <td class="ds-activities-col ds-activities-col--authority"><span class="ds-activities-cell-ellipsis" title="${escapeHtml(row.authority || '—')}">${escapeHtml(row.authority || '—')}</span></td>
+        <td class="ds-activities-col ds-activities-col--school"><span class="ds-activities-cell-ellipsis" title="${escapeHtml(row.school || '—')}">${escapeHtml(row.school || '—')}</span></td>
+        <td class="ds-activities-col ds-activities-col--instructor"><div class="ds-activities-instructor-wrap">${instructorDisplay}</div></td>
+        <td class="ds-activities-col ds-activities-col--date"><time class="ds-activities-date">${escapeHtml(startHe)}</time></td>
+        <td class="ds-activities-col ds-activities-col--date"><time class="ds-activities-date">${escapeHtml(endHe)}</time></td>
         ${canSeePrivateNotes ? `<td>${escapeHtml(row.private_note || '')}</td>` : ''}
       </tr>
     `;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7821,3 +7821,120 @@ select.ds-activity-add-field .ds-input,
   font-size: 0.56rem;
   padding: 2px 5px;
 }
+
+
+/* ===== Activities hard-fix: compact symmetric table + compact header nav ===== */
+.shell-header-nav.ds-act-nav-grid--header {
+  gap: 4px;
+  padding: 0;
+}
+
+.shell-header-nav.ds-act-nav-grid--header .ds-act-nav-item--header {
+  min-height: 24px;
+  height: 24px;
+  padding: 1px 6px;
+  border-radius: 7px;
+  font-size: 0.56rem;
+  line-height: 1;
+  gap: 0;
+}
+
+.shell-header-nav.ds-act-nav-grid--header .ds-act-nav-item__icon {
+  display: none;
+}
+
+.ds-table--activities-list {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.ds-table--activities-list col.ds-activities-col--program { width: 30%; }
+.ds-table--activities-list col.ds-activities-col--authority { width: 15%; }
+.ds-table--activities-list col.ds-activities-col--school { width: 20%; }
+.ds-table--activities-list col.ds-activities-col--instructor { width: 18%; }
+.ds-table--activities-list col.ds-activities-col--date { width: 8.5%; }
+
+.ds-table--activities-list th,
+.ds-table--activities-list td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ds-table--activities-list th {
+  padding: 6px 8px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  background: #f4f7fb;
+  border-bottom: 1px solid rgba(26, 51, 88, 0.18);
+}
+
+.ds-table--activities-list td {
+  padding: 4px 8px;
+  height: 34px;
+  line-height: 1.15;
+}
+
+.ds-activities-cell-ellipsis {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ds-activities-program-cell {
+  min-width: 0;
+  gap: 1px;
+}
+
+.ds-activities-program-name {
+  display: block;
+  font-size: 0.79rem;
+  font-weight: 800;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ds-activities-program-type {
+  display: block;
+  font-size: 0.64rem;
+  color: #64748b;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ds-activities-instructor-wrap {
+  min-width: 0;
+}
+
+.ds-activities-instructor-name {
+  display: inline-block;
+  max-width: 100%;
+  font-size: 0.74rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ds-activities-instructor-name.is-derived {
+  font-size: 0.68rem;
+  color: #64748b;
+}
+
+.ds-chip--instructor-empty {
+  min-height: 16px;
+  font-size: 0.58rem;
+  padding: 0 6px;
+  border-radius: 999px;
+}
+
+.ds-activities-date {
+  display: block;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  direction: ltr;
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "sw.js",
   "type": "module",
   "scripts": {
-    "test": "node --test tests/interactions.test.mjs"
+    "test": "node --test tests/*.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { activitiesScreen } from '../frontend/src/screens/activities.js';
+import fs from 'node:fs';
+
+function baseState() {
+  return {
+    activitiesMonthYm: '2026-04',
+    user: { display_role: 'admin', can_add_activity: true },
+    clientSettings: { hide_emp_id_on_screens: true, dropdown_options: {} },
+    activityListFilters: {},
+    screenDataCache: {}
+  };
+}
+
+test('activities render: emp_id without name does not show "ללא מדריך"', () => {
+  const data = {
+    rows: [{
+      RowID: 'SHORT-1',
+      activity_name: 'תכנית בדיקה',
+      activity_type: 'workshop',
+      authority: 'רשות א',
+      school: 'בית ספר א',
+      start_date: '2026-04-01',
+      end_date: '2026-04-02',
+      emp_id: 'EMP-77',
+      instructor_name: '',
+      emp_id_2: '',
+      instructor_name_2: ''
+    }]
+  };
+  const html = activitiesScreen.render(data, { state: baseState() });
+  assert.match(html, /מדריך משויך/);
+  assert.doesNotMatch(html, /ללא מדריך/);
+});
+
+test('activities render: truly missing instructor shows "ללא מדריך"', () => {
+  const data = {
+    rows: [{
+      RowID: 'SHORT-2',
+      activity_name: 'תכנית בדיקה 2',
+      activity_type: 'workshop',
+      authority: 'רשות ב',
+      school: 'בית ספר ב',
+      start_date: '2026-04-01',
+      end_date: '2026-04-02',
+      emp_id: '',
+      instructor_name: '',
+      emp_id_2: '',
+      instructor_name_2: ''
+    }]
+  };
+  const html = activitiesScreen.render(data, { state: baseState() });
+  assert.match(html, /ללא מדריך/);
+});
+
+test('activities css includes fixed proportional column widths', () => {
+  const css = fs.readFileSync('frontend/src/styles/main.css', 'utf8');
+  assert.match(css, /ds-activities-col--program \{ width: 30%/);
+  assert.match(css, /ds-activities-col--authority \{ width: 15%/);
+  assert.match(css, /ds-activities-col--school \{ width: 20%/);
+  assert.match(css, /ds-activities-col--instructor \{ width: 18%/);
+  assert.match(css, /ds-activities-col--date \{ width: 8\.5%/);
+});


### PR DESCRIPTION
### Motivation
- Activities was showing `ללא מדריך` broadly because snapshot rows sometimes lacked instructor aliases and the frontend treated hidden `emp_id` as absent instructor. 
- The goal was to ensure the activities screen only shows `ללא מדריך` when the source actually has no instructor, and to make the activities table symmetric and compact.
- Keep snapshot-first behavior but detect and recover when the snapshot is the source of the missing-instructor regression.

### Description
- Backend: expanded aliases in `normalizeActivitiesSnapshotRow_` to accept additional inventoried variants of instructor/employee fields and added `activitiesInstructorCoverageStats_` to compute per-payload instructor coverage. 
- Backend: updated `actionActivitiesSnapshotFirst_` to compare snapshot coverage vs legacy full read and fall back to the legacy payload (and best-effort `refreshActivitiesSnapshot_()`) when the snapshot shows pathological missing-instructor coverage, while still returning metadata (`_snapshot_instructor_stats`, `_snapshot_fallback_reason`).
- Frontend: replaced instructor formatter with `activityInstructorMeta` so the UI shows names when present, shows a small `מדריך משויך` label when only `emp_id` exists (and IDs are hidden), and shows `ללא מדריך` only when both names and emp IDs are missing. 
- Markup/CSS: tightened activities row markup (emphasized activity name, smaller type line, ellipsis wrappers, `<time>` for dates) and appended a scoped CSS block enforcing `table-layout: fixed` and the exact column widths (30% / 15% / 20% / 18% / 8.5% / 8.5%), compact uniform row height and compact header-nav buttons.
- Tests/config: added `tests/activities-screen.test.mjs` and changed `npm test` to run `tests/*.test.mjs`.

### Testing
- Ran `npm test` (now runs `tests/*.test.mjs`) and all tests passed (22 assertions across suites, new activities tests included). 
- Ran `node --check frontend/src/screens/activities.js` with no syntax errors. 
- Verified there are no conflict markers in repository files via `rg` search. 
- Confirmed route still uses snapshot-first: `activities` -> `actionActivitiesSnapshotFirst_`. 
- Inspected local source-of-truth payload and computed instructor coverage: `total=6`, `with_instructor_name=0`, `with_emp_id=0`, `missing_instructor=6`, and added per-response `_snapshot_instructor_stats` to surface this data; fallback logic triggers a legacy fetch and best-effort `refreshActivitiesSnapshot_()` when snapshot coverage is worse than legacy. 
- Verified UI behavior with unit tests: row with `emp_id` but no name does not render `ללא מדריך`, a truly missing-instructor row does render `ללא מדריך`, and CSS contains the fixed proportional column widths (all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0188216dc832bbf716f09e74e0808)