### PR TITLE
Unify exceptions to a single source-of-truth model

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -173,9 +173,10 @@ function collectProgramExceptions_(rows, opts) {
   };
 }
 
-function computeCourseExceptionsModel_(rows, ym, opts) {
+function computeExceptionsModel_(rows, ym, opts) {
   var options = opts || {};
   var includeRows = options.include_rows === true;
+  var includeDebug = options.include_debug === true;
   var sourceRows = Array.isArray(rows) ? rows : [];
   var month = text_(ym || '');
   var payload = collectProgramExceptions_(sourceRows, {
@@ -188,37 +189,53 @@ function computeCourseExceptionsModel_(rows, ym, opts) {
     if (month && !activityOverlapsYm_(row, month)) return false;
     return !isExcludedStatusForControl_(row && row.status);
   });
-  var byManagerExceptionInstances = {};
+
+  var byManager = {};
+  var sampleRows = [];
   relevantRows.forEach(function(row) {
     var manager = text_(row && row.activity_manager) || 'unassigned';
-    var exceptionsForRow = rowExceptionTypes_(row).length;
-    if (!exceptionsForRow) return;
-    byManagerExceptionInstances[manager] = (byManagerExceptionInstances[manager] || 0) + exceptionsForRow;
+    var types = rowExceptionTypes_(row);
+    if (!types.length) return;
+    if (!byManager[manager]) byManager[manager] = { exceptions: 0, rows: 0 };
+    byManager[manager].exceptions += types.length;
+    byManager[manager].rows += 1;
+    if (includeDebug && sampleRows.length < 25) {
+      sampleRows.push({
+        RowID: text_(row && row.RowID),
+        activity_name: text_(row && row.activity_name),
+        activity_manager: manager,
+        exception_types: types.slice(),
+        source_sheet: text_(row && row.source_sheet),
+        start_date: text_(row && row.start_date),
+        end_date: text_(row && row.end_date),
+        instructor_name: text_(row && row.instructor_name),
+        instructor_name_2: text_(row && row.instructor_name_2),
+        status: text_(row && row.status)
+      });
+    }
   });
+
+  var debug = includeDebug ? {
+    totalExceptionInstances: payload.total_exception_instances || 0,
+    totalExceptionRows: payload.total_exception_rows || 0,
+    counts: payload.counts || {},
+    byManager: byManager,
+    sampleRows: sampleRows
+  } : null;
 
   return {
     month: month,
-    counts: payload.counts || {},
     rows: payload.rows || [],
-    total_exception_instances: payload.total_exception_instances || 0,
-    total_exception_rows: payload.total_exception_rows || 0,
-    by_manager_exception_instances: byManagerExceptionInstances
+    totalExceptionInstances: payload.total_exception_instances || 0,
+    totalExceptionRows: payload.total_exception_rows || 0,
+    counts: payload.counts || {},
+    byManager: byManager,
+    debug: debug
   };
 }
 
 function getExceptionsSummary_(rows, ym, opts) {
-  var sourceRows = Array.isArray(rows) ? rows : [];
-  var normalizedYm = text_(ym || '');
-  var settings = opts && typeof opts === 'object' ? opts : {};
-  var includeRows = settings.include_rows === true;
-  var model = computeCourseExceptionsModel_(sourceRows, normalizedYm, { include_rows: includeRows });
-  return {
-    totalExceptions: model.total_exception_instances || 0,
-    currentMonthExceptions: model.total_exception_instances || 0,
-    exceptionsByManager: model.by_manager_exception_instances || {},
-    counts: model.counts || {},
-    rows: model.rows || []
-  };
+  return computeExceptionsModel_(rows, ym, opts || {});
 }
 
 function primaryExceptionForRow_(row) {
@@ -517,7 +534,7 @@ function actionDashboard_(user, payload) {
   });
 
   var exceptionSummary = getExceptionsSummary_(combined, ym, { include_rows: false });
-  managerExceptions = exceptionSummary.exceptionsByManager || {};
+  managerExceptions = exceptionSummary.byManager || {};
 
   Object.keys(byManager).forEach(function(manager) {
     byManager[manager].num_instructors = Object.keys(managerInstructorSets[manager] || {}).length;
@@ -581,7 +598,7 @@ function actionDashboard_(user, payload) {
   missingInstructorCount = exceptionSummary.counts.missing_instructor || 0;
   missingStartDateCount = exceptionSummary.counts.missing_start_date || 0;
   lateEndDateCount = exceptionSummary.counts.late_end_date || 0;
-  var exceptionSum = exceptionSummary.totalExceptions || 0;
+  var exceptionSum = exceptionSummary.totalExceptionInstances || 0;
 
   var shortActivitiesByType = {};
   shortRowsBySource.forEach(function(row) {
@@ -1475,7 +1492,7 @@ function actionExceptions_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
   var month = text_((payload && payload.month) || '');
   var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
-  var exceptionSummary = getExceptionsSummary_(rows, month, { include_rows: true });
+  var exceptionSummary = getExceptionsSummary_(rows, month, { include_rows: true, include_debug: yesNo_(payload && payload.debug) === 'yes' });
   var counts = exceptionSummary.counts || {};
   var result = exceptionSummary.rows || [];
   var relevantRows = rows.filter(function(row) {
@@ -1511,7 +1528,11 @@ function actionExceptions_(user, payload) {
   return {
     month: month || '',
     rows: result,
+    totalExceptionInstances: exceptionSummary.totalExceptionInstances || 0,
+    totalExceptionRows: exceptionSummary.totalExceptionRows || 0,
     counts: counts,
+    byManager: exceptionSummary.byManager || {},
+    debug: exceptionSummary.debug || null,
     priority: configuredExceptionPriority_()
   };
 }

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -254,8 +254,8 @@ function enrichDashboardPayloadWithSharedExceptions_(payload, ym) {
   if (!payload || typeof payload !== 'object') return payload;
   var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
   var exceptionSummary = getExceptionsSummary_(rows, ym, { include_rows: false });
-  var total = exceptionSummary.totalExceptions || 0;
-  var byManager = exceptionSummary.exceptionsByManager || {};
+  var total = exceptionSummary.totalExceptionInstances || 0;
+  var byManager = exceptionSummary.byManager || {};
 
   if (!payload.summary || typeof payload.summary !== 'object') payload.summary = {};
   payload.summary.exceptions_count = total;

--- a/backend/views.gs
+++ b/backend/views.gs
@@ -311,9 +311,9 @@ function buildViewDashboardMonthlyRows_(activitiesSummaryRows, meetingsViewRows)
       }
     });
 
-    var monthExceptionSummary = computeCourseExceptionsModel_(monthActivities, ym, { include_rows: false });
-    managerExceptions = monthExceptionSummary.by_manager_exception_instances || {};
-    primaryExceptionRowCount = monthExceptionSummary.total_exception_instances || 0;
+    var monthExceptionSummary = computeExceptionsModel_(monthActivities, ym, { include_rows: false });
+    managerExceptions = monthExceptionSummary.byManager || {};
+    primaryExceptionRowCount = monthExceptionSummary.totalExceptionInstances || 0;
 
     monthMeetings.forEach(function(row) {
       var i1 = text_(row.instructor_name || row.emp_id);

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -74,15 +74,8 @@ function renderStructuredSummary(summary, ym, byManager) {
   const missingInstrField = getStrictNumericField(summary, 'missing_instructor_count');
   const missingDateField = getStrictNumericField(summary, 'missing_start_date_count');
   const lateEndField = getStrictNumericField(summary, 'late_end_date_count');
-  const exceptionsFromParts = pickNumericFallback(summary, 'missing_instructor_count')
-    + pickNumericFallback(summary, 'missing_start_date_count')
-    + pickNumericFallback(summary, 'late_end_date_count');
   const exceptionsTotalField = getStrictNumericField(summary, 'exceptions_count');
-  const byManagerExceptions = (Array.isArray(byManager) ? byManager : [])
-    .reduce((sum, row) => sum + (Number(row?.exceptions || 0) || 0), 0);
-  const exceptionsTotalResolved = exceptionsTotalField.ok
-    ? Math.max(exceptionsTotalField.value, exceptionsFromParts, byManagerExceptions)
-    : Math.max(exceptionsFromParts, byManagerExceptions);
+  const exceptionsTotalResolved = exceptionsTotalField.ok ? exceptionsTotalField.value : 'שגיאת מיפוי';
 
   const activeCurrent = escapeHtml(String(activeCurrentField.ok ? activeCurrentField.value : 'שגיאת מיפוי'));
   const endingCurrent = escapeHtml(String(endingCurrentField.ok ? endingCurrentField.value : 'שגיאת מיפוי'));

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -132,7 +132,7 @@ export const exceptionsScreen = {
     return dsScreenStack(`
       ${toolbarHtml}
       ${dsCard({
-        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(data.month)}` : ''} · ${total}`,
+        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(data.month)}` : ''} · סה״כ חריגות: ${escapeHtml(String(data?.totalExceptionInstances ?? total))}`,
         body: compact,
         padded: visibleRows.length === 0
       })}

--- a/tests/exceptions-single-source.test.mjs
+++ b/tests/exceptions-single-source.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const actions = fs.readFileSync(new URL('../backend/actions.gs', import.meta.url), 'utf8');
+const dashboardScreen = fs.readFileSync(new URL('../frontend/src/screens/dashboard.js', import.meta.url), 'utf8');
+
+function mustMatch(source, re, msg) {
+  assert.match(source, re, msg);
+}
+
+test('exceptions model exposes single-source fields and both totals', () => {
+  mustMatch(actions, /function computeExceptionsModel_\(rows, ym, opts\)/);
+  mustMatch(actions, /totalExceptionInstances:\s*payload\.total_exception_instances \|\| 0/);
+  mustMatch(actions, /totalExceptionRows:\s*payload\.total_exception_rows \|\| 0/);
+  mustMatch(actions, /counts:\s*payload\.counts \|\| \{\}/);
+  mustMatch(actions, /byManager:\s*byManager/);
+});
+
+test('exceptions endpoint returns totals and optional debug payload', () => {
+  mustMatch(actions, /include_debug:\s*yesNo_\(payload && payload\.debug\) === 'yes'/);
+  mustMatch(actions, /totalExceptionInstances:\s*exceptionSummary\.totalExceptionInstances \|\| 0/);
+  mustMatch(actions, /totalExceptionRows:\s*exceptionSummary\.totalExceptionRows \|\| 0/);
+  mustMatch(actions, /debug:\s*exceptionSummary\.debug \|\| null/);
+});
+
+test('dashboard summary does not reconcile exceptions with Math.max fallback', () => {
+  assert.doesNotMatch(dashboardScreen, /Math\.max\(exceptionsTotalField\.value/);
+});


### PR DESCRIPTION
### Motivation
- להפסיק פיזור לוגיקות חישוב של חריגות ולספק מקור אמת אחד שדרכו כל המסכים וה-snapshot מקבלים את אותם מספרים והמבנה.
- למנוע השוואות/רקונסיליאציות בין מקורות (למשל `Math.max`) שגורמות לאי-התאמות בין עמוד החריגות, לוח הבקרה ו-snapshot.

### Description
- יצרתי את `computeExceptionsModel_(rows, ym, opts)` שמאגד את כל חישובי החריגות ומחזיר מבנה עקבי עם `month`, `rows`, `totalExceptionInstances`, `totalExceptionRows`, `counts`, `byManager` ו-`debug` (כולל `sampleRows`).
- הפכתי את `getExceptionsSummary_` לעטיפה דקה שמחזירה את התוצאה של `computeExceptionsModel_` ומשדרתי `actionExceptions_` להחזיר את השדות החדשים (`totalExceptionInstances`, `totalExceptionRows`, `byManager`, `debug`).
- עדכנתי את המרי החישובים בצד השרת/תצוגות כך שישתמשו במודל המאוחד: `backend/dashboard-snapshot.gs`, `backend/views.gs`, ו`backend/actions.gs` מחזיקים/מזינים כעת את הערכים מהמודל הזה במקום לוגיקות נפרדות.
- הסרתי את ה־`Math.max` ברנדור הסיכום בדאשבורד כך ש־`summary.exceptions_count` נלקח ישירות מהמודל המאוחד, ושיניתי את כותרת עמוד החריגות להצגת `סה"כ חריגות` מתוך `totalExceptionInstances` של ה-API.
- נוספו בדיקות רגרסיה חדשות `tests/exceptions-single-source.test.mjs` שמאשרות שדה אחד כמקור אמת ושהדשבורד לא מבצע את ה-fallback של `Math.max`.

### Testing
- הרצת הסט המקומי: `node --test tests/*.test.mjs` / `npm test` — כל הבדיקות עברו בהצלחה (39 passed).
- הרצת הבדיקה החדשה הממוקדת `tests/exceptions-single-source.test.mjs` עברה בהצלחה ובדקה את הנקודות החדשות (חשיפת שדות המודל, debug, והיעדר `Math.max`).
- הערה: לא הופעלה בפועל רענון `refreshDashboardSnapshots` / `refreshDataViews` מול גיליון פרודקשן מכיוון שזה דורש סביבה של Apps Script/Spreadsheet ולכן לא נכלל בהרצות המקומיות.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c21145ec832b9e15541c44f7cfce)