### PR TITLE
Harden frontend read-model requests with full fallback and emergency switch

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -69,6 +69,15 @@ const monthReadModelCache = new Map();
 const READ_MODEL_CACHE_STORAGE_KEY = 'ds_read_model_cache_v1';
 const MANIFEST_TTL_MS = 30 * 1000;
 let manifestCache = { t: 0, data: null };
+
+const READ_MODELS_ENABLED = (() => {
+  try {
+    return localStorage.getItem('disable_read_models') !== '1';
+  } catch {
+    return true;
+  }
+})();
+
 const RETRYABLE_SERVER_ERRORS = new Set([
   'network_error',
   'server_error',
@@ -181,25 +190,31 @@ function manifestEntryForReadModel(key, params = {}) {
 }
 
 async function requestReadModel(key, params = {}, fallbackAction, fallbackPayload = {}) {
-  const manifest = await getReadModelManifestCached();
-  const manifestKey = manifestEntryForReadModel(key, params);
-  const manifestMeta = manifestKey ? manifest?.[manifestKey] : null;
-  const localKey = readModelLocalCacheKey(key, params);
-  const cachedModels = safeLocalStorageGetJson(READ_MODEL_CACHE_STORAGE_KEY, {});
-  const hit = cachedModels?.[localKey];
-  if (
-    hit &&
-    manifestMeta &&
-    hit.version &&
-    hit.hash &&
-    hit.version === manifestMeta.version &&
-    hit.hash === manifestMeta.hash
-  ) {
-    return hit.data;
+  if (!READ_MODELS_ENABLED) {
+    return request(fallbackAction, fallbackPayload);
   }
   try {
+    const manifest = await getReadModelManifestCached();
+    const manifestKey = manifestEntryForReadModel(key, params);
+    const manifestMeta = manifestKey ? manifest?.[manifestKey] : null;
+    const localKey = readModelLocalCacheKey(key, params);
+    const cachedModels = safeLocalStorageGetJson(READ_MODEL_CACHE_STORAGE_KEY, {});
+    const hit = cachedModels?.[localKey];
+
+    if (
+      hit &&
+      manifestMeta &&
+      hit.version &&
+      hit.hash &&
+      hit.version === manifestMeta.version &&
+      hit.hash === manifestMeta.hash
+    ) {
+      return hit.data;
+    }
+
     const envelope = await request('readModelGet', { key, params });
     const data = envelope?.data ?? envelope ?? {};
+
     const nextCache = {
       ...cachedModels,
       [localKey]: {
@@ -210,9 +225,15 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
         data
       }
     };
+
     safeLocalStorageSetJson(READ_MODEL_CACHE_STORAGE_KEY, nextCache);
     return data;
-  } catch {
+  } catch (err) {
+    console.warn('[readModel] fallback to legacy endpoint', {
+      key,
+      fallbackAction,
+      error: err?.message || err
+    });
     return request(fallbackAction, fallbackPayload);
   }
 }


### PR DESCRIPTION
### Motivation
- Read-model failures during startup (manifest, cache, hashing, localStorage, or readModelGet) could throw before the existing fallback and crash the UI, so the read-model path must never bring the app down.

### Description
- Added an emergency flag `READ_MODELS_ENABLED` (based on `localStorage.disable_read_models`) to short-circuit read-model logic and force legacy endpoints when needed in `frontend/src/api.js`.
- Reworked `requestReadModel()` so all prefetch, manifest, cache, and network operations are inside a top-level `try/catch` and any error falls back to the provided legacy `fallbackAction`/`fallbackPayload`.
- Added a `console.warn` with diagnostic details when the fallback is triggered to aid production debugging.
- Kept existing local cache handling and manifest TTL behavior while ensuring any exception in those steps triggers the legacy fallback.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dc7ed4dc832ba71eadeb5a1eb301)