### PR TITLE
Ensure finance helpers available in Apps Script: add parseFinanceRowAmount_/parseFinanceRowPending_ and diagnostics backendVersion

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -402,6 +402,31 @@ function dateColumnsPatchFromChanges_(changes) {
 }
 
 
+
+function parseFinanceRowAmount_(row) {
+  var candidate = toNumberOrNull_(row && row.amount);
+  if (candidate === null) candidate = toNumberOrNull_(row && row.price);
+  if (candidate === null) candidate = toNumberOrNull_(row && row.total_amount);
+  if (candidate === null) candidate = toNumberOrNull_(row && row.amount_due);
+  if (candidate === null) return 0;
+  return candidate;
+}
+
+function parseFinanceRowPending_(row) {
+  var explicitPending = toNumberOrNull_(row && row.pending_amount);
+  if (explicitPending === null) explicitPending = toNumberOrNull_(row && row.pending);
+  if (explicitPending === null) explicitPending = toNumberOrNull_(row && row.balance);
+  if (explicitPending === null) explicitPending = toNumberOrNull_(row && row.remaining_amount);
+  if (explicitPending !== null) return explicitPending;
+
+  var due = toNumberOrNull_(row && row.sessions);
+  if (due === null) due = 0;
+  var paymentValue = toNumberOrNull_(row && row.Payment);
+  if (paymentValue === null) paymentValue = toNumberOrNull_(row && row.payment);
+  var received = paymentValue > 0 ? 1 : 0;
+  return Math.max(due - received, 0);
+}
+
 function actionDiagnosticsConsistency_(user, payload) {
   requireAnyRole_(user, ['admin', 'operation_manager']);
   var month = dashboardPayloadYm_(payload || {});
@@ -545,7 +570,8 @@ function actionDiagnosticsConsistency_(user, payload) {
         pendingAmount: financePendingAmount
       },
       timings: timings,
-      mismatches: []
+      mismatches: [],
+      backendVersion: 'stage2c-finance-helper-fix-v1'
     };
 
     function pushMismatch_(metric, dashboardValue, sourceValue, sourceName, suspectedFunction, critical, reason) {

--- a/tests/diagnostics-consistency-finance-helpers.test.mjs
+++ b/tests/diagnostics-consistency-finance-helpers.test.mjs
@@ -10,17 +10,16 @@ function mustMatch(src, regex, msg) {
 
 test('diagnostics consistency uses defined backend finance helpers and keeps read-only behavior', async () => {
   const actions = await read('backend/actions.gs');
-  const helpers = await read('backend/helpers.gs');
 
   mustMatch(actions, /amount:\s*parseFinanceRowAmount_\(row\)/);
   mustMatch(actions, /pending:\s*parseFinanceRowPending_\(row\)/);
 
-  mustMatch(helpers, /function parseFinanceRowAmount_\(row\) \{/);
-  mustMatch(helpers, /function parseFinanceRowPending_\(row\) \{/);
+  mustMatch(actions, /function parseFinanceRowAmount_\(row\) \{/);
+  mustMatch(actions, /function parseFinanceRowPending_\(row\) \{/);
 
   mustMatch(actions, /finance_status:\s*normalizeFinance_\(row\.finance_status\)/);
-
   mustMatch(actions, /finance:\s*\{[\s\S]*openAmount:[\s\S]*closedAmount:[\s\S]*pendingAmount:[\s\S]*\}/);
+  mustMatch(actions, /backendVersion:\s*'stage2c-finance-helper-fix-v1'/);
 
   const diagnosticsFn = actions.match(/function actionDiagnosticsConsistency_\([\s\S]*?\n}\n\nfunction /);
   assert.ok(diagnosticsFn, 'actionDiagnosticsConsistency_ function not found');


### PR DESCRIPTION
### Motivation
- Prevent `ReferenceError` in `actionDiagnosticsConsistency_` by making finance parsing helpers available in the same file loaded by Apps Script runtime. 
- Provide a visible backend marker so the running deployment can be verified (`backendVersion`).

### Description
- Added `function parseFinanceRowAmount_(row)` and `function parseFinanceRowPending_(row)` directly into `backend/actions.gs` immediately before `actionDiagnosticsConsistency_`, with safe parsing of common field aliases and `0` fallback for invalid/missing values. 
- Updated the diagnostics payload returned by `actionDiagnosticsConsistency_` to include `backendVersion: 'stage2c-finance-helper-fix-v1'`.
- Adjusted the regression test `tests/diagnostics-consistency-finance-helpers.test.mjs` to assert the helpers exist in `backend/actions.gs`, that `actionDiagnosticsConsistency_` uses them, and that `backendVersion` is present in the diagnostics payload.

### Testing
- Ran the full test suite with `npm test` and all tests passed (`74/74`).
- Verified the new helper functions appear in `backend/actions.gs` and that `actionDiagnosticsConsistency_` maps finance `openAmount`/`closedAmount`/`pendingAmount` using the new helpers. 
- Confirmed the modified regression test now checks for `parseFinanceRowAmount_`, `parseFinanceRowPending_`, and `backendVersion` in `backend/actions.gs` and succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d6af15dc832b8d2a0360317f2a3b)