### PR TITLE
hotfix: update frontend Apps Script deployment URL

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbyRgPaytGRBYT2_6p-qvXsU5oZYV-mV9FPd6uNhWifBOlKFDnWdJd2aVB4GQIoeH00H/exec';
+  'https://script.google.com/macros/s/AKfycbzExyeOk5SWLVAU4Q5-kMhxGXXcFj-Tp1FUA-8RlwtUteRODrjIQwnmd0eOPhunmQ62/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();


### PR DESCRIPTION
### Motivation
- Point the frontend to the new Google Apps Script Web App deployment URL so all runtime API calls use the updated endpoint without changing business logic or read models.

### Description
- Replaced `DEFAULT_API_URL` in `frontend/src/config.js` with the provided new `/exec` URL and kept API routing centralized so `login`, `dashboard`, `activities`, `finance`, `exceptions`, and `diagnosticsConsistency` resolve via `config.apiUrl`; no business logic, read-model code, or dashboard/finance/exception calculations were modified, and legacy occurrences in docs/scripts were left as non-runtime references.

### Testing
- Ran `npm test` (command: `npm test`) and all tests passed (72/72), and verified the service worker is disabled during the hotfix via `STABILITY_HOTFIX_DISABLE_SERVICE_WORKER = true` so old cached JS should not be served.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c488c590832babc024c550f60bae)