### PR TITLE
Fix diagnosticsConsistency finance helper ReferenceError

### DIFF
--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -107,6 +107,23 @@ function normalizeFinance_(value) {
   return text_(value).toLowerCase() === 'closed' ? 'closed' : 'open';
 }
 
+function parseFinanceRowAmount_(row) {
+  var explicit = parseFloat((row && (row.Payment || row.payment || row.payment_amount)) || 0) || 0;
+  if (explicit > 0) return explicit;
+  var price = parseFloat(row && row.price) || 0;
+  var sessions = parseFloat(row && row.sessions) || 0;
+  return sessions > 0 ? price * sessions : price;
+}
+
+function parseFinanceRowPending_(row) {
+  var price = parseFloat(row && row.price) || 0;
+  var sessions = parseFloat(row && row.sessions) || 0;
+  var expected = sessions > 0 ? price * sessions : price;
+  var recorded = parseFloat((row && (row.Payment || row.payment || row.payment_amount)) || 0) || 0;
+  var pending = expected - recorded;
+  return pending > 0 ? pending : 0;
+}
+
 function pickYesNo_(input, key, fallback) {
   if (Object.prototype.hasOwnProperty.call(input || {}, key)) {
     return yesNo_(input[key]);

--- a/tests/diagnostics-consistency-finance-helpers.test.mjs
+++ b/tests/diagnostics-consistency-finance-helpers.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const read = (p) => fs.readFile(new URL(`../${p}`, import.meta.url), 'utf8');
+
+function mustMatch(src, regex, msg) {
+  assert.match(src, regex, msg || String(regex));
+}
+
+test('diagnostics consistency uses defined backend finance helpers and keeps read-only behavior', async () => {
+  const actions = await read('backend/actions.gs');
+  const helpers = await read('backend/helpers.gs');
+
+  mustMatch(actions, /amount:\s*parseFinanceRowAmount_\(row\)/);
+  mustMatch(actions, /pending:\s*parseFinanceRowPending_\(row\)/);
+
+  mustMatch(helpers, /function parseFinanceRowAmount_\(row\) \{/);
+  mustMatch(helpers, /function parseFinanceRowPending_\(row\) \{/);
+
+  mustMatch(actions, /finance_status:\s*normalizeFinance_\(row\.finance_status\)/);
+
+  mustMatch(actions, /finance:\s*\{[\s\S]*openAmount:[\s\S]*closedAmount:[\s\S]*pendingAmount:[\s\S]*\}/);
+
+  const diagnosticsFn = actions.match(/function actionDiagnosticsConsistency_\([\s\S]*?\n}\n\nfunction /);
+  assert.ok(diagnosticsFn, 'actionDiagnosticsConsistency_ function not found');
+  const body = diagnosticsFn[0];
+  assert.doesNotMatch(body, /refreshReadModelsForActivityRow_|refreshSingleReadModel_|readModel|cache/i);
+});


### PR DESCRIPTION
### Motivation
- The diagnostics action threw `ReferenceError: parseFinanceRowAmount_ is not defined` because `actionDiagnosticsConsistency_` relied on finance helper functions that did not exist in the Apps Script backend runtime. 
- The goal was to fix this pointwise so diagnostics uses real backend finance helpers and remains read-only.

### Description
- Added backend helper functions `parseFinanceRowAmount_` and `parseFinanceRowPending_` to `backend/helpers.gs` that mirror the finance screen logic (prefer `Payment` if present, otherwise `price * sessions`; pending = expected - recorded clamped to 0). 
- Kept `actionDiagnosticsConsistency_` using existing `normalizeFinance_` and the new helpers so no duplicated or conflicting finance logic was introduced. 
- Added a regression test `tests/diagnostics-consistency-finance-helpers.test.mjs` to assert diagnostics references the defined helpers and that the diagnostics function remains read-only (no read-model/cache refresh patterns).
- Changed files: `backend/helpers.gs` (helpers added) and new test `tests/diagnostics-consistency-finance-helpers.test.mjs`.

### Testing
- Ran the full suite with `npm test` and all tests passed (`74` tests, `0` failures). 
- The new regression test verifies `actionDiagnosticsConsistency_` uses `parseFinanceRowAmount_` and `parseFinanceRowPending_`, the helpers are defined, diagnostics exposes `openAmount`/`closedAmount`/`pendingAmount`, and no read-model/cache refresh calls exist in the diagnostics body. 
- Note: the Apps Script backend will need a new deployment/version so the added helpers are available in the live Apps Script runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c6f2f62c832b802102ad4b347ce4)