### PR TITLE
Add perf metadata propagation for read-model requests, dedupe dashboard month prefetch, and bump asset/cache versions

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -191,8 +191,15 @@ function manifestEntryForReadModel(key, params = {}) {
 }
 
 async function requestReadModel(key, params = {}, fallbackAction, fallbackPayload = {}) {
+  const perfBase = {
+    action: fallbackAction,
+    used_read_model: false,
+    fallback_used: false,
+    cache_hit: false,
+    sheet_reads_count: null
+  };
   if (!READ_MODELS_ENABLED) {
-    return request(fallbackAction, fallbackPayload);
+    return request(fallbackAction, fallbackPayload, perfBase);
   }
   try {
     const manifestKey = manifestEntryForReadModel(key, params);
@@ -201,10 +208,24 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
     const hit = cachedModels?.[localKey];
     if (hit && hit.data) {
       refreshReadModelInBackground_(key, params, localKey, manifestKey, hit);
+      pushPerfRequest({
+        action: fallbackAction,
+        duration_ms: 0,
+        payload_size: JSON.stringify(hit.data || {}).length,
+        used_read_model: true,
+        fallback_used: false,
+        cache_hit: true,
+        sheet_reads_count: null
+      });
       return hit.data;
     }
     // Cache miss: avoid an extra blocking manifest round-trip and fetch payload directly.
-    const envelope = await request('readModelGet', { key, params });
+    const envelope = await request('readModelGet', { key, params }, {
+      action: fallbackAction,
+      used_read_model: true,
+      fallback_used: false,
+      cache_hit: false
+    });
     const data = envelope?.data ?? envelope ?? {};
 
     const nextCache = {
@@ -226,7 +247,9 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
       fallbackAction,
       error: err?.message || err
     });
-    return request(fallbackAction, fallbackPayload);
+    const allowHeavyFallback = true;
+    if (!allowHeavyFallback) throw err;
+    return request(fallbackAction, fallbackPayload, { ...perfBase, fallback_used: true });
   }
 }
 
@@ -327,7 +350,15 @@ async function postWithTimeout(action, requestBody) {
   }
 }
 
-async function request(action, payload = {}) {
+function emitPerfEntry(entry) {
+  pushPerfRequest(entry);
+  if (isPerfDebugEnabled()) {
+    // eslint-disable-next-line no-console
+    console.info('[perf]', entry);
+  }
+}
+
+async function request(action, payload = {}, perfMeta = {}) {
   if (!config.apiUrl) {
     throw new Error('חסר קישור API. עדכנו frontend/src/config.js או window.__DASHBOARD_CONFIG__.');
   }
@@ -419,10 +450,15 @@ async function request(action, payload = {}) {
     invalidateScreenDataByAction(action);
     invalidateReadModelLocalCacheByAction(action);
   }
-  pushPerfRequest({
-    action,
+  const sheetReads = json?.data?.debug_perf?.sheet_reads_count ?? json?.data?.sheet_reads_count ?? null;
+  emitPerfEntry({
+    action: perfMeta.action || action,
     duration_ms: Math.round(performance.now() - requestStart),
-    payload_bytes: lastResponseText.length,
+    payload_size: lastResponseText.length,
+    used_read_model: Boolean(perfMeta.used_read_model || action === 'readModelGet'),
+    fallback_used: Boolean(perfMeta.fallback_used),
+    cache_hit: Boolean(perfMeta.cache_hit),
+    sheet_reads_count: sheetReads,
     backend_debug: json.data && json.data.debug_perf ? json.data.debug_perf : null
   });
   return normalized;

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -145,6 +145,8 @@ const ALLOWED_KPI_ACTIONS = new Set([
   'kpi|instructors',
   'kpi|endings'
 ]);
+const dashboardMonthPrefetchInflight = new Set();
+let dashboardMonthPrefetchScheduledToken = '';
 
 function filterKpiCards(cards, showOnlyNonzero) {
   const list = Array.isArray(cards) ? cards : [];
@@ -333,11 +335,16 @@ export const dashboardScreen = {
       const key = `dashboard:${validYm}`;
       const cached = state.screenDataCache[key];
       if (cached?.data && Date.now() - cached.t < DASHBOARD_TTL_MS) return;
+      if (dashboardMonthPrefetchInflight.has(key)) return;
+      dashboardMonthPrefetchInflight.add(key);
       api.dashboardSnapshot({ month: validYm })
         .then((payload) => {
           putDashboardCache(key, payload);
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => {
+          dashboardMonthPrefetchInflight.delete(key);
+        });
     };
 
     const applyYm = async (nextYm) => {
@@ -362,11 +369,14 @@ export const dashboardScreen = {
         rerender();
       }
       state.dashboardNavLoading = false;
-      rerender();
+      if (state.route === 'dashboard') rerender();
       prefetchDashboardMonth(shiftYm(nextYm, -1));
       prefetchDashboardMonth(shiftYm(nextYm, 1));
     };
 
+    const prefetchToken = `${ym}|${!!state.dashboardNavLoading}`;
+    if (dashboardMonthPrefetchScheduledToken === prefetchToken) return;
+    dashboardMonthPrefetchScheduledToken = prefetchToken;
     setTimeout(() => {
       if (!state.dashboardNavLoading) {
         prefetchDashboardMonth(shiftYm(ym, -1));

--- a/index_marvell.html
+++ b/index_marvell.html
@@ -12,8 +12,8 @@
   <link rel="manifest" href="./frontend/public/manifest.json" />
   <link rel="icon" href="./frontend/assets/favicon.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./frontend/assets/apple-touch-icon.png" />
-  <link rel="preload" href="./frontend/src/styles/main.css?v=2604280" as="style" />
-  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2604280" />
+  <link rel="preload" href="./frontend/src/styles/main.css?v=2604301" as="style" />
+  <link rel="stylesheet" href="./frontend/src/styles/main.css?v=2604301" />
   <style>
     body {
       background-image: url('Premium/images/marvell-bg.png');
@@ -27,6 +27,6 @@
 </head>
 <body>
   <main id="app"></main>
-  <script type="module" src="./frontend/src/main.js?v=2604280"></script>
+  <script type="module" src="./frontend/src/main.js?v=2604301"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service worker at repository root so scope covers the whole GitHub Pages site. */
-const CACHE_VERSION = 229;
+const CACHE_VERSION = 230;
 const CACHE = `internal-dashboard-v${CACHE_VERSION}`;
 
 const APP_SHELL = [


### PR DESCRIPTION
### Motivation

- Improve telemetry around when read-model endpoints and legacy fallbacks are used so perf entries reflect cache/hit/fallback state.
- Avoid duplicate/parallel dashboard month prefetch requests and prevent unnecessary rerenders when navigating months.
- Ensure clients pick up updated assets by bumping asset querystrings and service worker cache version.

### Description

- In `frontend/src/api.js` added `emitPerfEntry` and extended `request` to accept an optional `perfMeta` argument so perf payloads include `used_read_model`, `fallback_used`, `cache_hit`, and `sheet_reads_count` and log when perf debug is enabled.
- Updated `requestReadModel` to construct and forward perf metadata (`perfBase`) to `request`, and to emit a perf entry on local cache hit and on direct read-model fetches.
- Normalized perf payload field name to `payload_size` and enriched perf entries with backend debug info when available.
- In `frontend/src/screens/dashboard.js` added `dashboardMonthPrefetchInflight` and `dashboardMonthPrefetchScheduledToken` to dedupe inflight prefetches and scheduled prefetches, added `.finally()` cleanup, and avoid rerendering unless the route is still `dashboard`.
- Bumped frontend asset querystrings in `index_marvell.html` for `main.js` and `main.css` and incremented the service worker `CACHE_VERSION` in `sw.js`.

### Testing

- Ran linting via `npm run lint` which completed successfully.
- Built the frontend via `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f1362a80832ba88278ad04fbf067)