### PR TITLE
docs: add production ops readiness checklist for login/dashboard slowness

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,26 @@ node scripts/apps_script_snapshot_ops.mjs
 5. בדיקה שמספר ה-triggers עבור `refreshDashboardSnapshotsTrigger` אינו גדול מ-1.
 6. redeploy (אם הופעל בדגלים המתאימים).
 
+
+## בדיקת מוכנות תפעולית קצרה (Production) – login/dashboard איטי
+
+מטרת הבדיקה: לוודא שאיטיות שנותרה אינה נובעת מחוסר trigger או מ־snapshot stale/missing בצד Apps Script.
+
+1. אשרו שב־`backend/Code.gs` קיימת הפונקציה `keepWarm()` וש־trigger שלה מוגדר כל 10 דקות (Time-driven).
+2. אשרו שב־`backend/Code.gs` קיימות פונקציות הרענון:
+   - `refreshDashboardSnapshotsTrigger`
+   - `runRefreshDataViewsManually`
+   - `refreshAllReadModelsTrigger` (לשימוש עתידי/תחזוקה)
+3. אשרו שב־Apps Script יש trigger/פעולה פעילה לרענון snapshots/data views (בפועל לפחות אחד מהמסלולים: trigger ל־`refreshDashboardSnapshotsTrigger` או הרצה ידנית של `runRefreshDataViewsManually` לפי נוהל התפעול).
+4. אם ה־dashboard איטי, בדקו בגיליון `dashboard_refresh_control` לפחות את:
+   - `last_status`
+   - `data_views_version`
+5. לוגיקת freshness של `dashboardSnapshot`:
+   - אם `last_status === "ok"` וגם `data_views_version` תואם לגרסה הנוכחית – משתמשים ב־snapshot/view המהיר.
+   - אחרת המערכת עוברת ל־fallback כבד דרך `actionDashboard_` ומחזירה `_snapshot_fallback_reason`.
+
+> הבדיקה הזו תפעולית בלבד (Apps Script/Sheets) ואינה דורשת שינוי UI, הפעלת Read Models, החזרת service worker, או הפעלת persistent cache.
+
 ## תחזוקה נכונה
 
 ### כשמחליפים URL של Apps Script


### PR DESCRIPTION
### Motivation
- Add a concise production operational-readiness checklist to help triage slow `login`/`dashboard` incidents by verifying Apps Script triggers and snapshot freshness rather than changing UI or backend behavior.

### Description
- Insert a new section in `README.md` titled "Production ops readiness (login/dashboard slowness)" that enumerates verification steps for `keepWarm()` and its recommended 10-minute Time-driven trigger and lists refresh entrypoints `refreshDashboardSnapshotsTrigger`, `runRefreshDataViewsManually`, and `refreshAllReadModelsTrigger`.
- Document operational checks for Apps Script triggers/actions for snapshot/data-view refresh and what to inspect in the `dashboard_refresh_control` sheet (`last_status`, `data_views_version`) and explain when `dashboardSnapshot` falls back to the heavy `actionDashboard_` path and sets `_snapshot_fallback_reason`.
- This is a documentation-only change; no backend source behavior was modified and the relevant backend functions and freshness logic were inspected and confirmed present.

### Testing
- Ran the full automated suite with `npm test`, which completed successfully with all tests passing (98 tests passed).
- The test run also served as a smoke check that the documentation change did not introduce lint/import or runtime test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e19310b0832b8ba5ab2614ab025b)