### PR TITLE
Improve read-model caching resilience; add auth route/permission fixes and tests

### DIFF
--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -300,6 +300,10 @@ function buildRoutesFromPermission_(permission, role) {
   };
 
   return allRoutes.filter(function(route) {
+    if (route === 'edit-requests') {
+      if (role === 'admin' || isOperationManagerRole_(role)) return true;
+      return permYes_(permission, 'view_edit_requests');
+    }
     if (route === 'permissions') {
       if (!canDirectWriteRole_(role)) return false;
       return permYes_(permission, 'view_permissions');
@@ -476,6 +480,8 @@ function effectiveCanRequestEdit_(permission, role) {
   if (role === 'instructor') return false;
   if (canDirectWriteRole_(role)) return true;
   var explicit = text_(permission.can_request_edit).toLowerCase();
+  // Backward-compat alias: older permissions sheets may still use can_edit_request.
+  if (!explicit) explicit = text_(permission.can_edit_request).toLowerCase();
   if (explicit === 'yes') return true;
   if (explicit === 'no') return false;
   return hasWorkViewForEdit_(permission);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -203,21 +203,7 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
       refreshReadModelInBackground_(key, params, localKey, manifestKey, hit);
       return hit.data;
     }
-
-    const manifest = await getReadModelManifestCached();
-    const manifestMeta = manifestKey ? manifest?.[manifestKey] : null;
-
-    if (
-      hit &&
-      manifestMeta &&
-      hit.version &&
-      hit.hash &&
-      hit.version === manifestMeta.version &&
-      hit.hash === manifestMeta.hash
-    ) {
-      return hit.data;
-    }
-
+    // Cache miss: avoid an extra blocking manifest round-trip and fetch payload directly.
     const envelope = await request('readModelGet', { key, params });
     const data = envelope?.data ?? envelope ?? {};
 

--- a/tests/auth-permissions-routes.test.mjs
+++ b/tests/auth-permissions-routes.test.mjs
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const AUTH_FILE = new URL('../backend/auth.gs', import.meta.url);
+const MAIN_FILE = new URL('../frontend/src/main.js', import.meta.url);
+
+test('can_edit_request is treated as backward-compatible alias for can_request_edit', async () => {
+  const source = await readFile(AUTH_FILE, 'utf8');
+  assert.match(source, /explicit\s*=\s*text_\(permission\.can_request_edit\)\.toLowerCase\(\)/);
+  assert.match(source, /if\s*\(!explicit\)\s*explicit\s*=\s*text_\(permission\.can_edit_request\)\.toLowerCase\(\)/);
+});
+
+test('view_edit_requests does not grant can_request_edit in effectiveCanRequestEdit_', async () => {
+  const source = await readFile(AUTH_FILE, 'utf8');
+  const fnMatch = source.match(/function effectiveCanRequestEdit_\([\s\S]*?\n}\n/);
+  assert.ok(fnMatch, 'effectiveCanRequestEdit_ function should exist');
+  assert.doesNotMatch(fnMatch[0], /view_edit_requests/);
+});
+
+test('operation_manager can access edit-requests route, non-manager still uses view_edit_requests', async () => {
+  const source = await readFile(AUTH_FILE, 'utf8');
+  assert.match(source, /if \(route === 'edit-requests'\) \{[\s\S]*isOperationManagerRole_\(role\)[\s\S]*permYes_\(permission, 'view_edit_requests'\)/);
+});
+
+test('operations route is not part of known routes and operations default maps to dashboard', async () => {
+  const authSource = await readFile(AUTH_FILE, 'utf8');
+  const knownRoutesBlock = authSource.match(/function allKnownRoutes_\(\) \{[\s\S]*?\n}\n/);
+  assert.ok(knownRoutesBlock, 'allKnownRoutes_ should exist');
+  assert.doesNotMatch(knownRoutesBlock[0], /'operations'/);
+  assert.match(authSource, /view_operations_data:\s*'dashboard'/);
+
+  const mainSource = await readFile(MAIN_FILE, 'utf8');
+  assert.doesNotMatch(mainSource, /operations:\s*\(\)\s*=>\s*import\('\.\/screens\/operations\.js'\)/);
+});

--- a/tests/readmodel-resilience.test.mjs
+++ b/tests/readmodel-resilience.test.mjs
@@ -1,0 +1,66 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const API_MODULE = new URL('../frontend/src/api.js', import.meta.url).href;
+const STATE_MODULE = new URL('../frontend/src/state.js', import.meta.url).href;
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  global.sessionStorage = dom.window.sessionStorage;
+  global.performance = { now: () => 0 };
+  global.requestAnimationFrame = (cb) => cb();
+}
+
+beforeEach(() => {
+  setupDom();
+});
+
+async function freshModules() {
+  const stamp = Date.now() + Math.random();
+  const stateMod = await import(`${STATE_MODULE}?bust=${stamp}`);
+  const apiMod = await import(`${API_MODULE}?bust=${stamp}`);
+  return { ...stateMod, ...apiMod };
+}
+
+test('read-model cache miss fetches readModelGet without blocking on readModelManifest first', async () => {
+  const { api, state } = await freshModules();
+  state.token = 'token';
+  const calls = [];
+  global.fetch = async (_url, req) => {
+    const body = JSON.parse(req.body);
+    calls.push(body.action);
+    if (body.action === 'readModelGet') {
+      return { status: 200, async text() { return JSON.stringify({ ok: true, data: { data: { items: [] }, version: 'v1', hash: 'h1' } }); } };
+    }
+    if (body.action === 'readModelManifest') {
+      return { status: 200, async text() { return JSON.stringify({ ok: true, data: {} }); } };
+    }
+    throw new Error(`unexpected action: ${body.action}`);
+  };
+
+  await api.activities({});
+  assert.equal(calls[0], 'readModelGet');
+});
+
+test('manifest/get failures fallback to legacy endpoint and do not break screen load', async () => {
+  const { api, state } = await freshModules();
+  state.token = 'token';
+  global.fetch = async (_url, req) => {
+    const body = JSON.parse(req.body);
+    if (body.action === 'readModelGet') {
+      throw new Error('network failure');
+    }
+    if (body.action === 'activities') {
+      return { status: 200, async text() { return JSON.stringify({ ok: true, data: { rows: [{ RowID: 'A1' }] } }); } };
+    }
+    return { status: 200, async text() { return JSON.stringify({ ok: true, data: {} }); } };
+  };
+
+  const data = await api.activities({});
+  assert.ok(Array.isArray(data?.rows));
+  assert.equal(data.rows[0]?.RowID, 'A1');
+});


### PR DESCRIPTION
### Motivation
- Reduce client latency on read-model cache misses by avoiding a blocking manifest round-trip when the payload can be fetched directly. 
- Fix permission/route edge-cases so operation managers can access the `edit-requests` route and older permission sheets using `can_edit_request` remain compatible. 
- Add automated tests to verify the new read-model behavior and the permission/route logic.

### Description
- Update `requestReadModel` in `frontend/src/api.js` to skip an extra manifest lookup on cache miss and directly request the read model via `readModelGet`, then update local storage with the returned envelope. 
- Adjust `buildRoutesFromPermission_` in `backend/auth.gs` to special-case the `'edit-requests'` route so that `admin` and `isOperationManagerRole_` roles are allowed without relying solely on the `view_edit_requests` permission. 
- Add a backward-compatible alias in `effectiveCanRequestEdit_` in `backend/auth.gs` so `can_edit_request` is treated as the same as `can_request_edit` if the latter is unset. 
- Add tests `tests/readmodel-resilience.test.mjs` and `tests/auth-permissions-routes.test.mjs` to validate the read-model fetch ordering, fallback behavior, and permission/route rules.

### Testing
- Ran node tests in `tests/readmodel-resilience.test.mjs` which assert that `readModelGet` is requested first on cache miss and that manifest/get failures fallback to legacy endpoints, and these tests passed. 
- Ran node tests in `tests/auth-permissions-routes.test.mjs` which validate the `can_edit_request` alias, `edit-requests` routing for operation managers, and the known-routes expectations, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e76f8088832bb529684056456118)