### PR TITLE
Unify course exceptions counting and tighten calendar/activities UX

### DIFF
--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -236,9 +236,7 @@ function resolveExceptionsCountForDashboard_(summaryObj, rawExceptions) {
   var lateEnd = parseInt(text_(summary.late_end_date_count), 10) || 0;
   var fromSummaryParts = missingInstr + missingStart + lateEnd;
   var fromRaw = parseInt(text_(rawExceptions), 10);
-  if (isNaN(fromRaw) || fromRaw < 0) return fromSummaryParts;
-  if (fromSummaryParts > 0 && fromRaw !== fromSummaryParts) return fromSummaryParts;
-  return fromRaw;
+  return (isNaN(fromRaw) || fromRaw < 0) ? fromSummaryParts : fromRaw;
 }
 
 function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, canViewFinance) {

--- a/backend/views.gs
+++ b/backend/views.gs
@@ -300,11 +300,6 @@ function buildViewDashboardMonthlyRows_(activitiesSummaryRows, meetingsViewRows)
       }
 
       if (t === 'course' && text_(row.source_sheet) === CONFIG.SHEETS.DATA_LONG) {
-        if (primaryExceptionForRow_(row)) {
-          if (!managerExceptions[manager]) managerExceptions[manager] = 0;
-          managerExceptions[manager] += 1;
-          primaryExceptionRowCount += 1;
-        }
         if (text_(row.end_date).slice(0, 7) === ym) {
           if (!managerCourseEndings[manager]) managerCourseEndings[manager] = 0;
           managerCourseEndings[manager] += 1;
@@ -315,6 +310,10 @@ function buildViewDashboardMonthlyRows_(activitiesSummaryRows, meetingsViewRows)
         managerFinanceOpen[manager] += 1;
       }
     });
+
+    var monthExceptionSummary = computeCourseExceptionsModel_(monthActivities, ym, { include_rows: false });
+    managerExceptions = monthExceptionSummary.by_manager_exception_instances || {};
+    primaryExceptionRowCount = monthExceptionSummary.total_exception_instances || 0;
 
     monthMeetings.forEach(function(row) {
       var i1 = text_(row.instructor_name || row.emp_id);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -809,17 +809,16 @@ function clearScreenDataCache() {
     Object.keys(state.screenDataCache).forEach((key) => {
       if (key.startsWith('finance:')) { delete state.screenDataCache[key]; deletedKeys.push(key); }
     });
+  } else if (state.route === 'week' || state.route === 'month' || state.route === 'dashboard') {
+    const ownPrefix = `${state.route}:`;
+    Object.keys(state.screenDataCache).forEach((key) => {
+      if (key.startsWith(ownPrefix)) { delete state.screenDataCache[key]; deletedKeys.push(key); }
+    });
   } else {
     const k = screenDataCacheKey();
     delete state.screenDataCache[k];
     deletedKeys.push(k);
   }
-  Object.keys(state.screenDataCache).forEach((key) => {
-    if (key.startsWith('dashboard:') || key.startsWith('week:') || key.startsWith('month:')) {
-      delete state.screenDataCache[key];
-      deletedKeys.push(key);
-    }
-  });
   deletedKeys.forEach(persistCacheDelete);
 }
 

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -18,13 +18,18 @@ function applyActiveFilter(rows, activeOnly) {
   return rows.filter((r) => (r.programs_count || 0) + (r.one_day_count || 0) > 0);
 }
 
-function renderInstructorRow(row) {
+function renderInstructorRow(row, state, detailsCache) {
   const name       = escapeHtml(row.full_name || row.emp_id || '—');
+  const empId      = String(row.emp_id || '').trim();
   const endDate    = row.latest_end_date ? formatDateHe(row.latest_end_date) : '';
   const programs   = row.programs_count || 0;
   const oneDay     = row.one_day_count  || 0;
   const hasActivity = (programs + oneDay) > 0;
   const inactiveClass = hasActivity ? '' : ' ci-row--inactive';
+  const expandedEmpId = String(state?.instructorsExpandedEmpId || '').trim();
+  const isExpanded = !!empId && expandedEmpId === empId;
+  const cachedDetails = Array.isArray(detailsCache?.[empId]) ? detailsCache[empId] : null;
+  const isLoading = String(state?.instructorsDetailsLoadingEmpId || '') === empId;
 
   const statsHtml = `<span class="instr-stats">
     <span class="instr-stat"><span class="instr-stat__lbl">תוכניות</span><span class="instr-stat__num">${programs}</span></span>
@@ -32,13 +37,27 @@ function renderInstructorRow(row) {
     <span class="instr-stat"><span class="instr-stat__lbl">תאריך אחרון</span><span class="instr-stat__num instr-stat__num--date">${escapeHtml(endDate || '—')}</span></span>
   </span>`;
 
-  return `
-    <button type="button" class="ci-row instr-summary-row${inactiveClass}" dir="rtl" data-instructor-card="${escapeHtml(String(row.emp_id || ''))}">
+  const detailsHtml = !isExpanded
+    ? ''
+    : `<div class="instr-card-details" dir="rtl" data-instructor-details="${escapeHtml(empId)}">
+      ${isLoading
+        ? '<p class="ds-muted">טוען פעילויות…</p>'
+        : !cachedDetails
+          ? '<p class="ds-muted">אין נתונים להצגה.</p>'
+          : cachedDetails.length
+            ? `<ul class="instr-act-list">${cachedDetails.map((item) => `<li class="instr-act-item">${item}</li>`).join('')}</ul>`
+            : '<p class="ds-muted">אין פעילויות משויכות.</p>'}
+    </div>`;
+
+  return `<article class="instr-card${isExpanded ? ' is-expanded' : ''}" data-instructor-item="${escapeHtml(empId)}">
+    <button type="button" class="ci-row instr-summary-row${inactiveClass}" dir="rtl" data-instructor-card="${escapeHtml(empId)}" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="instructor-details-${escapeHtml(empId)}">
       <div class="ci-row__main">
         <span class="ci-row__name">${name}</span>
         ${statsHtml}
       </div>
-    </button>`;
+    </button>
+    ${detailsHtml}
+  </article>`;
 }
 
 export const instructorsScreen = {
@@ -63,9 +82,10 @@ export const instructorsScreen = {
     const ymLabel = ym ? ym.slice(0, 7) : '';
     const activeChk = activeOnly ? 'checked' : '';
 
+    const detailsCache = state?.instructorsActivityDetailsCache || {};
     const bodyHtml = visibleRows.length === 0
       ? dsEmptyState(filters.q || activeOnly ? 'לא נמצאו מדריכים לסינון זה' : 'אין נתוני מדריכים')
-      : `<div class="ci-list ci-list--instr-grid">${visibleRows.map(renderInstructorRow).join('')}</div>${
+      : `<div class="ci-list ci-list--instr-grid">${visibleRows.map((row) => renderInstructorRow(row, state, detailsCache)).join('')}</div>${
         hasMore ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${INSTRUCTORS_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>` : ''
       }`;
 
@@ -85,7 +105,7 @@ export const instructorsScreen = {
     `);
   },
 
-  bind({ root, data, state, rerender, ui, api }) {
+  bind({ root, data, state, rerender, api }) {
     bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 300 });
     root.querySelector(`[data-list-show-more="${INSTRUCTORS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, INSTRUCTORS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
@@ -97,13 +117,28 @@ export const instructorsScreen = {
       rerender();
     });
 
+    state.instructorsActivityDetailsCache = state.instructorsActivityDetailsCache || {};
     root.querySelectorAll('[data-instructor-card]').forEach((btn) => {
       btn.addEventListener('click', async () => {
         const empId = String(btn.dataset.instructorCard || '').trim();
-        if (!empId || !ui) return;
-        ui.openDrawer({ title: 'מדריך', content: '<p class="ds-muted">טוען פעילויות…</p>' });
+        if (!empId) return;
+        if (state.instructorsExpandedEmpId === empId) {
+          state.instructorsExpandedEmpId = '';
+          state.instructorsDetailsLoadingEmpId = '';
+          rerender();
+          return;
+        }
+        state.instructorsExpandedEmpId = empId;
+        if (Array.isArray(state.instructorsActivityDetailsCache[empId])) {
+          state.instructorsDetailsLoadingEmpId = '';
+          rerender();
+          return;
+        }
+        state.instructorsDetailsLoadingEmpId = empId;
+        rerender();
         try {
-          const res = await api.activities({ activity_type: 'all' });
+          const cachedActivities = state?.screenDataCache?.['activities:all']?.data;
+          const res = cachedActivities || await api.activities({ activity_type: 'all' });
           const allRows = Array.isArray(res?.rows) ? res.rows : [];
           const ym = String(res?.ym || '').slice(0, 7); // "YYYY-MM"
 
@@ -136,12 +171,12 @@ export const instructorsScreen = {
             return [`<li class="instr-act-item">${metaHtml}</li>`];
           });
 
-          const list = items.length
-            ? `<ul class="ds-summary-panel__list instr-act-list">${items.join('')}</ul>`
-            : '<p class="ds-muted">אין פעילויות משויכות.</p>';
-          ui.openDrawer({ title: 'פעילויות מדריך', content: list });
+          state.instructorsActivityDetailsCache[empId] = items;
         } catch (_e) {
-          ui.openDrawer({ title: 'פעילויות מדריך', content: '<p class="ds-muted">טעינת הפעילויות נכשלה.</p>' });
+          state.instructorsActivityDetailsCache[empId] = [];
+        } finally {
+          state.instructorsDetailsLoadingEmpId = '';
+          rerender();
         }
       });
     });

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -207,9 +207,22 @@ export const monthScreen = {
     ).join('');
 
     const slots = [];
+    const prevMonthDate = new Date(y, mo - 2, 1);
+    const prevDays = daysInMonth1Based(prevMonthDate.getFullYear(), prevMonthDate.getMonth() + 1);
     for (let i = 0; i < slotCount; i += 1) {
       if (i < firstWeekday || i >= firstWeekday + dim) {
-        slots.push('<div class="ds-cal-slot ds-cal-slot--empty" aria-hidden="true"></div>');
+        const isPrev = i < firstWeekday;
+        const dayNum = isPrev
+          ? (prevDays - firstWeekday + i + 1)
+          : (i - (firstWeekday + dim) + 1);
+        const outTitle = String(dayNum);
+        slots.push(
+          `<div class="ds-cal-slot-hit is-other-month" aria-hidden="true">
+            <article class="ds-interactive-card ds-interactive-card--day-cell is-other-month">
+              <p class="ds-interactive-card__title">${escapeHtml(outTitle)}</p>
+            </article>
+          </div>`
+        );
         continue;
       }
       const dayNum = i - firstWeekday + 1;
@@ -256,8 +269,9 @@ export const monthScreen = {
       );
     }
 
+    const navLoading = !!state.monthNavLoading;
     const gridHtml = `
-      <div class="ds-cal-wrap${hideSaturday ? ' ds-cal-wrap--hide-shabbat' : ''}" dir="rtl">
+      <div class="ds-cal-wrap${hideSaturday ? ' ds-cal-wrap--hide-shabbat' : ''}${navLoading ? ' is-inline-loading' : ''}" dir="rtl">
         <div class="ds-cal-weekdays" role="row">${weekdayRow}</div>
         <div class="ds-cal-grid" role="grid" aria-label="לוח חודש">${slots.join('')}</div>
       </div>`;
@@ -265,7 +279,6 @@ export const monthScreen = {
     const currentYm = data?.month || `${y}-${String(mo).padStart(2, '0')}`;
     const monthTitle = monthTitleHebrew(spec);
 
-    const navLoading = !!state.monthNavLoading;
     const html = dsScreenStack(`
       <nav class="ds-cal-nav${navLoading ? ' is-nav-loading' : ''}" role="navigation" aria-label="ניווט חודשי" dir="rtl">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-month-prev aria-label="חודש קודם" title="חודש קודם" ${navLoading ? 'disabled' : ''}>▶</button>
@@ -381,6 +394,7 @@ export const monthScreen = {
     const todayBtn = root.querySelector('[data-month-today]');
     const doMonthShift = (delta) => {
       if (state.monthNavLoading) return;
+      const startedAt = Date.now();
       const targetYm = shiftMonthYm(resolveBaseYm(), delta);
       const targetKey = monthCacheKey(targetYm);
       const hasCachedTarget = !!state?.screenDataCache?.[targetKey];
@@ -395,8 +409,13 @@ export const monthScreen = {
         root.setAttribute('aria-busy', 'true');
         rerender?.();
       }
-      state.monthNavLoading = false;
-      rerender?.();
+      const minMs = 420;
+      setTimeout(() => {
+        state.monthNavLoading = false;
+        root.classList.remove('is-month-loading');
+        root.setAttribute('aria-busy', 'false');
+        rerender?.();
+      }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
     prevBtn?.addEventListener('click', () => { doMonthShift(-1); });
     nextBtn?.addEventListener('click', () => { doMonthShift(1); });

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -266,7 +266,7 @@ export const weekScreen = {
         <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-next aria-label="שבוע הבא" title="שבוע הבא" ${navLoading ? 'disabled' : ''}>◀</button>
       </nav>
       ${toolbarHtml}
-      <div class="ds-week-board" style="--week-cols:${safeDays.length || 7}" role="region" aria-label="לוח שבוע">${body}</div>
+      <div class="ds-week-board${navLoading ? ' is-inline-loading' : ''}" style="--week-cols:${safeDays.length || 7}" role="region" aria-label="לוח שבוע">${body}</div>
     `);
     return html;
   },

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8050,3 +8050,150 @@ select.ds-activity-add-field .ds-input,
 .ds-table--activities-list .ds-activities-col--school { width: 20%; }
 .ds-table--activities-list .ds-activities-col--instructor { width: 18%; }
 .ds-table--activities-list .ds-activities-col--date { width: 8.5%; }
+
+/* === Focused polish fixes (2026-04-28) === */
+.ds-activities-title-row {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+}
+
+.ds-activities-title-row .ds-btn--nav-arrow {
+  width: 30px;
+  min-width: 30px;
+  height: 30px;
+  min-height: 30px;
+  padding: 0;
+}
+
+.ds-activities-main-toolbar {
+  gap: 4px;
+}
+
+.ds-activities-main-toolbar .ds-toolbar--filters-inline {
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.ds-activities-search-sm {
+  width: clamp(180px, 24vw, 220px);
+  min-width: 180px;
+}
+
+.ds-filter-select-inline {
+  min-width: 86px;
+  max-width: 128px;
+  flex: 0 1 112px;
+  min-height: 30px;
+}
+
+.ds-activities-main-toolbar .ds-btn--icon-only {
+  min-width: 26px;
+  width: 26px;
+  min-height: 26px;
+  height: 26px;
+  padding: 0;
+  font-size: 0.86rem;
+}
+
+.ds-week-col__head {
+  background: #fff;
+  border: 1px solid rgba(26, 51, 88, 0.12);
+  box-shadow: 0 1px 6px rgba(26, 51, 88, 0.08);
+}
+
+.ds-week-board.is-inline-loading,
+.ds-cal-wrap.is-inline-loading {
+  position: relative;
+}
+
+.ds-week-board.is-inline-loading::after,
+.ds-cal-wrap.is-inline-loading::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(255,255,255,0), rgba(125, 211, 252, 0.12), rgba(255,255,255,0));
+  animation: ds-inline-shimmer 0.6s ease-in-out 1;
+  pointer-events: none;
+}
+
+@keyframes ds-today-glow {
+  0% { box-shadow: 0 0 0 1px rgba(14, 165, 233, 0.2), 0 0 10px rgba(14, 165, 233, 0.18); }
+  50% { box-shadow: 0 0 0 1px rgba(168, 85, 247, 0.24), 0 0 14px rgba(168, 85, 247, 0.2); }
+  100% { box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2), 0 0 12px rgba(34, 197, 94, 0.18); }
+}
+
+@keyframes ds-inline-shimmer {
+  from { opacity: 0; transform: translateX(18px); }
+  50% { opacity: 1; }
+  to { opacity: 0; transform: translateX(-18px); }
+}
+
+.ds-interactive-card.is-cal-today,
+.ds-week-col.is-today .ds-week-col__head {
+  animation: ds-today-glow 5.4s ease-in-out infinite alternate;
+}
+
+.ds-cal-grid {
+  gap: 5px;
+}
+
+.ds-cal-grid .ds-interactive-card--day-cell {
+  background: #fff;
+  border: 1px solid rgba(26, 51, 88, 0.13);
+  border-radius: 10px;
+}
+
+.ds-cal-slot--empty {
+  background: rgba(248, 250, 252, 0.9);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.ds-cal-wrap .ds-cal-slot-hit.is-other-month,
+.ds-cal-wrap .ds-interactive-card--day-cell.is-other-month {
+  opacity: 0.55;
+}
+
+.ci-list--instr-grid {
+  grid-template-columns: repeat(auto-fill, minmax(180px, 220px));
+  gap: 8px;
+}
+
+.instr-card .instr-summary-row {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.06));
+  border: 1px solid rgba(26, 51, 88, 0.1);
+}
+
+.instr-card-details {
+  margin-top: 4px;
+  padding: 8px;
+  border: 1px solid rgba(26, 51, 88, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.instr-act-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.instr-act-item {
+  font-size: 0.74rem;
+  border: 1px solid rgba(26, 51, 88, 0.1);
+  border-radius: 8px;
+  padding: 4px 6px;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-interactive-card.is-cal-today,
+  .ds-week-col.is-today .ds-week-col__head,
+  .ds-week-board.is-inline-loading::after,
+  .ds-cal-wrap.is-inline-loading::after {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Align exception counts across dashboard card, by-manager table and exceptions page by using one canonical rule: only rows with `activity_type === 'course'` are considered exceptions. 
- Provide focused, low-risk UX polish to calendar/week/month/activities/instructors to improve clarity and navigation feedback without broad refactors or permission changes.

### Description
- Unify exceptions logic in the monthly dashboard view by using `computeCourseExceptionsModel_` for manager breakdown and KPI total, and make `exceptions_count` resolution in `dashboard-snapshot` more deterministic (trust canonical field when present). (changed `backend/views.gs`, `backend/dashboard-snapshot.gs`).
- Ensure backend `exceptions` route and dashboard snapshot remain course-only and consistent with the unified model (`actionExceptions_` / `computeCourseExceptionsModel_` usage left intact). (inspected `backend/actions.gs`, `backend/router.gs`).
- Improve calendar/week/month navigation feedback by adding short inline loading states, disabling nav buttons during the transition, and showing an inline shimmer/loading dot for at least ~420ms to provide immediate UX feedback. (changed `frontend/src/screens/month.js`, `frontend/src/screens/week.js`).
- Reduce aggressive cache invalidation on route transitions so already-loaded screen data is preserved where appropriate, improving perceived navigation speed (`frontend/src/main.js`).
- Tighten activities toolbar and header layout (compact centered nav, uniform arrow buttons, compact search width and dropdown sizing, compact add/clear buttons) and add CSS to make month cells visually separated and the today cell glow subtle and respectful of `prefers-reduced-motion`. (changed `frontend/src/styles/main.css`, small markup/CSS hooks in activities/month/week screens).
- Add inline expand/collapse instructor cards with lazy-loaded, cached per-instructor activity lists (showing activity name, school, authority and proper empty-state text). (changed `frontend/src/screens/instructors.js`).

### Testing
- Checked for conflict markers with `rg` and found none. (passed)
- Ran unit tests with `npm test` which completed successfully (`22/22` tests passing). (passed)
- Attempted `npm run build` but repository has no `build` script; no build performed. (no-op / informational)

Notes: full end-to-end verification against real Google Sheets data, login/permissions flows and live dashboard↔exceptions counts require a runtime with the Sheets backend and were not possible in this automated run; a refresh of snapshots/data-views after deployment is recommended so precomputed snapshots reflect the unified exceptions logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a2917a00832b89560d19a6cc6977)