### PR TITLE
Stabilize post-login first-route render flow

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -41,7 +41,7 @@ let latestNavigationRoute = '';
 let activeRouteTransitionLabel = null;
 const activeConsoleTimers = new Set();
 let shellEventsBound = false;
-const STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = false;
+const STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = true;
 const STABILITY_HOTFIX_DISABLE_PERSISTENT_SCREEN_CACHE = true;
 const STABILITY_HOTFIX_DISABLE_SERVICE_WORKER = true;
 const ROUTE_LOAD_GUARD_MS = 25000;
@@ -1375,9 +1375,16 @@ async function render() {
             applyBootstrapFromLoginData(data);
             loginBootstrapDurationMs = performance.now() - bootstrapApplyStartMs;
             renderShellLoadingImmediately();
+            // eslint-disable-next-line no-console
+            console.info('[login-success]', { route: state.route, routes_count: effectiveRoutes().length });
+            // eslint-disable-next-line no-console
+            console.info('[first-route-render:start]', { route: state.route });
             loginInlineError = '';
             endPerfTimer('login:applyBootstrap');
+            scheduleRender();
             mountScreen().then(() => {
+              // eslint-disable-next-line no-console
+              console.info('[first-route-render:success]', { route: state.route });
               if (loginPerfStartMs > 0 && !initialRoutePerfReported) {
                 initialRoutePerfReported = true;
                 const firstScreenDurationMs = performance.now() - loginPerfStartMs;
@@ -1392,7 +1399,9 @@ async function render() {
                   source: 'login'
                 });
               }
-            }).catch(async () => {
+            }).catch(async (error) => {
+              // eslint-disable-next-line no-console
+              console.warn('[first-route-render:failed]', { route: state.route, error: error?.message || String(error) });
               rollbackToLogin('כשל בטעינת נתוני משתמש אחרי התחברות');
               await render();
             });

--- a/tests/emergency-stabilization-hotfix.test.mjs
+++ b/tests/emergency-stabilization-hotfix.test.mjs
@@ -33,6 +33,28 @@ test('frontend does not render hotfix/build marker text in header UI', async () 
   assert.doesNotMatch(src, /title="frontend build marker"/);
 });
 
+test('frontend keeps background refresh disabled during stabilization hotfix', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = true/);
+});
+
+test('login success flow forces first-route render and emits explicit lifecycle logs', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /\[login-success\]/);
+  assert.match(src, /\[first-route-render:start\]/);
+  assert.match(src, /\[first-route-render:success\]/);
+  assert.match(src, /\[first-route-render:failed\]/);
+  assert.match(src, /renderShellLoadingImmediately\(\);[\s\S]*scheduleRender\(\);[\s\S]*mountScreen\(\)/);
+});
+
+test('route render flow reports start\/success\/failed and never silently leaves loading screen', async () => {
+  const src = await read(MAIN_FILE);
+  assert.match(src, /\[route-render:start\]/);
+  assert.match(src, /\[route-render:success\]/);
+  assert.match(src, /\[route-render:failed\]/);
+  assert.match(src, /if \(afterText === 'טוען נתונים\.\.\.'\) \{\s*throw new Error\('render_stuck_on_loading'\);/);
+});
+
 test('deploymentInfo action exists and returns static read-only deployment identity', async () => {
   const router = await read(ROUTER_FILE);
   const actions = await read(ACTIONS_FILE);


### PR DESCRIPTION
### Motivation
- Users reported that after successful login the shell showed the loading spinner indefinitely because the first authenticated route was not being reliably mounted despite successful API responses. 
- The goal is a minimal, temporary stabilization: restore a simple, deterministic first-render path and disable non-essential background refresh mechanisms until the system is back up.

### Description
- Re-enabled an explicit post-login render trigger by calling `scheduleRender()` immediately after `setSession`, `applyBootstrapFromLoginData` and `renderShellLoadingImmediately` in `frontend/src/main.js` to force the first-route mount. 
- Temporarily disabled background refresh by setting `STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH = true` to avoid races from background refresh/SWR during initial post-login load. 
- Added explicit lifecycle console logs around the login/first-route flow: `[login-success]`, `[first-route-render:start]`, `[first-route-render:success]`, and `[first-route-render:failed]`. 
- Kept existing route-render lifecycle and fail-safe behavior (logs `[route-render:start|success|failed]` and throws `render_stuck_on_loading` if the DOM still contains the loading text), and updated tests to assert the hotfix behavior. 
- Files changed: `frontend/src/main.js` and `tests/emergency-stabilization-hotfix.test.mjs`.

### Testing
- Ran the project test suite with `npm test` which executes `node --test tests/*.test.mjs`, and the full suite passed (`136` tests, `0` failures). 
- Added/updated assertions in `tests/emergency-stabilization-hotfix.test.mjs` that verify the background refresh flag is `true`, the login-first-route log sequence and trigger (`renderShellLoadingImmediately(); ... scheduleRender(); ... mountScreen()`), and that route-render lifecycle and the loading-stuck guard remain present. 
- All automated tests succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50c3456bc832b854ac7710e61dfa5)