### PR TITLE
Week navigation transition and month-day activity highlighting

### DIFF
--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -258,6 +258,7 @@ export const weekScreen = {
         : `${rangeLabel || 'שבוע'}`;
 
     const navLoading = !!state.weekNavLoading;
+    const navDirection = state.weekNavDirection === 'prev' ? ' week-transition is-entering-prev' : state.weekNavDirection === 'next' ? ' week-transition is-entering-next' : '';
     const html = dsScreenStack(`
       <nav class="ds-cal-nav${navLoading ? ' is-nav-loading' : ''}" role="navigation" aria-label="ניווט שבועי" dir="rtl">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-prev aria-label="שבוע קודם" title="שבוע קודם" ${navLoading ? 'disabled' : ''}>▶</button>
@@ -266,7 +267,7 @@ export const weekScreen = {
         <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-next aria-label="שבוע הבא" title="שבוע הבא" ${navLoading ? 'disabled' : ''}>◀</button>
       </nav>
       ${toolbarHtml}
-      <div class="ds-week-board${navLoading ? ' is-inline-loading' : ''}" style="--week-cols:${safeDays.length || 7}" role="region" aria-label="לוח שבוע">${body}</div>
+      <div class="ds-week-board${navLoading ? ' is-inline-loading' : ''}${navDirection}" style="--week-cols:${safeDays.length || 7}" role="region" aria-label="לוח שבוע">${body}</div>
     `);
     return html;
   },
@@ -306,11 +307,13 @@ export const weekScreen = {
       if (state.weekNavLoading) return;
       const startedAt = Date.now();
       state.weekNavLoading = true;
+      state.weekNavDirection = delta > 0 ? 'next' : 'prev';
       state.weekOffset = (state.weekOffset || 0) + delta;
       rerender?.();
-      const minMs = 420;
+      const minMs = 220;
       setTimeout(() => {
         state.weekNavLoading = false;
+        state.weekNavDirection = '';
         rerender?.();
       }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
@@ -318,6 +321,7 @@ export const weekScreen = {
     bindListener(nextBtn, 'click', () => doWeekShift(1));
     bindListener(todayBtn, 'click', () => {
       if (state.weekNavLoading) return;
+      state.weekNavDirection = '';
       state.weekOffset = 0;
       rerender?.();
     });

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8343,3 +8343,62 @@ select.ds-activity-add-field .ds-input,
     animation: none !important;
   }
 }
+
+/* Week navigation transition (week board only) */
+.ds-week-board.week-transition.is-entering-next {
+  animation: ds-week-enter-next 220ms ease both;
+}
+
+.ds-week-board.week-transition.is-entering-prev {
+  animation: ds-week-enter-prev 220ms ease both;
+}
+
+@keyframes ds-week-enter-next {
+  from {
+    opacity: 0.38;
+    transform: translateX(-16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ds-week-enter-prev {
+  from {
+    opacity: 0.38;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Month day cell highlighting for days with activities */
+.ds-cal-grid .ds-interactive-card--day-cell.has-activities {
+  background: rgba(59, 130, 246, 0.08);
+  border-color: rgba(59, 130, 246, 0.2);
+}
+
+.ds-cal-grid .ds-interactive-card--day-cell.has-activities:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.12);
+}
+
+/* Keep TODAY dominant while preserving activity indication */
+.ds-interactive-card.is-cal-today.has-activities {
+  background: linear-gradient(165deg, #deeaff 0%, #eef4ff 100%);
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.22),
+              0 0 0 1px rgba(59, 130, 246, 0.13),
+              0 0 18px rgba(59, 130, 246, 0.14),
+              0 4px 14px rgba(26, 51, 88, 0.07);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-week-board.week-transition.is-entering-next,
+  .ds-week-board.week-transition.is-entering-prev {
+    animation: none !important;
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve week-to-week navigation UX by adding a subtle directional transition to avoid abrupt content jumps. 
- Make days with activities more visually distinguishable in the month view without changing business logic, date calculations, data structures, or filters. 

### Description
- Added directional state and dynamic classes to the week view render so the week board gets `week-transition is-entering-next` / `week-transition is-entering-prev` during navigation, using `state.weekNavDirection` to avoid overlapping transitions (`frontend/src/screens/week.js`).
- Reduced the visual transition duration to ~220ms and preserved the existing `weekNavLoading` guard to prevent double clicks/race conditions (`frontend/src/screens/week.js`).
- Added CSS keyframes, reduced-motion fallback, and classes for the week-board slide+fade effect (`frontend/src/styles/main.css`).
- Emphasized month day cells that contain activities by adding a subtle tinted background, border and hover state, and ensured the existing `TODAY` styling remains dominant when both states apply (`frontend/src/styles/main.css`).

### Testing
- Ran `git diff --check` on the repository and it passed. 
- Attempted to run `npm --prefix frontend run -s lint` but it failed in this environment because `frontend/package.json` is not present, so frontend linting could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2be02a8a4832b846b9232f6b0a2bc)