### PR TITLE
Add perf summary helper, mark slow API calls, read-model options, contact cache invalidation, and month cell filter fix

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -95,7 +95,9 @@ function invalidateScreenDataByAction(action) {
     reactivateUser: ['permissions', 'dashboard:'],
     deleteUser: ['permissions', 'dashboard:'],
     savePrivateNote: ['activities:', 'operations:'],
-    savePermission: ['permissions']
+    savePermission: ['permissions'],
+    addContact: ['contacts', 'instructor-contacts'],
+    saveContact: ['contacts', 'instructor-contacts']
   };
   const prefixes = targetedMutations[action];
   if (!prefixes || !prefixes.length) return;
@@ -187,7 +189,7 @@ function manifestEntryForReadModel(key, params = {}) {
   return null;
 }
 
-async function requestReadModel(key, params = {}, fallbackAction, fallbackPayload = {}) {
+async function requestReadModel(key, params = {}, fallbackAction, fallbackPayload = {}, options = {}) {
   const perfBase = {
     action: fallbackAction,
     used_read_model: false,
@@ -196,7 +198,7 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
     sheet_reads_count: null
   };
   if (!READ_MODELS_ENABLED) {
-    return request(fallbackAction, fallbackPayload, perfBase);
+    return request(fallbackAction, fallbackPayload, { ...perfBase, ...options });
   }
   try {
     const manifestKey = manifestEntryForReadModel(key, params);
@@ -221,7 +223,8 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
       action: fallbackAction,
       used_read_model: true,
       fallback_used: false,
-      cache_hit: false
+      cache_hit: false,
+      ...options
     });
     const data = envelope?.data ?? envelope ?? {};
 
@@ -246,7 +249,7 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
     });
     const allowHeavyFallback = true;
     if (!allowHeavyFallback) throw err;
-    return request(fallbackAction, fallbackPayload, { ...perfBase, fallback_used: true });
+    return request(fallbackAction, fallbackPayload, { ...perfBase, fallback_used: true, ...options });
   }
 }
 
@@ -350,7 +353,10 @@ async function postWithTimeout(action, requestBody, timeoutOverrideMs) {
 }
 
 function emitPerfEntry(entry) {
-  pushPerfRequest(entry);
+  pushPerfRequest({
+    ...entry,
+    slow: Number(entry?.duration_ms || 0) > 3000
+  });
   if (isPerfDebugEnabled()) {
     // eslint-disable-next-line no-console
     console.info('[perf]', entry);
@@ -474,18 +480,18 @@ export const api = {
   login: (user_id, entry_code) => request('login', { user_id, entry_code }),
   bootstrap: () => request('bootstrap'),
   dashboard: (filters) => request('dashboard', filters || {}),
-  dashboardSnapshot: (filters) => requestReadModel('dashboard', filters || {}, 'dashboardSnapshot', filters || {}),
-  activities: (filters) => requestReadModel('activities', filters || {}, 'activities', filters || {}),
+  dashboardSnapshot: (filters, options) => requestReadModel('dashboard', filters || {}, 'dashboardSnapshot', filters || {}, options || {}),
+  activities: (filters, options) => requestReadModel('activities', filters || {}, 'activities', filters || {}, options || {}),
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
-  week: (params) => requestReadModel('week', params || { week_offset: 0 }, 'week', params || {}),
-  month: (params) => requestReadModel('month', params || {}, 'month', params || {}),
-  exceptions: (params) => requestReadModel('exceptions', params || {}, 'exceptions', params || {}),
-  finance: (params) => requestReadModel('finance', params || {}, 'finance', params || {}),
+  week: (params, options) => requestReadModel('week', params || { week_offset: 0 }, 'week', params || {}, options || {}),
+  month: (params, options) => requestReadModel('month', params || {}, 'month', params || {}, options || {}),
+  exceptions: (params, options) => requestReadModel('exceptions', params || {}, 'exceptions', params || {}, options || {}),
+  finance: (params, options) => requestReadModel('finance', params || {}, 'finance', params || {}, options || {}),
   financeDetail: (source_row_id, source_sheet) => request('financeDetail', { source_row_id, source_sheet }),
   instructors: () => request('instructors'),
   instructorContacts: () => request('instructorContacts'),
   contacts: () => request('contacts'),
-  endDates: () => requestReadModel('end-dates', {}, 'endDates', {}),
+  endDates: (options) => requestReadModel('end-dates', {}, 'endDates', {}, options || {}),
   myData: () => request('myData'),
   operations: (params) => request('operations', params || {}),
   operationsDetail: (source_row_id, source_sheet) => request('operationsDetail', { source_row_id, source_sheet }),

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -162,6 +162,43 @@ function perfStore() {
   return window.__dsPerf;
 }
 
+function ensurePerfSummaryPrinter() {
+  if (typeof window === 'undefined') return;
+  if (typeof window.__printDsPerfSummary === 'function') return;
+  window.__printDsPerfSummary = () => {
+    const store = perfStore() || { requests: [], renders: [], screens: {}, navigation: {} };
+    const requests = Array.isArray(store.requests) ? store.requests : [];
+    const renders = Array.isArray(store.renders) ? store.renders : [];
+    const duplicateRequests = Array.isArray(store?.navigation?.duplicate_requests) ? store.navigation.duplicate_requests : [];
+
+    const topApi = [...requests].sort((a, b) => (b.duration_ms || 0) - (a.duration_ms || 0)).slice(0, 10);
+    const topRenders = [...renders].sort((a, b) => (b.duration_ms || 0) - (a.duration_ms || 0)).slice(0, 10);
+    const byAction = requests.reduce((acc, row) => {
+      const key = String(row?.action || 'unknown');
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+    const slowCount = requests.filter((row) => row?.slow === true).length;
+
+    // eslint-disable-next-line no-console
+    console.groupCollapsed(`[dsPerf] summary: api=${requests.length}, renders=${renders.length}, slow_api=${slowCount}`);
+    // eslint-disable-next-line no-console
+    console.table(topApi);
+    // eslint-disable-next-line no-console
+    console.table(topRenders);
+    // eslint-disable-next-line no-console
+    console.table(Object.entries(byAction).map(([action, count]) => ({ action, count })).sort((a, b) => b.count - a.count));
+    // eslint-disable-next-line no-console
+    console.info('[dsPerf] slow_api_count', slowCount);
+    // eslint-disable-next-line no-console
+    console.info('[dsPerf] duplicate_requests', duplicateRequests.length);
+    // eslint-disable-next-line no-console
+    console.groupEnd();
+  };
+}
+
+ensurePerfSummaryPrinter();
+
 function pushDuplicateRequestPerf(cacheKey, route) {
   const store = perfStore();
   if (!store) return;
@@ -497,6 +534,10 @@ function shell(content) {
     route: state.route,
     routes: effectiveRoutes().filter((r) => !adminHeaderExclude.has(r))
   });
+  const headerTechHtml = isAdminUser
+    ? `<small style="opacity:.72;margin-inline-end:8px" title="hotfix version">${escapeHtml(String(config.HOTFIX_VERSION || ''))}</small>
+            <small style="opacity:.72" title="frontend build marker">emergency-disable-diagnostics-v2</small>`
+    : '';
 
   return `
     <div class="app-shell${drawerClass} route-${escapeHtml(String(state.route || ''))}" data-current-route="${escapeHtml(String(state.route || ''))}" dir="rtl">
@@ -533,8 +574,7 @@ function shell(content) {
           </div>
           ${headerNavHtml}
           <div class="shell-top__end">
-            <small style="opacity:.72;margin-inline-end:8px" title="hotfix version">${escapeHtml(String(config.HOTFIX_VERSION || ''))}</small>
-            <small style="opacity:.72" title="frontend build marker">emergency-disable-diagnostics-v2</small>
+            ${headerTechHtml}
             <button type="button" class="shell-logout-btn" id="logoutBtn" aria-label="התנתקות" title="התנתקות">
               <span aria-hidden="true">⏻</span>
             </button>

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -240,7 +240,7 @@ export const monthScreen = {
       const n = cellItems.length;
       const isToday = cell.date === todayIso;
       const isShabbat = cellDate.getDay() === 6;
-      const warn = dayNeedsAttention(cell.items);
+      const warn = dayNeedsAttention(cellItems);
       const extra = [
         isToday ? 'is-cal-today' : '',
         warn ? 'is-month-warn' : '',
@@ -250,7 +250,7 @@ export const monthScreen = {
       const holiday = getHolidayLabel(cell.date);
       const subtitle = holiday || '';
       const meta = n > 0 ? `${n} פעילויות` : '';
-      const hay = (Array.isArray(cell.items) ? cell.items : [])
+      const hay = cellItems
         .map((it) =>
           [it.activity_name, it.RowID, it.emp_id, it.emp_id_2, it.instructor_name, it.instructor_name_2].filter(Boolean).join(' ')
         )

--- a/tests/api-mutations.test.mjs
+++ b/tests/api-mutations.test.mjs
@@ -113,11 +113,40 @@ test('api mutation cache invalidation map includes required keys', async () => {
 test('heavy screens request read models by default with legacy fallback', async () => {
   const fs = await import('node:fs/promises');
   const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
-  assert.match(source, /dashboardSnapshot:\s*\(filters\)\s*=>\s*requestReadModel\('dashboard'/);
-  assert.match(source, /activities:\s*\(filters\)\s*=>\s*requestReadModel\('activities'/);
-  assert.match(source, /week:\s*\(params\)\s*=>\s*requestReadModel\('week'/);
-  assert.match(source, /month:\s*\(params\)\s*=>\s*requestReadModel\('month'/);
-  assert.match(source, /exceptions:\s*\(params\)\s*=>\s*requestReadModel\('exceptions'/);
-  assert.match(source, /finance:\s*\(params\)\s*=>\s*requestReadModel\('finance'/);
-  assert.match(source, /endDates:\s*\(\)\s*=>\s*requestReadModel\('end-dates'/);
+  assert.match(source, /dashboardSnapshot:\s*\(filters,\s*options\)\s*=>\s*requestReadModel\('dashboard'/);
+  assert.match(source, /activities:\s*\(filters,\s*options\)\s*=>\s*requestReadModel\('activities'/);
+  assert.match(source, /week:\s*\(params,\s*options\)\s*=>\s*requestReadModel\('week'/);
+  assert.match(source, /month:\s*\(params,\s*options\)\s*=>\s*requestReadModel\('month'/);
+  assert.match(source, /exceptions:\s*\(params,\s*options\)\s*=>\s*requestReadModel\('exceptions'/);
+  assert.match(source, /finance:\s*\(params,\s*options\)\s*=>\s*requestReadModel\('finance'/);
+  assert.match(source, /endDates:\s*\(options\)\s*=>\s*requestReadModel\('end-dates'/);
+});
+
+test('perf request marks slow=true for API calls longer than 3000ms', async () => {
+  const { api, state } = await freshModules();
+  state.token = 'token';
+  let nowTick = 0;
+  global.performance = { now: () => nowTick };
+  global.fetch = async () => {
+    nowTick = 3501;
+    return {
+      status: 200,
+      async text() {
+        return JSON.stringify({ ok: true, data: { done: true } });
+      }
+    };
+  };
+
+  await api.week({ week_offset: 0 });
+  const reqs = global.window.__dsPerf?.requests || [];
+  assert.ok(reqs.length > 0);
+  assert.equal(reqs[0].slow, true);
+});
+
+test('perf summary helper is defined in main when window is available', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/main.js', import.meta.url), 'utf8');
+  assert.match(source, /window\.__printDsPerfSummary\s*=\s*\(\)\s*=>/);
+  assert.match(source, /const topApi = \[\.\.\.requests\]/);
+  assert.match(source, /const topRenders = \[\.\.\.renders\]/);
 });


### PR DESCRIPTION
### Motivation

- Expose a developer helper to summarize client-side performance data and make slow API calls visible for debugging.
- Allow passing options (e.g. timeouts/flags) through read-model helpers so callers can control request behavior and perf metadata.
- Ensure newly added contact mutations properly invalidate caches and fix month calendar cell filtering so warnings/search use the filtered set.

### Description

- Add `ensurePerfSummaryPrinter()` in `frontend/src/main.js` to define `window.__printDsPerfSummary` which prints top API calls, renders, action counts and duplicate requests, and invoke it at startup. 
- Mark perf entries as `slow: true` in `emitPerfEntry` inside `frontend/src/api.js` when `duration_ms > 3000` and include that flag in the perf store payload. 
- Extend `requestReadModel` signature to `requestReadModel(..., options = {})` and thread `options` through the `READ_MODELS_ENABLED` fallback path and the envelope perf push so callers can pass extra perf/meta data; update `api` exports for heavy screens to accept an `options` parameter. 
- Add `addContact` and `saveContact` keys to the mutation cache invalidation map in `frontend/src/api.js`. 
- Fix calendar month rendering in `frontend/src/screens/month.js` to compute `warn` and searchable `hay` from the filtered `cellItems` instead of the unfiltered `cell.items`. 
- Hide the small header tech markers for non-admin users by composing `headerTechHtml` conditionally in `frontend/src/main.js`.

### Testing

- Ran the unit test suite `tests/api-mutations.test.mjs` and updated assertions to check new `options` signatures and the presence of the perf summary helper, and the tests passed. 
- Added a test asserting that perf requests longer than 3000ms get `slow: true` and it passed. 
- Ran existing mutation and read-model related tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45f9276bc832b9bb8fcf570347513)