### PR TITLE
Fix add-activity save flow and add payload validation (frontend + backend)

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -2158,6 +2158,34 @@ function actionAddActivity_(user, payload) {
 
   var activity = payload.activity || {};
   var source = text_(activity.source || 'short').toLowerCase();
+
+  var requiredFields = [
+    'source',
+    'activity_type',
+    'activity_name',
+    'activity_manager',
+    'authority',
+    'school',
+    'start_date',
+    'end_date',
+    'sessions',
+    'price',
+    'funding',
+    'start_time',
+    'end_time',
+    'instructor_name',
+    'emp_id',
+    'notes'
+  ];
+  var missingFields = requiredFields.filter(function(field) {
+    return !text_(activity[field]);
+  });
+  if (missingFields.length) {
+    throw new Error('Missing required fields: ' + missingFields.join(', '));
+  }
+  if (source !== 'long' && source !== 'short') {
+    throw new Error('Invalid source: ' + source + '. Expected long or short.');
+  }
   var targetSheet = source === 'long' ? CONFIG.SHEETS.DATA_LONG : CONFIG.SHEETS.DATA_SHORT;
   var rowId = nextId_(targetSheet, targetSheet === CONFIG.SHEETS.DATA_LONG ? 'LONG-' : 'SHORT-');
 

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -750,9 +750,22 @@ export const activitiesScreen = {
       }
 
       const required = [
+        ['source', 'מקור'],
         ['activity_type', 'סוג פעילות'],
         ['activity_name', 'שם פעילות'],
-        ['start_date', 'תאריך התחלה']
+        ['activity_manager', 'מנהל פעילות'],
+        ['authority', 'רשות'],
+        ['school', 'בית ספר'],
+        ['start_date', 'תאריך התחלה'],
+        ['end_date', 'תאריך סיום'],
+        ['sessions', 'מספר מפגשים'],
+        ['price', 'מחיר'],
+        ['funding', 'מימון'],
+        ['start_time', 'שעת התחלה'],
+        ['end_time', 'שעת סיום'],
+        ['instructor_name', 'מדריך/ה'],
+        ['emp_id', 'מספר עובד'],
+        ['notes', 'הערות']
       ];
       const missing = required.filter(([key]) => !String(payload[key] || '').trim()).map(([, label]) => label);
       if (missing.length) {
@@ -767,7 +780,10 @@ export const activitiesScreen = {
           submitBtn.textContent = 'שומר...';
         }
         if (statusEl) statusEl.textContent = 'שומר...';
+        console.info('[addActivity] submit fired');
+        console.info('[addActivity] payload', payload);
         const rsp = await api.addActivity(payload);
+        console.info('[addActivity] success', rsp);
         if (statusEl) statusEl.textContent = 'הפעילות נשמרה';
         const localRow = {
           RowID: rsp?.RowID || '',
@@ -792,6 +808,7 @@ export const activitiesScreen = {
         ui?.closeModal?.();
         void scheduleQuietRefresh();
       } catch (err) {
+        console.error('[addActivity] failed', err);
         if (statusEl) statusEl.textContent = `שגיאה בשמירה: ${String(err?.message || '')}`;
       } finally {
         if (submitBtn) {
@@ -800,6 +817,19 @@ export const activitiesScreen = {
         }
       }
     }
+
+    const modalRoot = document;
+    const addActivityForm = modalRoot.querySelector('[data-add-activity-form]');
+    if (addActivityForm && addActivityForm.dataset.submitBound !== 'yes') {
+      addActivityForm.dataset.submitBound = 'yes';
+      addActivityForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const submitBtn = document.querySelector('[data-add-activity-submit]');
+        if (submitBtn?.disabled) return;
+        await submitAddActivityForm(addActivityForm, submitBtn);
+      }, addActivitySig);
+    }
+
 
     document.addEventListener('submit', (ev) => {
       const form = ev.target?.closest?.('[data-add-activity-form]');


### PR DESCRIPTION
### Motivation
- Ensure clicking "שמור" in the add-activity modal always triggers a real `submit -> payload -> api.addActivity` flow even when the button is outside the `<form>` element.  
- Make failures visible to the user and to debug (don't fail silently).  
- Prevent empty/partial payloads reaching the backend by validating required fields earlier.

### Description
- Frontend: wired the add-activity modal to a guaranteed form submit flow by adding an explicit `submit` listener on the form (`[data-add-activity-form]`) and guarding with `dataset.submitBound`, while keeping the existing `requestSubmit`/click handlers; the handler invokes `submitAddActivityForm` (file `frontend/src/screens/activities.js`).
- Frontend: added temporary debug logs around the API call (`console.info('[addActivity] submit fired')`, `console.info('[addActivity] payload', payload)`, `console.info('[addActivity] success', rsp)`, and `console.error('[addActivity] failed', err)`) and improved user-visible status messages in `[data-add-activity-status]` for saving/success/error.  
- Frontend: tightened client-side required-field validation for the add activity payload to include `source`, `activity_manager`, `authority`, `school`, `sessions`, `price`, `funding`, `start_time`, `end_time`, `instructor_name`, `emp_id`, `notes` (and others) before calling `api.addActivity` (file `frontend/src/screens/activities.js`).
- Backend: hardened `actionAddActivity_` to validate required fields and to validate `source` is `long` or `short`, returning a clear error when fields are missing or `source` is invalid (file `backend/actions.gs`).

### Testing
- Ran the automated test suite with `npm test --silent` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bfc1cfac832b93a7e5eb15c78e8d)