### PR TITLE
Add route-level screen-load timeout guard and lifecycle logging

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -44,6 +44,8 @@ let shellEventsBound = false;
 const STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = true;
 const STABILITY_HOTFIX_DISABLE_PERSISTENT_SCREEN_CACHE = true;
 const STABILITY_HOTFIX_DISABLE_SERVICE_WORKER = true;
+const ROUTE_LOAD_GUARD_MS = 25000;
+const ROUTE_LOAD_ERROR_HE = 'טעינת המסך נמשכת זמן רב מדי. נסו לרענן או להיכנס שוב.';
 
 if (typeof window !== 'undefined') {
   window.__HOTFIX_VERSION__ = config.HOTFIX_VERSION;
@@ -1084,6 +1086,9 @@ async function mountScreen() {
   if (!screen) throw new Error('מסך לא זמין');
 
   const cacheKey = screenDataCacheKey();
+  const routeLoadStartMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  // eslint-disable-next-line no-console
+  console.info('[route-load:start]', { route: requestedRoute, cacheKey });
   const rawEntry = screen.load ? state.screenDataCache[cacheKey] : null;
   const isStale = rawEntry && Date.now() - rawEntry.t >= screenCacheTtl();
 
@@ -1162,7 +1167,16 @@ async function mountScreen() {
       firstDashboardSnapshotTimerStarted = true;
       beginPerfTimer('dashboardSnapshot:firstLoad');
     }
-    const data = await loadScreenDataWithCache(screen);
+    let routeLoadGuardTimer = null;
+    const routeLoadGuard = new Promise((_, reject) => {
+      routeLoadGuardTimer = setTimeout(() => reject(new Error('route_load_timeout')), ROUTE_LOAD_GUARD_MS);
+    });
+    let data;
+    try {
+      data = await Promise.race([loadScreenDataWithCache(screen), routeLoadGuard]);
+    } finally {
+      clearTimeout(routeLoadGuardTimer);
+    }
     endPerfTimer('route:loadData');
     if (transitionToken !== activeNavigationToken || requestedRoute !== latestNavigationRoute) return;
     if (state.route !== requestedRoute) return;
@@ -1181,9 +1195,15 @@ async function mountScreen() {
     recordRenderPerf(state.route, 'fresh-data-render', performance.now() - renderStart, {
       cache_key: cacheKey
     });
+    // eslint-disable-next-line no-console
+    console.info('[route-load:success]', {
+      route: requestedRoute,
+      duration_ms: Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routeLoadStartMs)
+    });
     if (routeChanged) lastRenderedRoute = state.route;
     maybePrefetchFromDashboard();
   } catch (err) {
+    inflightRequests.delete(cacheKey);
     endPerfTimer('route:loadData');
     endPerfTimer('route:renderScreen');
     endPerfTimer('route:bindScreen');
@@ -1193,13 +1213,22 @@ async function mountScreen() {
     }
     const screenRoot = document.getElementById('screenRoot');
     if (screenRoot) {
-      const msg = translateApiErrorForUser(err?.message) || 'אירעה שגיאה בטעינת הדף';
+      const isRouteTimeout = String(err?.message || '').includes('route_load_timeout');
+      const msg = isRouteTimeout
+        ? ROUTE_LOAD_ERROR_HE
+        : (translateApiErrorForUser(err?.message) || 'אירעה שגיאה בטעינת הדף');
       screenRoot.innerHTML = `<div class="ds-loading-card" dir="rtl" role="alert">
         <p style="color:var(--ds-color-danger,#c0392b);font-weight:600;">⚠ שגיאה בטעינת הדף</p>
         <p>${msg}</p>
         <button type="button" class="ds-btn ds-btn--sm" style="margin-top:8px" onclick="window.location.reload()">נסה שוב</button>
       </div>`;
     }
+    // eslint-disable-next-line no-console
+    console.warn('[route-load:failed]', {
+      route: requestedRoute,
+      duration_ms: Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routeLoadStartMs),
+      error: err?.message || String(err)
+    });
   } finally {
     if (!hasMountedAuthenticatedShell) {
       hasMountedAuthenticatedShell = true;

--- a/tests/dashboard-load-guard.test.mjs
+++ b/tests/dashboard-load-guard.test.mjs
@@ -65,6 +65,28 @@ test('main.js catch block releases loading on any screen error', async () => {
     'setShellNavBusy(false) must be in finally block so it runs even on error');
 });
 
+test('main.js adds a route-level load timeout guard with Hebrew fallback error', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /ROUTE_LOAD_GUARD_MS\s*=\s*25000/,
+    'should define a 25s route-level load guard');
+  assert.match(src, /Promise\.race\(\[loadScreenDataWithCache\(screen\), routeLoadGuard\]\)/,
+    'should race route data loading against a timeout guard');
+  assert.match(src, /טעינת המסך נמשכת זמן רב מדי\. נסו לרענן או להיכנס שוב\./,
+    'should show a clear Hebrew timeout message instead of infinite loading');
+});
+
+test('main.js route load failures clean inflight requests and log lifecycle', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /inflightRequests\.delete\(cacheKey\)/,
+    'should cleanup inflight request on failure/timeout');
+  assert.match(src, /console\.info\('\[route-load:start\]'/,
+    'should log route load start');
+  assert.match(src, /console\.info\('\[route-load:success\]'/,
+    'should log route load success');
+  assert.match(src, /console\.warn\('\[route-load:failed\]'/,
+    'should log route load failure');
+});
+
 test('translateApiErrorForUser passes through Hebrew error messages unchanged', async () => {
   const src = await read(
     new URL('../frontend/src/screens/shared/ui-hebrew.js', import.meta.url)


### PR DESCRIPTION
### Motivation
- Prevent routes from staying in an infinite "טוען נתונים..." state when a `screen.load` call (including `dashboard`) stalls or never resolves. 
- Provide clear Hebrew user feedback on long-running loads and make route load lifecycle observable via logs for debugging.

### Description
- Added a 25s route-level guard in `main.js` with `ROUTE_LOAD_GUARD_MS = 25000` and Hebrew fallback message `ROUTE_LOAD_ERROR_HE` shown inside the screen error card instead of leaving the spinner forever. 
- Wrapped `loadScreenDataWithCache(screen)` with `Promise.race(...)` and a timeout sentinel, ensuring the guard `clearTimeout` runs in all paths. 
- Cleaned up `inflightRequests` on route-level failure/timeouts and added lifecycle logs: `console.info('[route-load:start]')`, `console.info('[route-load:success]')` and `console.warn('[route-load:failed]')`. 
- Tests updated to assert presence of the guard, the Hebrew timeout message, `inflightRequests` cleanup and lifecycle logging; no wide UI or design changes were made (only the in-screen error card message on failure).

### Testing
- Updated `tests/dashboard-load-guard.test.mjs` to cover the new route-level guard, timeout message, inflight cleanup and logs. 
- Ran the full test suite with `npm test`; all tests passed (`131` tests, `0` failures). 
- Changes made: `frontend/src/main.js`, `tests/dashboard-load-guard.test.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4fe9d2090832b8f6a8d83ce0214d9)