### PR TITLE
Hotfix: restore in-memory SWR UX and dedupe week/month navigation requests

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -41,7 +41,7 @@ let latestNavigationRoute = '';
 let activeRouteTransitionLabel = null;
 const activeConsoleTimers = new Set();
 let shellEventsBound = false;
-const STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = true;
+const STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = false;
 const STABILITY_HOTFIX_DISABLE_PERSISTENT_SCREEN_CACHE = true;
 const STABILITY_HOTFIX_DISABLE_SERVICE_WORKER = true;
 const ROUTE_LOAD_GUARD_MS = 25000;
@@ -788,7 +788,6 @@ async function backgroundRefreshScreen(screen, cacheKey) {
   if (STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH) return;
   if (!screen.load) return;
   if (inflightRequests.has(cacheKey)) return;
-  delete state.screenDataCache[cacheKey];
   const guardedToken = activeNavigationToken;
   const guardedRoute = state.route;
   try {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -396,7 +396,7 @@ export const dashboardScreen = {
           putDashboardCache(cacheKey, snapshotData);
           snapshotLoaded = true;
         } catch (_err) {
-          if (!snapshotLoaded) clearScreenDataCache?.();
+          // Keep currently rendered dashboard content when refresh fails.
         }
         rerender();
       }

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -14,6 +14,7 @@ import {
 import { getFilterOptionOverrides } from './shared/activity-options.js';
 
 const inflightActivityDetailRequests = new Map();
+const inflightMonthRequests = new Map();
 const MONTH_SCOPE = 'calendar';
 const CALENDAR_FILTER_FIELDS = [
   { key: 'activity_manager', label: 'מנהל פעילות' },
@@ -405,28 +406,37 @@ export const monthScreen = {
       state.monthNavLoading = true;
       try { localStorage.setItem('dashboard_calendar_month_ym', state.monthYm); } catch { /* ignore */ }
 
-      if (hasCachedTarget) {
-        rerender?.();
-      } else {
-        root.classList.add('is-month-loading');
-        root.setAttribute('aria-busy', 'true');
-        rerender?.();
-        try {
-          const monthData = await api.month({ ym: targetYm }, { timeout_ms: 12000 });
-          if (state?.screenDataCache) {
+      try {
+        if (hasCachedTarget) {
+          rerender?.();
+        } else {
+          root.classList.add('is-month-loading');
+          root.setAttribute('aria-busy', 'true');
+          rerender?.();
+          let request = inflightMonthRequests.get(targetKey);
+          if (!request) {
+            request = api.month({ ym: targetYm }, { timeout_ms: 12000 })
+              .finally(() => {
+                inflightMonthRequests.delete(targetKey);
+              });
+            inflightMonthRequests.set(targetKey, request);
+          }
+          const monthData = await request;
+          if (state?.screenDataCache && monthData) {
             state.screenDataCache[targetKey] = { data: monthData, t: Date.now() };
           }
-        } catch {
-          // Release loading state and allow default loader to retry.
         }
+      } catch {
+        // Keep current month content and allow regular route load retry.
+      } finally {
+        const minMs = 250;
+        setTimeout(() => {
+          state.monthNavLoading = false;
+          root.classList.remove('is-month-loading');
+          root.setAttribute('aria-busy', 'false');
+          rerender?.();
+        }, Math.max(0, minMs - (Date.now() - startedAt)));
       }
-      const minMs = 250;
-      setTimeout(() => {
-        state.monthNavLoading = false;
-        root.classList.remove('is-month-loading');
-        root.setAttribute('aria-busy', 'false');
-        rerender?.();
-      }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
     prevBtn?.addEventListener('click', () => { doMonthShift(-1); });
     nextBtn?.addEventListener('click', () => { doMonthShift(1); });

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -15,6 +15,7 @@ import { getFilterOptionOverrides } from './shared/activity-options.js';
 import { bindActNavGrid } from './shared/act-nav-grid.js';
 
 const inflightActivityDetailRequests = new Map();
+const inflightWeekRequests = new Map();
 const WEEK_SCOPE = 'calendar';
 const CALENDAR_FILTER_FIELDS = [
   { key: 'activity_manager', label: 'מנהל פעילות' },
@@ -316,23 +317,31 @@ export const weekScreen = {
       state.weekOffset = nextOffset;
       rerender?.();
 
-      if (!hasFreshCache) {
-        try {
-          const weekData = await api.week({ week_offset: nextOffset }, { timeout_ms: 12000 });
-          if (state?.screenDataCache) {
+      try {
+        if (!hasFreshCache) {
+          let request = inflightWeekRequests.get(nextKey);
+          if (!request) {
+            request = api.week({ week_offset: nextOffset }, { timeout_ms: 12000 })
+              .finally(() => {
+                inflightWeekRequests.delete(nextKey);
+              });
+            inflightWeekRequests.set(nextKey, request);
+          }
+          const weekData = await request;
+          if (state?.screenDataCache && weekData) {
             state.screenDataCache[nextKey] = { data: weekData, t: Date.now() };
           }
-        } catch {
-          // Let main renderer fallback to normal load path; don't block navigation.
         }
+      } catch {
+        // Keep current week content and let regular route load retry if needed.
+      } finally {
+        const minMs = 180;
+        setTimeout(() => {
+          state.weekNavLoading = false;
+          state.weekNavDirection = '';
+          rerender?.();
+        }, Math.max(0, minMs - (Date.now() - startedAt)));
       }
-
-      const minMs = 180;
-      setTimeout(() => {
-        state.weekNavLoading = false;
-        state.weekNavDirection = '';
-        rerender?.();
-      }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
     bindListener(prevBtn, 'click', () => doWeekShift(-1));
     bindListener(nextBtn, 'click', () => doWeekShift(1));


### PR DESCRIPTION
### Motivation
- התנהגות המשתמש נפגעה לאחר שינוי שהפיל עדכונים רק-לאחור וגרם לכך שכל מעבר מסך נראה כ"טוען" גם כשיש נתונים בזיכרון.
- המטרה הייתה לשחזר stale-while-revalidate בזיכרון בלבד (session memory) ולהציג cache מיידי עם refresh ברקע מבלי למחוק את התצוגה הנוכחית.
- בנוסף למנוע פיצוץ קריאות API בניווטי לוח זמן (שבוע/חודש) על ידי דידופ של בקשות זהות בזמן קצר.

### Description
- החזרתי הפעלת background refresh עבור מסכי route (בטלו את ה-hotfix שכבא כבהירות) כדי לאפשר SWR בזיכרון בלבד ללא persistent cache; השינוי בקובץ `frontend/src/main.js` (הדגל וה-flow של `backgroundRefreshScreen`).
- התיקון ב־`backgroundRefreshScreen` מוודא שלא נמחק ה-cache לפני fetch ברקע כך שהתוכן הנוכחי נשאר על המסך עד שהrefresh מצליח; קוד ב־`frontend/src/main.js` הותקן בהתאמה.
- הוספתי דידופ (in-flight dedupe) לניווט שבועי ולניווט חודשי באמצעות `inflightWeekRequests` ו־`inflightMonthRequests` כדי לחסום קריאות כפולות לאותו `week:<offset>` / `month:<ym>` ובכך לצמצם קריאות API מיותרות (`frontend/src/screens/week.js`, `frontend/src/screens/month.js`).
- הבטחתי ששחרור הדגלים `weekNavLoading` ו־`monthNavLoading` תמיד מתבצע ב־`finally` כך שהמסך לא יישאר בסטטוס טעינה אקטיבי; בנוסף שיניתי את התנהגות חוסר הצלחת refresh בדשבורד כך שלא ינקה תוכן קיים (`frontend/src/screens/dashboard.js`).
- קבצים ששונו: `frontend/src/main.js`, `frontend/src/screens/week.js`, `frontend/src/screens/month.js`, `frontend/src/screens/dashboard.js`.

### Testing
- הרצתי את כל המבחנים האוטומטיים באמצעות `npm test` וכל המבחנים עברו בהצלחה (`133/133 passed`).
- המבחנים היחידתיים/אינטגרציה שרלוונטיים לאג'נדה עברו: ניווט חודש/שבוע (בודק single-fetch per click / dedupe), דשבורד (nav flag release), ועמוד החריגות (multi-instance exceptions) — כולם עברו.
- אין רגרסיות מזוהות בריצת המבחנים שכללו בדיקות ל־SWR, מדדי ביצועים והרשאות, ולכן התיקון אושר בצד ה־frontend בלבד.
- דרישת פריסה: נדרש deploy של ה־frontend בלבד; לא נחוץ שינוי backend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f506aa4f18832bba0a540b3a7b3cba)