### PR TITLE
Add defensive finance parsers for diagnostics and expose backendVersion

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -403,26 +403,46 @@ function dateColumnsPatchFromChanges_(changes) {
 
 
 
+function parseFinanceCellNumber_(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') {
+    if (!isFinite(value)) return null;
+    return value;
+  }
+  var raw = String(value).trim();
+  if (!raw) return null;
+  var normalized = raw
+    .replace(/\u200f|\u200e/g, '')
+    .replace(/[₪,\s]/g, '')
+    .replace(/[^\d.\-]/g, '');
+  if (!normalized || normalized === '-' || normalized === '.' || normalized === '-.') return null;
+  var parsed = Number(normalized);
+  if (!isFinite(parsed)) return null;
+  return parsed;
+}
+
 function parseFinanceRowAmount_(row) {
-  var candidate = toNumberOrNull_(row && row.amount);
-  if (candidate === null) candidate = toNumberOrNull_(row && row.price);
-  if (candidate === null) candidate = toNumberOrNull_(row && row.total_amount);
-  if (candidate === null) candidate = toNumberOrNull_(row && row.amount_due);
+  if (!row) return 0;
+  var candidate = parseFinanceCellNumber_(row.amount);
+  if (candidate === null) candidate = parseFinanceCellNumber_(row.price);
+  if (candidate === null) candidate = parseFinanceCellNumber_(row.total_amount);
+  if (candidate === null) candidate = parseFinanceCellNumber_(row.amount_due);
   if (candidate === null) return 0;
   return candidate;
 }
 
 function parseFinanceRowPending_(row) {
-  var explicitPending = toNumberOrNull_(row && row.pending_amount);
-  if (explicitPending === null) explicitPending = toNumberOrNull_(row && row.pending);
-  if (explicitPending === null) explicitPending = toNumberOrNull_(row && row.balance);
-  if (explicitPending === null) explicitPending = toNumberOrNull_(row && row.remaining_amount);
+  if (!row) return 0;
+  var explicitPending = parseFinanceCellNumber_(row.pending_amount);
+  if (explicitPending === null) explicitPending = parseFinanceCellNumber_(row.pending);
+  if (explicitPending === null) explicitPending = parseFinanceCellNumber_(row.balance);
+  if (explicitPending === null) explicitPending = parseFinanceCellNumber_(row.remaining_amount);
   if (explicitPending !== null) return explicitPending;
 
-  var due = toNumberOrNull_(row && row.sessions);
+  var due = parseFinanceCellNumber_(row.sessions);
   if (due === null) due = 0;
-  var paymentValue = toNumberOrNull_(row && row.Payment);
-  if (paymentValue === null) paymentValue = toNumberOrNull_(row && row.payment);
+  var paymentValue = parseFinanceCellNumber_(row.Payment);
+  if (paymentValue === null) paymentValue = parseFinanceCellNumber_(row.payment);
   var received = paymentValue > 0 ? 1 : 0;
   return Math.max(due - received, 0);
 }
@@ -571,7 +591,7 @@ function actionDiagnosticsConsistency_(user, payload) {
       },
       timings: timings,
       mismatches: [],
-      backendVersion: 'stage2c-finance-helper-fix-v1'
+      backendVersion: 'stage2c-finance-helper-fix-v2'
     };
 
     function pushMismatch_(metric, dashboardValue, sourceValue, sourceName, suspectedFunction, critical, reason) {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -169,6 +169,7 @@ function renderDiagnosticsMonthBlock(result) {
   const d = result?.dashboard || {};
   const ex = result?.exceptions || {};
   const fi = result?.finance || {};
+  const backendVersion = escapeHtml(String(result?.backendVersion || ''));
   const mismatches = Array.isArray(result?.mismatches) ? result.mismatches : [];
   const hasCritical = !!result?.critical || mismatches.some((m) => !!m?.critical);
   const successMsg = mismatches.length === 0
@@ -188,6 +189,7 @@ function renderDiagnosticsMonthBlock(result) {
     <p><strong>Dashboard</strong>: total_short=${escapeHtml(String(d.total_short ?? 0))}, total_long=${escapeHtml(String(d.total_long ?? 0))}, exceptions_count=${escapeHtml(String(d.exceptions_count ?? 0))}, finance_open_count=${escapeHtml(String(d.finance_open_count ?? 0))}, active_instructors=${escapeHtml(String(d.active_instructors ?? 0))}, course_endings=${escapeHtml(String(d.course_endings ?? 0))}</p>
     <p><strong>Exceptions</strong>: totalExceptionInstances=${escapeHtml(String(ex.totalExceptionInstances ?? 0))}, sumByManager=${escapeHtml(String(ex.sumByManager ?? 0))}, byManager=${escapeHtml(JSON.stringify(ex.byManager || {}))}</p>
     <p><strong>Finance</strong>: openRows=${escapeHtml(String(fi.openRows ?? 0))}, closedRows=${escapeHtml(String(fi.closedRows ?? 0))}, openAmount=${escapeHtml(String(fi.openAmount ?? 0))}, closedAmount=${escapeHtml(String(fi.closedAmount ?? 0))}, pendingAmount=${escapeHtml(String(fi.pendingAmount ?? 0))}</p>
+    <p><strong>backendVersion</strong>: ${backendVersion}</p>
     <h5>פערים שהתגלו</h5>
     ${mismatchesTable}
   </div></div>`;

--- a/tests/dashboard-stage2c-live-ui.test.mjs
+++ b/tests/dashboard-stage2c-live-ui.test.mjs
@@ -18,6 +18,7 @@ test('dashboard diagnostics button is admin/ops only and labeled correctly', asy
 test('dashboard diagnostics runs one selected month at a time with timeout', async () => {
   const source = await readFile(DASHBOARD_FILE, 'utf8');
   assert.match(source, /api\.diagnosticsConsistency\(\{ month: selectedMonth \}, \{ timeout_ms: 25000 \}\)/);
+  assert.match(source, /<strong>backendVersion<\/strong>/);
   assert.match(source, /בדיקת הדיאגנוסטיקה נמשכה יותר מדי זמן ונעצרה/);
   assert.doesNotMatch(source, /const months = \['2026-04', '2026-05'\]/);
   assert.doesNotMatch(source, /Promise\.all\(months\.map/);

--- a/tests/diagnostics-consistency-finance-helpers.test.mjs
+++ b/tests/diagnostics-consistency-finance-helpers.test.mjs
@@ -19,7 +19,7 @@ test('diagnostics consistency uses defined backend finance helpers and keeps rea
 
   mustMatch(actions, /finance_status:\s*normalizeFinance_\(row\.finance_status\)/);
   mustMatch(actions, /finance:\s*\{[\s\S]*openAmount:[\s\S]*closedAmount:[\s\S]*pendingAmount:[\s\S]*\}/);
-  mustMatch(actions, /backendVersion:\s*'stage2c-finance-helper-fix-v1'/);
+  mustMatch(actions, /backendVersion:\s*'stage2c-finance-helper-fix-v2'/);
 
   const diagnosticsFn = actions.match(/function actionDiagnosticsConsistency_\([\s\S]*?\n}\n\nfunction /);
   assert.ok(diagnosticsFn, 'actionDiagnosticsConsistency_ function not found');


### PR DESCRIPTION
### Motivation
- Prevent `ReferenceError`/`TypeError` during diagnostics when finance helper functions are missing or values are malformed by adding defensive, guaranteed-backend helpers. 
- Surface the backend diagnostics version to the UI to make it clear which backend code produced the diagnostics.

### Description
- Added a numeric normalizer `parseFinanceCellNumber_` and explicit global wrappers `parseFinanceRowAmount_(row)` and `parseFinanceRowPending_(row)` in `backend/actions.gs` before `actionDiagnosticsConsistency_` to ensure the functions exist in the deployed Apps Script runtime (functions added at approximately lines 406–448). 
- The new parsers are defensive: they return `0` for missing/empty/invalid rows, strip `₪`, commas, spaces and other non-numeric characters, and never throw `ReferenceError`/`TypeError`. 
- Bumped the diagnostics result field `backendVersion` to `'stage2c-finance-helper-fix-v2'` in `backend/actions.gs`. 
- Exposed the returned `backendVersion` in the dashboard diagnostics block by rendering it in `frontend/src/screens/dashboard.js`, and updated tests to expect the new version and UI marker (`tests/diagnostics-consistency-finance-helpers.test.mjs` and `tests/dashboard-stage2c-live-ui.test.mjs`).

### Testing
- Ran the full automated suite with `npm test` and all tests passed (`74 passed, 0 failed`).
- Verified the updated backend file contains the new functions placed before `actionDiagnosticsConsistency_` and that the diagnostics payload includes `backendVersion: 'stage2c-finance-helper-fix-v2'` via the updated tests which passed. 
- Note: the deployed Apps Script must be re-deployed so the runtime includes the new backend functions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3dbe8e59c832ba9e86627196e96d9)