### PR TITLE
Merge missing instructor data from legacy rows into activities snapshot and improve add-activity form submit/end_date handling

### DIFF
--- a/backend/activities-snapshot.gs
+++ b/backend/activities-snapshot.gs
@@ -84,6 +84,10 @@ function normalizeActivitiesSnapshotRow_(row) {
   normalized.instructor_name_2 = instructor2;
   normalized.emp_id = emp1;
   normalized.emp_id_2 = emp2;
+  normalized.Employee = text_(src.Employee || src.employee || instructor1);
+  normalized.Employee2 = text_(src.Employee2 || src.employee2 || instructor2);
+  normalized.EmployeeID = text_(src.EmployeeID || src.employee_id || emp1);
+  normalized.EmployeeID2 = text_(src.EmployeeID2 || src.EmployeeID_2 || src.employee_id_2 || emp2);
   if (!normalized.source_sheet) {
     var rowId = text_(src.RowID);
     normalized.source_sheet = rowId.indexOf('LONG-') === 0 ? CONFIG.SHEETS.DATA_LONG : CONFIG.SHEETS.DATA_SHORT;
@@ -154,6 +158,45 @@ function filterActivitiesSnapshotRows_(rows, payload) {
   });
 }
 
+function rowHasInstructorData_(row) {
+  var hasName = !!(text_(row && row.instructor_name) || text_(row && row.instructor_name_2) || text_(row && row.Employee) || text_(row && row.Employee2));
+  var hasEmp = !!(text_(row && row.emp_id) || text_(row && row.emp_id_2) || text_(row && row.EmployeeID) || text_(row && row.EmployeeID2));
+  return hasName || hasEmp;
+}
+
+function mergeInstructorFieldsByRowId_(snapshotRows, legacyRows) {
+  var snapRows = Array.isArray(snapshotRows) ? snapshotRows : [];
+  var legacyMap = {};
+  (Array.isArray(legacyRows) ? legacyRows : []).forEach(function(row) {
+    legacyMap[text_(row && row.RowID)] = normalizeActivitiesSnapshotRow_(row);
+  });
+  var mergedCount = 0;
+  var missingCount = 0;
+  var out = snapRows.map(function(row) {
+    var normalized = normalizeActivitiesSnapshotRow_(row);
+    if (rowHasInstructorData_(normalized)) return normalized;
+    missingCount += 1;
+    var match = legacyMap[text_(normalized && normalized.RowID)];
+    if (!match || !rowHasInstructorData_(match)) return normalized;
+    mergedCount += 1;
+    normalized.instructor_name = text_(match.instructor_name);
+    normalized.instructor_name_2 = text_(match.instructor_name_2);
+    normalized.emp_id = text_(match.emp_id);
+    normalized.emp_id_2 = text_(match.emp_id_2);
+    normalized.Employee = text_(match.Employee || match.instructor_name);
+    normalized.Employee2 = text_(match.Employee2 || match.instructor_name_2);
+    normalized.EmployeeID = text_(match.EmployeeID || match.emp_id);
+    normalized.EmployeeID2 = text_(match.EmployeeID2 || match.emp_id_2);
+    return normalized;
+  });
+  return {
+    rows: out,
+    missing_before: missingCount,
+    merged: mergedCount,
+    still_missing: Math.max(0, missingCount - mergedCount)
+  };
+}
+
 function actionActivitiesLegacy_(user, payload) {
   return actionActivities_(user, payload);
 }
@@ -181,21 +224,26 @@ function actionActivitiesSnapshotFirst_(user, payload) {
   var filtered = filterActivitiesSnapshotRows_(rows, payload || {});
   var snapStats = activitiesInstructorCoverageStats_(filtered);
 
-  if (filtered.length && snapStats.missing_instructor === filtered.length) {
-    var fallbackAllMissing = actionActivitiesLegacy_(user, payload || {});
-    var fallbackRowsMissing = Array.isArray(fallbackAllMissing.rows) ? fallbackAllMissing.rows : [];
-    var fallbackStatsMissing = activitiesInstructorCoverageStats_(fallbackRowsMissing);
-    if (fallbackStatsMissing.missing_instructor < snapStats.missing_instructor) {
-      try { refreshActivitiesSnapshot_(); } catch (_refreshErrAllMissing) {}
-      fallbackAllMissing._is_snapshot = false;
-      fallbackAllMissing._activities_fallback_used = true;
-      fallbackAllMissing._snapshot_fallback_reason = 'snapshot_missing_instructor';
-      fallbackAllMissing._snapshot_instructor_stats = {
-        snapshot: snapStats,
-        fallback: fallbackStatsMissing
-      };
-      return fallbackAllMissing;
+  var needsFallbackMerge = filtered.some(function(row) {
+    return !rowHasInstructorData_(row);
+  });
+  var mergeReport = { missing_before: 0, merged: 0, still_missing: 0 };
+
+  if (needsFallbackMerge) {
+    var fallbackData = actionActivitiesLegacy_(user, payload || {});
+    var fallbackRows = Array.isArray(fallbackData.rows) ? fallbackData.rows : [];
+    var merged = mergeInstructorFieldsByRowId_(filtered, fallbackRows);
+    filtered = merged.rows;
+    mergeReport = {
+      missing_before: merged.missing_before,
+      merged: merged.merged,
+      still_missing: merged.still_missing
+    };
+    var mergedStats = activitiesInstructorCoverageStats_(filtered);
+    if (merged.merged > 0 || mergedStats.missing_instructor < snapStats.missing_instructor) {
+      try { refreshActivitiesSnapshot_(); } catch (_refreshErrInstructorMerge) {}
     }
+    snapStats = mergedStats;
   }
 
   return {
@@ -205,7 +253,7 @@ function actionActivitiesSnapshotFirst_(user, payload) {
     _is_snapshot: true,
     _activities_fallback_used: false,
     _snapshot_updated_at: text_(snap.updated_at),
-    _snapshot_instructor_stats: { snapshot: snapStats }
+    _snapshot_instructor_stats: { snapshot: snapStats, merge: mergeReport }
   };
 }
 

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -193,6 +193,7 @@ function addActivityModalHtml(settings) {
         <label class="ds-activity-add-field" data-field-instructor2 style="display:none"><span>מדריך/ה 2</span><select class="ds-input" name="instructor_name_2" data-add-instructor-2>${optionsHtml(instructorOptions)}</select></label>
         <input type="hidden" name="emp_id_2" value="">
         <label class="ds-activity-add-field"><span>תאריך התחלה</span><input class="ds-input" name="start_date" type="date"></label>
+        <label class="ds-activity-add-field"><span>תאריך סיום</span><input class="ds-input" name="end_date" type="date"></label>
         <label class="ds-activity-add-field"><span>תדירות</span><select class="ds-input" name="frequency" data-add-frequency>${optionsHtml(['weekly', 'biweekly'], 'weekly', 'בחרו תדירות')}</select></label>
         <div class="ds-activity-add-field ds-activity-add-field--span2" data-add-date-rows-wrap>
           <span>תאריכי מפגשים</span>
@@ -200,6 +201,7 @@ function addActivityModalHtml(settings) {
         </div>
         <label class="ds-activity-add-field"><span>הערות</span><textarea class="ds-input" name="notes" rows="2"></textarea></label>
       </div>
+      <button type="submit" hidden aria-hidden="true"></button>
       <p class="ds-muted" role="status" data-add-activity-status></p>
     </form>
   `;
@@ -694,16 +696,11 @@ export const activitiesScreen = {
       form.querySelector('[data-add-frequency]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
     }
 
-    document.addEventListener('click', async (ev) => {
-      const submit = ev.target.closest('[data-add-activity-submit]');
-      if (!submit) return;
-      const modal = document.querySelector('.ds-modal__content');
-      const form = modal?.querySelector('[data-add-activity-form]');
-      if (!form) return;
+    async function submitAddActivityForm(form, submitBtn) {
       const statusEl = form.querySelector('[data-add-activity-status]');
       const activityMap = decodeJsonAttr(form.dataset.addActivityNames, []);
       const roster = decodeJsonAttr(form.dataset.addRosterUsers, []);
-      const fd = new FormData(form);
+      const fd = new (window?.FormData || FormData)(form);
       const get = (k) => String(fd.get(k) || '').trim();
       const familySource = get('source') || 'long';
       const selectedName = get('activity_name');
@@ -738,6 +735,8 @@ export const activitiesScreen = {
         instructor_name_2: isShort ? get('instructor_name_2') : '',
         emp_id_2: isShort ? pickEmp(get('instructor_name_2')) : '',
         start_date: get('start_date'),
+        end_date: get('end_date') || '',
+        frequency: get('frequency'),
         status: 'פעיל',
         notes: get('notes')
       };
@@ -745,15 +744,31 @@ export const activitiesScreen = {
       dateInputs.forEach((input, index) => {
         payload[`Date${index + 1}`] = String(input.value || '').trim();
       });
-      if (!payload.activity_type || !payload.activity_name || !payload.start_date) {
-        if (statusEl) statusEl.textContent = 'יש למלא לפחות סוג פעילות, שם פעילות ותאריך התחלה';
+      if (!payload.end_date) {
+        const lastDate = [...dateInputs].map((input) => String(input.value || '').trim()).filter(Boolean).pop();
+        payload.end_date = lastDate || payload.start_date || '';
+      }
+
+      const required = [
+        ['activity_type', 'סוג פעילות'],
+        ['activity_name', 'שם פעילות'],
+        ['start_date', 'תאריך התחלה']
+      ];
+      const missing = required.filter(([key]) => !String(payload[key] || '').trim()).map(([, label]) => label);
+      if (missing.length) {
+        if (statusEl) statusEl.textContent = `יש להשלים שדות חובה: ${missing.join(' ,')}`;
         return;
       }
+
+      const originalText = submitBtn?.textContent || 'שמור';
       try {
-        submit.disabled = true;
+        if (submitBtn) {
+          submitBtn.disabled = true;
+          submitBtn.textContent = 'שומר...';
+        }
         if (statusEl) statusEl.textContent = 'שומר...';
         const rsp = await api.addActivity(payload);
-        if (statusEl) statusEl.textContent = 'נשמר בהצלחה';
+        if (statusEl) statusEl.textContent = 'הפעילות נשמרה';
         const localRow = {
           RowID: rsp?.RowID || '',
           source_sheet: rsp?.source_sheet || (payload.source === 'long' ? 'data_long' : 'data_short'),
@@ -767,7 +782,7 @@ export const activitiesScreen = {
           emp_id: payload.emp_id,
           emp_id_2: payload.emp_id_2,
           start_date: payload.start_date,
-          end_date: payload.Date2 || payload.start_date,
+          end_date: payload.end_date,
           status: 'פעיל',
           private_note: '',
           meeting_dates: dateInputs.map((input) => String(input.value || '').trim()).filter(Boolean)
@@ -777,10 +792,32 @@ export const activitiesScreen = {
         ui?.closeModal?.();
         void scheduleQuietRefresh();
       } catch (err) {
-        if (statusEl) statusEl.textContent = `שגיאה: ${String(err?.message || '')}`;
+        if (statusEl) statusEl.textContent = `שגיאה בשמירה: ${String(err?.message || '')}`;
       } finally {
-        submit.disabled = false;
+        if (submitBtn) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = originalText;
+        }
       }
+    }
+
+    document.addEventListener('submit', (ev) => {
+      const form = ev.target?.closest?.('[data-add-activity-form]');
+      if (!form) return;
+      ev.preventDefault();
+      const submitBtn = document.querySelector('[data-add-activity-submit]');
+      if (submitBtn?.disabled) return;
+      void submitAddActivityForm(form, submitBtn);
+    }, addActivitySig);
+
+    document.addEventListener('click', (ev) => {
+      const submit = ev.target.closest('[data-add-activity-submit]');
+      if (!submit) return;
+      const modal = document.querySelector('.ds-modal__content');
+      const form = modal?.querySelector('[data-add-activity-form]');
+      if (!form) return;
+      if (submit.disabled) return;
+      form.requestSubmit?.();
     }, addActivitySig);
 
     const addBtn = root.querySelector('[data-activities-add-btn]');

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -72,3 +72,16 @@ test('activities table keeps expected columns structure', () => {
   const html = activitiesScreen.render(data, { state: baseState() });
   assert.match(html, /<th>תוכנית \/ סוג<\/th><th>רשות<\/th><th>בית ספר<\/th><th>מדריך<\/th><th>תאריך התחלה<\/th><th>תאריך סיום<\/th><th>הערות<\/th>/);
 });
+
+
+
+
+
+test('activities screen wires add-activity form submit to api.addActivity flow', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
+  assert.match(source, /data-add-activity-form/);
+  assert.match(source, /document\.addEventListener\('submit'[\s\S]*submitAddActivityForm/);
+  assert.match(source, /await api\.addActivity\(payload\)/);
+  assert.match(source, /statusEl\) statusEl\.textContent = `שגיאה בשמירה:/);
+});

--- a/tests/backend-write-flows-guard.test.mjs
+++ b/tests/backend-write-flows-guard.test.mjs
@@ -50,3 +50,13 @@ test('activities snapshot refresh persists rows and bumps data-views version', (
   mustMatch(snapshot, /JSON\.stringify\(payload\.rows \|\| \[\]\)/);
   mustMatch(snapshot, /bumpDataViewsCacheVersion_\(\);/);
 });
+
+
+test('activities snapshot normalizes instructor aliases and merges missing instructor fields by RowID fallback', () => {
+  mustMatch(snapshot, /normalized\.instructor_name = instructor1;/);
+  mustMatch(snapshot, /normalized\.EmployeeID2 = text_\(src\.EmployeeID2 \|\| src\.EmployeeID_2 \|\| src\.employee_id_2 \|\| emp2\);/);
+  mustMatch(snapshot, /function mergeInstructorFieldsByRowId_\(snapshotRows, legacyRows\)/);
+  mustMatch(snapshot, /var match = legacyMap\[text_\(normalized && normalized\.RowID\)\];/);
+  mustMatch(snapshot, /needsFallbackMerge = filtered\.some\(function\(row\) \{/);
+  mustMatch(snapshot, /var fallbackData = actionActivitiesLegacy_\(user, payload \|\| \{\}\);/);
+});


### PR DESCRIPTION
### Motivation

- Ensure activities snapshot contains instructor identifiers even when some rows lack instructor fields by merging data from legacy rows matched by `RowID`.
- Improve the add-activity UX by explicitly capturing `end_date`, deriving it from session dates when omitted, and wiring the form submit flow to a dedicated handler that disables the submit button and reports clearer status messages.

### Description

- Backend: add normalization of alternate instructor aliases by populating `Employee`, `Employee2`, `EmployeeID`, and `EmployeeID2` in `normalizeActivitiesSnapshotRow_` to unify multiple field variants.  
- Backend: introduce `rowHasInstructorData_` and `mergeInstructorFieldsByRowId_` to detect missing instructor data and merge fields from legacy fallback rows keyed by `RowID`, and integrate this merge into `actionActivitiesSnapshotFirst_` with a merge report included in `_snapshot_instructor_stats`.  
- Frontend: add an `end_date` input to the add-activity modal and ensure `end_date` is populated from session date rows when not provided.  
- Frontend: refactor submission flow into `submitAddActivityForm` with robust FormData handling, required-field validation (localized messages), submit button disable/text updates, `form.requestSubmit` support, and submission via `document` `submit` and click handlers that call the new handler and call `api.addActivity`.  
- Tests: update and add unit tests to assert snapshot normalization/merge behavior and to verify the new frontend wiring to `api.addActivity` and error message text.

### Testing

- Ran the automated test suite with `npm test`, and all tests completed successfully.  
- Updated `tests/backend-write-flows-guard.test.mjs` to assert presence of `mergeInstructorFieldsByRowId_` and normalization lines, and those assertions passed.  
- Updated `tests/activities-screen.test.mjs` to add a test that verifies the add-activity form submission wiring to `api.addActivity` and localized error text, and that test passed.  
- Existing rendering and snapshot-related tests were re-run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ba1d84a4832b82d80574ee569a94)