### PR TITLE
Fix end-dates Excel export, calendar highlights, activities table alignment, and dashboard exceptions count

### DIFF
--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -78,7 +78,11 @@ function renderStructuredSummary(summary, ym, byManager) {
     + pickNumericFallback(summary, 'missing_start_date_count')
     + pickNumericFallback(summary, 'late_end_date_count');
   const exceptionsTotalField = getStrictNumericField(summary, 'exceptions_count');
-  const exceptionsTotalResolved = exceptionsTotalField.ok ? exceptionsTotalField.value : exceptionsFromParts;
+  const byManagerExceptions = (Array.isArray(byManager) ? byManager : [])
+    .reduce((sum, row) => sum + (Number(row?.exceptions || 0) || 0), 0);
+  const exceptionsTotalResolved = exceptionsTotalField.ok
+    ? Math.max(exceptionsTotalField.value, exceptionsFromParts, byManagerExceptions)
+    : Math.max(exceptionsFromParts, byManagerExceptions);
 
   const activeCurrent = escapeHtml(String(activeCurrentField.ok ? activeCurrentField.value : 'שגיאת מיפוי'));
   const endingCurrent = escapeHtml(String(endingCurrentField.ok ? endingCurrentField.value : 'שגיאת מיפוי'));

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -73,6 +73,7 @@ function renderMonthTable(month, monthIdx) {
       <tr class="ds-end-expand-row" id="ds-end-expand-${escapeHtml(rowId)}" hidden>
         <td colspan="5" class="ds-end-expand-td">
           <div class="ds-end-dates__dates-list">${pillsHtml}</div>
+          <p class="ds-end-dates__meta"><strong>מנהל פעילויות:</strong> ${escapeHtml(String(row.activity_manager || '—'))}</p>
         </td>
       </tr>`;
   }).join('');
@@ -96,15 +97,20 @@ function renderMonthTable(month, monthIdx) {
 }
 
 function buildExcelBlob(rows) {
-  const headers = ['שם פעילות', 'בית ספר', 'רשות', 'תאריך סיום', 'תאריכי מפגשים'];
+  const maxMeetingDates = rows.reduce((max, row) => Math.max(max, Array.isArray(row?._dates) ? row._dates.length : 0), 0);
+  const dateHeaders = Array.from({ length: maxMeetingDates }, (_, idx) => `תאריך סיום ${idx + 1}`);
+  const headers = ['שם פעילות', 'בית ספר', 'רשות', 'תאריך סיום', ...dateHeaders];
   const tableRows = rows.map((row) => {
-    const datesText = (row._dates || []).map((iso) => formatDateHe(iso)).join(', ');
+    const dateCells = Array.from({ length: maxMeetingDates }, (_, idx) => {
+      const iso = row?._dates?.[idx];
+      return `<td>${escapeHtml(iso ? formatDateHe(iso) : '')}</td>`;
+    }).join('');
     return `<tr>
       <td>${escapeHtml(String(row.activity_name || ''))}</td>
       <td>${escapeHtml(String(row.school || ''))}</td>
       <td>${escapeHtml(String(row.authority || ''))}</td>
       <td>${escapeHtml(formatDateHe(row.end_date))}</td>
-      <td>${escapeHtml(datesText)}</td>
+      ${dateCells}
     </tr>`;
   }).join('');
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7375,6 +7375,11 @@ select.ds-input {
   color: #1e3a8a;
   border: 1px solid #d9e6ff;
 }
+.ds-end-dates__meta {
+  margin: 8px 0 0;
+  font-size: 0.74rem;
+  color: #334155;
+}
 
 .ds-end-dates__muted {
   font-size: 0.78rem;
@@ -7951,6 +7956,11 @@ select.ds-activity-add-field .ds-input,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  border-inline-start: 1px solid rgba(26, 51, 88, 0.08);
+}
+.ds-table--activities-list th:first-child,
+.ds-table--activities-list td:first-child {
+  border-inline-start: none;
 }
 
 .ds-table--activities-list th {
@@ -7970,6 +7980,12 @@ select.ds-activity-add-field .ds-input,
   line-height: 1.15;
   vertical-align: middle;
   text-align: right;
+}
+.ds-table--activities-list th:nth-child(5),
+.ds-table--activities-list th:nth-child(6),
+.ds-table--activities-list td:nth-child(5),
+.ds-table--activities-list td:nth-child(6) {
+  text-align: center;
 }
 
 .ds-activities-cell-ellipsis {
@@ -8185,10 +8201,25 @@ select.ds-activity-add-field .ds-input,
   grid-template-columns: repeat(auto-fill, minmax(180px, 220px));
   gap: 8px;
 }
+@media (min-width: 1200px) {
+  .ci-list--instr-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
 
 .instr-card .instr-summary-row {
   background: linear-gradient(160deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.06));
   border: 1px solid rgba(26, 51, 88, 0.1);
+}
+
+.ds-week-col.is-today .ds-week-col__head {
+  background: rgba(255, 235, 59, 0.45);
+  border-bottom-color: rgba(245, 158, 11, 0.35);
+}
+.ds-week-col__today-badge {
+  background: rgba(255, 215, 0, 0.92);
+  color: #5b3a00;
+  border: 1px solid rgba(217, 119, 6, 0.45);
 }
 
 /* ——— Instructor popup ——— */


### PR DESCRIPTION
### Motivation
- לתקן ייצוא תאריכי סיום כך שכל תאריך מפגש יוצא לעמודה נפרדת ולא כרשימה בתוך תא אחד, ולהציג בחלון פרטי השורה את שדה "מנהל פעילויות".
- לשפר את נראות לוח החודש/שבוע והטבלה בעמוד פעילויות לפי הדרישות (הדגשת ימים עם פעילויות, TODAY בולט יותר, הפרדה עדינה בין עמודות, ויישור תאריכים למרכז).
- לתקן את חישוב "חריגות החודש" בלוח הבקרה כך שיסתנכרן עם הנתונים שמופיעים בעמוד החריגות.

### Description
- בעמוד תאריכי סיום עדכנתי את `frontend/src/screens/end-dates.js` ב־`buildExcelBlob` כך שהיא יוצרת כותרות דינמיות `תאריך סיום 1`, `תאריך סיום 2`, … וממירה כל תאריך מפגש לעמודה נפרדת בקובץ ה־Excel במקום להצמיד את כל התאריכים לתא יחיד.
- בעמוד תאריכי סיום הוספתי בתצוגת ההרחבה של כל שורה תצוגה של `מנהל פעילויות` כדי שיופיע ביחד עם שאר פרטי השורה (`frontend/src/screens/end-dates.js`).
- בלוח הבקרה שיניתי את לוגיקת סיכום החריגות ב־`frontend/src/screens/dashboard.js` (`renderStructuredSummary`) כך שהערך הסופי לחריגות הוא המקסימום בין שדה ה־`exceptions_count`, סכימת רכיבי החריגות החלקיים וסקירת סכום החריגות לפי מנהל, כדי למנוע מצב שבו הסיכום יופיע כ־0 למרות שיש חריגות ברמת מנהלים.
- בעמודים והסגנון (קובץ `frontend/src/styles/main.css`) עשיתי התאמות עיצוביות שמביאות את הבקשות לפועל בלי לשנות פונקציונליות רחבה: הוספתי `.ds-end-dates__meta` להצגת מנהל פעילויות, הוספתי הפרדה עדינה אנכית בטבלת הפעילויות (`border-inline-start`), מרכזתי את עמודות התאריכים (`th/td` מסווגות), חידדתי את המראה של TODAY בתצוגת שבוע (`.ds-week-col.is-today` ו־`.ds-week-col__today-badge`) והוספתי media query בעמוד המדריכים כדי להציב 5 כרטיסים בשורה במסכים רחבים (`.ci-list--instr-grid`).

### Testing
- הרצתי את מערך הבדיקות האוטומטיות עם `npm run -s test` והכל עבר בהצלחה (`34/34 passing`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b4b8cae0832b8776529814cec8c7)