### PR TITLE
Show edit-request status on activities; add backend lookup and validate/normalize submissions

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -785,11 +785,17 @@ function actionActivities_(user, payload) {
 
   var noteMap = buildPrivateNotesMap_();
   var activitiesMeetingsMap = buildMeetingsMap_();
+  var editRequestMap = latestEditRequestBySourceRowForUser_(user.user_id);
 
   return {
     activity_type_counts: activityTypeCounts,
     rows: rows.map(function(row) {
-      return mapActivitySummaryRowForList_(row, user, noteMap, activitiesMeetingsMap, today);
+      var mapped = mapActivitySummaryRowForList_(row, user, noteMap, activitiesMeetingsMap, today);
+      var editReq = editRequestMap[text_(mapped.RowID)] || {};
+      mapped.edit_request_status = text_(editReq.edit_request_status);
+      mapped.edit_request_id = text_(editReq.edit_request_id);
+      mapped.edit_request_requested_at = text_(editReq.edit_request_requested_at);
+      return mapped;
     }),
     can_add_activity: canAddActivity,
     filters: {
@@ -842,6 +848,28 @@ function mapActivitySummaryRowForList_(row, user, noteMap, meetingsMap, today) {
       ? text_(noteRow.note_text)
       : ''
   };
+}
+
+function latestEditRequestBySourceRowForUser_(userId) {
+  var uid = text_(userId);
+  if (!uid) return {};
+  var rows = readRows_(CONFIG.SHEETS.EDIT_REQUESTS).filter(function(row) {
+    return yesNo_(row.active) === 'yes' && text_(row.requested_by_user_id) === uid;
+  });
+  rows.sort(function(a, b) {
+    return text_(b.requested_at).localeCompare(text_(a.requested_at));
+  });
+  var map = {};
+  rows.forEach(function(row) {
+    var key = text_(row.source_row_id || row.RowID);
+    if (!key || map[key]) return;
+    map[key] = {
+      edit_request_id: text_(row.request_id),
+      edit_request_status: text_(row.status),
+      edit_request_requested_at: text_(row.requested_at)
+    };
+  });
+  return map;
 }
 
 function mapActivityDetailRowForDrawer_(row, user) {
@@ -929,7 +957,13 @@ function actionActivityDetail_(user, payload) {
   var sourceRowId = text_((payload || {}).source_row_id || (payload || {}).RowID);
   var sourceSheet = text_((payload || {}).source_sheet);
   var row = findActivityRowById_(sourceRowId, sourceSheet);
-  return { row: mapActivityDetailRowForDrawer_(row, user) };
+  var mapped = mapActivityDetailRowForDrawer_(row, user);
+  var editRequestMap = latestEditRequestBySourceRowForUser_(user.user_id);
+  var editReq = editRequestMap[text_(mapped.RowID)] || {};
+  mapped.edit_request_status = text_(editReq.edit_request_status);
+  mapped.edit_request_id = text_(editReq.edit_request_id);
+  mapped.edit_request_requested_at = text_(editReq.edit_request_requested_at);
+  return { row: mapped };
 }
 
 function actionAddActivityOptions_(user) {

--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -250,7 +250,6 @@ function allKnownRoutes_() {
     'finance',
     'end-dates',
     'my-data',
-    'operations',
     'edit-requests',
     'permissions'
   ];
@@ -296,7 +295,6 @@ function buildRoutesFromPermission_(permission, role) {
     contacts: '__school_contacts__',
     finance: 'view_finance',
     'end-dates': '__end_dates__',
-    operations: 'view_operations_data',
     'edit-requests': 'view_edit_requests',
     permissions: 'view_permissions'
   };
@@ -340,7 +338,7 @@ function effectiveRoutesForUser_(permission, role) {
 function defaultRouteForRole_(role) {
   if (role === 'instructor') return 'my-data';
   if (isOperationManagerRole_(role)) {
-    return viewKeyToRouteId_(getSettingText_('operations_default_view_key', 'view_operations_data')) || 'dashboard';
+    return 'dashboard';
   }
   if (role === 'admin') {
     return viewKeyToRouteId_(getSettingText_('admin_default_view_key', 'view_admin')) || 'dashboard';
@@ -367,7 +365,7 @@ function viewKeyToRouteId_(viewKey) {
     my_data: 'my-data',
     'my-data': 'my-data',
     view_my_data: 'my-data',
-    view_operations_data: 'operations',
+    view_operations_data: 'dashboard',
     instructor_contacts: 'instructor-contacts',
     'instructor-contacts': 'instructor-contacts',
     view_contacts_instructors: 'instructor-contacts',

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -313,7 +313,22 @@ export const api = {
     b !== undefined && b !== null
       ? request('saveActivity', { source_row_id: a, changes: b })
       : request('saveActivity', a),
-  submitEditRequest: (source_row_id, changes) => request('submitEditRequest', { source_row_id, changes }),
+  submitEditRequest: (source_row_id, changes) => {
+    const normalizedChanges = Object.entries(changes || {}).reduce((acc, [key, value]) => {
+      if (value === undefined || value === null) return acc;
+      const normalizedValue = String(value).trim();
+      acc[key] = normalizedValue;
+      return acc;
+    }, {});
+    // eslint-disable-next-line no-console
+    console.info('[submitEditRequest] source_row_id', source_row_id);
+    // eslint-disable-next-line no-console
+    console.info('[submitEditRequest] changes', normalizedChanges);
+    if (!source_row_id || !Object.keys(normalizedChanges).length) {
+      throw new Error('No changes to submit');
+    }
+    return request('submitEditRequest', { source_row_id, changes: normalizedChanges });
+  },
   reviewEditRequest: (request_id, status) => request('reviewEditRequest', { request_id, status }),
   savePermission: (row) => request('savePermission', { row }),
   addUser: (row) => request('addUser', { row }),

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -327,7 +327,6 @@ const screenLabels = {
   contacts: 'אנשי קשר',
   'end-dates': 'תאריכי סיום',
   'my-data': 'הנתונים שלי',
-  operations: 'תפעול',
   'edit-requests': 'אישורים',
   permissions: 'הרשאות'
 };
@@ -344,7 +343,6 @@ const screenLoaders = {
   contacts: () => import('./screens/contacts.js').then((m) => m.contactsScreen),
   'end-dates': () => import('./screens/end-dates.js').then((m) => m.endDatesScreen),
   'my-data': () => import('./screens/my-data.js').then((m) => m.myDataScreen),
-  operations: () => import('./screens/operations.js').then((m) => m.operationsScreen),
   'edit-requests': () => import('./screens/edit-requests.js').then((m) => m.editRequestsScreen),
   permissions: () => import('./screens/permissions.js').then((m) => m.permissionsScreen)
 };
@@ -584,9 +582,6 @@ function buildScreenDataCacheKey(route, cacheState = state) {
       ym: cacheState.financeMonthYm || ''
     };
     return `finance:${JSON.stringify(filters)}`;
-  }
-  if (route === 'operations') {
-    return `operations:${cacheState.operationsSearch || ''}:${cacheState.operationsActivityType || ''}`;
   }
   if (route === 'dashboard') {
     const ym = cacheState.dashboardMonthYm && /^\d{4}-\d{2}$/.test(cacheState.dashboardMonthYm) ? cacheState.dashboardMonthYm : 'default';

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -297,6 +297,14 @@ function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, 
   });
 }
 
+function editRequestStatusLabel(status) {
+  if (status === 'pending') return 'בקשת עריכה ממתינה';
+  if (status === 'approved') return 'בקשת העריכה אושרה';
+  if (status === 'rejected') return 'בקשת העריכה נדחתה';
+  if (status === 'conflict') return 'בקשת העריכה בקונפליקט';
+  return '';
+}
+
 function activityDetailCacheKey(summaryRow) {
   return `activityDetail:${summaryRow.source_sheet || ''}:${summaryRow.RowID || ''}`;
 }
@@ -348,6 +356,10 @@ export const activitiesScreen = {
           : '<span class="ds-chip ds-chip--status ds-chip--warn ds-chip--instructor-empty">ללא מדריך</span>';
         const activityTypeLabel = escapeHtml(visibleActivityCategoryLabel(row.activity_type));
         const activityName = escapeHtml(row.activity_name || '—');
+        const editStatus = editRequestStatusLabel(String(row.edit_request_status || ''));
+        const editStatusBadge = editStatus
+          ? `<span class="ds-chip ds-chip--status ds-chip--warn" title="${escapeHtml(editStatus)}">${escapeHtml(editStatus)}</span>`
+          : '';
         const startHe = formatDateHe(row.start_date) || '—';
         const endRaw = String(row?.end_date || '').trim() || String(row?.start_date || '').trim();
         const endHe = endRaw ? formatDateHe(endRaw) || '—' : '—';
@@ -369,7 +381,7 @@ export const activitiesScreen = {
           .join(' ');
         return `
       <tr class="ds-data-row ds-activities-row" data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="" data-row-id="${escapeHtml(row.RowID)}">
-        <td class="ds-activities-col ds-activities-col--program"><div class="ds-activities-program-cell"><strong class="ds-activities-program-name" title="${activityName}">${activityName}</strong><span class="ds-activities-program-type" title="${activityTypeLabel}">${activityTypeLabel}</span></div></td>
+        <td class="ds-activities-col ds-activities-col--program"><div class="ds-activities-program-cell"><strong class="ds-activities-program-name" title="${activityName}">${activityName}</strong><span class="ds-activities-program-type" title="${activityTypeLabel}">${activityTypeLabel}</span>${editStatusBadge}</div></td>
         <td class="ds-activities-col ds-activities-col--authority"><span class="ds-activities-cell-ellipsis" title="${escapeHtml(row.authority || '—')}">${escapeHtml(row.authority || '—')}</span></td>
         <td class="ds-activities-col ds-activities-col--school"><span class="ds-activities-cell-ellipsis" title="${escapeHtml(row.school || '—')}">${escapeHtml(row.school || '—')}</span></td>
         <td class="ds-activities-col ds-activities-col--instructor"><div class="ds-activities-instructor-wrap">${instructorDisplay}</div></td>

--- a/frontend/src/screens/edit-requests.js
+++ b/frontend/src/screens/edit-requests.js
@@ -129,12 +129,14 @@ export const editRequestsScreen = {
     if (!root) return;
 
     const list = root.querySelector('[data-er-list]');
+    let activeFilter = 'pending';
 
     root.querySelectorAll('[data-er-filter]').forEach((btn) => {
       btn.addEventListener('click', () => {
         root.querySelectorAll('[data-er-filter]').forEach((b) => b.classList.remove('is-active'));
         btn.classList.add('is-active');
         const filterVal = btn.dataset.erFilter;
+        activeFilter = filterVal;
         if (!list) return;
         list.querySelectorAll('.ds-er-group').forEach((g) => {
           const show = !filterVal || g.dataset.status === filterVal;
@@ -154,6 +156,17 @@ export const editRequestsScreen = {
 
         try {
           await api.reviewEditRequest(requestId, status);
+          const groupEl = btn.closest('.ds-er-group');
+          if (groupEl) {
+            if (activeFilter === 'pending') {
+              groupEl.remove();
+            } else {
+              groupEl.dataset.status = status;
+              const statusChipWrap = groupEl.querySelector('.ds-er-group-head > div:last-child');
+              if (statusChipWrap) statusChipWrap.innerHTML = dsStatusChip(statusLabel(status), statusVariant(status));
+              groupEl.querySelector('.ds-er-actions')?.remove();
+            }
+          }
           clearScreenDataCache?.();
           showToast(status === 'approved' ? 'הבקשה אושרה' : 'הבקשה נדחתה', 'success');
           rerender?.();

--- a/frontend/src/screens/shared/act-nav-grid.js
+++ b/frontend/src/screens/shared/act-nav-grid.js
@@ -11,7 +11,6 @@ export const ACT_SUBNAV_ITEMS = [
   { route: 'contacts',            label: 'אנשי קשר',             icon: '📇' },
   { route: 'finance',             label: 'כספים',                icon: '💰' },
   { route: 'permissions',         label: 'הרשאות',               icon: '🔑' },
-  { route: 'operations',          label: 'תפעול',                icon: '⚙️' },
   { route: 'edit-requests',       label: 'אישורים',              icon: '✅' },
   { route: 'my-data',             label: 'הנתונים שלי',          icon: '👤' }
 ];

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -476,6 +476,15 @@ function blockNotes(row, { privateNote = null, showPrivateNote = false } = {}) {
 function singleForm(row, { settings = {}, privateNote = null, canEdit = false, canDirectEdit = false, showPrivateNote = false, idx = 0 } = {}) {
   const computedEnd = autoEndDate(row);
   const activityType = String(row.activity_type || '').trim();
+  const editReqStatus = String(row.edit_request_status || '').trim();
+  const editReqLabel =
+    editReqStatus === 'pending' ? 'ממתין לאישור' :
+      editReqStatus === 'approved' ? 'אושר' :
+        editReqStatus === 'rejected' ? 'נדחה' :
+          editReqStatus === 'conflict' ? 'בקונפליקט' : '';
+  const editReqBadge = editReqLabel
+    ? `<div class="ds-chip ds-chip--status ds-chip--warn" data-edit-request-status="${escapeHtml(editReqStatus)}">בקשת עריכה: ${escapeHtml(editReqLabel)}</div>`
+    : '';
   return `
     <form class="activity-drawer__form" data-drawer-form data-editing="no"
       data-source-sheet="${escapeHtml(String(row.source_sheet || ''))}"
@@ -483,6 +492,7 @@ function singleForm(row, { settings = {}, privateNote = null, canEdit = false, c
       data-can-direct-edit="${canDirectEdit ? 'yes' : 'no'}"
       data-auto-end-date="${escapeHtml(computedEnd)}"
       data-is-once="${ONCE_TYPES.includes(activityType) ? 'yes' : 'no'}">
+      ${editReqBadge}
       <input type="hidden" name="activity_no" value="${escapeHtml(String(row.activity_no || ''))}" data-activity-no>
       <input type="hidden" name="_activity_idx" value="${idx}">
       ${blockPeople(row, { settings })}

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -171,15 +171,34 @@ export function bindActivityEditForm(contentRoot, {
     const sourceRowId = form.getAttribute('data-row-id') || '';
     const canDirectEdit = String(form.dataset.canDirectEdit || '') === 'yes';
     const changes = {};
+    const initialValues = form._initialValues || {};
 
     form.querySelectorAll('[name]').forEach((el) => {
       const name = el.getAttribute('name');
       if (!name || name.startsWith('_')) return;
       if (el.closest('[hidden]')) return;
-      changes[name] = String(el.value ?? '').trim();
+      const rawValue = el.value;
+      if (rawValue === undefined || rawValue === null) return;
+      const nextValue = String(rawValue).trim();
+      const prevValue = String(initialValues[name] ?? '').trim();
+      if (nextValue === prevValue) return;
+      changes[name] = nextValue;
     });
 
     try {
+      if (!Object.keys(changes).length) {
+        setStatus(statusEl, 'is-error', 'לא זוהו שינויים לשמירה');
+        showToast('לא זוהו שינויים לשמירה', 'info', 2200);
+        return;
+      }
+
+      if (!canDirectEdit) {
+        // eslint-disable-next-line no-console
+        console.info('[submitEditRequest] source_row_id', sourceRowId);
+        // eslint-disable-next-line no-console
+        console.info('[submitEditRequest] changes', changes);
+      }
+
       setStatus(statusEl, 'is-pending', canDirectEdit ? 'שומר...' : 'שולח לאישור...');
       if (submitBtn) {
         submitBtn.disabled = true;
@@ -294,6 +313,13 @@ export function bindActivityEditForm(contentRoot, {
     updateMeetingWeekdays(form);
     updateMoreDatesToggle(form);
     updateEndDateDisplay(form);
+    const initialValues = {};
+    form.querySelectorAll('[name]').forEach((el) => {
+      const name = el.getAttribute('name');
+      if (!name || name.startsWith('_')) return;
+      initialValues[name] = String(el.value ?? '').trim();
+    });
+    form._initialValues = initialValues;
 
     form.addEventListener(
       'change',


### PR DESCRIPTION
### Motivation
- Surface the user's latest edit-request status on activity lists and details so users can see pending/approved/rejected requests.
- Ensure edit-request submissions contain only meaningful, trimmed values and prevent empty requests from being sent.
- Remove the legacy/hidden `operations` route from navigation and default-route mappings to avoid exposing that view.

### Description
- Backend: added `latestEditRequestBySourceRowForUser_` and wire its results into `actionActivities_` and `actionActivityDetail_` so each activity includes `edit_request_status`, `edit_request_id`, and `edit_request_requested_at`.
- Backend: removed `operations` from `allKnownRoutes_`, adjusted `defaultRouteForRole_` for operation managers to return `dashboard`, and remapped `view_operations_data` to `dashboard` in `viewKeyToRouteId_`.
- Frontend: `api.submitEditRequest` now trims and filters out `undefined`/`null` values, logs payload, and rejects empty submissions; activities list and activity drawer show an edit-request badge via `edit_request_status`; edit form tracks `initialValues` and only submits changed fields while showing a message when no changes detected.
- Frontend: removed `operations` from screen labels, loaders, cache keys, and the activities subnav; improved `edit-requests` screen filter state so UI updates immediately after approval/rejection.

### Testing
- Built the frontend (`npm run build`) to verify the bundle and imports updated without errors and the app starts successfully.
- Exercised activity list/detail and edit-request submission flows in a local dev server to confirm badges appear and invalid/empty submissions are blocked.
- No new unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c3119c40832b980d23925df83d2f)