### PR TITLE
Hide technical hotfix/build markers from header UI

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -567,10 +567,7 @@ function shell(content) {
     route: state.route,
     routes: effectiveRoutes().filter((r) => !adminHeaderExclude.has(r))
   });
-  const headerTechHtml = isAdminUser
-    ? `<small style="opacity:.72;margin-inline-end:8px" title="hotfix version">${escapeHtml(String(config.HOTFIX_VERSION || ''))}</small>
-            <small style="opacity:.72" title="frontend build marker">emergency-disable-diagnostics-v2</small>`
-    : '';
+  const headerTechHtml = '';
 
   return `
     <div class="app-shell${drawerClass} route-${escapeHtml(String(state.route || ''))}" data-current-route="${escapeHtml(String(state.route || ''))}" dir="rtl">

--- a/tests/emergency-stabilization-hotfix.test.mjs
+++ b/tests/emergency-stabilization-hotfix.test.mjs
@@ -25,11 +25,12 @@ test('dashboard load and render do not auto-run diagnostics', async () => {
   assert.doesNotMatch(src, /DIAGNOSTICS_UI_ENABLED && isAdminOpsUser/);
 });
 
-test('frontend shows explicit hotfix + frontend build marker', async () => {
+test('frontend does not render hotfix/build marker text in header UI', async () => {
   const src = await read(MAIN_FILE);
   assert.match(src, /__HOTFIX_VERSION__/);
   assert.match(src, /emergency-disable-diagnostics-v2/);
-  assert.match(src, /frontend build marker/);
+  assert.doesNotMatch(src, /title="hotfix version"/);
+  assert.doesNotMatch(src, /title="frontend build marker"/);
 });
 
 test('deploymentInfo action exists and returns static read-only deployment identity', async () => {


### PR DESCRIPTION
### Motivation
- The header UI was exposing an internal build/hotfix marker (`emergency-disable-diagnostics-v2` and `config.HOTFIX_VERSION`) which is an internal build marker and must not be visible to users.  
- The change must avoid touching runtime constants or backend logic and only remove the visible text from the Header HTML.  

### Description
- Stopped rendering the technical marker elements in the shell header by setting `headerTechHtml` to an empty string in `frontend/src/main.js`.  
- Kept the runtime/internal markers/constants intact (no constants removed or backend changes).  
- Updated the test in `tests/emergency-stabilization-hotfix.test.mjs` to assert the marker constants still exist in source while confirming the header does not contain the visible `title=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d0920970832b9b32e6548acd395e)