### PR TITLE
Optimize login/session and client cache to reduce permission lookups and speed navigation

### DIFF
--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -61,6 +61,8 @@ function actionLogin_(payload) {
     can_view_finance: role === 'admin' || yesNo_(matchByUser.view_finance) === 'yes'
   };
 
+  user.effective_routes = routes.slice();
+  user.default_route = defaultRoute;
   var token = createSessionToken_(user);
   CacheService.getScriptCache().put(
     sessionCacheKey_(token),
@@ -103,10 +105,12 @@ function requireAuth_(token) {
           can_add_activity: !!(enriched.can_add_activity || sessionFromToken.can_add_activity),
           can_edit_direct: !!enriched.can_edit_direct,
           can_request_edit: !!enriched.can_request_edit,
-          can_view_finance: !!enriched.can_view_finance
+          can_view_finance: !!enriched.can_view_finance,
+          __session_token: value
         };
       } catch (_e) {}
     }
+    sessionFromToken.__session_token = value;
     return sessionFromToken;
   }
 
@@ -115,7 +119,9 @@ function requireAuth_(token) {
   if (!raw) raw = CacheService.getScriptCache().get('session:' + value);
   if (!raw) throw new Error('Unauthorized');
 
-  return JSON.parse(raw);
+  var parsed = JSON.parse(raw);
+  parsed.__session_token = value;
+  return parsed;
 }
 
 function sessionCacheKey_(token) {
@@ -223,6 +229,7 @@ function requireAnyRole_(user, roles) {
 }
 
 function getPermissionRow_(userId) {
+  setRequestPerfField_('permissions_lookup', true);
   var rows = readRows_(CONFIG.SHEETS.PERMISSIONS);
   var match = rows.find(function(row) {
     return text_(row.user_id) === text_(userId);
@@ -407,6 +414,17 @@ function canUserAccessRoute_(user, route) {
   }
   var permission = getPermissionRow_(user.user_id);
   var effective = effectiveRoutesForUser_(permission, user.display_role);
+  if (user && user.user_id) {
+    user.effective_routes = effective.slice();
+    user.default_route = resolveDefaultRoute_(text_(permission.default_view), effective, user.display_role);
+    try {
+      CacheService.getScriptCache().put(
+        sessionCacheKey_(text_(user.__session_token || '')),
+        JSON.stringify(user),
+        CONFIG.SESSION_CACHE_SECONDS
+      );
+    } catch (_e) {}
+  }
   return effective.indexOf(r) >= 0;
 }
 

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -282,8 +282,16 @@ function beginRequestPerf_(action, payload) {
     marks: [{ label: 'request_start', at_ms: perfNowMs_() }],
     sheet_reads: [],
     sheets_total_ms: 0,
-    custom: {}
+    custom: {
+      permissions_lookup: false,
+      data_source: 'full'
+    }
   };
+  try {
+    __rqPerf_.custom.request_size_bytes = JSON.stringify(payload || {}).length;
+  } catch (_e) {
+    __rqPerf_.custom.request_size_bytes = 0;
+  }
 }
 
 function markRequestPerf_(label) {

--- a/frontend/src/cache-persist.js
+++ b/frontend/src/cache-persist.js
@@ -3,7 +3,7 @@ import { state } from './state.js';
 export const SCREEN_CACHE_STORAGE_PREFIX = 'ds_screen_cache_v1';
 
 const PERSIST_BLOCKED_PREFIXES = [
-  'activities:', 'week:', 'month:', 'finance:', 'activityDetail:'
+  'activityDetail:'
 ];
 const PERSIST_MAX_BYTES = 100 * 1024; // 100 KB
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -623,10 +623,6 @@ function screenCacheTtl() {
   return SCREEN_CACHE_TTL_MS[state.route] ?? DEFAULT_CACHE_TTL_MS;
 }
 const MEMORY_ONLY_CACHE_PREFIXES = [
-  'activities:',
-  'month:',
-  'week:',
-  'finance:',
   'activityDetail:',
   'operations:'
 ];
@@ -641,15 +637,34 @@ function shouldPersistScreenCacheEntry(key, entry) {
   }
 
   try {
-    return JSON.stringify(entry || {}).length <= MAX_PERSISTED_CACHE_ENTRY_BYTES;
+    const normalized = normalizeEntryForPersistentCache(cacheKey, entry);
+    if (!normalized) return false;
+    return JSON.stringify(normalized).length <= MAX_PERSISTED_CACHE_ENTRY_BYTES;
   } catch {
     return false;
   }
 }
 
+function normalizeEntryForPersistentCache(cacheKey, entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const payload = entry.data;
+  if (cacheKey.startsWith('activities:') && payload && Array.isArray(payload.rows)) {
+    return { ...entry, data: { ...payload, rows: payload.rows.slice(0, 60) } };
+  }
+  if (cacheKey.startsWith('finance:') && payload && Array.isArray(payload.rows)) {
+    return { ...entry, data: { ...payload, rows: payload.rows.slice(0, 50) } };
+  }
+  if (cacheKey.startsWith('week:') || cacheKey.startsWith('month:')) {
+    if (payload && Array.isArray(payload.rows)) {
+      return { ...entry, data: { ...payload, rows: payload.rows.slice(0, 80) } };
+    }
+  }
+  return entry;
+}
+
 function maybePersistScreenCacheEntry(key, entry) {
   if (!shouldPersistScreenCacheEntry(key, entry)) return;
-  persistCacheEntry(key, entry);
+  persistCacheEntry(key, normalizeEntryForPersistentCache(String(key || ''), entry));
 }
 /**
  * Returns cached data immediately if available and fresh (within TTL).


### PR DESCRIPTION
### Motivation
- Reduce slow post-login and route transitions by avoiding redundant `bootstrap`/permissions sheet reads and by returning usable routes and settings immediately from `login` responses.
- Improve UX for heavy screens by persisting small snapshots instead of forcing full reloads on refresh or navigation.

### Description
- Enrich session payload at `actionLogin_` with `effective_routes` and `default_route` so the frontend can apply routes immediately after login and avoid a blocking `bootstrap` call (`backend/auth.gs`).
- Make `requireAuth_` and fallback session parsing carry an internal `__session_token` marker and persist small session updates back to the script cache when `canUserAccessRoute_` computes routes, reducing repeated `getPermissionRow_` sheet reads (`backend/auth.gs`).
- Add request perf defaults (`permissions_lookup`, `data_source`, `request_size_bytes`) and expose `permissions_lookup` when reading the permissions sheet to improve backend observability (`backend/helpers.gs`).
- Change frontend cache persistence policy to allow lightweight snapshots for heavy screens by normalizing/persisting truncated `rows` (slicing) and remove blanket memory-only blocking for `activities/week/month/finance`, while keeping `activityDetail` memory-only (`frontend/src/main.js`, `frontend/src/cache-persist.js`).

### Testing
- Ran `npm run -s lint` in this environment which returned a non-zero exit (no lint output available here), so automated lint did not complete successfully.
- Verified repository state and created a commit including `backend/auth.gs`, `backend/helpers.gs`, `frontend/src/main.js` and `frontend/src/cache-persist.js` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b9062ea0832ba0c5e2de4d1069d2)