### PR TITLE
Add Hebrew RTL all-news static page (`allnews.html`)

### DIFF
--- a/Premium/marvell_web/news/allnews.html
+++ b/Premium/marvell_web/news/allnews.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>כל החדשות</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: #f7f7f8;
+      color: #111;
+    }
+
+    .news-list {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 24px 16px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .news-item {
+      display: grid;
+      grid-template-columns: 160px 1fr;
+      gap: 12px;
+      align-items: start;
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    }
+
+    .news-item img {
+      width: 160px;
+      height: 120px;
+      object-fit: cover;
+      background: #f1f5f9;
+      display: block;
+    }
+
+    .news-content {
+      padding: 10px 12px 12px;
+    }
+
+    .news-title {
+      margin: 0 0 8px;
+      font-size: 18px;
+      line-height: 1.35;
+    }
+
+    .news-summary {
+      margin: 0;
+      color: #475569;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+  <section class="news-list">
+    <article class="news-item" data-article-number="1">
+      <img src="./1 תמונה 1.PNG" alt="תמונה לכתבה 1" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 1</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>1 תמונה 1.PNG</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="2">
+      <img src="./2.png" alt="תמונה לכתבה 2" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 2</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>2.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="3">
+      <img src="./3.png" alt="תמונה לכתבה 3" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 3</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>3.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="4">
+      <img src="./4.png" alt="תמונה לכתבה 4" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 4</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>4.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="5">
+      <img src="./5.png" alt="תמונה לכתבה 5" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 5</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>5.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="6">
+      <img src="./6.png" alt="תמונה לכתבה 6" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 6</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>6.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="7">
+      <img src="./7.png" alt="תמונה לכתבה 7" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 7</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>7.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="8">
+      <img src="./8.png" alt="תמונה לכתבה 8" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 8</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>8.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="9">
+      <img src="./9.png" alt="תמונה לכתבה 9" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 9</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>9.png</strong>.</p>
+      </div>
+    </article>
+
+    <article class="news-item" data-article-number="10">
+      <img src="./10.png" alt="תמונה לכתבה 10" loading="lazy" />
+      <div class="news-content">
+        <h2 class="news-title">כתבה 10</h2>
+        <p class="news-summary">תמונה מותאמת: <strong>10.png</strong>.</p>
+      </div>
+    </article>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, Hebrew (RTL) all-news listing page for the Premium marvell_web news section to present multiple articles with images and summaries.
- Deliver a simple, responsive card-style layout that matches site styling and supports lazy-loading images for performance.

### Description
- Added a new static file `Premium/marvell_web/news/allnews.html` which sets `lang="he"` and `dir="rtl"` and includes the full HTML/CSS for the page.
- Implemented a responsive grid layout (`.news-list` and `.news-item`) with card styling, fixed thumbnail slot, and content area for titles and summaries.
- Images use `loading="lazy"` and each article element includes a `data-article-number` attribute for easy identification or scripting.
- Included ten example article entries referencing local image files and Hebrew text for titles and summaries.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f110b3d8a8832bac1f700111bae0ae)