### PR TITLE
Stabilize read-model-first data flow and critical mutation paths.

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -75,3 +75,28 @@ function installDataMaintenanceTrigger() {
 function runRefreshDataViewsManually() {
   return refreshDataViews_();
 }
+
+function refreshAllReadModels() {
+  return refreshAllReadModels_();
+}
+
+function refreshAllReadModelsTrigger() {
+  refreshAllReadModels_();
+}
+
+function installReadModelsTriggers() {
+  var targetHandler = 'refreshAllReadModelsTrigger';
+  ScriptApp.getProjectTriggers().forEach(function(t) {
+    if (t.getHandlerFunction && t.getHandlerFunction() === targetHandler) {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+  [7, 13, 19].forEach(function(hour) {
+    ScriptApp.newTrigger(targetHandler)
+      .timeBased()
+      .atHour(hour)
+      .everyDays(1)
+      .create();
+  });
+  return { status: 'installed', hours: [7, 13, 19] };
+}

--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -2082,7 +2082,7 @@ function actionEditRequests_(user) {
       originalValues[text_(r.field_name)] = text_(r.old_value);
       requestedValues[text_(r.field_name)] = text_(r.new_value);
     }
-    return {
+    var mapped = {
       request_id: text_(r.request_id),
       RowID: text_(r.RowID || r.source_row_id),
       source_sheet: text_(r.source_sheet),
@@ -2108,6 +2108,10 @@ function actionEditRequests_(user) {
         };
       })
     };
+    return mapped;
+  });
+  result = result.filter(function(item) {
+    return Array.isArray(item.fields) && item.fields.length > 0;
   });
   result.sort(function(a, b) {
     return (b.requested_at || '').localeCompare(a.requested_at || '');
@@ -2222,15 +2226,12 @@ function actionAddActivity_(user, payload) {
     'authority',
     'school',
     'start_date',
-    'end_date',
     'sessions',
     'price',
     'funding',
     'start_time',
     'end_time',
-    'instructor_name',
-    'emp_id',
-    'notes'
+    'instructor_name'
   ];
   var missingFields = requiredFields.filter(function(field) {
     return !text_(activity[field]);
@@ -2290,6 +2291,9 @@ function actionAddActivity_(user, payload) {
   var instructorName2 = text_(activity.instructor_name_2);
   var derivedEmpId1 = empIdForInstructorName_(instructorName1);
   var derivedEmpId2 = empIdForInstructorName_(instructorName2);
+  if (!text_(derivedEmpId1 || activity.emp_id)) {
+    throw new Error('Missing required fields: emp_id');
+  }
   var firstStartDate = normalizeDateTextToIso_(activity.start_date || dateCols.Date1);
   var plannedMeetings = meetingScheduleFromPayload_(firstStartDate, activity.sessions);
   var meetingsTotal = plannedMeetings.length;

--- a/backend/config.gs
+++ b/backend/config.gs
@@ -26,7 +26,8 @@ const CONFIG = {
     PRIVATE_NOTES: 'operations_private_notes',
     DASHBOARD_SUMMARY_SNAPSHOT: 'dashboard_summary_snapshot',
     DASHBOARD_BY_MANAGER_SNAPSHOT: 'dashboard_by_manager_snapshot',
-    DASHBOARD_REFRESH_CONTROL: 'dashboard_refresh_control'
+    DASHBOARD_REFRESH_CONTROL: 'dashboard_refresh_control',
+    READ_MODELS: 'read_models'
   },
   /** ברירת מחדל כשגיליון lists ריק או חסר — מיושר ל־lists במקור הנתונים */
   DEFAULT_PROGRAM_ACTIVITY_TYPES: ['course', 'after_school'],

--- a/backend/read-models.gs
+++ b/backend/read-models.gs
@@ -1,0 +1,406 @@
+var READ_MODEL_ADMIN_USER_ = { user_id: 'read_model_refresh', display_role: 'admin' };
+var READ_MODEL_NO_FINANCE_USER_ = { user_id: 'read_model_refresh_nf', display_role: 'authorized_user' };
+var READ_MODEL_SHEET_FALLBACK_ = 'read_models';
+var READ_MODEL_HEADERS_ = [
+  'key',
+  'updated_at',
+  'version',
+  'hash',
+  'rows_json',
+  'payload_json',
+  'source_updated_at',
+  'status',
+  'duration_ms',
+  'rows_count',
+  'payload_size',
+  'last_error'
+];
+
+function readModelSheetName_() {
+  return (CONFIG.SHEETS && CONFIG.SHEETS.READ_MODELS) || READ_MODEL_SHEET_FALLBACK_;
+}
+
+function ensureReadModelsSheet_() {
+  var ss = getSpreadsheet_();
+  var sheet = ss.getSheetByName(readModelSheetName_());
+  if (!sheet) sheet = ss.insertSheet(readModelSheetName_());
+  sheet.getRange(CONFIG.HEADER_ROW, 1, 1, READ_MODEL_HEADERS_.length).setValues([READ_MODEL_HEADERS_]);
+  invalidateReadRowsCache_(readModelSheetName_());
+  return sheet;
+}
+
+function readModelRows_() {
+  ensureReadModelsSheet_();
+  try {
+    return readRowsProjected_(readModelSheetName_(), READ_MODEL_HEADERS_);
+  } catch (_e) {
+    return [];
+  }
+}
+
+function readModelRowByKey_(key) {
+  var k = text_(key);
+  if (!k) return null;
+  var rows = readModelRows_();
+  for (var i = 0; i < rows.length; i++) {
+    if (text_(rows[i].key) === k) return rows[i];
+  }
+  return null;
+}
+
+function computeReadModelHash_(value) {
+  var raw = JSON.stringify(value || {});
+  var bytes = Utilities.computeDigest(Utilities.DigestAlgorithm.MD5, raw);
+  return bytes.map(function(b) {
+    var n = b < 0 ? b + 256 : b;
+    var h = n.toString(16);
+    return h.length === 1 ? '0' + h : h;
+  }).join('');
+}
+
+function parseReadModelJson_(raw, fallback) {
+  if (raw === null || raw === undefined) return fallback;
+  if (typeof raw === 'object') return raw;
+  var s = String(raw || '').trim();
+  if (!s) return fallback;
+  try {
+    return JSON.parse(s);
+  } catch (_e) {
+    return fallback;
+  }
+}
+
+function buildReadModelStorageKey_(key, params) {
+  var k = text_(key);
+  var p = params && typeof params === 'object' ? params : {};
+  var body = {};
+  Object.keys(p).sort().forEach(function(name) {
+    if (p[name] === null || p[name] === undefined) return;
+    var val = text_(p[name]);
+    if (!val) return;
+    body[name] = val;
+  });
+  var qs = Object.keys(body).map(function(name) {
+    return name + '=' + body[name];
+  }).join('&');
+  return qs ? (k + '?' + qs) : k;
+}
+
+function upsertReadModelRow_(rowObj) {
+  ensureReadModelsSheet_();
+  upsertRowByKey_(readModelSheetName_(), 'key', rowObj);
+}
+
+function markReadModelStatus_(key, status, message) {
+  var existing = readModelRowByKey_(key) || {};
+  upsertReadModelRow_({
+    key: key,
+    updated_at: text_(existing.updated_at || formatDate_(new Date())),
+    version: text_(existing.version || dataViewsCacheVersion_()),
+    hash: text_(existing.hash),
+    rows_json: text_(existing.rows_json),
+    payload_json: text_(existing.payload_json),
+    source_updated_at: text_(existing.source_updated_at),
+    status: text_(status || existing.status || 'stale'),
+    duration_ms: text_(existing.duration_ms),
+    rows_count: text_(existing.rows_count),
+    payload_size: text_(existing.payload_size),
+    last_error: text_(message || existing.last_error)
+  });
+}
+
+function payloadRowsCount_(payload) {
+  if (!payload || typeof payload !== 'object') return 0;
+  if (Array.isArray(payload.rows)) return payload.rows.length;
+  if (Array.isArray(payload.cells)) return payload.cells.length;
+  if (Array.isArray(payload.days)) return payload.days.length;
+  return 0;
+}
+
+function persistReadModelPayload_(storageKey, payload, sourceUpdatedAt) {
+  var nowIso = new Date().toISOString();
+  var version = String(new Date().getTime());
+  var hash = computeReadModelHash_(payload);
+  var payloadText = JSON.stringify(payload || {});
+  var rows = payload && Array.isArray(payload.rows) ? payload.rows : [];
+  upsertReadModelRow_({
+    key: storageKey,
+    updated_at: nowIso,
+    version: version,
+    hash: hash,
+    rows_json: JSON.stringify(rows),
+    payload_json: payloadText,
+    source_updated_at: text_(sourceUpdatedAt || ''),
+    status: 'fresh',
+    duration_ms: '',
+    rows_count: String(payloadRowsCount_(payload)),
+    payload_size: String(payloadText.length),
+    last_error: ''
+  });
+}
+
+function refreshSingleReadModel_(logicalKey, params, builder) {
+  var storageKey = buildReadModelStorageKey_(logicalKey, params || {});
+  var started = perfNowMs_();
+  markReadModelStatus_(storageKey, 'rebuilding', '');
+  try {
+    var payload = builder(params || {});
+    var nowIso = new Date().toISOString();
+    var version = String(new Date().getTime());
+    var hash = computeReadModelHash_(payload);
+    var payloadText = JSON.stringify(payload || {});
+    var rows = payload && Array.isArray(payload.rows) ? payload.rows : [];
+    upsertReadModelRow_({
+      key: storageKey,
+      updated_at: nowIso,
+      version: version,
+      hash: hash,
+      rows_json: JSON.stringify(rows),
+      payload_json: payloadText,
+      source_updated_at: nowIso,
+      status: 'fresh',
+      duration_ms: String(Math.max(0, perfNowMs_() - started)),
+      rows_count: String(payloadRowsCount_(payload)),
+      payload_size: String(payloadText.length),
+      last_error: ''
+    });
+    return { key: storageKey, status: 'fresh', hash: hash, version: version };
+  } catch (e) {
+    upsertReadModelRow_({
+      key: storageKey,
+      updated_at: new Date().toISOString(),
+      version: String(new Date().getTime()),
+      hash: '',
+      rows_json: '[]',
+      payload_json: '{}',
+      source_updated_at: '',
+      status: 'failed',
+      duration_ms: String(Math.max(0, perfNowMs_() - started)),
+      rows_count: '0',
+      payload_size: '2',
+      last_error: text_(e && e.message ? e.message : String(e))
+    });
+    return { key: storageKey, status: 'failed', error: text_(e && e.message ? e.message : String(e)) };
+  }
+}
+
+function refreshDashboardReadModel_() {
+  return refreshSingleReadModel_('dashboard', {}, function() {
+    return actionDashboardSnapshot_(READ_MODEL_NO_FINANCE_USER_, {});
+  });
+}
+
+function refreshActivitiesReadModel_() {
+  return refreshSingleReadModel_('activities', {}, function() {
+    return actionActivitiesSnapshotFirst_(READ_MODEL_ADMIN_USER_, { activity_type: 'all' });
+  });
+}
+
+function refreshWeekReadModel_() {
+  return refreshSingleReadModel_('week', { week_offset: 0 }, function() {
+    return actionWeek_(READ_MODEL_ADMIN_USER_, { week_offset: 0 });
+  });
+}
+
+function refreshMonthReadModel_() {
+  var ym = formatDate_(new Date()).slice(0, 7);
+  return refreshSingleReadModel_('month', { ym: ym }, function() {
+    return actionMonth_(READ_MODEL_ADMIN_USER_, { ym: ym });
+  });
+}
+
+function refreshExceptionsReadModel_() {
+  var month = formatDate_(new Date()).slice(0, 7);
+  return refreshSingleReadModel_('exceptions', { month: month }, function() {
+    return actionExceptions_(READ_MODEL_ADMIN_USER_, { month: month });
+  });
+}
+
+function refreshFinanceReadModel_() {
+  var month = formatDate_(new Date()).slice(0, 7);
+  return refreshSingleReadModel_('finance', { month: month, tab: 'active' }, function() {
+    return actionFinance_(READ_MODEL_ADMIN_USER_, { month: month, tab: 'active' });
+  });
+}
+
+function refreshEndDatesReadModel_() {
+  return refreshSingleReadModel_('end-dates', {}, function() {
+    return actionEndDates_(READ_MODEL_ADMIN_USER_);
+  });
+}
+
+function refreshAllReadModels_() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(2000)) return { skipped: true, reason: 'read_models_refresh_already_running' };
+  var hadCache = !!__rqCache_;
+  if (!hadCache) beginRequestCache_();
+  try {
+    var results = [];
+    results.push(refreshDashboardReadModel_());
+    results.push(refreshActivitiesReadModel_());
+    results.push(refreshWeekReadModel_());
+    results.push(refreshMonthReadModel_());
+    results.push(refreshExceptionsReadModel_());
+    results.push(refreshFinanceReadModel_());
+    results.push(refreshEndDatesReadModel_());
+    bumpDataViewsCacheVersion_();
+    return { ok: true, refreshed_at: new Date().toISOString(), results: results };
+  } finally {
+    if (!hadCache) __rqCache_ = null;
+    lock.releaseLock();
+  }
+}
+
+function normalizeReadModelManifest_(rows) {
+  var nowMonth = formatDate_(new Date()).slice(0, 7);
+  var map = {};
+  map.dashboard = readModelRowByKey_('dashboard') || {};
+  map.activities = readModelRowByKey_('activities') || {};
+  map.week = readModelRowByKey_('week?week_offset=0') || {};
+  map.month = readModelRowByKey_('month?ym=' + nowMonth) || {};
+  map.exceptions = readModelRowByKey_('exceptions?month=' + nowMonth) || {};
+  map.finance = readModelRowByKey_('finance?month=' + nowMonth + '&tab=active') || {};
+  map['end_dates'] = readModelRowByKey_('end-dates') || {};
+  var out = {};
+  Object.keys(map).forEach(function(key) {
+    var r = map[key] || {};
+    out[key] = {
+      version: text_(r.version || ''),
+      updated_at: text_(r.updated_at || ''),
+      hash: text_(r.hash || ''),
+      status: text_(r.status || 'missing')
+    };
+  });
+  return out;
+}
+
+function actionReadModelManifest_(user) {
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
+  var rows = readModelRows_();
+  return normalizeReadModelManifest_(rows);
+}
+
+function markReadModelStale_(logicalKey, params, reason) {
+  var storageKey = buildReadModelStorageKey_(logicalKey, params || {});
+  var row = readModelRowByKey_(storageKey);
+  if (!row) {
+    upsertReadModelRow_({
+      key: storageKey,
+      updated_at: new Date().toISOString(),
+      version: String(new Date().getTime()),
+      hash: '',
+      rows_json: '[]',
+      payload_json: '{}',
+      source_updated_at: '',
+      status: 'stale',
+      duration_ms: '',
+      rows_count: '0',
+      payload_size: '2',
+      last_error: text_(reason || 'marked_stale')
+    });
+    return;
+  }
+  markReadModelStatus_(storageKey, 'stale', reason || '');
+}
+
+function markReadModelsDirtyByMutation_(action, payload) {
+  var nowMonth = formatDate_(new Date()).slice(0, 7);
+  var targets = [];
+  if (action === 'addActivity' || action === 'saveActivity') {
+    targets = [
+      ['activities', {}], ['dashboard', {}], ['week', { week_offset: 0 }],
+      ['month', { ym: nowMonth }], ['exceptions', { month: nowMonth }], ['end-dates', {}]
+    ];
+  } else if (action === 'submitEditRequest' || action === 'reviewEditRequest') {
+    targets = [
+      ['activities', {}], ['dashboard', {}], ['exceptions', { month: nowMonth }],
+      ['month', { ym: nowMonth }], ['week', { week_offset: 0 }], ['end-dates', {}]
+    ];
+  } else if (action === 'saveFinanceRow' || action === 'syncFinance') {
+    targets = [['finance', { month: nowMonth, tab: 'active' }], ['dashboard', {}]];
+  } else if (action === 'savePermission') {
+    targets = [['dashboard', {}]];
+  }
+  targets.forEach(function(pair) {
+    markReadModelStale_(pair[0], pair[1], 'mutation:' + action);
+  });
+}
+
+function refreshReadModelsForMutation_(action) {
+  if (action === 'addActivity' || action === 'saveActivity' || action === 'submitEditRequest' || action === 'reviewEditRequest') {
+    refreshActivitiesReadModel_();
+    refreshDashboardReadModel_();
+    refreshWeekReadModel_();
+    refreshMonthReadModel_();
+    refreshExceptionsReadModel_();
+    refreshEndDatesReadModel_();
+  } else if (action === 'saveFinanceRow' || action === 'syncFinance') {
+    refreshFinanceReadModel_();
+    refreshDashboardReadModel_();
+  } else if (action === 'savePermission') {
+    refreshDashboardReadModel_();
+  }
+}
+
+function resolveReadModelBuilder_(key, user, params) {
+  if (key === 'dashboard') return function() { return actionDashboardSnapshot_(user, params || {}); };
+  if (key === 'activities') return function() { return actionActivitiesSnapshotFirst_(user, params || { activity_type: 'all' }); };
+  if (key === 'week') return function() { return actionWeek_(user, params || { week_offset: 0 }); };
+  if (key === 'month') return function() { return actionMonth_(user, params || {}); };
+  if (key === 'exceptions') return function() { return actionExceptions_(user, params || {}); };
+  if (key === 'finance') return function() { return actionFinance_(user, params || {}); };
+  if (key === 'end-dates') return function() { return actionEndDates_(user); };
+  if (key === 'instructors') return function() { return actionInstructors_(user); };
+  return null;
+}
+
+function actionReadModelGet_(user, payload) {
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user', 'instructor']);
+  var key = text_(payload && payload.key);
+  if (!key) throw new Error('read model key is required');
+  var params = parseJsonObject_((payload && payload.params) || {}, {});
+  var storageKey = buildReadModelStorageKey_(key, params);
+  var row = readModelRowByKey_(storageKey);
+  if (row && text_(row.status) === 'fresh') {
+    return {
+      key: key,
+      cache_key: storageKey,
+      version: text_(row.version),
+      hash: text_(row.hash),
+      updated_at: text_(row.updated_at),
+      status: text_(row.status),
+      data: parseReadModelJson_(row.payload_json, {})
+    };
+  }
+  var builder = resolveReadModelBuilder_(key, user, params);
+  if (!builder) throw new Error('unknown read model key: ' + key);
+  var data = builder();
+  persistReadModelPayload_(storageKey, data, new Date().toISOString());
+  var fresh = readModelRowByKey_(storageKey) || {};
+  return {
+    key: key,
+    cache_key: storageKey,
+    version: text_(fresh.version),
+    hash: text_(fresh.hash),
+    updated_at: text_(fresh.updated_at),
+    status: text_(fresh.status || 'fresh'),
+    data: data,
+    warning: row ? 'fallback_rebuild_from_source' : 'missing_read_model_fallback'
+  };
+}
+
+function getReadModelHealth_() {
+  var rows = readModelRows_();
+  return rows.map(function(row) {
+    return {
+      key: text_(row.key),
+      updated_at: text_(row.updated_at),
+      duration_ms: parseInt(text_(row.duration_ms), 10) || 0,
+      rows_count: parseInt(text_(row.rows_count), 10) || 0,
+      payload_size: parseInt(text_(row.payload_size), 10) || 0,
+      hash: text_(row.hash),
+      status: text_(row.status || 'missing'),
+      last_error: text_(row.last_error)
+    };
+  });
+}

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -22,6 +22,10 @@ function handlePost_(e) {
     var handlers = {
       login: function() { return actionLogin_(payload); },
       bootstrap: function() { return actionBootstrap_(user); },
+      readModelManifest: function() { return actionReadModelManifest_(user); },
+      readModelGet: function() { return actionReadModelGet_(user, payload); },
+      readModelHealth: function() { requireAnyRole_(user, ['admin', 'operation_manager']); return getReadModelHealth_(); },
+      refreshAllReadModels: function() { requireAnyRole_(user, ['admin', 'operation_manager']); return refreshAllReadModels_(); },
       dashboard: function() { return actionDashboard_(user, payload); },
       dashboardSnapshot: function() { return actionDashboardSnapshot_(user, payload); },
       activities: function() { return actionActivitiesSnapshotFirst_(user, payload); },
@@ -114,10 +118,18 @@ function handlePost_(e) {
     var writeData = handlers[action]();
     if (action === 'addActivity' ||
         action === 'saveActivity' ||
+        action === 'submitEditRequest' ||
         action === 'reviewEditRequest' ||
         action === 'saveFinanceRow' ||
         action === 'syncFinance' ||
+        action === 'savePermission' ||
         action === 'syncEndDates') {
+      try {
+        markReadModelsDirtyByMutation_(action, payload || {});
+      } catch (_rmDirtyErr) {}
+      try {
+        refreshReadModelsForMutation_(action);
+      } catch (_rmRefreshErr) {}
       try {
         markDashboardSnapshotsRefreshNeeded_('mutation:' + action);
       } catch (snapshotErr) {
@@ -128,7 +140,7 @@ function handlePost_(e) {
           );
         } catch (_e) {}
       }
-      if (action === 'addActivity' || action === 'saveActivity' || action === 'reviewEditRequest') {
+      if (action === 'addActivity' || action === 'saveActivity' || action === 'submitEditRequest' || action === 'reviewEditRequest') {
         try {
           refreshActivitiesSnapshot_();
         } catch (_activitiesSnapshotErr) {
@@ -160,6 +172,9 @@ function isReadActionCacheable_(action, user) {
   if (!user) return false;
   var map = {
     bootstrap: true,
+    readModelManifest: true,
+    readModelGet: true,
+    readModelHealth: true,
     dashboard: true,
     dashboardSnapshot: true,
     activities: true,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -55,7 +55,10 @@ const READ_ACTIONS = {
   operationsDetail: true,
   editRequests: true,
   permissions: true,
-  listSheets: true
+  listSheets: true,
+  readModelManifest: true,
+  readModelGet: true,
+  readModelHealth: true
 };
 
 const API_TIMEOUT_MS_READ = 20000;
@@ -63,6 +66,9 @@ const API_TIMEOUT_MS_WRITE = 30000;
 const PERF_MAX_REQUESTS = 150;
 const MONTH_READ_MODEL_TTL_MS = 5 * 60 * 1000;
 const monthReadModelCache = new Map();
+const READ_MODEL_CACHE_STORAGE_KEY = 'ds_read_model_cache_v1';
+const MANIFEST_TTL_MS = 30 * 1000;
+let manifestCache = { t: 0, data: null };
 const RETRYABLE_SERVER_ERRORS = new Set([
   'network_error',
   'server_error',
@@ -100,6 +106,28 @@ function invalidateScreenDataByAction(action) {
   });
 }
 
+function invalidateReadModelLocalCacheByAction(action) {
+  const targeted = {
+    saveActivity: ['dashboard', 'activities', 'week', 'month', 'exceptions', 'end-dates'],
+    addActivity: ['dashboard', 'activities', 'week', 'month', 'exceptions', 'end-dates'],
+    submitEditRequest: ['dashboard', 'activities', 'week', 'month', 'exceptions', 'end-dates'],
+    reviewEditRequest: ['dashboard', 'activities', 'week', 'month', 'exceptions'],
+    saveFinanceRow: ['dashboard', 'finance'],
+    syncFinance: ['dashboard', 'finance'],
+    savePermission: ['dashboard']
+  };
+  const keys = targeted[action];
+  if (!keys?.length) return;
+  const allCache = safeLocalStorageGetJson(READ_MODEL_CACHE_STORAGE_KEY, {});
+  Object.keys(allCache).forEach((cacheKey) => {
+    if (keys.some((key) => cacheKey === key || cacheKey.startsWith(`${key}?`))) {
+      delete allCache[cacheKey];
+    }
+  });
+  safeLocalStorageSetJson(READ_MODEL_CACHE_STORAGE_KEY, allCache);
+  manifestCache = { t: 0, data: null };
+}
+
 function monthReadModelKey(payload = {}) {
   const ym = String(payload?.ym || payload?.month || '').trim();
   return /^\d{4}-\d{2}$/.test(ym) ? ym : '__current__';
@@ -107,6 +135,86 @@ function monthReadModelKey(payload = {}) {
 
 function clearMonthReadModelCache() {
   monthReadModelCache.clear();
+}
+
+function safeLocalStorageGetJson(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeLocalStorageSetJson(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch { /* ignore */ }
+}
+
+async function getReadModelManifestCached() {
+  const now = Date.now();
+  if (manifestCache.data && now - manifestCache.t < MANIFEST_TTL_MS) return manifestCache.data;
+  const fresh = await request('readModelManifest', {});
+  manifestCache = { t: now, data: fresh || {} };
+  return manifestCache.data;
+}
+
+function readModelLocalCacheKey(key, params = {}) {
+  const normalized = Object.entries(params || {})
+    .filter(([, v]) => v !== undefined && v !== null && String(v).trim() !== '')
+    .sort(([a], [b]) => a.localeCompare(b));
+  const suffix = normalized.map(([k, v]) => `${k}=${String(v).trim()}`).join('&');
+  return suffix ? `${key}?${suffix}` : key;
+}
+
+function manifestEntryForReadModel(key, params = {}) {
+  if (key === 'dashboard') return 'dashboard';
+  if (key === 'activities') return 'activities';
+  if (key === 'week') return 'week';
+  if (key === 'month') return 'month';
+  if (key === 'exceptions') return 'exceptions';
+  if (key === 'finance') return 'finance';
+  if (key === 'end-dates') return 'end_dates';
+  if (key === 'instructors') return 'instructors';
+  return null;
+}
+
+async function requestReadModel(key, params = {}, fallbackAction, fallbackPayload = {}) {
+  const manifest = await getReadModelManifestCached();
+  const manifestKey = manifestEntryForReadModel(key, params);
+  const manifestMeta = manifestKey ? manifest?.[manifestKey] : null;
+  const localKey = readModelLocalCacheKey(key, params);
+  const cachedModels = safeLocalStorageGetJson(READ_MODEL_CACHE_STORAGE_KEY, {});
+  const hit = cachedModels?.[localKey];
+  if (
+    hit &&
+    manifestMeta &&
+    hit.version &&
+    hit.hash &&
+    hit.version === manifestMeta.version &&
+    hit.hash === manifestMeta.hash
+  ) {
+    return hit.data;
+  }
+  try {
+    const envelope = await request('readModelGet', { key, params });
+    const data = envelope?.data ?? envelope ?? {};
+    const nextCache = {
+      ...cachedModels,
+      [localKey]: {
+        key,
+        version: envelope?.version || '',
+        hash: envelope?.hash || '',
+        updated_at: envelope?.updated_at || '',
+        data
+      }
+    };
+    safeLocalStorageSetJson(READ_MODEL_CACHE_STORAGE_KEY, nextCache);
+    return data;
+  } catch {
+    return request(fallbackAction, fallbackPayload);
+  }
 }
 
 function isPerfDebugEnabled() {
@@ -269,6 +377,7 @@ async function request(action, payload = {}) {
   }
   if (MUTATING_ACTIONS[action]) {
     invalidateScreenDataByAction(action);
+    invalidateReadModelLocalCacheByAction(action);
   }
   pushPerfRequest({
     action,
@@ -283,18 +392,18 @@ export const api = {
   login: (user_id, entry_code) => request('login', { user_id, entry_code }),
   bootstrap: () => request('bootstrap'),
   dashboard: (filters) => request('dashboard', filters || {}),
-  dashboardSnapshot: (filters) => request('dashboardSnapshot', filters || {}),
-  activities: (filters) => request('activities', filters),
+  dashboardSnapshot: (filters) => requestReadModel('dashboard', filters || {}, 'dashboardSnapshot', filters || {}),
+  activities: (filters) => requestReadModel('activities', filters || {}, 'activities', filters || {}),
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
-  week: (params) => request('week', params || {}),
-  month: (params) => request('month', params || {}),
-  exceptions: (params) => request('exceptions', params || {}),
-  finance: (params) => request('finance', params || {}),
+  week: (params) => requestReadModel('week', params || { week_offset: 0 }, 'week', params || {}),
+  month: (params) => requestReadModel('month', params || {}, 'month', params || {}),
+  exceptions: (params) => requestReadModel('exceptions', params || {}, 'exceptions', params || {}),
+  finance: (params) => requestReadModel('finance', params || {}, 'finance', params || {}),
   financeDetail: (source_row_id, source_sheet) => request('financeDetail', { source_row_id, source_sheet }),
   instructors: () => request('instructors'),
   instructorContacts: () => request('instructorContacts'),
   contacts: () => request('contacts'),
-  endDates: () => request('endDates'),
+  endDates: () => requestReadModel('end-dates', {}, 'endDates', {}),
   myData: () => request('myData'),
   operations: (params) => request('operations', params || {}),
   operationsDetail: (source_row_id, source_sheet) => request('operationsDetail', { source_row_id, source_sheet }),
@@ -347,5 +456,8 @@ export const api = {
     }
     return request('savePrivateNote', { source_sheet: a, source_row_id: b, note: c });
   },
-  listSheets: () => request('listSheets')
+  listSheets: () => request('listSheets'),
+  readModelManifest: () => request('readModelManifest', {}),
+  readModelGet: (key, params = {}) => request('readModelGet', { key, params }),
+  readModelHealth: () => request('readModelHealth', {})
 };

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -65,6 +65,26 @@ function mergeListStrings(map, keys) {
   return out;
 }
 
+function buildInstructorLookup(settings) {
+  const users = settings?.dropdown_options?.instructor_users;
+  const map = {};
+  if (!Array.isArray(users)) return map;
+  users.forEach((u) => {
+    const empId = String(u?.emp_id || '').trim();
+    const name = String(u?.name || '').trim();
+    if (empId && name && !map[empId]) map[empId] = name;
+  });
+  return map;
+}
+
+function resolveInstructorDisplayName(name, empId, lookup) {
+  const direct = String(name || '').trim();
+  if (direct) return direct;
+  const emp = String(empId || '').trim();
+  if (emp && lookup?.[emp]) return lookup[emp];
+  return '';
+}
+
 function normalizeActivityNameOptions(raw) {
   if (!Array.isArray(raw)) return [];
   const out = [];
@@ -217,24 +237,27 @@ function blockPeople(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
   const managers = mergeListStrings(options, ['activity_manager', 'activity_managers']);
   const instructors = mergeListStrings(options, ['instructor_name', 'instructor_names']);
+  const instructorLookup = buildInstructorLookup(settings);
+  const instructor1Display = resolveInstructorDisplayName(row.instructor_name, row.emp_id, instructorLookup);
+  const instructor2Display = resolveInstructorDisplayName(row.instructor_name_2, row.emp_id_2, instructorLookup);
   const activityType = String(row.activity_type || '').trim();
   const twoInstructors = activityType === 'workshop';
   const instructorFields = twoInstructors
     ? `
       ${fieldViewEdit(
         'מדריך/ה 1',
-        `${escapeHtml(fallback(row.instructor_name))}`,
+        `${escapeHtml(fallback(instructor1Display))}`,
         selectHtml({ name: 'instructor_name', value: row.instructor_name, options: instructors })
       )}
       ${fieldViewEdit(
         'מדריך/ה 2',
-        `${escapeHtml(fallback(row.instructor_name_2))}`,
+        `${escapeHtml(fallback(instructor2Display))}`,
         selectHtml({ name: 'instructor_name_2', value: row.instructor_name_2, options: instructors })
       )}
     `
     : fieldViewEdit(
         'מדריך/ה',
-        `${escapeHtml(fallback(row.instructor_name))}`,
+        `${escapeHtml(fallback(instructor1Display))}`,
         selectHtml({ name: 'instructor_name', value: row.instructor_name, options: instructors })
       );
   return `

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -212,6 +213,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -85,3 +85,10 @@ test('activities screen wires add-activity form submit to api.addActivity flow',
   assert.match(source, /await api\.addActivity\(payload\)/);
   assert.match(source, /statusEl\) statusEl\.textContent = `שגיאה בשמירה:/);
 });
+
+test('activity drawer uses instructor emp_id fallback for display consistency', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/screens/shared/activity-detail-html.js', import.meta.url), 'utf8');
+  assert.match(source, /function resolveInstructorDisplayName\(name, empId, lookup\)/);
+  assert.match(source, /resolveInstructorDisplayName\(row\.instructor_name,\s*row\.emp_id,\s*instructorLookup\)/);
+});

--- a/tests/api-mutations.test.mjs
+++ b/tests/api-mutations.test.mjs
@@ -109,3 +109,15 @@ test('api mutation cache invalidation map includes required keys', async () => {
   assert.match(source, /reviewEditRequest:\s*\['edit-requests',\s*'activities:',\s*'activityDetail:',\s*'dashboard:',\s*'exceptions:'/);
   assert.match(source, /addActivity:\s*\['activities:',\s*'activityDetail:'/);
 });
+
+test('heavy screens request read models by default with legacy fallback', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  assert.match(source, /dashboardSnapshot:\s*\(filters\)\s*=>\s*requestReadModel\('dashboard'/);
+  assert.match(source, /activities:\s*\(filters\)\s*=>\s*requestReadModel\('activities'/);
+  assert.match(source, /week:\s*\(params\)\s*=>\s*requestReadModel\('week'/);
+  assert.match(source, /month:\s*\(params\)\s*=>\s*requestReadModel\('month'/);
+  assert.match(source, /exceptions:\s*\(params\)\s*=>\s*requestReadModel\('exceptions'/);
+  assert.match(source, /finance:\s*\(params\)\s*=>\s*requestReadModel\('finance'/);
+  assert.match(source, /endDates:\s*\(\)\s*=>\s*requestReadModel\('end-dates'/);
+});

--- a/tests/backend-write-flows-guard.test.mjs
+++ b/tests/backend-write-flows-guard.test.mjs
@@ -41,8 +41,17 @@ test('reviewEditRequest handles approve/reject, missing requests and already rev
 });
 
 test('router triggers snapshot refresh or cache version bump after write actions', () => {
-  mustMatch(router, /if \(action === 'addActivity' \|\|[\s\S]*action === 'saveActivity' \|\|[\s\S]*action === 'reviewEditRequest'/);
-  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'reviewEditRequest'\) \{[\s\S]*refreshActivitiesSnapshot_\(\);[\s\S]*\} catch \(_activitiesSnapshotErr\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);/);
+  mustMatch(router, /if \(action === 'addActivity' \|\|[\s\S]*action === 'saveActivity' \|\|[\s\S]*action === 'submitEditRequest' \|\|[\s\S]*action === 'reviewEditRequest'/);
+  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'submitEditRequest' \|\| action === 'reviewEditRequest'\) \{[\s\S]*refreshActivitiesSnapshot_\(\);[\s\S]*\} catch \(_activitiesSnapshotErr\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);/);
+});
+
+test('addActivity requires core fields but does not force notes/end_date when derivable', () => {
+  mustMatch(actions, /var requiredFields = \[[\s\S]*'start_date',[\s\S]*'sessions',[\s\S]*'instructor_name'[\s\S]*\];/);
+  mustMatch(actions, /if \(!text_\(derivedEmpId1 \|\| activity\.emp_id\)\) \{[\s\S]*Missing required fields: emp_id/);
+});
+
+test('edit requests list excludes empty change sets', () => {
+  mustMatch(actions, /result = result\.filter\(function\(item\) \{[\s\S]*item\.fields\.length > 0/);
 });
 
 test('activities snapshot refresh persists rows and bumps data-views version', () => {


### PR DESCRIPTION
Add a unified read models backend/manifest/get pipeline with trigger support, tighten stale/refresh invalidation after write actions, and fix critical activity/edit-request consistency issues including empty request filtering and instructor-name parity between list and drawer.

Made-with: Cursor