### PR TITLE
Add safe diagnosticsConsistency failure visibility for admin/ops

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -404,10 +404,20 @@ function dateColumnsPatchFromChanges_(changes) {
 
 function actionDiagnosticsConsistency_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager']);
-
   var month = dashboardPayloadYm_(payload || {});
-  var rows = allActivitiesSummary_();
-  var inMonth = rows.filter(function(row) { return activityOverlapsYm_(row, month); });
+  var role = text_(user && user.display_role);
+  var userId = text_(user && user.user_id);
+  Logger.log('diagnosticsConsistency started');
+  Logger.log('diagnosticsConsistency user id / role: ' + userId + ' / ' + role);
+  Logger.log('diagnosticsConsistency month: ' + month);
+  var allActivitiesOk = false;
+  var exceptionsOk = false;
+  var financeOk = false;
+  try {
+    var rows = allActivitiesSummary_();
+    allActivitiesOk = true;
+    Logger.log('diagnosticsConsistency allActivitiesSummary_ succeeded');
+    var inMonth = rows.filter(function(row) { return activityOverlapsYm_(row, month); });
 
   var oneDayTypes = configuredOneDayActivityTypes_();
   var programTypes = configuredProgramActivityTypes_();
@@ -423,6 +433,8 @@ function actionDiagnosticsConsistency_(user, payload) {
   }).length;
 
   var exceptionSummary = getExceptionsSummary_(inMonth, month, { include_rows: false });
+  exceptionsOk = true;
+  Logger.log('diagnosticsConsistency getExceptionsSummary_ succeeded');
   var exceptionsTotal = Number(exceptionSummary.totalExceptionInstances || 0);
   var byManager = exceptionSummary.byManager || {};
   var sumByManager = Object.keys(byManager).reduce(function(sum, manager) {
@@ -441,6 +453,8 @@ function actionDiagnosticsConsistency_(user, payload) {
   var financeOpenAmount = financeOpenRows.reduce(function(sum, row) { return sum + Number(row.amount || 0); }, 0);
   var financeClosedAmount = financeClosedRows.reduce(function(sum, row) { return sum + Number(row.amount || 0); }, 0);
   var financePendingAmount = financeRows.reduce(function(sum, row) { return sum + Number(row.pending || 0); }, 0);
+  financeOk = true;
+  Logger.log('diagnosticsConsistency finance calculation succeeded');
 
   var courseEndings = inMonth.filter(function(row) {
     return text_(row.activity_type) === 'course' && text_(row.end_date).slice(0, 7) === month;
@@ -526,6 +540,26 @@ function actionDiagnosticsConsistency_(user, payload) {
   } catch (_snapshotErr) {}
 
   return diagnostics;
+  } catch (err) {
+    var errMessage = err && err.message ? String(err.message) : String(err);
+    var fnMatch = errMessage.match(/([A-Za-z_][A-Za-z0-9_]+_)\s/);
+    var functionName = fnMatch ? fnMatch[1] : 'actionDiagnosticsConsistency_';
+    Logger.log('diagnosticsConsistency allActivitiesSummary_ success: ' + allActivitiesOk);
+    Logger.log('diagnosticsConsistency getExceptionsSummary_ success: ' + exceptionsOk);
+    Logger.log('diagnosticsConsistency finance calculation success: ' + financeOk);
+    Logger.log('diagnosticsConsistency failed + function: ' + functionName);
+    if (role === 'admin' || role === 'operation_manager') {
+      var safeDetails = {
+        errorCode: 'DIAGNOSTICS_CONSISTENCY_FAILED',
+        message: errMessage,
+        functionName: functionName,
+        month: month,
+        stack: err && err.stack ? String(err.stack).split('\n').slice(0, 3).join(' | ') : ''
+      };
+      throw new Error('DIAGNOSTICS_ADMIN_DETAILS:' + JSON.stringify(safeDetails));
+    }
+    throw new Error('server_error');
+  }
 }
 
 function actionDashboard_(user, payload) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -436,6 +436,12 @@ async function request(action, payload = {}, perfMeta = {}) {
     if ((json.error || '').toLowerCase() === 'unauthorized' && state.token === tokenAtCallTime) {
       setSession(null);
     }
+    if (action === 'diagnosticsConsistency' &&
+        typeof json.error === 'string' &&
+        json.error.indexOf('DIAGNOSTICS_ADMIN_DETAILS:') === 0 &&
+        ['admin', 'operation_manager'].includes(String(state?.user?.display_role || ''))) {
+      throw new Error(json.error.slice('DIAGNOSTICS_ADMIN_DETAILS:'.length));
+    }
     throw new Error(translateApiErrorForUser(json.error));
   }
   const normalized = normalizeData(json.data);

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -315,7 +315,21 @@ export const dashboardScreen = {
           const criticalMsg = critical ? '<p style="color:#b42318;font-weight:800">נמצא פער קריטי — אין לעבור ל-Stage 3</p>' : '';
           resultsHost.innerHTML = `${criticalMsg}${stage3}${blocks}`;
         } catch (err) {
-          resultsHost.innerHTML = `<p style="color:#b42318">שגיאה בהרצת הדיאגנוסטיקה: ${escapeHtml(String(err?.message || err))}</p>`;
+          const rawMessage = String(err?.message || err || '');
+          let adminDetailsHtml = '';
+          if (isAdminOps) {
+            try {
+              const details = JSON.parse(rawMessage);
+              adminDetailsHtml = `<div style="color:#b42318"><p><strong>שגיאה בהרצת הדיאגנוסטיקה</strong></p>
+                <p>errorCode: ${escapeHtml(String(details?.errorCode || ''))}</p>
+                <p>message: ${escapeHtml(String(details?.message || ''))}</p>
+                <p>functionName: ${escapeHtml(String(details?.functionName || ''))}</p>
+                <p>month: ${escapeHtml(String(details?.month || ''))}</p>
+                ${details?.stack ? `<p>stack: ${escapeHtml(String(details.stack))}</p>` : ''}
+              </div>`;
+            } catch (_e) {}
+          }
+          resultsHost.innerHTML = adminDetailsHtml || `<p style="color:#b42318">שגיאה בהרצת הדיאגנוסטיקה: ${escapeHtml(rawMessage)}</p>`;
         } finally {
           runBtn.disabled = false;
         }

--- a/tests/diagnostics-admin-error-ui.test.mjs
+++ b/tests/diagnostics-admin-error-ui.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('dashboard diagnostics shows detailed admin error payload fields', async () => {
+  const source = readFileSync(new URL('../frontend/src/screens/dashboard.js', import.meta.url), 'utf8');
+  assert.match(source, /JSON\.parse\(rawMessage\)/);
+  assert.match(source, /errorCode:/);
+  assert.match(source, /functionName:/);
+  assert.match(source, /month:/);
+  assert.doesNotMatch(source, /שגיאת שרת — נסו שוב מאוחר יותר/);
+});


### PR DESCRIPTION
### Motivation
- Improve observability of failures when running `diagnosticsConsistency` so admin/ops can see safe, actionable error details instead of a generic server message.
- Leave diagnostics read-only and confined to admin/operation_manager role to avoid accidental data mutation or cache/read-model refresh.

### Description
- Wrapped `actionDiagnosticsConsistency_` in a `try/catch`, added `Logger.log` milestones (`diagnosticsConsistency started`, user id/role, month, stage success flags, and failure function marker) and set flags for `allActivitiesSummary_`, `getExceptionsSummary_` and finance calculation success.
- On error, throw a prefixed admin-only payload `DIAGNOSTICS_ADMIN_DETAILS:` containing `errorCode`, `message`, `functionName`, `month` and a short `stack` when the caller is `admin` or `operation_manager`, and otherwise return a generic `server_error` to non-admins.
- Frontend `request()` now unwraps and surfaces the `DIAGNOSTICS_ADMIN_DETAILS:` payload only for admin/ops users, and `dashboard` screen renders parsed admin details (or falls back to the existing generic error text for others).
- Confirmed `diagnosticsConsistency` route exists and is mapped to `actionDiagnosticsConsistency_`, kept diagnostics read-only, and added a unit test that asserts the admin error rendering code is present.

### Testing
- Ran `npm test` which executed the full suite and passed: `72/72` tests passed (including the new `tests/diagnostics-admin-error-ui.test.mjs`).
- The new UI test asserts presence of the admin error parsing and displayed fields and succeeded as part of the suite.
- No automated tests modify Sheets, refresh read-models, or enable cache from this action and the diagnostics flow remains read-only as validated by the existing diagnostics consistency tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b96b9f18832bb7d0e5b91c26fe4c)