### PR TITLE
Render authenticated shell immediately after login; load first screen asynchronously

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1205,22 +1205,20 @@ async function render() {
             beginPerfTimer('login:applyBootstrap');
             applyBootstrapFromLoginData(data);
             renderShellLoadingImmediately();
-            try {
-              await mountScreen();
+            loginInlineError = '';
+            endPerfTimer('login:applyBootstrap');
+            scheduleRender();
+            mountScreen().then(() => {
               if (loginPerfStartMs > 0 && !initialRoutePerfReported) {
                 initialRoutePerfReported = true;
                 reportPerfMilestone('initial_route_loaded', performance.now() - loginPerfStartMs, {
                   route: String(state.route || '')
                 });
               }
-              loginInlineError = '';
-            } catch {
+            }).catch(async () => {
               rollbackToLogin('כשל בטעינת נתוני משתמש אחרי התחברות');
               await render();
-            }
-            endPerfTimer('login:applyBootstrap');
-            loginInlineError = '';
-            scheduleRender();
+            });
           } catch (error) {
             endPerfTimer('login:api.login');
             endPerfTimer('login:setSession');


### PR DESCRIPTION
### Motivation
- Reduce perceived login time by showing the authenticated shell/skeleton as soon as `api.login` returns without waiting for the full first-screen load. 
- Reuse the data returned from `api.login` (`token`, `user`, `routes`, `default_route`, `client_settings`) to initialise the session and routing without changing permissions or token structure. 
- Avoid blocking the UI on the potentially slow `mountScreen()` operation so the user leaves the login view sooner.

### Description
- Updated the post-login flow in `frontend/src/main.js` to stop `await`ing `mountScreen()` after a successful `api.login` and `setSession` call. 
- After `setSession` and `applyBootstrapFromLoginData(data)`, the code now calls `renderShellLoadingImmediately()` and `scheduleRender()` and then starts `mountScreen()` asynchronously with `.then().catch()` so the shell is displayed immediately. 
- Preserved rollback behaviour: if the asynchronous `mountScreen()` fails the code clears the session and restores the login view exactly as before. 
- No changes were made to permission handling, token structure, UI design, or introducing an immediate `api.bootstrap` call in the login path.

### Testing
- Ran `npm test`; test runner completed but there are 2 failing tests that appear pre-existing and unrelated to this change (failures: `activities render...` and `activities css includes fixed proportional column widths`).
- Checked for merge conflict markers with a repository-wide search and found none in the relevant source and tests.
- Verified the change touches only `frontend/src/main.js` and preserves existing error/rollback timers and perf reporting logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13291ef68832babaf80ddbae02b45)