### PR TITLE
Consistent dashboard/exceptions (force_full snapshot) and faster month navigation

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -173,6 +173,39 @@ function collectProgramExceptions_(rows, opts) {
   };
 }
 
+function computeCourseExceptionsModel_(rows, ym, opts) {
+  var options = opts || {};
+  var includeRows = options.include_rows === true;
+  var sourceRows = Array.isArray(rows) ? rows : [];
+  var month = text_(ym || '');
+  var payload = collectProgramExceptions_(sourceRows, {
+    month: month,
+    include_activity_types: ['course'],
+    include_per_type_rows: includeRows
+  });
+  var relevantRows = sourceRows.filter(function(row) {
+    if (text_(row && row.activity_type) !== 'course') return false;
+    if (month && !activityOverlapsYm_(row, month)) return false;
+    return !isExcludedStatusForControl_(row && row.status);
+  });
+  var byManagerExceptionInstances = {};
+  relevantRows.forEach(function(row) {
+    var manager = text_(row && row.activity_manager) || 'unassigned';
+    var exceptionsForRow = rowExceptionTypes_(row).length;
+    if (!exceptionsForRow) return;
+    byManagerExceptionInstances[manager] = (byManagerExceptionInstances[manager] || 0) + exceptionsForRow;
+  });
+
+  return {
+    month: month,
+    counts: payload.counts || {},
+    rows: payload.rows || [],
+    total_exception_instances: payload.total_exception_instances || 0,
+    total_exception_rows: payload.total_exception_rows || 0,
+    by_manager_exception_instances: byManagerExceptionInstances
+  };
+}
+
 function primaryExceptionForRow_(row) {
   var types = rowExceptionTypes_(row);
   if (!types.length) return '';
@@ -452,12 +485,8 @@ function actionDashboard_(user, payload) {
       managerFinanceOpen[manager] += 1;
     }
 
-    if (programTypes.indexOf(t) >= 0) {
-      if (activityOverlapsYm_(row, ym)) {
-        var rowExceptionsCount = rowExceptionTypes_(row).length;
-        if (rowExceptionsCount > 0) managerExceptions[manager] += rowExceptionsCount;
-      }
-      if (t === 'course' && text_(row.end_date).slice(0, 7) === ym) managerCourseEndings[manager] += 1;
+    if (programTypes.indexOf(t) >= 0 && t === 'course' && text_(row.end_date).slice(0, 7) === ym) {
+      managerCourseEndings[manager] += 1;
     }
 
     if (activityOverlapsYm_(row, ym) && isActivityActiveBySpec_(row, dashboardRefIso)) {
@@ -531,15 +560,12 @@ function actionDashboard_(user, payload) {
     }
     if (exceptionTypes.indexOf('late_end_date') >= 0) lateEndDateCount += 1;
   });
-  var exceptionSummary = collectProgramExceptions_(longRows, {
-    month: ym,
-    include_activity_types: ['course'],
-    include_per_type_rows: false
-  });
+  var exceptionSummary = computeCourseExceptionsModel_(longRows, ym, { include_rows: false });
   missingInstructorCount = exceptionSummary.counts.missing_instructor || 0;
   missingStartDateCount = exceptionSummary.counts.missing_start_date || 0;
   lateEndDateCount = exceptionSummary.counts.late_end_date || 0;
   var exceptionSum = exceptionSummary.total_exception_instances || 0;
+  managerExceptions = exceptionSummary.by_manager_exception_instances || {};
 
 
   var shortActivitiesByType = {};
@@ -1431,18 +1457,13 @@ function actionMonth_(user, payload) {
 function actionExceptions_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var month = text_((payload && payload.month) || '');
-  var includeActivityTypes = ['course'];
   var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
-  var exceptionPayload = collectProgramExceptions_(rows, {
-    month: month,
-    include_activity_types: includeActivityTypes,
-    include_per_type_rows: true
-  });
+  var exceptionPayload = computeCourseExceptionsModel_(rows, month, { include_rows: true });
   var counts = exceptionPayload.counts || {};
   var result = exceptionPayload.rows || [];
   var relevantRows = rows.filter(function(row) {
     return !isExcludedStatusForControl_(row && row.status) &&
-      includeActivityTypes.indexOf(text_(row && row.activity_type)) >= 0 &&
+      text_(row && row.activity_type) === 'course' &&
       (!month || activityOverlapsYm_(row, month));
   });
   var missingInstructorExamples = [];

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -187,6 +187,24 @@ function getDashboardSnapshotFlags_() {
   return flags;
 }
 
+function getDashboardSnapshotFreshness_(controlMap) {
+  var map = controlMap && typeof controlMap === 'object' ? controlMap : readDashboardRefreshControlMap_();
+  var status = text_(map.last_status).toLowerCase();
+  var controlVersion = text_(map.data_views_version);
+  var currentVersion = dataViewsCacheVersion_();
+  var hasVersion = !!controlVersion;
+  var versionMatch = hasVersion && controlVersion === currentVersion;
+  var isPendingLike = !status || status === 'pending' || status === 'stale' || status === 'missing';
+  var fresh = status === 'ok' && versionMatch;
+  return {
+    fresh: fresh,
+    status: status || 'missing',
+    control_version: controlVersion,
+    current_version: currentVersion,
+    reason: !hasVersion ? 'missing_version' : (isPendingLike ? ('status_' + (status || 'missing')) : (versionMatch ? '' : 'version_mismatch'))
+  };
+}
+
 function parseJsonObjectSafeForDashboard_(raw, fallback) {
   if (raw === null || raw === undefined) return fallback;
   if (typeof raw === 'object' && !Array.isArray(raw)) return raw;
@@ -366,6 +384,37 @@ function actionDashboardSnapshot_(user, payload) {
 
   var ym = dashboardPayloadYm_(payload || {});
   var nextYm = shiftYm_(ym, 1);
+
+  if (payload && payload.force_full === true) {
+    var forcedData = actionDashboard_(user, payload);
+    if (forcedData && typeof forcedData === 'object') forcedData._is_snapshot = false;
+    setRequestPerfField_('dashboard_used_view', false);
+    setRequestPerfField_('dashboard_cache_hit', false);
+    setRequestPerfField_('dashboard_fallback_used', true);
+    setRequestPerfField_('dashboard_view_rows_read', 0);
+    setRequestPerfField_('payload_bytes', JSON.stringify(forcedData || {}).length);
+    markRequestPerf_('dashboard:force_full:true');
+    markRequestPerf_('dashboard:fallback_used:true');
+    return forcedData;
+  }
+
+  var refreshControlMap = readDashboardRefreshControlMap_();
+  var snapshotFreshness = getDashboardSnapshotFreshness_(refreshControlMap);
+  if (!snapshotFreshness.fresh) {
+    var freshFallback = actionDashboard_(user, payload || {});
+    if (freshFallback && typeof freshFallback === 'object') {
+      freshFallback._is_snapshot = false;
+      freshFallback._snapshot_fallback_reason = snapshotFreshness.reason || 'stale_snapshot';
+    }
+    setRequestPerfField_('dashboard_used_view', false);
+    setRequestPerfField_('dashboard_cache_hit', false);
+    setRequestPerfField_('dashboard_fallback_used', true);
+    setRequestPerfField_('dashboard_view_rows_read', 0);
+    setRequestPerfField_('payload_bytes', JSON.stringify(freshFallback || {}).length);
+    markRequestPerf_('dashboard:force_fallback_by_freshness:true');
+    markRequestPerf_('dashboard:fallback_used:true');
+    return freshFallback;
+  }
 
   markRequestPerf_('dashboardSnapshot:monthly view lookup:start');
   var viewTry = null;
@@ -777,7 +826,8 @@ function updateDashboardRefreshControl_(status, message) {
   var entries = [
     { key: 'last_refresh_at', value: now,     label_he: 'עדכון אחרון' },
     { key: 'last_status',     value: status,  label_he: 'סטטוס' },
-    { key: 'last_message',    value: message, label_he: 'הודעה' }
+    { key: 'last_message',    value: message, label_he: 'הודעה' },
+    { key: 'data_views_version', value: dataViewsCacheVersion_(), label_he: 'גרסת נתונים' }
   ];
 
   entries.forEach(function(entry) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -61,6 +61,8 @@ const READ_ACTIONS = {
 const API_TIMEOUT_MS_READ = 20000;
 const API_TIMEOUT_MS_WRITE = 30000;
 const PERF_MAX_REQUESTS = 150;
+const MONTH_READ_MODEL_TTL_MS = 5 * 60 * 1000;
+const monthReadModelCache = new Map();
 const RETRYABLE_SERVER_ERRORS = new Set([
   'network_error',
   'server_error',
@@ -72,10 +74,10 @@ const RETRYABLE_SERVER_ERRORS = new Set([
 
 function invalidateScreenDataByAction(action) {
   const targetedMutations = {
-    saveActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:', 'end-dates'],
-    addActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:', 'end-dates'],
+    saveActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
+    addActivity: ['activities:', 'activityDetail:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     submitEditRequest: ['activities:', 'edit-requests', 'week:', 'month:', 'dashboard:', 'end-dates'],
-    reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:'],
+    reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:', 'exceptions:'],
     saveFinanceRow: ['finance:', 'dashboard:'],
     syncFinance: ['finance:', 'dashboard:'],
     addUser: ['permissions', 'dashboard:'],
@@ -96,6 +98,15 @@ function invalidateScreenDataByAction(action) {
       delete state.screenDataCache[key];
     }
   });
+}
+
+function monthReadModelKey(payload = {}) {
+  const ym = String(payload?.ym || payload?.month || '').trim();
+  return /^\d{4}-\d{2}$/.test(ym) ? ym : '__current__';
+}
+
+function clearMonthReadModelCache() {
+  monthReadModelCache.clear();
 }
 
 function isPerfDebugEnabled() {
@@ -172,6 +183,13 @@ async function request(action, payload = {}) {
   if (!config.apiUrl) {
     throw new Error('חסר קישור API. עדכנו frontend/src/config.js או window.__DASHBOARD_CONFIG__.');
   }
+  if (action === 'month') {
+    const key = monthReadModelKey(payload);
+    const cached = monthReadModelCache.get(key);
+    if (cached && Date.now() - cached.t < MONTH_READ_MODEL_TTL_MS) {
+      return cached.data;
+    }
+  }
 
   const tokenAtCallTime = state.token;
 
@@ -242,6 +260,13 @@ async function request(action, payload = {}) {
     }
     throw new Error(translateApiErrorForUser(json.error));
   }
+  const normalized = normalizeData(json.data);
+  if (action === 'month') {
+    monthReadModelCache.set(monthReadModelKey(payload), { data: normalized, t: Date.now() });
+  }
+  if (action === 'saveActivity' || action === 'addActivity' || action === 'reviewEditRequest') {
+    clearMonthReadModelCache();
+  }
   if (MUTATING_ACTIONS[action]) {
     invalidateScreenDataByAction(action);
   }
@@ -251,7 +276,7 @@ async function request(action, payload = {}) {
     payload_bytes: lastResponseText.length,
     backend_debug: json.data && json.data.debug_perf ? json.data.debug_perf : null
   });
-  return normalizeData(json.data);
+  return normalized;
 }
 
 export const api = {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -168,7 +168,7 @@ export const dashboardScreen = {
       ym = currentMonthYm();
     }
     state.dashboardMonthYm = ym;
-    return api.dashboardSnapshot({ month: ym });
+    return api.dashboardSnapshot({ month: ym, force_full: true });
   },
   render(data, { state } = {}) {
     const ym = data?.month || currentMonthYm();
@@ -327,9 +327,21 @@ export const dashboardScreen = {
       }
     }
 
+    const prefetchDashboardMonth = (targetYm) => {
+      const validYm = /^\d{4}-\d{2}$/.test(targetYm || '') ? targetYm : '';
+      if (!validYm) return;
+      const key = `dashboard:${validYm}`;
+      const cached = state.screenDataCache[key];
+      if (cached?.data && Date.now() - cached.t < DASHBOARD_TTL_MS) return;
+      api.dashboardSnapshot({ month: validYm, force_full: true })
+        .then((payload) => {
+          putDashboardCache(key, payload);
+        })
+        .catch(() => {});
+    };
+
     const applyYm = async (nextYm) => {
       if (state.dashboardNavLoading) return;
-      const startedAt = Date.now();
       state.dashboardNavLoading = true;
       state.dashboardMonthYm = nextYm;
       const cacheKey = `dashboard:${/^\d{4}-\d{2}$/.test(nextYm) ? nextYm : 'default'}`;
@@ -341,7 +353,7 @@ export const dashboardScreen = {
         showDataAreaLoading();
         let snapshotLoaded = false;
         try {
-          const snapshotData = await api.dashboardSnapshot({ month: nextYm });
+          const snapshotData = await api.dashboardSnapshot({ month: nextYm, force_full: true });
           putDashboardCache(cacheKey, snapshotData);
           snapshotLoaded = true;
         } catch (_err) {
@@ -349,12 +361,14 @@ export const dashboardScreen = {
         }
         rerender();
       }
-      const minMs = 420;
-      setTimeout(() => {
-        state.dashboardNavLoading = false;
-        rerender();
-      }, Math.max(0, minMs - (Date.now() - startedAt)));
+      state.dashboardNavLoading = false;
+      rerender();
+      prefetchDashboardMonth(shiftYm(nextYm, -1));
+      prefetchDashboardMonth(shiftYm(nextYm, 1));
     };
+
+    prefetchDashboardMonth(shiftYm(ym, -1));
+    prefetchDashboardMonth(shiftYm(ym, 1));
 
     root.querySelector('[data-dash-month-prev]')?.addEventListener('click', () => {
       applyYm(shiftYm(state.dashboardMonthYm || currentMonthYm(), -1));

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -436,8 +436,6 @@ export const monthScreen = {
       const targetYm = shiftMonthYm(resolveBaseYm(), delta);
       const targetKey = monthCacheKey(targetYm);
       const hasCachedTarget = !!state?.screenDataCache?.[targetKey];
-      const startedAt = Date.now();
-
       state.monthYm = targetYm;
       state.monthNavLoading = true;
       try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
@@ -449,14 +447,25 @@ export const monthScreen = {
         root.setAttribute('aria-busy', 'true');
         rerender?.();
       }
-      const minMs = 420;
-      setTimeout(() => {
-        state.monthNavLoading = false;
-        rerender?.();
-      }, Math.max(0, minMs - (Date.now() - startedAt)));
+      state.monthNavLoading = false;
+      rerender?.();
     };
     prevBtn?.addEventListener('click', () => { doMonthShift(-1); });
     nextBtn?.addEventListener('click', () => { doMonthShift(1); });
+
+    const prefetchMonth = (targetYm) => {
+      if (!/^\d{4}-\d{2}$/.test(String(targetYm || ''))) return;
+      const targetKey = monthCacheKey(targetYm);
+      if (state?.screenDataCache?.[targetKey]) return;
+      api.month({ ym: targetYm })
+        .then((payload) => {
+          state.screenDataCache[targetKey] = { data: payload, t: Date.now() };
+        })
+        .catch(() => {});
+    };
+    const baseYm = resolveBaseYm();
+    prefetchMonth(shiftMonthYm(baseYm, -1));
+    prefetchMonth(shiftMonthYm(baseYm, 1));
 
     ui?.bindInteractiveCards(root, (action) => {
       if (!action.startsWith('monthcell|')) return;


### PR DESCRIPTION
### Motivation
- Fix divergence between the dashboard and exceptions screens caused by the dashboard reading snapshots / monthly view while exceptions read live `actionExceptions_` data, which produced inconsistent exception counts when snapshots or views were stale. 
- Provide a safe fast-path for snapshots only when snapshot metadata is fresh, otherwise always fall back to the live `actionDashboard_` computation.
- Reduce UI-perceived latency when switching months and add simple adjacent-month prefetching and a month read-model cache to improve responsiveness.

### Description
- Backend: added an early `force_full` short-circuit to `actionDashboardSnapshot_` so `payload.force_full === true` immediately calls `actionDashboard_`, sets `_is_snapshot = false` and returns before reading view/snapshot sheets. (modified `backend/dashboard-snapshot.gs`).
- Backend: introduced `getDashboardSnapshotFreshness_()` and persist `data_views_version` in `updateDashboardRefreshControl_()` so snapshot fast-path is only used when `last_status === 'ok'` and `data_views_version === dataViewsCacheVersion_()`; otherwise the code falls back to `actionDashboard_`. (modified `backend/dashboard-snapshot.gs`).
- Backend: extracted course-exception aggregation into `computeCourseExceptionsModel_()` and reused it from both `actionDashboard_` and `actionExceptions_` to centralize counts and per-manager exception instances. (modified `backend/actions.gs`).
- Frontend (dashboard): changed initial load and month-switch to call `api.dashboardSnapshot({ month: ym, force_full: true })`, removed the artificial `minMs = 420` delay on month transitions, and added prefetch for previous/next month; cache put logic preserved snapshot vs full payload semantics. (modified `frontend/src/screens/dashboard.js`).
- Frontend (month): removed the `minMs = 420` delay on month navigation and added prefetch for adjacent months. (modified `frontend/src/screens/month.js`).
- Frontend (api): added a monthly read-model cache for `api.month` with TTL and a small in-memory cache (`MONTH_READ_MODEL_TTL_MS`), plus cache invalidation of the month read-model after `saveActivity`, `addActivity`, and `reviewEditRequest`; also updated `invalidateScreenDataByAction` to include `exceptions:` invalidation where applicable. (modified `frontend/src/api.js`).

### Testing
- Ran static checks: `node --check frontend/src/api.js`, `node --check frontend/src/screens/dashboard.js`, and `node --check frontend/src/screens/month.js`, all succeeded.  
- Ran full test suite with `npm test`; observed 2 failing tests in `tests/activities-screen.test.mjs` (same pre-existing failures reported), these failures are unrelated to the dashboard/exception changes.  
- Verified code runs (no runtime syntax errors) and hand-checked key data-flow: snapshot freshness gating, `force_full` path, and front-end calls updated to request `force_full: true` on dashboard load and month navigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08281de14832ba81be7a17f94c293)