### PR TITLE
Unify exceptions counting across dashboard and exceptions page

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -206,6 +206,21 @@ function computeCourseExceptionsModel_(rows, ym, opts) {
   };
 }
 
+function getExceptionsSummary_(rows, ym, opts) {
+  var sourceRows = Array.isArray(rows) ? rows : [];
+  var normalizedYm = text_(ym || '');
+  var settings = opts && typeof opts === 'object' ? opts : {};
+  var includeRows = settings.include_rows === true;
+  var model = computeCourseExceptionsModel_(sourceRows, normalizedYm, { include_rows: includeRows });
+  return {
+    totalExceptions: model.total_exception_instances || 0,
+    currentMonthExceptions: model.total_exception_instances || 0,
+    exceptionsByManager: model.by_manager_exception_instances || {},
+    counts: model.counts || {},
+    rows: model.rows || []
+  };
+}
+
 function primaryExceptionForRow_(row) {
   var types = rowExceptionTypes_(row);
   if (!types.length) return '';
@@ -501,8 +516,8 @@ function actionDashboard_(user, payload) {
     managerActiveLong[manager] = (managerActiveLong[manager] || 0) + 1;
   });
 
-  var exceptionSummary = computeCourseExceptionsModel_(combined, ym, { include_rows: false });
-  managerExceptions = exceptionSummary.by_manager_exception_instances || {};
+  var exceptionSummary = getExceptionsSummary_(combined, ym, { include_rows: false });
+  managerExceptions = exceptionSummary.exceptionsByManager || {};
 
   Object.keys(byManager).forEach(function(manager) {
     byManager[manager].num_instructors = Object.keys(managerInstructorSets[manager] || {}).length;
@@ -566,7 +581,7 @@ function actionDashboard_(user, payload) {
   missingInstructorCount = exceptionSummary.counts.missing_instructor || 0;
   missingStartDateCount = exceptionSummary.counts.missing_start_date || 0;
   lateEndDateCount = exceptionSummary.counts.late_end_date || 0;
-  var exceptionSum = exceptionSummary.total_exception_instances || 0;
+  var exceptionSum = exceptionSummary.totalExceptions || 0;
 
   var shortActivitiesByType = {};
   shortRowsBySource.forEach(function(row) {
@@ -1460,9 +1475,9 @@ function actionExceptions_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var month = text_((payload && payload.month) || '');
   var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
-  var exceptionPayload = computeCourseExceptionsModel_(rows, month, { include_rows: true });
-  var counts = exceptionPayload.counts || {};
-  var result = exceptionPayload.rows || [];
+  var exceptionSummary = getExceptionsSummary_(rows, month, { include_rows: true });
+  var counts = exceptionSummary.counts || {};
+  var result = exceptionSummary.rows || [];
   var relevantRows = rows.filter(function(row) {
     return !isExcludedStatusForControl_(row && row.status) &&
       text_(row && row.activity_type) === 'course' &&

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -246,13 +246,41 @@ function pickField_(row, fieldNames, fallback) {
 }
 
 function resolveExceptionsCountForDashboard_(summaryObj, rawExceptions) {
-  var summary = summaryObj && typeof summaryObj === 'object' ? summaryObj : {};
-  var missingInstr = parseInt(text_(summary.missing_instructor_count), 10) || 0;
-  var missingStart = parseInt(text_(summary.missing_start_date_count), 10) || 0;
-  var lateEnd = parseInt(text_(summary.late_end_date_count), 10) || 0;
-  var fromSummaryParts = missingInstr + missingStart + lateEnd;
   var fromRaw = parseInt(text_(rawExceptions), 10);
-  return (isNaN(fromRaw) || fromRaw < 0) ? fromSummaryParts : fromRaw;
+  return (isNaN(fromRaw) || fromRaw < 0) ? 0 : fromRaw;
+}
+
+function enrichDashboardPayloadWithSharedExceptions_(payload, ym) {
+  if (!payload || typeof payload !== 'object') return payload;
+  var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
+  var exceptionSummary = getExceptionsSummary_(rows, ym, { include_rows: false });
+  var total = exceptionSummary.totalExceptions || 0;
+  var byManager = exceptionSummary.exceptionsByManager || {};
+
+  if (!payload.summary || typeof payload.summary !== 'object') payload.summary = {};
+  payload.summary.exceptions_count = total;
+  payload.summary.current_month_exceptions_count = exceptionSummary.currentMonthExceptions || 0;
+
+  if (payload.totals && typeof payload.totals === 'object') {
+    payload.totals.exceptions_count = total;
+  }
+  if (Array.isArray(payload.kpi_cards)) {
+    payload.kpi_cards = payload.kpi_cards.map(function(card) {
+      if (card && card.id === 'exceptions') {
+        card.title = String(total);
+        card.value = total;
+      }
+      return card;
+    });
+  }
+  if (Array.isArray(payload.by_activity_manager)) {
+    payload.by_activity_manager = payload.by_activity_manager.map(function(row) {
+      var manager = text_(row && row.activity_manager) || 'unassigned';
+      row.exceptions = byManager[manager] || 0;
+      return row;
+    });
+  }
+  return payload;
 }
 
 function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, canViewFinance) {
@@ -441,6 +469,7 @@ function actionDashboardSnapshot_(user, payload) {
   markRequestPerf_('dashboardSnapshot:monthly view lookup:end');
 
   if (viewTry && viewTry.ok && viewTry.payload) {
+    viewTry.payload = enrichDashboardPayloadWithSharedExceptions_(viewTry.payload, ym);
     setRequestPerfField_('dashboard_used_view', true);
     setRequestPerfField_('dashboard_fallback_used', false);
     setRequestPerfField_('dashboard_cache_hit', !!viewTry.cache_hit);
@@ -609,6 +638,7 @@ function actionDashboardSnapshot_(user, payload) {
     show_only_nonzero_kpis: flags.show_only_nonzero_kpis !== false,
     _is_snapshot: true
   };
+  sheetSnapshotPayload = enrichDashboardPayloadWithSharedExceptions_(sheetSnapshotPayload, ym);
   setRequestPerfField_('dashboard_fallback_used', false);
   setRequestPerfField_('dashboard_view_rows_read', 0);
   setRequestPerfField_('payload_bytes', JSON.stringify(sheetSnapshotPayload).length);


### PR DESCRIPTION
### Motivation

- Fix inconsistent exception counts shown across the Exceptions page, Dashboard KPI card and Dashboard summary snapshot by introducing one canonical computation path for exceptions.
- Ensure the Dashboard uses the exact same source and calculation as the Exceptions screen so "סה"כ חריגות" shows the same number everywhere.

### Description

- Added `getExceptionsSummary_` in `backend/actions.gs` as a single helper that wraps `computeCourseExceptionsModel_` and returns `totalExceptions`, `currentMonthExceptions`, `exceptionsByManager`, plus `counts` and `rows` for compatibility. 
- Updated `actionExceptions_` and `actionDashboard_` to call `getExceptionsSummary_` so both screens derive totals and per-manager tallies from the shared helper. 
- Replaced the previous snapshot fallback logic that reconstructed totals from individual category parts by changing `resolveExceptionsCountForDashboard_` to avoid the unreliable sum and added `enrichDashboardPayloadWithSharedExceptions_` in `backend/dashboard-snapshot.gs` to overwrite snapshot payload fields (KPI card, `summary.exceptions_count`, `totals.exceptions_count`, `by_activity_manager[].exceptions`) with values from the shared helper. 
- Applied the enrichment both when the dashboard is served from the monthly view payload and when it is served from snapshot sheets so all load paths use the unified source of truth. 

### Testing

- Ran repository searches with `rg` to confirm all exception calculations reference the new `getExceptionsSummary_` and enrichment helper, and the `rg` checks returned the expected updated references (success). 
- Inspected updated files with `sed`/`nl` to verify code locations and changes applied as intended (success). 
- Performed `git add` + `git commit` and created the PR using the internal `make_pr` helper; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b8004b20832ba0f659191ddf1992)