### PR TITLE
Improve diagnosticsConsistency error visibility for admin/ops

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -407,6 +407,7 @@ function actionDiagnosticsConsistency_(user, payload) {
   var month = dashboardPayloadYm_(payload || {});
   var role = text_(user && user.display_role);
   var userId = text_(user && user.user_id);
+  var currentFunction = 'actionDiagnosticsConsistency_';
   Logger.log('diagnosticsConsistency started');
   Logger.log('diagnosticsConsistency user id / role: ' + userId + ' / ' + role);
   Logger.log('diagnosticsConsistency month: ' + month);
@@ -414,6 +415,7 @@ function actionDiagnosticsConsistency_(user, payload) {
   var exceptionsOk = false;
   var financeOk = false;
   try {
+    currentFunction = 'allActivitiesSummary_';
     var rows = allActivitiesSummary_();
     allActivitiesOk = true;
     Logger.log('diagnosticsConsistency allActivitiesSummary_ succeeded');
@@ -432,6 +434,7 @@ function actionDiagnosticsConsistency_(user, payload) {
     return true;
   }).length;
 
+  currentFunction = 'getExceptionsSummary_';
   var exceptionSummary = getExceptionsSummary_(inMonth, month, { include_rows: false });
   exceptionsOk = true;
   Logger.log('diagnosticsConsistency getExceptionsSummary_ succeeded');
@@ -441,6 +444,7 @@ function actionDiagnosticsConsistency_(user, payload) {
     return sum + Number(byManager[manager] || 0);
   }, 0);
 
+  currentFunction = 'financeCalculation_';
   var financeRows = inMonth.map(function(row) {
     return {
       finance_status: normalizeFinance_(row.finance_status),
@@ -543,7 +547,7 @@ function actionDiagnosticsConsistency_(user, payload) {
   } catch (err) {
     var errMessage = err && err.message ? String(err.message) : String(err);
     var fnMatch = errMessage.match(/([A-Za-z_][A-Za-z0-9_]+_)\s/);
-    var functionName = fnMatch ? fnMatch[1] : 'actionDiagnosticsConsistency_';
+    var functionName = currentFunction || (fnMatch ? fnMatch[1] : 'actionDiagnosticsConsistency_');
     Logger.log('diagnosticsConsistency allActivitiesSummary_ success: ' + allActivitiesOk);
     Logger.log('diagnosticsConsistency getExceptionsSummary_ success: ' + exceptionsOk);
     Logger.log('diagnosticsConsistency finance calculation success: ' + financeOk);

--- a/tests/diagnostics-consistency-error-tracking.test.mjs
+++ b/tests/diagnostics-consistency-error-tracking.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('diagnostics consistency tracks failing internal function for admin-safe details', async () => {
+  const source = readFileSync(new URL('../backend/actions.gs', import.meta.url), 'utf8');
+  assert.match(source, /var currentFunction = 'actionDiagnosticsConsistency_';/);
+  assert.match(source, /currentFunction = 'allActivitiesSummary_';/);
+  assert.match(source, /currentFunction = 'getExceptionsSummary_';/);
+  assert.match(source, /currentFunction = 'financeCalculation_';/);
+  assert.match(source, /var functionName = currentFunction \|\| \(fnMatch \? fnMatch\[1\] : 'actionDiagnosticsConsistency_'\);/);
+});


### PR DESCRIPTION
### Motivation
- Make the `diagnosticsConsistency` flow expose the internal failing step safely to admin/operation_manager users so the source of runtime failures is easier to triage.
- Preserve existing read-only behavior and the generic error shown to non-admin users while improving admin observability.

### Description
- Added a `currentFunction` tracker inside `actionDiagnosticsConsistency_` and set it around the main internal steps (`allActivitiesSummary_`, `getExceptionsSummary_`, and the finance calculation).
- Use `currentFunction` as the primary `functionName` in the admin-safe error payload that is thrown as `DIAGNOSTICS_ADMIN_DETAILS:...`, falling back to the previous regex-based extraction if needed.
- Added a regression test `tests/diagnostics-consistency-error-tracking.test.mjs` to assert the presence of the `currentFunction` tracking and the error-name selection logic.
- No change to permissions, frontend payload shape, side-effects (no writes to Sheets, no read-model refresh, no cache invalidation), or behaviour for non-admin users.

### Testing
- Ran the full test suite with `npm test` and all tests passed (`73/73`), including the new regression test.
- Verified the `diagnosticsConsistency` route exists and is mapped to `actionDiagnosticsConsistency_` via `backend/router.gs` and that the frontend continues to call `api.diagnosticsConsistency({ month })` with existing auth/token semantics.
- Confirmed existing frontend logic still renders the detailed admin error payload for admin/ops users and maintains the generic server error for non-admin users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c478d304832b828081c0afe5a7d3)