### PR TITLE
perf: snapshot stale path, auth cache, unified debug_perf metrics

### DIFF
--- a/backend/auth.gs
+++ b/backend/auth.gs
@@ -1,41 +1,103 @@
+/** Projected headers for login permission row (must stay aligned with actionLogin_ / permission logic). */
+var PERMISSIONS_LOGIN_PROJECTED_HEADERS_ = [
+  'user_id',
+  'full_name',
+  'entry_code',
+  'active',
+  'display_role',
+  'display_role2',
+  'default_view',
+  'org_id',
+  'emp_id',
+  'can_add_activity',
+  'can_edit_direct',
+  'can_request_edit',
+  'view_dashboard',
+  'view_activities',
+  'view_week',
+  'view_month',
+  'view_instructors',
+  'view_exceptions',
+  'view_finance',
+  'view_permissions',
+  'view_operations_data',
+  'view_edit_requests',
+  'view_my_data',
+  'view_contacts',
+  'view_contacts_instructors',
+  'view_contacts_instructors 2',
+  'view_end_dates'
+];
+
+/** TTL for per-user permission rows in ScriptCache (invalidated when dataViewsCacheVersion_ changes). */
+var PERMISSION_LOGIN_CACHE_SECONDS_ = 3600;
+
+var PERMISSION_LOGIN_CACHE_KEY_PREFIX_ = 'pc:perm-login:v1:';
+var PERMISSION_LOGIN_CACHE_NO_ROW_ = '__NO_ROW__';
+
+function permissionLoginCacheKey_(userId, dataViewsVersion) {
+  var v = dataViewsVersion !== undefined && dataViewsVersion !== null ? String(dataViewsVersion) : dataViewsCacheVersion_();
+  return PERMISSION_LOGIN_CACHE_KEY_PREFIX_ + v + ':' + text_(userId);
+}
+
+/**
+ * Single ScriptCache lookup per login (hit path). On miss, one sheet read builds the versioned index
+ * for all users (same projection as login) and populates cache entries.
+ */
+function getPermissionRowForLoginCached_(userId) {
+  setRequestPerfField_('permissions_lookup', true);
+  var uid = text_(userId);
+  if (!uid) return null;
+
+  var cache = CacheService.getScriptCache();
+  var key = permissionLoginCacheKey_(uid);
+  var raw = cache.get(key);
+
+  if (raw === PERMISSION_LOGIN_CACHE_NO_ROW_) {
+    return null;
+  }
+  if (raw) {
+    try {
+      var parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') return parsed;
+    } catch (_e) {}
+    return null;
+  }
+
+  return warmPermissionLoginIndexForUser_(uid);
+}
+
+function warmPermissionLoginIndexForUser_(requestedUserId) {
+  var ver = dataViewsCacheVersion_();
+  var rows = readRowsProjected_(CONFIG.SHEETS.PERMISSIONS, PERMISSIONS_LOGIN_PROJECTED_HEADERS_);
+  var byUser = {};
+  rows.forEach(function(row) {
+    var id = text_(row.user_id);
+    if (!id) return;
+    if (!byUser[id]) byUser[id] = row;
+  });
+
+  var cache = CacheService.getScriptCache();
+  var ttl = PERMISSION_LOGIN_CACHE_SECONDS_;
+  for (var uid in byUser) {
+    if (!Object.prototype.hasOwnProperty.call(byUser, uid)) continue;
+    cache.put(permissionLoginCacheKey_(uid, ver), JSON.stringify(byUser[uid]), ttl);
+  }
+
+  var req = text_(requestedUserId);
+  if (byUser[req]) return byUser[req];
+
+  cache.put(permissionLoginCacheKey_(req, ver), PERMISSION_LOGIN_CACHE_NO_ROW_, ttl);
+  return null;
+}
+
 function actionLogin_(payload) {
   var userId = text_(payload.user_id || payload.userId);
   var entryCode = text_(payload.entry_code || payload.entryCode);
   if (!userId) throw new Error('user_id is required');
   if (!entryCode) throw new Error('entry_code is required');
 
-  var permissionRows = readRowsProjected_(CONFIG.SHEETS.PERMISSIONS, [
-    'user_id',
-    'full_name',
-    'entry_code',
-    'active',
-    'display_role',
-    'display_role2',
-    'default_view',
-    'org_id',
-    'emp_id',
-    'can_add_activity',
-    'can_edit_direct',
-    'can_request_edit',
-    'view_dashboard',
-    'view_activities',
-    'view_week',
-    'view_month',
-    'view_instructors',
-    'view_exceptions',
-    'view_finance',
-    'view_permissions',
-    'view_operations_data',
-    'view_edit_requests',
-    'view_my_data',
-    'view_contacts',
-    'view_contacts_instructors',
-    'view_contacts_instructors 2',
-    'view_end_dates'
-  ]);
-  var matchByUser = permissionRows.find(function(row) {
-    return text_(row.user_id) === userId;
-  });
+  var matchByUser = getPermissionRowForLoginCached_(userId);
 
   if (!matchByUser) throw new Error('invalid_credentials');
   if (yesNo_(matchByUser.active) !== 'yes') throw new Error('user_inactive');
@@ -70,13 +132,18 @@ function actionLogin_(payload) {
     CONFIG.SESSION_CACHE_SECONDS
   );
 
-  return {
+  var loginData = {
     token: token,
     user: user,
     routes: routes,
     default_route: defaultRoute,
     client_settings: buildClientSettingsPayload_()
   };
+  setRequestPerfField_('fallback_used', false);
+  try {
+    setRequestPerfField_('payload_bytes', JSON.stringify(loginData).length);
+  } catch (_e) {}
+  return loginData;
 }
 
 function requireAuth_(token) {

--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -7,6 +7,9 @@
  *
  * גיליונות: dashboard_summary_snapshot, dashboard_by_manager_snapshot,
  *            dashboard_refresh_control
+ *
+ * Performance: עם debug_perf (או Script property DEBUG_PERF=1) נאספים סימוני זמן,
+ * sheet_reads_count, payload_size, dashboard_fallback_used ב-debug_perf בתשובה.
  */
 
 var SNAPSHOT_ADMIN_USER_ = { user_id: 'snapshot_refresh', display_role: 'admin' };
@@ -220,6 +223,127 @@ function getDashboardSnapshotFreshness_(controlMap) {
   };
 }
 
+/**
+ * Reads persisted snapshot sheet rows for one month (summary + by-manager). No live dashboard computation.
+ */
+function readPersistedDashboardSnapshotRowsForMonth_(ym) {
+  var snap = null;
+  var byManagerRows = [];
+  var ss = getSpreadsheet_();
+  var hasSummarySnapshotSheet = !!ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT);
+  if (hasSummarySnapshotSheet) {
+    var summaryRows = readSnapshotRowsFast_(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT, SUMMARY_SNAPSHOT_HEADERS_);
+    snap = summaryRows.find(function(r) {
+      return normalizeSnapshotMonthYm_(r.month_ym) === ym;
+    }) || null;
+  }
+  if (ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT)) {
+    var allByMgr = readSnapshotRowsFast_(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT, BY_MANAGER_SNAPSHOT_HEADERS_);
+    var filteredByMgr = allByMgr.filter(function(r) {
+      return normalizeSnapshotMonthYm_(r.month_ym) === ym;
+    });
+    var seenMgrKeys = {};
+    byManagerRows = filteredByMgr.filter(function(r) {
+      var key = text_(r.activity_manager);
+      if (!key || seenMgrKeys[key]) return false;
+      seenMgrKeys[key] = true;
+      return true;
+    });
+  }
+  return { snap: snap, byManagerRows: byManagerRows, hasSummarySnapshotSheet: hasSummarySnapshotSheet };
+}
+
+/**
+ * Builds the dashboard API payload shape from one summary snapshot row + by-manager rows (snapshot sheets only).
+ */
+function composeDashboardPayloadFromSummarySnapshot_(ym, canViewFinance, snap, byManagerRows, showOnlyNonzeroKpis) {
+  var s = snap || {};
+
+  var totalShort     = parseInt(text_(s.total_short_activities),   10) || 0;
+  var totalLong      = parseInt(text_(s.total_long_activities),    10) || 0;
+  var totalInstr     = parseInt(text_(s.active_instructors_count), 10) || 0;
+  var courseEndings  = parseInt(text_(s.course_endings_current_month), 10) || 0;
+  var financeOpen    = parseInt(text_(s.finance_open_count),       10) || 0;
+  var missingInstr   = parseInt(text_(s.missing_instructor_count), 10) || 0;
+  var missingDate    = parseInt(text_(s.missing_start_date_count), 10) || 0;
+  var lateEnd        = parseInt(text_(s.late_end_date_count),      10) || 0;
+  var exceptCount    = resolveExceptionsCountForDashboard_({
+    missing_instructor_count: missingInstr,
+    missing_start_date_count: missingDate,
+    late_end_date_count: lateEnd
+  }, s.exceptions_count);
+  var activeCurrent  = parseInt(text_(s.active_courses_current_month), 10) || 0;
+  var activeNext     = parseInt(text_(s.active_courses_next_month), 10) || 0;
+
+  var combinedStr = text_(s.active_instructors_names);
+  var allInstructorNames = combinedStr
+    ? combinedStr.split(',').map(function(n) { return n.trim(); }).filter(Boolean)
+    : [];
+
+  var byActivityManager = byManagerRows.map(function(r) {
+    var row = {
+      activity_manager: text_(r.activity_manager),
+      total_short:     parseInt(text_(r.total_short),    10) || 0,
+      total_long:      parseInt(text_(r.total_long),     10) || 0,
+      total:           parseInt(text_(r.total),          10) || 0,
+      num_instructors: parseInt(text_(r.num_instructors),10) || 0,
+      course_endings:  parseInt(text_(r.course_endings), 10) || 0,
+      exceptions:      parseInt(text_(r.exceptions),     10) || 0
+    };
+    if (canViewFinance) {
+      row.finance_open = parseInt(text_(r.finance_open), 10) || 0;
+    }
+    return row;
+  });
+
+  var snapshotData = {
+    total_short_activities:    totalShort,
+    total_long_activities:     totalLong,
+    active_instructors_count:  totalInstr,
+    course_endings_current_month: courseEndings,
+    finance_open_count:        canViewFinance ? financeOpen : 0,
+    exceptions_count:          exceptCount,
+    active_courses_current_month: activeCurrent,
+    active_courses_next_month: activeNext,
+    missing_instructor_count:  missingInstr,
+    missing_start_date_count:  missingDate,
+    late_end_date_count:       lateEnd
+  };
+
+  var kpiCards = buildDashboardSnapshotKpis_(snapshotData, canViewFinance);
+
+  return {
+    month: ym,
+    can_view_finance: canViewFinance,
+    totals: {
+      total_short_activities:           totalShort,
+      total_long_activities:            totalLong,
+      total_instructors:                totalInstr,
+      total_course_endings_current_month: courseEndings,
+      exceptions_count:                 exceptCount,
+      short: totalShort,
+      long:  totalLong
+    },
+    by_activity_manager: byActivityManager,
+    summary: {
+      active_courses_current_month: activeCurrent,
+      ending_courses_current_month: courseEndings,
+      active_courses_next_month:    activeNext,
+      exceptions_count:             exceptCount,
+      current_month_exceptions_count: 0,
+      active_instructors:           allInstructorNames,
+      active_instructors_by_manager: {},
+      missing_instructor_count:  missingInstr,
+      missing_start_date_count:  missingDate,
+      late_end_date_count:       lateEnd,
+      short_activities:          []
+    },
+    kpi_cards: kpiCards,
+    show_only_nonzero_kpis: showOnlyNonzeroKpis !== false,
+    _is_snapshot: true
+  };
+}
+
 function parseJsonObjectSafeForDashboard_(raw, fallback) {
   if (raw === null || raw === undefined) return fallback;
   if (typeof raw === 'object' && !Array.isArray(raw)) return raw;
@@ -265,39 +389,6 @@ function resolveExceptionsCountForDashboard_(summaryObj, rawExceptions) {
   return (isNaN(fromRaw) || fromRaw < 0) ? 0 : fromRaw;
 }
 
-function enrichDashboardPayloadWithSharedExceptions_(payload, ym) {
-  if (!payload || typeof payload !== 'object') return payload;
-  var rows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
-  var exceptionSummary = getExceptionsSummary_(rows, ym, { include_rows: false });
-  var total = exceptionSummary.totalExceptionInstances || 0;
-  var byManager = exceptionSummary.byManager || {};
-
-  if (!payload.summary || typeof payload.summary !== 'object') payload.summary = {};
-  payload.summary.exceptions_count = total;
-  payload.summary.current_month_exceptions_count = exceptionSummary.currentMonthExceptions || 0;
-
-  if (payload.totals && typeof payload.totals === 'object') {
-    payload.totals.exceptions_count = total;
-  }
-  if (Array.isArray(payload.kpi_cards)) {
-    payload.kpi_cards = payload.kpi_cards.map(function(card) {
-      if (card && card.id === 'exceptions') {
-        card.title = String(total);
-        card.value = total;
-      }
-      return card;
-    });
-  }
-  if (Array.isArray(payload.by_activity_manager)) {
-    payload.by_activity_manager = payload.by_activity_manager.map(function(row) {
-      var manager = text_(row && row.activity_manager) || 'unassigned';
-      row.exceptions = byManager[manager] || 0;
-      return row;
-    });
-  }
-  return payload;
-}
-
 function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, canViewFinance) {
   var summary = parseJsonObjectSafeForDashboard_(pickField_(primaryRow, ['summary_json'], null), {});
   if (!Array.isArray(summary.active_instructors) || !summary.active_instructors.length) {
@@ -315,6 +406,9 @@ function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, can
     summary,
     pickField_(primaryRow, ['exceptions_count', 'exceptions'], summary.exceptions_count)
   );
+  var cmExc = summary.current_month_exceptions_count;
+  summary.current_month_exceptions_count =
+    typeof cmExc === 'number' && !isNaN(cmExc) ? cmExc : (parseInt(text_(cmExc), 10) || 0);
   var finRaw = summary.finance_open_count;
   summary.finance_open_count = typeof finRaw === 'number' && !isNaN(finRaw)
     ? finRaw
@@ -376,6 +470,7 @@ function buildDashboardSnapshotPayloadFromViewRows_(primaryRow, nextRow, ym, can
       total_long_activities: totalLongActive,
       total_instructors: totalInstr,
       total_course_endings_current_month: courseEndings,
+      exceptions_count: exceptCount,
       short: totalShort,
       long: totalLongActive
     },
@@ -459,19 +554,51 @@ function actionDashboardSnapshot_(user, payload) {
   var refreshControlMap = readDashboardRefreshControlMap_();
   var snapshotFreshness = getDashboardSnapshotFreshness_(refreshControlMap);
   if (!snapshotFreshness.fresh) {
-    var freshFallback = actionDashboard_(user, payload || {});
-    if (freshFallback && typeof freshFallback === 'object') {
-      freshFallback._is_snapshot = false;
-      freshFallback._snapshot_fallback_reason = snapshotFreshness.reason || 'stale_snapshot';
+    var staleReason = snapshotFreshness.reason || 'stale_snapshot';
+    var showOnlyFromControl = yesNo_(refreshControlMap.show_only_nonzero_kpis) !== 'no';
+
+    markRequestPerf_('dashboardSnapshot:stale snapshot reads:start');
+    var persistedStale = readPersistedDashboardSnapshotRowsForMonth_(ym);
+    markRequestPerf_('dashboardSnapshot:stale snapshot reads:end');
+
+    var stalePayload;
+    if (!persistedStale.snap || !persistedStale.hasSummarySnapshotSheet) {
+      stalePayload = {
+        month: ym,
+        can_view_finance: canViewFinance,
+        totals: {},
+        summary: {},
+        by_activity_manager: [],
+        kpi_cards: [],
+        show_only_nonzero_kpis: showOnlyFromControl,
+        _is_snapshot: true,
+        _is_stale: true,
+        _snapshot_fallback_reason: staleReason
+      };
+    } else {
+      markRequestPerf_('dashboardSnapshot:build kpi cards:start');
+      stalePayload = composeDashboardPayloadFromSummarySnapshot_(
+        ym,
+        canViewFinance,
+        persistedStale.snap,
+        persistedStale.byManagerRows,
+        showOnlyFromControl
+      );
+      markRequestPerf_('dashboardSnapshot:build kpi cards:end');
+      stalePayload._is_stale = true;
+      stalePayload._snapshot_fallback_reason = staleReason;
     }
+
     setRequestPerfField_('dashboard_used_view', false);
     setRequestPerfField_('dashboard_cache_hit', false);
-    setRequestPerfField_('dashboard_fallback_used', true);
+    setRequestPerfField_('dashboard_fallback_used', false);
     setRequestPerfField_('dashboard_view_rows_read', 0);
-    setRequestPerfField_('payload_bytes', JSON.stringify(freshFallback || {}).length);
+    setRequestPerfField_('payload_bytes', JSON.stringify(stalePayload || {}).length);
     markRequestPerf_('dashboard:force_fallback_by_freshness:true');
-    markRequestPerf_('dashboard:fallback_used:true');
-    return freshFallback;
+    markRequestPerf_('dashboard:stale_snapshot:true');
+    markRequestPerf_('dashboard:fallback_used:false');
+    markRequestPerf_('dashboardSnapshot:total actionDashboardSnapshot:end');
+    return stalePayload;
   }
 
   markRequestPerf_('dashboardSnapshot:monthly view lookup:start');
@@ -484,7 +611,6 @@ function actionDashboardSnapshot_(user, payload) {
   markRequestPerf_('dashboardSnapshot:monthly view lookup:end');
 
   if (viewTry && viewTry.ok && viewTry.payload) {
-    viewTry.payload = enrichDashboardPayloadWithSharedExceptions_(viewTry.payload, ym);
     setRequestPerfField_('dashboard_used_view', true);
     setRequestPerfField_('dashboard_fallback_used', false);
     setRequestPerfField_('dashboard_cache_hit', !!viewTry.cache_hit);
@@ -499,36 +625,13 @@ function actionDashboardSnapshot_(user, payload) {
   setRequestPerfField_('dashboard_used_view', false);
   setRequestPerfField_('dashboard_cache_hit', false);
 
-  var snap = null;
-  var byManagerRows = [];
+  markRequestPerf_('dashboardSnapshot:read persisted snapshot sheets:start');
+  var persisted = readPersistedDashboardSnapshotRowsForMonth_(ym);
+  markRequestPerf_('dashboardSnapshot:read persisted snapshot sheets:end');
 
-  var ss = getSpreadsheet_();
-  var hasSummarySnapshotSheet = !!ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT);
-
-  if (hasSummarySnapshotSheet) {
-    markRequestPerf_('dashboardSnapshot:read summary snapshot:start');
-    var summaryRows = readSnapshotRowsFast_(CONFIG.SHEETS.DASHBOARD_SUMMARY_SNAPSHOT, SUMMARY_SNAPSHOT_HEADERS_);
-    snap = summaryRows.find(function(r) {
-      return normalizeSnapshotMonthYm_(r.month_ym) === ym;
-    }) || null;
-    markRequestPerf_('dashboardSnapshot:read summary snapshot:end');
-  }
-
-  if (ss.getSheetByName(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT)) {
-    markRequestPerf_('dashboardSnapshot:read by manager snapshot:start');
-    var allByMgr = readSnapshotRowsFast_(CONFIG.SHEETS.DASHBOARD_BY_MANAGER_SNAPSHOT, BY_MANAGER_SNAPSHOT_HEADERS_);
-    var filteredByMgr = allByMgr.filter(function(r) {
-      return normalizeSnapshotMonthYm_(r.month_ym) === ym;
-    });
-    var seenMgrKeys = {};
-    byManagerRows = filteredByMgr.filter(function(r) {
-      var key = text_(r.activity_manager);
-      if (!key || seenMgrKeys[key]) return false;
-      seenMgrKeys[key] = true;
-      return true;
-    });
-    markRequestPerf_('dashboardSnapshot:read by manager snapshot:end');
-  }
+  var snap = persisted.snap;
+  var byManagerRows = persisted.byManagerRows;
+  var hasSummarySnapshotSheet = persisted.hasSummarySnapshotSheet;
 
   if (!snap || !hasSummarySnapshotSheet) {
     if (payload && payload.force_full === true) {
@@ -564,96 +667,20 @@ function actionDashboardSnapshot_(user, payload) {
     return stubPayload;
   }
 
-  var s = snap || {};
-
-  var totalShort     = parseInt(text_(s.total_short_activities),   10) || 0;
-  var totalLong      = parseInt(text_(s.total_long_activities),    10) || 0;
-  var totalInstr     = parseInt(text_(s.active_instructors_count), 10) || 0;
-  var courseEndings  = parseInt(text_(s.course_endings_current_month), 10) || 0;
-  var financeOpen    = parseInt(text_(s.finance_open_count),       10) || 0;
-  var missingInstr   = parseInt(text_(s.missing_instructor_count), 10) || 0;
-  var missingDate    = parseInt(text_(s.missing_start_date_count), 10) || 0;
-  var lateEnd        = parseInt(text_(s.late_end_date_count),      10) || 0;
-  var exceptCount    = resolveExceptionsCountForDashboard_({
-    missing_instructor_count: missingInstr,
-    missing_start_date_count: missingDate,
-    late_end_date_count: lateEnd
-  }, s.exceptions_count);
-  var activeCurrent  = parseInt(text_(s.active_courses_current_month), 10) || 0;
-  var activeNext     = parseInt(text_(s.active_courses_next_month), 10) || 0;
-
-  var combinedStr = text_(s.active_instructors_names);
-  var allInstructorNames = combinedStr
-    ? combinedStr.split(',').map(function(n) { return n.trim(); }).filter(Boolean)
-    : [];
-
-  var byActivityManager = byManagerRows.map(function(r) {
-    var row = {
-      activity_manager: text_(r.activity_manager),
-      total_short:     parseInt(text_(r.total_short),    10) || 0,
-      total_long:      parseInt(text_(r.total_long),     10) || 0,
-      total:           parseInt(text_(r.total),          10) || 0,
-      num_instructors: parseInt(text_(r.num_instructors),10) || 0,
-      course_endings:  parseInt(text_(r.course_endings), 10) || 0,
-      exceptions:      parseInt(text_(r.exceptions),     10) || 0
-    };
-    if (canViewFinance) {
-      row.finance_open = parseInt(text_(r.finance_open), 10) || 0;
-    }
-    return row;
-  });
-
-  var snapshotData = {
-    total_short_activities:    totalShort,
-    total_long_activities:     totalLong,
-    active_instructors_count:  totalInstr,
-    course_endings_current_month: courseEndings,
-    finance_open_count:        canViewFinance ? financeOpen : 0,
-    exceptions_count:          exceptCount,
-    active_courses_current_month: activeCurrent,
-    active_courses_next_month: activeNext,
-    missing_instructor_count:  missingInstr,
-    missing_start_date_count:  missingDate,
-    late_end_date_count:       lateEnd
-  };
-
-  markRequestPerf_('dashboardSnapshot:build kpi cards:start');
-  var kpiCards = buildDashboardSnapshotKpis_(snapshotData, canViewFinance);
-  markRequestPerf_('dashboardSnapshot:build kpi cards:end');
   markRequestPerf_('dashboardSnapshot:settings/show_only_nonzero_kpis:start');
   var flags = getDashboardSnapshotFlags_();
   markRequestPerf_('dashboardSnapshot:settings/show_only_nonzero_kpis:end');
+  markRequestPerf_('dashboardSnapshot:build kpi cards:start');
+  var sheetSnapshotPayload = composeDashboardPayloadFromSummarySnapshot_(
+    ym,
+    canViewFinance,
+    snap,
+    byManagerRows,
+    flags.show_only_nonzero_kpis !== false
+  );
+  markRequestPerf_('dashboardSnapshot:build kpi cards:end');
   markRequestPerf_('dashboardSnapshot:total actionDashboardSnapshot:end');
 
-  var sheetSnapshotPayload = {
-    month: ym,
-    can_view_finance: canViewFinance,
-    totals: {
-      total_short_activities:           totalShort,
-      total_long_activities:            totalLong,
-      total_instructors:                totalInstr,
-      total_course_endings_current_month: courseEndings,
-      short: totalShort,
-      long:  totalLong
-    },
-    by_activity_manager: byActivityManager,
-    summary: {
-      active_courses_current_month: activeCurrent,
-      ending_courses_current_month: courseEndings,
-      active_courses_next_month:    activeNext,
-      exceptions_count:             exceptCount,
-      active_instructors:           allInstructorNames,
-      active_instructors_by_manager: {},
-      missing_instructor_count:  missingInstr,
-      missing_start_date_count:  missingDate,
-      late_end_date_count:       lateEnd,
-      short_activities:          []
-    },
-    kpi_cards: kpiCards,
-    show_only_nonzero_kpis: flags.show_only_nonzero_kpis !== false,
-    _is_snapshot: true
-  };
-  sheetSnapshotPayload = enrichDashboardPayloadWithSharedExceptions_(sheetSnapshotPayload, ym);
   setRequestPerfField_('dashboard_fallback_used', false);
   setRequestPerfField_('dashboard_view_rows_read', 0);
   setRequestPerfField_('payload_bytes', JSON.stringify(sheetSnapshotPayload).length);

--- a/backend/helpers.gs
+++ b/backend/helpers.gs
@@ -286,12 +286,46 @@ function perfNowMs_() {
   return new Date().getTime();
 }
 
-function beginRequestPerf_(action, payload) {
-  var debugFlag = payload && (
-    payload.debug_perf === true ||
-    text_(payload.debug_perf) === '1' ||
-    text_(payload.debug_perf).toLowerCase() === 'true'
-  );
+/**
+ * Enable per-request perf when any of:
+ * - JSON body debug_perf true / "1" / "true"
+ * - Query string debug_perf=1 (web app POST may still carry e.parameter)
+ * - Script property DEBUG_PERF=1 (Apps Script project settings → Script properties)
+ */
+function debugPerfRequested_(payload, httpEvent) {
+  var p = payload || {};
+  if (
+    p.debug_perf === true ||
+    text_(p.debug_perf) === '1' ||
+    text_(p.debug_perf).toLowerCase() === 'true'
+  ) {
+    return true;
+  }
+  try {
+    if (httpEvent && httpEvent.parameter) {
+      var q = text_(httpEvent.parameter.debug_perf).toLowerCase();
+      if (q === '1' || q === 'true') return true;
+    }
+  } catch (_e) {}
+  try {
+    if (PropertiesService.getScriptProperties().getProperty('DEBUG_PERF') === '1') return true;
+  } catch (_e2) {}
+  return false;
+}
+
+function inferFallbackUsedFromPerfCustom_(custom) {
+  if (!custom || typeof custom !== 'object') return false;
+  if (custom.fallback_used !== undefined && custom.fallback_used !== null) {
+    return !!custom.fallback_used;
+  }
+  if (custom.dashboard_fallback_used) return true;
+  if (custom.week_fallback_used) return true;
+  if (custom._activities_fallback_used) return true;
+  return false;
+}
+
+function beginRequestPerf_(action, payload, httpEvent) {
+  var debugFlag = debugPerfRequested_(payload, httpEvent);
   __rqPerf_ = {
     enabled: !!debugFlag,
     action: text_(action),
@@ -350,19 +384,28 @@ function buildPerfPayload_(responsePayload, meta) {
     });
   }
   var responseSize = JSON.stringify(responsePayload || {}).length;
+  var totalMs = endMs - __rqPerf_.started_ms;
+  var sheetReadsArr = __rqPerf_.sheet_reads || [];
   var perfPayload = {
     action: text_((meta && meta.action) || __rqPerf_.action),
     cache_hit: !!(meta && meta.cache_hit),
     errored: !!(meta && meta.errored),
-    total_ms: endMs - __rqPerf_.started_ms,
+    total_ms: totalMs,
+    duration_ms: totalMs,
     sheets_total_ms: __rqPerf_.sheets_total_ms,
-    sheet_reads: __rqPerf_.sheet_reads,
+    sheet_reads: sheetReadsArr,
+    sheet_reads_count: sheetReadsArr.length,
     steps: stepDurations,
-    response_size_bytes: responseSize
+    response_size_bytes: responseSize,
+    payload_size: responseSize
   };
   Object.keys(__rqPerf_.custom || {}).forEach(function(key) {
     perfPayload[key] = __rqPerf_.custom[key];
   });
+  perfPayload.fallback_used = inferFallbackUsedFromPerfCustom_(__rqPerf_.custom);
+  perfPayload.duration_ms = totalMs;
+  perfPayload.sheet_reads_count = sheetReadsArr.length;
+  perfPayload.payload_size = responseSize;
   return perfPayload;
 }
 

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -15,8 +15,11 @@ function handlePost_(e) {
   try {
     beginRequestCache_();
     var payload = parsePayload_(e);
+    if (e && e.parameter && e.parameter.debug_perf != null && payload.debug_perf === undefined) {
+      payload.debug_perf = e.parameter.debug_perf;
+    }
     var action = text_(payload.action);
-    beginRequestPerf_(action, payload);
+    beginRequestPerf_(action, payload, e);
     var user = action === 'login' ? null : requireAuth_(payload.token);
 
     var handlers = {
@@ -103,6 +106,7 @@ function handlePost_(e) {
       var readHit = scriptCacheGetJson_(readKey);
       if (readHit !== null) {
         markRequestPerf_('cache_lookup_done');
+        markRequestPerf_('action_done');
         return jsonResponse_({ ok: true, data: readHit }, {
           action: action,
           cache_hit: true

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -286,10 +286,26 @@ async function refreshReadModelInBackground_(key, params, localKey, manifestKey,
   } catch (_err) {}
 }
 
+/**
+ * When true, requests include debug_perf and console logs [perf] lines with server metrics.
+ * Enable any of:
+ *   localStorage.setItem('ds_debug_perf', '1')
+ *   localStorage.setItem('debug_perf', '1')   // legacy
+ *   window.__DEBUG_PERF__ = true
+ *   ?debug_perf=1 on the app URL
+ * Server: set script property DEBUG_PERF=1 for all requests without client flags.
+ */
 function isPerfDebugEnabled() {
   try {
     if (typeof window !== 'undefined' && window.__DEBUG_PERF__ === true) return true;
-    if (typeof localStorage !== 'undefined' && localStorage.getItem('debug_perf') === '1') return true;
+    if (typeof localStorage !== 'undefined') {
+      if (localStorage.getItem('ds_debug_perf') === '1') return true;
+      if (localStorage.getItem('debug_perf') === '1') return true;
+    }
+    if (typeof window !== 'undefined' && window.location?.search) {
+      const q = new URLSearchParams(window.location.search).get('debug_perf');
+      if (q === '1' || (q && q.toLowerCase() === 'true')) return true;
+    }
   } catch { /* ignore */ }
   return false;
 }
@@ -365,23 +381,47 @@ function emitPerfEntry(entry) {
     slow: Number(entry?.duration_ms || 0) > 3000
   });
   if (isPerfDebugEnabled()) {
+    const line = {
+      action: entry.action,
+      duration_ms: entry.duration_ms,
+      server_duration_ms: entry.server_duration_ms,
+      sheet_reads_count: entry.sheet_reads_count,
+      payload_size: entry.payload_size,
+      server_payload_size: entry.server_payload_size,
+      fallback_used: entry.fallback_used,
+      cache_hit: entry.cache_hit
+    };
     // eslint-disable-next-line no-console
-    console.info('[perf]', entry);
+    console.info('[perf]', line, entry.backend_debug || '');
   }
 }
 
 function buildPerfRequestEntry(action, requestStart, lastResponseText, perfMeta = {}, sheetReads = null, backendDebug = null) {
   const durationMs = Math.round(performance.now() - requestStart);
+  const dbg = backendDebug && typeof backendDebug === 'object' ? backendDebug : null;
+  const fromServerCount = dbg?.sheet_reads_count;
+  const fromServerArray = Array.isArray(dbg?.sheet_reads) ? dbg.sheet_reads.length : null;
+  const mergedSheetReads =
+    sheetReads != null && sheetReads !== ''
+      ? sheetReads
+      : (fromServerCount != null ? fromServerCount : fromServerArray);
+  const serverDuration = dbg?.duration_ms ?? dbg?.total_ms ?? null;
+  const serverPayloadSize = dbg?.payload_size ?? dbg?.response_size_bytes ?? null;
+  const serverFallback = dbg?.fallback_used;
   return {
     action: perfMeta.action || action,
     duration_ms: durationMs,
+    server_duration_ms: serverDuration,
     slow: durationMs > 3000,
     payload_size: typeof lastResponseText === 'string' ? lastResponseText.length : null,
+    server_payload_size: serverPayloadSize,
     used_read_model: Boolean(perfMeta.used_read_model || action === 'readModelGet'),
-    fallback_used: Boolean(perfMeta.fallback_used),
-    cache_hit: Boolean(perfMeta.cache_hit),
-    sheet_reads_count: sheetReads,
-    backend_debug: backendDebug
+    fallback_used: Boolean(
+      serverFallback !== undefined && serverFallback !== null ? serverFallback : perfMeta.fallback_used
+    ),
+    cache_hit: Boolean(perfMeta.cache_hit || dbg?.cache_hit),
+    sheet_reads_count: mergedSheetReads,
+    backend_debug: dbg
   };
 }
 
@@ -484,14 +524,19 @@ async function request(action, payload = {}, perfMeta = {}) {
     invalidateScreenDataByAction(action);
     invalidateReadModelLocalCacheByAction(action);
   }
-  const sheetReads = json?.data?.debug_perf?.sheet_reads_count ?? json?.data?.sheet_reads_count ?? null;
+  const backendDbg = json?.data?.debug_perf && typeof json.data.debug_perf === 'object' ? json.data.debug_perf : null;
+  const sheetReads =
+    backendDbg?.sheet_reads_count ??
+    (Array.isArray(backendDbg?.sheet_reads) ? backendDbg.sheet_reads.length : null) ??
+    json?.data?.sheet_reads_count ??
+    null;
   emitPerfEntry(buildPerfRequestEntry(
     action,
     requestStart,
     lastResponseText,
     perfMeta,
     sheetReads,
-    json.data && json.data.debug_perf ? json.data.debug_perf : null
+    backendDbg
   ));
   return normalized;
 }
@@ -569,3 +614,5 @@ export const api = {
   readModelGet: (key, params = {}) => request('readModelGet', { key, params }),
   readModelHealth: () => request('readModelHealth', {}),
 };
+
+export { isPerfDebugEnabled, getPerfStore };


### PR DESCRIPTION
- Auth: ScriptCache permissions index by user_id (versioned TTL) for login.
- Dashboard snapshot: serve stale snapshot sheets when control is not fresh; drop live exception enrichment; shared compose helpers.
- Helpers/router: standard debug_perf payload (duration_ms, sheet_reads_count, payload_size, fallback_used); DEBUG_PERF script property and query param.
- Frontend api: richer perf logging and ds_debug_perf / URL toggles.