### PR TITLE
Add lightweight DS perf summary and slow-call markers

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -210,6 +210,7 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
       pushPerfRequest({
         action: fallbackAction,
         duration_ms: 0,
+        slow: false,
         payload_size: JSON.stringify(hit.data || {}).length,
         used_read_model: true,
         fallback_used: false,
@@ -360,6 +361,21 @@ function emitPerfEntry(entry) {
   }
 }
 
+function buildPerfRequestEntry(action, requestStart, lastResponseText, perfMeta = {}, sheetReads = null, backendDebug = null) {
+  const durationMs = Math.round(performance.now() - requestStart);
+  return {
+    action: perfMeta.action || action,
+    duration_ms: durationMs,
+    slow: durationMs > 3000,
+    payload_size: typeof lastResponseText === 'string' ? lastResponseText.length : null,
+    used_read_model: Boolean(perfMeta.used_read_model || action === 'readModelGet'),
+    fallback_used: Boolean(perfMeta.fallback_used),
+    cache_hit: Boolean(perfMeta.cache_hit),
+    sheet_reads_count: sheetReads,
+    backend_debug: backendDebug
+  };
+}
+
 async function request(action, payload = {}, perfMeta = {}) {
   const timeoutMs = typeof perfMeta?.timeout_ms === 'number' ? perfMeta.timeout_ms : undefined;
   if (!config.apiUrl) {
@@ -460,16 +476,14 @@ async function request(action, payload = {}, perfMeta = {}) {
     invalidateReadModelLocalCacheByAction(action);
   }
   const sheetReads = json?.data?.debug_perf?.sheet_reads_count ?? json?.data?.sheet_reads_count ?? null;
-  emitPerfEntry({
-    action: perfMeta.action || action,
-    duration_ms: Math.round(performance.now() - requestStart),
-    payload_size: lastResponseText.length,
-    used_read_model: Boolean(perfMeta.used_read_model || action === 'readModelGet'),
-    fallback_used: Boolean(perfMeta.fallback_used),
-    cache_hit: Boolean(perfMeta.cache_hit),
-    sheet_reads_count: sheetReads,
-    backend_debug: json.data && json.data.debug_perf ? json.data.debug_perf : null
-  });
+  emitPerfEntry(buildPerfRequestEntry(
+    action,
+    requestStart,
+    lastResponseText,
+    perfMeta,
+    sheetReads,
+    json.data && json.data.debug_perf ? json.data.debug_perf : null
+  ));
   return normalized;
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -119,10 +119,12 @@ function recordRenderPerf(route, phase, durationMs, extra = {}) {
       window.__dsPerf = { requests: [], renders: [], screens: {} };
     };
   }
+  const normalizedDuration = Math.round(durationMs);
   const entry = {
     route: String(route || 'unknown'),
     phase: String(phase || 'render'),
-    duration_ms: Math.round(durationMs),
+    duration_ms: normalizedDuration,
+    slow: normalizedDuration > 3000,
     at: new Date().toISOString(),
     ...extra
   };
@@ -159,7 +161,44 @@ function perfStore() {
       heavy_renders: []
     };
   }
+  if (typeof window.__printDsPerfSummary !== 'function') {
+    window.__printDsPerfSummary = () => {
+      const currentStore = perfStore();
+      if (!currentStore) return null;
+      const requests = Array.isArray(currentStore.requests) ? currentStore.requests : [];
+      const renders = Array.isArray(currentStore.renders) ? currentStore.renders : [];
+      const slowestRequests = [...requests]
+        .sort((a, b) => (b?.duration_ms || 0) - (a?.duration_ms || 0))
+        .slice(0, 5);
+      const slowestScreens = [...renders]
+        .sort((a, b) => (b?.duration_ms || 0) - (a?.duration_ms || 0))
+        .slice(0, 5);
+      const actionCounts = requests.reduce((acc, item) => {
+        const key = String(item?.action || 'unknown');
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+      }, {});
+      const summary = {
+        slowest_requests: slowestRequests,
+        slowest_screens: slowestScreens,
+        action_counts: actionCounts
+      };
+      if (typeof console !== 'undefined' && typeof console.table === 'function') {
+        console.info('DS Perf Summary');
+        console.table(slowestRequests);
+        console.table(slowestScreens);
+        console.table(Object.entries(actionCounts).map(([action, count]) => ({ action, count })));
+      } else if (typeof console !== 'undefined' && typeof console.info === 'function') {
+        console.info('DS Perf Summary', summary);
+      }
+      return summary;
+    };
+  }
   return window.__dsPerf;
+}
+
+if (typeof window !== 'undefined') {
+  perfStore();
 }
 
 function pushDuplicateRequestPerf(cacheKey, route) {

--- a/tests/perf-summary-hook.test.mjs
+++ b/tests/perf-summary-hook.test.mjs
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const MAIN_MODULE = new URL('../frontend/src/main.js', import.meta.url).href;
+
+test('perf summary helper is defined behind window guard in main.js source', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/main.js', import.meta.url), 'utf8');
+  assert.match(source, /if \(typeof window === 'undefined'\) return null;/);
+  assert.match(source, /window\.__printDsPerfSummary\s*=\s*\(\)\s*=>\s*\{/);
+});
+
+test('browser-like environment can execute perf summary helper safely', async () => {
+  const dom = new JSDOM('<!doctype html><html><body><div id="app"></div></body></html>', { url: 'http://localhost' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  global.sessionStorage = dom.window.sessionStorage;
+  global.performance = { now: () => 0 };
+  global.requestAnimationFrame = (cb) => cb();
+
+  const stamp = Date.now() + Math.random();
+  await import(`${MAIN_MODULE}?bust=${stamp}`);
+
+  assert.equal(typeof window.__printDsPerfSummary, 'function');
+  const summary = window.__printDsPerfSummary();
+  assert.ok(summary);
+  assert.ok(Object.prototype.hasOwnProperty.call(summary, 'slowest_requests'));
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal internal performance tracing layer to identify slow API calls and slow screen renders without changing architecture, UI, or backend behavior.

### Description
- Added a centralized `buildPerfRequestEntry` helper in `frontend/src/api.js` and switched request emission to use it so each request entry consistently includes `action`, `duration_ms`, `payload_size`, `cache_hit`, `used_read_model` and a `slow` boolean when duration > 3000ms.
- Ensured read-model cache-hit entries include `slow: false` and preserved existing perf metadata such as `sheet_reads_count` and `backend_debug` in `frontend/src/api.js`.
- Extended render perf records in `frontend/src/main.js` (`recordRenderPerf`) to include `slow` and added a console-only diagnostic helper `window.__printDsPerfSummary()` that summarizes the slowest requests, slowest screens and request counts by `action` and is only initialized in browser-like environments (`window` guard).
- Added an automated test `tests/perf-summary-hook.test.mjs` to assert the helper is behind the `window` guard and can be executed safely in a jsdom test environment.

### Testing
- Ran `npm test` which executed the full test suite and the run succeeded with all tests passing (86/86).
- The new test `tests/perf-summary-hook.test.mjs` ran as part of the suite and passed.
- No import or syntax errors were encountered during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4bcee2f98832bad8bb57a8c066669)