### PR TITLE
Remove force_full from dashboard snapshot calls and delay bind prefetch

### DIFF
--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -165,7 +165,7 @@ export const dashboardScreen = {
       ym = currentMonthYm();
     }
     state.dashboardMonthYm = ym;
-    return api.dashboardSnapshot({ month: ym, force_full: true });
+    return api.dashboardSnapshot({ month: ym });
   },
   render(data, { state } = {}) {
     const ym = data?.month || currentMonthYm();
@@ -336,7 +336,7 @@ export const dashboardScreen = {
       const key = `dashboard:${validYm}`;
       const cached = state.screenDataCache[key];
       if (cached?.data && Date.now() - cached.t < DASHBOARD_TTL_MS) return;
-      api.dashboardSnapshot({ month: validYm, force_full: true })
+      api.dashboardSnapshot({ month: validYm })
         .then((payload) => {
           putDashboardCache(key, payload);
         })
@@ -356,7 +356,7 @@ export const dashboardScreen = {
         showDataAreaLoading();
         let snapshotLoaded = false;
         try {
-          const snapshotData = await api.dashboardSnapshot({ month: nextYm, force_full: true });
+          const snapshotData = await api.dashboardSnapshot({ month: nextYm });
           putDashboardCache(cacheKey, snapshotData);
           snapshotLoaded = true;
         } catch (_err) {
@@ -370,8 +370,12 @@ export const dashboardScreen = {
       prefetchDashboardMonth(shiftYm(nextYm, 1));
     };
 
-    prefetchDashboardMonth(shiftYm(ym, -1));
-    prefetchDashboardMonth(shiftYm(ym, 1));
+    setTimeout(() => {
+      if (!state.dashboardNavLoading) {
+        prefetchDashboardMonth(shiftYm(ym, -1));
+        prefetchDashboardMonth(shiftYm(ym, 1));
+      }
+    }, 1500);
 
     root.querySelector('[data-dash-month-prev]')?.addEventListener('click', () => {
       applyYm(shiftYm(state.dashboardMonthYm || currentMonthYm(), -1));


### PR DESCRIPTION
### Motivation
- Prevent the frontend from forcing a full dashboard recompute so the server-side snapshot mechanism can decide when to run the full action.
- Avoid unnecessary heavy requests during initial load, month navigation and prefetch to improve dashboard performance.
- Defer prefetch to avoid competing with immediate navigation/loading work during bind.

### Description
- Removed `force_full: true` from the `api.dashboardSnapshot` call in `load`, so it now calls `api.dashboardSnapshot({ month: ym })`.
- Removed `force_full: true` from the snapshot fetch in `applyYm` used during month navigation.
- Removed `force_full: true` from `prefetchDashboardMonth` prefetch calls.
- Replaced immediate prefetch at bind-time with a delayed prefetch using `setTimeout(..., 1500)` that checks `state.dashboardNavLoading` before executing the two adjacent-month prefetches.

### Testing
- Ran `rg -n "force_full" frontend/src/screens/dashboard.js` and inspected `frontend/src/screens/dashboard.js` to confirm no regular frontend snapshot calls include `force_full`, and the prefetch calls are deferred; the checks passed.
- Performed a static inspection of the modified file (`sed`/`nl`) to verify the three call sites and the delayed `setTimeout` prefetch were updated as intended; inspection succeeded.
- No automated unit/integration tests in the repo were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f108f74004832ba8bcdef090caacd6)