### PR TITLE
Fix unresponsive week/month navigation in calendar screens

### DIFF
--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -392,7 +392,7 @@ export const monthScreen = {
     const prevBtn = root.querySelector('[data-month-prev]');
     const nextBtn = root.querySelector('[data-month-next]');
     const todayBtn = root.querySelector('[data-month-today]');
-    const doMonthShift = (delta) => {
+    const doMonthShift = async (delta) => {
       if (state.monthNavLoading) return;
       const startedAt = Date.now();
       const targetYm = shiftMonthYm(resolveBaseYm(), delta);
@@ -408,8 +408,16 @@ export const monthScreen = {
         root.classList.add('is-month-loading');
         root.setAttribute('aria-busy', 'true');
         rerender?.();
+        try {
+          const monthData = await api.month({ ym: targetYm }, { timeout_ms: 12000 });
+          if (state?.screenDataCache) {
+            state.screenDataCache[targetKey] = { data: monthData, t: Date.now() };
+          }
+        } catch {
+          // Release loading state and allow default loader to retry.
+        }
       }
-      const minMs = 420;
+      const minMs = 250;
       setTimeout(() => {
         state.monthNavLoading = false;
         root.classList.remove('is-month-loading');
@@ -420,6 +428,7 @@ export const monthScreen = {
     prevBtn?.addEventListener('click', () => { doMonthShift(-1); });
     nextBtn?.addEventListener('click', () => { doMonthShift(1); });
     todayBtn?.addEventListener('click', () => {
+      if (state.monthNavLoading) return;
       state.monthYm = localYmd().slice(0, 7);
       rerender?.();
     });

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -303,14 +303,31 @@ export const weekScreen = {
     const prevBtn = root.querySelector('[data-week-prev]');
     const nextBtn = root.querySelector('[data-week-next]');
     const todayBtn = root.querySelector('[data-week-today]');
-    const doWeekShift = (delta) => {
+    const doWeekShift = async (delta) => {
       if (state.weekNavLoading) return;
       const startedAt = Date.now();
+      const nextOffset = (state.weekOffset || 0) + delta;
+      const nextKey = `week:${nextOffset}`;
+      const cached = state?.screenDataCache?.[nextKey];
+      const ttlMs = 8 * 60 * 1000;
+      const hasFreshCache = !!(cached && Date.now() - Number(cached.t || 0) < ttlMs);
       state.weekNavLoading = true;
       state.weekNavDirection = delta > 0 ? 'next' : 'prev';
-      state.weekOffset = (state.weekOffset || 0) + delta;
+      state.weekOffset = nextOffset;
       rerender?.();
-      const minMs = 220;
+
+      if (!hasFreshCache) {
+        try {
+          const weekData = await api.week({ week_offset: nextOffset }, { timeout_ms: 12000 });
+          if (state?.screenDataCache) {
+            state.screenDataCache[nextKey] = { data: weekData, t: Date.now() };
+          }
+        } catch {
+          // Let main renderer fallback to normal load path; don't block navigation.
+        }
+      }
+
+      const minMs = 180;
       setTimeout(() => {
         state.weekNavLoading = false;
         state.weekNavDirection = '';

--- a/tests/calendar-navigation.test.mjs
+++ b/tests/calendar-navigation.test.mjs
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const WEEK_MODULE = new URL('../frontend/src/screens/week.js', import.meta.url).href;
+const MONTH_MODULE = new URL('../frontend/src/screens/month.js', import.meta.url).href;
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Element = dom.window.Element;
+  global.localStorage = dom.window.localStorage;
+  return dom;
+}
+
+async function freshModules() {
+  const week = await import(`${WEEK_MODULE}?v=${Date.now()}-${Math.random()}`);
+  const month = await import(`${MONTH_MODULE}?v=${Date.now()}-${Math.random()}`);
+  return { weekScreen: week.weekScreen, monthScreen: month.monthScreen };
+}
+
+test('month nav: next/prev update ym, trigger rerender, and do single fetch', async () => {
+  setupDom();
+  const { monthScreen } = await freshModules();
+  const state = { monthYm: '2026-04', monthNavLoading: false, screenDataCache: {} };
+  const root = document.createElement('div');
+  root.innerHTML = monthScreen.render({ month: '2026-04', cells: [], items_by_id: {} }, { state });
+  let rerenders = 0;
+  const calls = [];
+  const api = { month: async (payload) => { calls.push(payload); return { month: payload.ym, cells: [], items_by_id: {} }; } };
+  monthScreen.bind({ root, ui: { bindInteractiveCards() {} }, data: { month: '2026-04', cells: [], items_by_id: {} }, state, rerender: () => { rerenders += 1; }, api });
+
+  const nextBtn = root.querySelector('[data-month-next]');
+  const prevBtn = root.querySelector('[data-month-prev]');
+  assert.equal(nextBtn?.disabled, false);
+  assert.equal(prevBtn?.disabled, false);
+
+  nextBtn.click();
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(state.monthYm, '2026-05');
+  assert.equal(calls.length, 1);
+
+  state.monthNavLoading = false;
+  prevBtn.click();
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(state.monthYm, '2026-04');
+  assert.equal(calls.length, 2);
+  assert.ok(rerenders >= 2);
+});
+
+test('week nav: next/prev update weekOffset, trigger rerender, and do single fetch per click', async () => {
+  setupDom();
+  const { weekScreen } = await freshModules();
+  const state = { weekOffset: 0, weekNavLoading: false, screenDataCache: {}, clientSettings: {}, user: {} };
+  const data = { days: [], items_by_id: {} };
+  const root = document.createElement('div');
+  root.innerHTML = weekScreen.render(data, { state });
+  let rerenders = 0;
+  const calls = [];
+  const api = { week: async (payload) => { calls.push(payload); return data; } };
+  weekScreen.bind({ root, ui: { bindInteractiveCards() {}, openDrawer() {} }, data, state, rerender: () => { rerenders += 1; }, api });
+
+  const nextBtn = root.querySelector('[data-week-next]');
+  const prevBtn = root.querySelector('[data-week-prev]');
+  assert.equal(nextBtn?.disabled, false);
+  assert.equal(prevBtn?.disabled, false);
+
+  nextBtn.click();
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(state.weekOffset, 1);
+  assert.equal(calls.length, 1);
+
+  state.weekNavLoading = false;
+  prevBtn.click();
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(state.weekOffset, 0);
+  assert.equal(calls.length, 2);
+  assert.ok(rerenders >= 2);
+});
+
+test('navigation logic is independent from diagnostics/read-model hooks', async () => {
+  const fs = await import('node:fs/promises');
+  const weekSrc = await fs.readFile(new URL('../frontend/src/screens/week.js', import.meta.url), 'utf8');
+  const monthSrc = await fs.readFile(new URL('../frontend/src/screens/month.js', import.meta.url), 'utf8');
+  assert.equal(/diagnosticsPing|diagnosticsConsistency|readModel|prefetch/i.test(weekSrc), false);
+  assert.equal(/diagnosticsPing|diagnosticsConsistency|readModel|prefetch/i.test(monthSrc), false);
+});


### PR DESCRIPTION
### Motivation
- Restore responsive navigation in the calendar screens so clicking week/month prev/next (and Today) reliably updates UI state and view.
- Ensure state changes (`weekOffset`, `monthYm`) drive a rerender and that target data is loaded so the screen does not appear to noop or stay stale.
- Prevent infinite loading and redundant parallel requests by adding a targeted fetch timeout and cache-safe prefetch behavior.

### Description
- Update `weekScreen` (`frontend/src/screens/week.js`) so `doWeekShift` is `async`, always updates `state.weekOffset`, toggles `weekNavLoading`/`weekNavDirection`, prefetches the single target week via `api.week(..., { timeout_ms: 12000 })` only when cache is stale, and stores the result in `state.screenDataCache` to avoid duplicate requests.
- Update `monthScreen` (`frontend/src/screens/month.js`) so `doMonthShift` is `async`, always updates `state.monthYm`, toggles `monthNavLoading`/loading DOM state, prefetches the single target month via `api.month(..., { timeout_ms: 12000 })` only when cache is missing, and persists the cached entry; also guard the Today button while `monthNavLoading` is active.
- Reduce minimum visible loading times slightly to keep UI snappy while ensuring transitions are noticeable and not instantaneous (small `minMs` adjustments).
- Add regression tests `tests/calendar-navigation.test.mjs` validating: month next/prev update `ym` and trigger rerender and a single fetch; week next/prev update `weekOffset` and trigger rerender and a single fetch; buttons are not disabled incorrectly; and navigation logic does not depend on diagnostics/read-model hooks.

### Testing
- Ran the new navigation tests via `npm test -- tests/calendar-navigation.test.mjs` and the new `calendar-navigation.test.mjs` passed (month/week transitions, rerender and single-call assertions succeeded).
- The full test run still shows one pre-existing unrelated failure in `tests/diagnostics-consistency-finance-helpers.test.mjs` that was present before these changes and is not impacted by this PR.
- Files changed: `frontend/src/screens/week.js`, `frontend/src/screens/month.js`, and new `tests/calendar-navigation.test.mjs` (committed and included in test runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e4892774832bb77d9c856a2ba99e)