### PR TITLE
Fix dashboard render stall after successful snapshot load

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -900,6 +900,46 @@ async function fastRerenderScreen(screen, routeAtBind) {
   recordRenderPerf(routeAtBind, 'fast-rerender', performance.now() - perfStart, { cache_key: key });
 }
 
+
+function renderScreenIntoRoot({ route, screen, data, screenRoot, phase, cacheKey }) {
+  const dataKeys = data && typeof data === 'object' ? Object.keys(data) : [];
+  // eslint-disable-next-line no-console
+  console.info('[route-render:start]', { route, data_keys: dataKeys });
+  const renderStart = performance.now();
+  try {
+    const markup = screen.render(data, { state });
+    screenRoot.innerHTML = markup;
+    const text = (screenRoot.textContent || '').trim();
+    if (text === 'טוען נתונים...' && data && typeof data === 'object') {
+      // eslint-disable-next-line no-console
+      console.warn('[route-render:retry]', { route, reason: 'loading-stuck-after-render' });
+      screenRoot.innerHTML = screen.render(data, { state });
+    }
+    const afterText = (screenRoot.textContent || '').trim();
+    if (afterText === 'טוען נתונים...') {
+      throw new Error('render_stuck_on_loading');
+    }
+    beginPerfTimer('route:bindScreen');
+    bindScreen(screen, screenRoot, data);
+    endPerfTimer('route:bindScreen');
+    recordRenderPerf(route, phase || 'fresh-data-render', performance.now() - renderStart, {
+      cache_key: cacheKey
+    });
+    // eslint-disable-next-line no-console
+    console.info('[route-render:success]', { route });
+    return true;
+  } catch (err) {
+    endPerfTimer('route:bindScreen');
+    // eslint-disable-next-line no-console
+    console.warn('[route-render:failed]', { route, error: err?.message || String(err), data_keys: dataKeys });
+    screenRoot.innerHTML = `<div class="ds-loading-card" dir="rtl" role="alert">
+      <p style="color:var(--ds-color-danger,#c0392b);font-weight:600;">⚠ שגיאה בהצגת המסך</p>
+      <p>אירעה תקלה בהצגת הנתונים. נסו לרענן את הדף.</p>
+      <button type="button" class="ds-btn ds-btn--sm" style="margin-top:8px" onclick="window.location.reload()">נסה שוב</button>
+    </div>`;
+    throw err;
+  }
+}
 function clearScreenDataCache() {
   const deletedKeys = [];
   if (state.route === 'activities') {
@@ -1184,17 +1224,17 @@ async function mountScreen() {
       endPerfTimer('dashboardSnapshot:firstLoad');
     }
     beginPerfTimer('route:renderScreen');
-    const renderStart = performance.now();
     const screenRoot = document.getElementById('screenRoot');
     if (!screenRoot) throw new Error('אזור התצוגה לא זמין');
-    screenRoot.innerHTML = screen.render(data, { state });
-    endPerfTimer('route:renderScreen');
-    beginPerfTimer('route:bindScreen');
-    bindScreen(screen, screenRoot, data);
-    endPerfTimer('route:bindScreen');
-    recordRenderPerf(state.route, 'fresh-data-render', performance.now() - renderStart, {
-      cache_key: cacheKey
+    renderScreenIntoRoot({
+      route: requestedRoute,
+      screen,
+      data,
+      screenRoot,
+      phase: 'fresh-data-render',
+      cacheKey
     });
+    endPerfTimer('route:renderScreen');
     // eslint-disable-next-line no-console
     console.info('[route-load:success]', {
       route: requestedRoute,

--- a/tests/dashboard-load-guard.test.mjs
+++ b/tests/dashboard-load-guard.test.mjs
@@ -94,3 +94,26 @@ test('translateApiErrorForUser passes through Hebrew error messages unchanged', 
   assert.match(src, /\\u0590-\\u05FF.*return raw/s,
     'translateApiErrorForUser should return Hebrew strings as-is so dashboard error message is shown verbatim');
 });
+
+
+test('main.js emits route-render lifecycle logs for dashboard rendering', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /console\.info\('\[route-render:start\]'/,
+    'should log route-render start');
+  assert.match(src, /console\.info\('\[route-render:success\]'/,
+    'should log route-render success');
+  assert.match(src, /console\.warn\('\[route-render:failed\]'/,
+    'should log route-render failure');
+});
+
+test('main.js fail-safe retries render and replaces stuck loading with Hebrew error', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /if \(text === 'טוען נתונים\.\.\.' && data && typeof data === 'object'\)/,
+    'should detect loading text stuck after successful data load');
+  assert.match(src, /\[route-render:retry\]/,
+    'should log a retry attempt when loading is stuck');
+  assert.match(src, /throw new Error\('render_stuck_on_loading'\)/,
+    'should fail explicitly if loading text is still stuck after retry');
+  assert.match(src, /שגיאה בהצגת המסך/,
+    'should show Hebrew render error fallback instead of leaving loading state');
+});


### PR DESCRIPTION
### Motivation
- The dashboard could remain stuck on the "טוען נתונים..." loading text even after a successful `dashboardSnapshot` because there was no guarded final render path and no explicit fallback when the DOM did not update.  
- The goal is to ensure that a successful data load always results in either a rendered screen or a clear Hebrew error, and to add lifecycle logs for debugging without changing backend/API or large refactors.

### Description
- Added a guarded helper `renderScreenIntoRoot(...)` in `frontend/src/main.js` that records `[route-render:start]`, performs `screen.render(data)`, retries once if the root text remains `"טוען נתונים..."`, records perf, and emits `[route-render:success]` or `[route-render:failed]` with details.  
- Wired the fresh-data mount flow to use `renderScreenIntoRoot(...)` so a successful `dashboardSnapshot` cannot silently leave the UI on the loading card.  
- Preserved existing cleanup logic for `inflightRequests` and left navigation token / pending-render logic unchanged while improving the post-load render layer.  
- Modified files: `frontend/src/main.js` and added assertions to `tests/dashboard-load-guard.test.mjs` to validate the new logs and fail-safe behavior.

### Testing
- Added tests in `tests/dashboard-load-guard.test.mjs` asserting the presence of `[route-render:start]`, `[route-render:success]`, `[route-render:failed]`, the retry detection of `"טוען נתונים..."`, and the Hebrew render error fallback.  
- Ran the full test suite with `npm test` and all tests passed (133/133).  
- The change is frontend-only (no backend/API changes), so a frontend deploy is sufficient to roll out the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f503bb45f0832bb39060056be71d6e)