### PR TITLE
Add index_marvell.html with Marvell background image

### DIFF
--- a/index_marvell.html
+++ b/index_marvell.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#111827" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="apple-mobile-web-app-title" content="Dashboard-Taasiyeda" />
+  <link rel="manifest" href="./frontend/public/manifest.json" />
+  <link rel="icon" href="./frontend/assets/favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="./frontend/assets/apple-touch-icon.png" />
+  <link rel="preload" href="./frontend/src/styles/main.css?v=2604280" as="style" />
+  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2604280" />
+  <style>
+    body {
+      background-image: url('Premium/images/marvell-bg.png');
+      background-size: cover;
+      background-position: center;
+      background-repeat: no-repeat;
+      min-height: 100vh;
+    }
+  </style>
+  <title>Dashboard-Taasiyeda</title>
+</head>
+<body>
+  <main id="app"></main>
+  <script type="module" src="./frontend/src/main.js?v=2604280"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated Marvell landing page that displays the requested background image for the Marvell-themed view.

### Description
- Added a new `index_marvell.html` file that mirrors the existing index structure and applies a body background image using `Premium/images/marvell-bg.png` with `background-size: cover`, `background-position: center`, `background-repeat: no-repeat`, and `min-height: 100vh`.

### Testing
- Ran repository file searches and inspected page contents using commands like `rg`, `sed -n '1,220p' index.html`, and `nl -ba index_marvell.html` to verify the new file and its contents; all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09ee1d4f8832b915654b62b2a0ec9)