### PR TITLE
Fix manager exceptions aggregation order and zero-state label on dashboard

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -567,8 +567,6 @@ function actionDashboard_(user, payload) {
   missingStartDateCount = exceptionSummary.counts.missing_start_date || 0;
   lateEndDateCount = exceptionSummary.counts.late_end_date || 0;
   var exceptionSum = exceptionSummary.total_exception_instances || 0;
-  managerExceptions = exceptionSummary.by_manager_exception_instances || {};
-
 
   var shortActivitiesByType = {};
   shortRowsBySource.forEach(function(row) {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -193,14 +193,17 @@ export const dashboardScreen = {
         const stats = [
           { label: 'תוכניות פעילות', value: row.total_long      ?? 0, action: `mstat|${mgr}|long` },
           { label: 'מדריכים פעילים',  value: row.num_instructors ?? 0, action: `mstat|${mgr}|instructors` },
-          { label: 'חריגות',           value: exceptionsValue > 0 ? exceptionsValue : 'מצב תקין', action: `mstat|${mgr}|exceptions` },
+          { label: 'חריגות',           value: exceptionsValue, action: `mstat|${mgr}|exceptions` },
           { label: 'סיומי קורסים',    value: row.course_endings  ?? 0, action: `mstat|${mgr}|endings` },
         ];
         const statsHtml = stats
-          .map((s) => `<button type="button" class="ds-manager-stat" data-card-action="${escapeHtml(s.action)}">
+          .map((s) => {
+            const displayValue = s.label === 'חריגות' && Number(s.value || 0) === 0 ? 'מצב תקין' : s.value;
+            return `<button type="button" class="ds-manager-stat" data-card-action="${escapeHtml(s.action)}">
               <span class="ds-manager-stat__label">${escapeHtml(s.label)}</span>
-              <span class="ds-manager-stat__value">${escapeHtml(String(s.value))}</span>
-            </button>`)
+              <span class="ds-manager-stat__value">${escapeHtml(String(displayValue))}</span>
+            </button>`;
+          })
           .join('');
         return `<div class="ds-manager-card">
           <div class="ds-manager-card__head">


### PR DESCRIPTION
### Motivation
- Fix a timing bug where `byManager[manager].exceptions` could be set to `0` before `managerExceptions` (from `computeCourseExceptionsModel_`) was populated, causing incorrect per-manager exception counts.
- Improve the manager card UX by showing `מצב תקין` for zero exceptions while keeping the card actions unchanged.

### Description
- Ensure `computeCourseExceptionsModel_(combined, ym, { include_rows: false })` is the source of `managerExceptions` used before enriching `byManager` in `actionDashboard_` in `backend/actions.gs` so per-manager exception values are correct.
- Remove a redundant late reassignment of `managerExceptions` that occurred after `byManager` was already built to avoid overwriting values.
- Change rendering in `frontend/src/screens/dashboard.js` so the `חריגות` stat displays `מצב תקין` when its numeric value is `0`, without altering the card `action` behavior.

### Testing
- Ran the automated test suite with `npm test` and all tests passed (`22/22`).
- Verified the modified files `backend/actions.gs` and `frontend/src/screens/dashboard.js` contain the intended changes and no other tests regressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09dc16de4832ba69ca64ee32cd46f)