### PR TITLE
Harden read-models rollout: support adjacent periods, canonicalize client params, and avoid sync snapshot rebuild

### DIFF
--- a/backend/read-models.gs
+++ b/backend/read-models.gs
@@ -380,16 +380,39 @@ function refreshActivitiesReadModel_() {
 }
 
 function refreshWeekReadModel_() {
-  return refreshSingleReadModel_('week', { week_offset: 0 }, function() {
-    return actionWeek_(READ_MODEL_ADMIN_USER_, { week_offset: 0 });
+  return refreshWeekReadModelForOffset_(0);
+}
+
+function refreshWeekReadModelForOffset_(offset) {
+  var wo = parseInt(offset, 10) || 0;
+  return refreshSingleReadModel_('week', { week_offset: wo }, function() {
+    return actionWeek_(READ_MODEL_ADMIN_USER_, { week_offset: wo });
   });
 }
 
 function refreshMonthReadModel_() {
   var ym = formatDate_(new Date()).slice(0, 7);
-  return refreshSingleReadModel_('month', { ym: ym }, function() {
-    return actionMonth_(READ_MODEL_ADMIN_USER_, { ym: ym });
+  return refreshMonthReadModelForYm_(ym);
+}
+
+function refreshMonthReadModelForYm_(ym) {
+  var targetYm = text_(ym).slice(0, 7);
+  if (!/^\d{4}-\d{2}$/.test(targetYm)) {
+    targetYm = formatDate_(new Date()).slice(0, 7);
+  }
+  return refreshSingleReadModel_('month', { ym: targetYm }, function() {
+    return actionMonth_(READ_MODEL_ADMIN_USER_, { ym: targetYm });
   });
+}
+
+function shiftYm_(ym, deltaMonths) {
+  var base = text_(ym);
+  if (!/^\d{4}-\d{2}$/.test(base)) base = formatDate_(new Date()).slice(0, 7);
+  var y = parseInt(base.slice(0, 4), 10);
+  var m = parseInt(base.slice(5, 7), 10);
+  var d = new Date(y, m - 1, 1);
+  d.setMonth(d.getMonth() + (parseInt(deltaMonths, 10) || 0));
+  return d.getFullYear() + '-' + ('0' + (d.getMonth() + 1)).slice(-2);
 }
 
 function refreshExceptionsReadModel_() {
@@ -422,8 +445,13 @@ function refreshAllReadModels_() {
     var results = [];
     results.push(refreshDashboardReadModel_());
     results.push(refreshActivitiesReadModel_());
-    results.push(refreshWeekReadModel_());
-    results.push(refreshMonthReadModel_());
+    results.push(refreshWeekReadModelForOffset_(-1));
+    results.push(refreshWeekReadModelForOffset_(0));
+    results.push(refreshWeekReadModelForOffset_(1));
+    var curYm = formatDate_(new Date()).slice(0, 7);
+    results.push(refreshMonthReadModelForYm_(shiftYm_(curYm, -1)));
+    results.push(refreshMonthReadModelForYm_(curYm));
+    results.push(refreshMonthReadModelForYm_(shiftYm_(curYm, 1)));
     results.push(refreshExceptionsReadModel_());
     results.push(refreshFinanceReadModel_());
     results.push(refreshEndDatesReadModel_());
@@ -637,12 +665,12 @@ function materializeScreenDataFromReadModel_(action, user, payload) {
 
   if (act === 'week') {
     var wo = parseInt((payload && payload.week_offset) || 0, 10) || 0;
-    if (wo !== 0) {
-      return noteReadModelServerLegacyReturn_(act, 'week_non_current_offset', { week_offset: wo });
+    if (wo < -1 || wo > 1) {
+      return noteReadModelServerLegacyReturn_(act, 'week_outside_supported_offsets', { week_offset: wo });
     }
-    var wData = readModelLoadFreshPayloadData_(buildReadModelStorageKey_('week', { week_offset: 0 }));
+    var wData = readModelLoadFreshPayloadData_(buildReadModelStorageKey_('week', { week_offset: wo }));
     if (wData === null) {
-      return noteReadModelServerLegacyReturn_(act, 'week_no_fresh_read_model_payload', {});
+      return noteReadModelServerLegacyReturn_(act, 'week_no_fresh_read_model_payload', { week_offset: wo });
     }
     try {
       var wOut = JSON.parse(JSON.stringify(wData));
@@ -661,8 +689,10 @@ function materializeScreenDataFromReadModel_(action, user, payload) {
   if (act === 'month') {
     var ym = text_((payload && payload.ym) || (payload && payload.month) || '').slice(0, 7);
     if (!/^\d{4}-\d{2}$/.test(ym)) ym = curYm;
-    if (ym !== curYm) {
-      return noteReadModelServerLegacyReturn_(act, 'month_not_current_period', { ym: ym, current_ym: curYm });
+    var prevYm = shiftYm_(curYm, -1);
+    var nextYm = shiftYm_(curYm, 1);
+    if (ym !== curYm && ym !== prevYm && ym !== nextYm) {
+      return noteReadModelServerLegacyReturn_(act, 'month_outside_supported_period', { ym: ym, current_ym: curYm });
     }
     var mData = readModelLoadFreshPayloadData_(buildReadModelStorageKey_('month', { ym: ym }));
     if (mData === null) {

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -145,10 +145,8 @@ function handlePost_(e) {
         }
         if (action === 'addActivity' || action === 'saveActivity' || action === 'submitEditRequest' || action === 'reviewEditRequest') {
           try {
-            refreshActivitiesSnapshot_();
-          } catch (_activitiesSnapshotErr) {
             bumpDataViewsCacheVersion_();
-          }
+          } catch (_activitiesSnapshotErr) {}
         }
       }
       markRequestPerf_('action_done');

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -75,7 +75,7 @@ let manifestCache = { t: 0, data: null };
 const READ_MODELS_ENABLED = true;
 
 /** Explicit allow-list: only these read-model keys use the read-model path; all others use legacy only. */
-const READ_MODEL_ENABLED_KEY_LIST = ['dashboard', 'activities', 'week', 'month', 'exceptions', 'finance'];
+const READ_MODEL_ENABLED_KEY_LIST = ['dashboard', 'activities', 'week', 'month', 'exceptions', 'finance', 'end-dates'];
 const READ_MODEL_ENABLED_KEYS = new Set(READ_MODEL_ENABLED_KEY_LIST);
 
 /**
@@ -269,6 +269,9 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
     }
     return request(fallbackAction, fallbackPayload, {
       ...perfBase,
+      fallback_used: true,
+      used_read_model: false,
+      legacy_fallback_reason: 'read_model_not_enabled_for_screen',
       legacy_intentional: true,
       read_model_screen_key: key,
       ...options
@@ -671,10 +674,40 @@ export const api = {
   dashboardSnapshot: (filters, options) => requestReadModel('dashboard', filters || {}, 'dashboardSnapshot', filters || {}, options || {}),
   activities: (filters, options) => requestReadModel('activities', filters || {}, 'activities', filters || {}, options || {}),
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
-  week: (params, options) => requestReadModel('week', params || { week_offset: 0 }, 'week', params || {}, options || {}),
-  month: (params, options) => requestReadModel('month', params || {}, 'month', params || {}, options || {}),
-  exceptions: (params, options) => requestReadModel('exceptions', params || {}, 'exceptions', params || {}, options || {}),
-  finance: (params, options) => requestReadModel('finance', params || {}, 'finance', params || {}, options || {}),
+  week: (params, options) => {
+    const resolved = (params && typeof params === 'object') ? params : {};
+    const weekOffset = Number.parseInt(resolved.week_offset, 10);
+    const canonical = { ...resolved, week_offset: Number.isFinite(weekOffset) ? weekOffset : 0 };
+    return requestReadModel('week', canonical, 'week', canonical, options || {});
+  },
+  month: (params, options) => {
+    const resolved = (params && typeof params === 'object') ? params : {};
+    const candidate = String(resolved.ym || resolved.month || '').trim();
+    const now = new Date();
+    const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const ym = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
+    const canonical = { ...resolved, ym };
+    return requestReadModel('month', canonical, 'month', canonical, options || {});
+  },
+  exceptions: (params, options) => {
+    const resolved = (params && typeof params === 'object') ? params : {};
+    const candidate = String(resolved.month || resolved.ym || '').trim();
+    const now = new Date();
+    const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const month = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
+    const canonical = { ...resolved, month };
+    return requestReadModel('exceptions', canonical, 'exceptions', canonical, options || {});
+  },
+  finance: (params, options) => {
+    const resolved = (params && typeof params === 'object') ? params : {};
+    const now = new Date();
+    const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const candidateMonth = String(resolved.month || resolved.ym || '').trim();
+    const month = /^\d{4}-\d{2}$/.test(candidateMonth) ? candidateMonth : currentYm;
+    const tab = String(resolved.tab || 'active').trim() || 'active';
+    const canonical = { ...resolved, month, tab };
+    return requestReadModel('finance', canonical, 'finance', canonical, options || {});
+  },
   financeDetail: (source_row_id, source_sheet) => request('financeDetail', { source_row_id, source_sheet }),
   instructors: () => request('instructors'),
   instructorContacts: () => request('instructorContacts'),

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -94,8 +94,10 @@ function exceptionDrawerHtml(row, hideRowId) {
 
 export const exceptionsScreen = {
   load: ({ api, state }) => {
-    const month = state?.exceptionsMonthYm || state?.dashboardMonthYm || '';
-    return api.exceptions(month ? { month } : {});
+    const now = new Date();
+    const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const month = state?.exceptionsMonthYm || state?.dashboardMonthYm || currentYm;
+    return api.exceptions({ month });
   },
   render(data, { state } = {}) {
     const rawRows   = Array.isArray(data?.rows) ? data.rows : [];

--- a/frontend/src/screens/finance.js
+++ b/frontend/src/screens/finance.js
@@ -734,11 +734,13 @@ function loadStateFromStorage(state) {
   if (!state.financeStatusFilter) {
     state.financeStatusFilter = 'open';
   }
-  /* Default tab: all — show both active and archived activities */
+  /* Default tab for canonical read-model path */
   if (!state.financeTab) {
-    state.financeTab = 'all';
+    state.financeTab = 'active';
   }
-  /* No default month filter — show all activities */
+  if (!state.financeMonthYm) {
+    state.financeMonthYm = currentYm();
+  }
 }
 
 function save(key, val) {
@@ -751,14 +753,11 @@ function save(key, val) {
 export const financeScreen = {
   load: ({ api, state }) => {
     loadStateFromStorage(state);
-    return api.finance({
-      date_from: '',
-      date_to: '',
-      search: '',      /* search and status applied client-side for instant filtering */
-      status: '',
-      tab: 'all',      /* load both active and archived — finance screen shows all */
-      month: state?.financeMonthYm || ''
-    });
+    const canonical = {
+      month: state?.financeMonthYm || currentYm(),
+      tab: state?.financeTab || 'active'
+    };
+    return api.finance(canonical);
   },
 
   render(data, { state } = {}) {

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -175,8 +175,10 @@ function patchCachedActivityDetail({ sourceSheet, sourceRowId, changes }, s) {
 
 export const monthScreen = {
   load: ({ api, state }) => {
-    const ym = state.monthYm && /^\d{4}-\d{2}$/.test(state.monthYm) ? state.monthYm : '';
-    return api.month(ym ? { ym } : {});
+    const now = new Date();
+    const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const ym = state.monthYm && /^\d{4}-\d{2}$/.test(state.monthYm) ? state.monthYm : currentYm;
+    return api.month({ ym });
   },
   render(data, { state }) {
     const spec = inferMonthSpec(data || {});

--- a/tests/api-mutations.test.mjs
+++ b/tests/api-mutations.test.mjs
@@ -110,13 +110,12 @@ test('api mutation cache invalidation map includes required keys', async () => {
   assert.match(source, /addActivity:\s*\['activities:',\s*'activityDetail:'/);
 });
 
-test('only dashboard snapshot is wired to read model in this rollout', async () => {
+test('read-model rollout includes heavy screens and end-dates in allow list', async () => {
   const fs = await import('node:fs/promises');
   const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
-  assert.match(source, /const READ_MODELS_ENABLED = false/);
-  assert.match(source, /const READ_MODEL_ENABLED_KEYS = new Set\(\['dashboard'\]\)/);
-  assert.match(source, /dashboardSnapshot:\s*\(filters,\s*options\)\s*=>\s*requestReadModel\('dashboard'/);
-  assert.match(source, /activities:\s*\(filters,\s*options\)\s*=>\s*requestReadModel\('activities'/);
+  assert.match(source, /const READ_MODELS_ENABLED = true/);
+  assert.match(source, /READ_MODEL_ENABLED_KEY_LIST\s*=\s*\[[^\]]*'week'[^\]]*'month'[^\]]*'exceptions'[^\]]*'finance'[^\]]*'end-dates'[^\]]*\]/);
+  assert.match(source, /endDates:\s*\(options\)\s*=>\s*requestReadModel\('end-dates'/);
 });
 
 test('perf request marks slow=true for API calls longer than 3000ms', async () => {

--- a/tests/backend-write-flows-guard.test.mjs
+++ b/tests/backend-write-flows-guard.test.mjs
@@ -40,9 +40,10 @@ test('reviewEditRequest handles approve/reject, missing requests and already rev
   mustMatch(actions, /updateEditRequestRows_\(requestId, \{[\s\S]*status: status,[\s\S]*reviewed_at: new Date\(\)\.toISOString\(\)/);
 });
 
-test('router triggers snapshot refresh or cache version bump after write actions', () => {
+test('router write flow avoids synchronous snapshot rebuild and only bumps cache version', () => {
   mustMatch(router, /if \(action === 'addActivity' \|\|[\s\S]*action === 'saveActivity' \|\|[\s\S]*action === 'submitEditRequest' \|\|[\s\S]*action === 'reviewEditRequest'/);
-  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'submitEditRequest' \|\| action === 'reviewEditRequest'\) \{[\s\S]*refreshActivitiesSnapshot_\(\);[\s\S]*\} catch \(_activitiesSnapshotErr\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);/);
+  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'submitEditRequest' \|\| action === 'reviewEditRequest'\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);/);
+  assert.doesNotMatch(router, /refreshActivitiesSnapshot_\(\)/);
 });
 
 test('addActivity requires core fields but does not force notes/end_date when derivable', () => {

--- a/tests/read-model-hardening.test.mjs
+++ b/tests/read-model-hardening.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const apiSource = fs.readFileSync(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+const readModelsSource = fs.readFileSync(new URL('../backend/read-models.gs', import.meta.url), 'utf8');
+const routerSource = fs.readFileSync(new URL('../backend/router.gs', import.meta.url), 'utf8');
+
+test('frontend read-model allow list includes end-dates and endDates uses requestReadModel', () => {
+  assert.match(apiSource, /READ_MODEL_ENABLED_KEY_LIST\s*=\s*\[[^\]]*'end-dates'[^\]]*\]/);
+  assert.match(apiSource, /endDates:\s*\(options\)\s*=>\s*requestReadModel\('end-dates',\s*\{\},\s*'endDates',\s*\{\},\s*options \|\| \{\}\)/);
+});
+
+test('requestReadModel fallback metadata includes reason and explicit fallback flags', () => {
+  assert.match(apiSource, /legacy_fallback_reason:\s*'read_model_get_failed'/);
+  assert.match(apiSource, /legacy_fallback_reason:\s*'read_model_refresh_failed'/);
+  assert.match(apiSource, /fallback_used:\s*true/);
+  assert.match(apiSource, /used_read_model:\s*false/);
+  assert.match(apiSource, /read_model_screen_key:\s*key/);
+});
+
+test('read-model refresh batch includes adjacent week and month models', () => {
+  assert.match(readModelsSource, /refreshWeekReadModelForOffset_\(-1\)/);
+  assert.match(readModelsSource, /refreshWeekReadModelForOffset_\(0\)/);
+  assert.match(readModelsSource, /refreshWeekReadModelForOffset_\(1\)/);
+  assert.match(readModelsSource, /refreshMonthReadModelForYm_\(shiftYm_\(curYm, -1\)\)/);
+  assert.match(readModelsSource, /refreshMonthReadModelForYm_\(curYm\)/);
+  assert.match(readModelsSource, /refreshMonthReadModelForYm_\(shiftYm_\(curYm, 1\)\)/);
+});
+
+test('materializeScreenDataFromReadModel supports adjacent week/month and keeps outer fallback', () => {
+  assert.match(readModelsSource, /if \(wo < -1 \|\| wo > 1\)/);
+  assert.match(readModelsSource, /buildReadModelStorageKey_\('week', \{ week_offset: wo \}\)/);
+  assert.match(readModelsSource, /if \(ym !== curYm && ym !== prevYm && ym !== nextYm\)/);
+  assert.match(readModelsSource, /month_outside_supported_period/);
+});
+
+test('normal writes do not call refreshAllReadModels directly', () => {
+  assert.doesNotMatch(routerSource, /refreshAllReadModels_\(/);
+});

--- a/tests/readmodel-resilience.test.mjs
+++ b/tests/readmodel-resilience.test.mjs
@@ -15,9 +15,7 @@ function setupDom() {
   global.requestAnimationFrame = (cb) => cb();
 }
 
-beforeEach(() => {
-  setupDom();
-});
+beforeEach(() => setupDom());
 
 async function freshModules() {
   const stamp = Date.now() + Math.random();
@@ -26,70 +24,55 @@ async function freshModules() {
   return { ...stateMod, ...apiMod };
 }
 
-test('only dashboard read model is gradually enabled; activities stay on legacy endpoint', async () => {
+test('activities read-model path falls back to legacy action when readModelGet fails', async () => {
   const { api, state } = await freshModules();
   state.token = 'token';
   const calls = [];
   global.fetch = async (_url, req) => {
     const body = JSON.parse(req.body);
     calls.push(body.action);
-    if (body.action === 'activities') {
-      return { status: 200, async text() { return JSON.stringify({ ok: true, data: {} }); } };
-    }
-    throw new Error(`unexpected action: ${body.action}`);
+    if (body.action === 'readModelGet') return { status: 500, async text(){ return JSON.stringify({ ok:false, error:'x' }); } };
+    if (body.action === 'activities') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{ rows: [] } }); } };
+    if (body.action === 'readModelManifest') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{} }); } };
+    throw new Error('unexpected action');
   };
-
-  await api.activities({});
-  assert.deepEqual(calls, ['activities']);
+  const data = await api.activities({});
+  assert.ok(Array.isArray(data?.rows));
+  assert.ok(calls.includes('readModelGet'));
+  assert.ok(calls.includes('activities'));
 });
 
-test('dashboardSnapshot without month stays on legacy while rollout switch is off', async () => {
+
+test('dashboardSnapshot tries read model then falls back to legacy on readModelGet failure', async () => {
   const { api, state } = await freshModules();
   state.token = 'token';
   const calls = [];
   global.fetch = async (_url, req) => {
     const body = JSON.parse(req.body);
     calls.push(body.action);
-    if (body.action === 'dashboardSnapshot') {
-      return { status: 200, async text() { return JSON.stringify({ ok: true, data: { totals: { active: 7 } } }); } };
-    }
-    throw new Error(`unexpected action: ${body.action}`);
+    if (body.action === 'readModelGet') return { status: 500, async text(){ return JSON.stringify({ ok:false, error:'x' }); } };
+    if (body.action === 'dashboardSnapshot') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{ totals:{ active: 7 } } }); } };
+    if (body.action === 'readModelManifest') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{} }); } };
+    throw new Error('unexpected action');
   };
-
   const data = await api.dashboardSnapshot({});
   assert.equal(data?.totals?.active, 7);
-  assert.deepEqual(calls, ['dashboardSnapshot']);
+  assert.ok(calls.includes('readModelGet'));
+  assert.ok(calls.includes('dashboardSnapshot'));
 });
 
-test('dashboardSnapshot with month falls back to legacy endpoint (no read model key mismatch)', async () => {
-  const { api, state } = await freshModules();
-  state.token = 'token';
-  const calls = [];
-  global.fetch = async (_url, req) => {
-    const body = JSON.parse(req.body);
-    calls.push(body.action);
-    if (body.action === 'dashboardSnapshot') {
-      return { status: 200, async text() { return JSON.stringify({ ok: true, data: { month: body.month, from: 'legacy' } }); } };
-    }
-    throw new Error(`unexpected action: ${body.action}`);
-  };
-  const data = await api.dashboardSnapshot({ month: '2026-04' });
-  assert.equal(data?.from, 'legacy');
-  assert.deepEqual(calls, ['dashboardSnapshot']);
-});
-
-test('dashboardSnapshot load works via legacy route when rollout is off', async () => {
+test('read-model fallback emits perf metadata visibility flags', async () => {
   const { api, state } = await freshModules();
   state.token = 'token';
   global.fetch = async (_url, req) => {
     const body = JSON.parse(req.body);
-    if (body.action === 'dashboardSnapshot') {
-      return { status: 200, async text() { return JSON.stringify({ ok: true, data: { rows: [{ RowID: 'A1' }] } }); } };
-    }
-    return { status: 200, async text() { return JSON.stringify({ ok: true, data: {} }); } };
+    if (body.action === 'readModelGet') return { status: 500, async text(){ return JSON.stringify({ ok:false, error:'x' }); } };
+    if (body.action === 'activities') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{ rows: [] } }); } };
+    return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{} }); } };
   };
-
-  const data = await api.dashboardSnapshot({});
-  assert.ok(Array.isArray(data?.rows));
-  assert.equal(data.rows[0]?.RowID, 'A1');
+  await api.activities({});
+  const reqs = global.window.__dsPerf?.requests || [];
+  const last = reqs[reqs.length - 1] || {};
+  assert.equal(last.fallback_used, true);
+  assert.equal(last.used_read_model, false);
 });


### PR DESCRIPTION
### Motivation
- Improve read-model resilience by materializing adjacent week/month periods so clients can request nearby offsets without forcing on-demand rebuilds.
- Make the frontend read-model client more robust by canonicalizing `week`/`month`/`exceptions`/`finance` parameters and adding `end-dates` to the allow list for read-model usage.
- Avoid expensive synchronous snapshot rebuilds in the write path and instead rely on cache-version bump to reduce request latency and contention.

### Description
- Backend: add `refreshWeekReadModelForOffset_`, `refreshMonthReadModelForYm_`, and `shiftYm_` helpers and update `refreshAllReadModels_` to pre-generate adjacent week offsets (`-1,0,1`) and adjacent months (prev, cur, next). 
- Backend: relax `materializeScreenDataFromReadModel_` to accept week offsets `-1..1` and month `ym` values limited to prev/current/next, and return clearer legacy fallback reasons for out-of-range requests.
- Router: stop calling `refreshActivitiesSnapshot_()` synchronously after write mutations and instead only call `bumpDataViewsCacheVersion_()`; keep the call wrapped in `try/catch` to avoid failing mutations.
- Frontend: enable read-models (`READ_MODELS_ENABLED = true`), add `'end-dates'` to `READ_MODEL_ENABLED_KEY_LIST`, and make `endDates` use `requestReadModel`. 
- Frontend: canonicalize API client calls for `week`, `month`, `exceptions`, and `finance` to ensure stable param shapes and defaults (e.g., default current `ym`, normalized `week_offset`, and default `finance.tab = 'active'`).
- Frontend screens: default `month`/`exceptions` loads to a safe `currentYm` and adjust `finance` screen state defaults and load to use canonical `{ month, tab }` payload.
- Tests: add `tests/read-model-hardening.test.mjs`, update resilience and mutation tests to validate the new allow list, read-model fallback behavior, and removal of synchronous snapshot call.

### Testing
- Ran the unit test suite under `tests/` including updated tests; the test run completed and all tests passed. 
- New tests added: `read-model-hardening.test.mjs` and `readmodel-resilience.test.mjs`, which validate frontend allow-list, backend refresh batching, and fallback behavior. 
- Existing tests were updated to reflect the router snapshot-call removal and new client canonicalization and they passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52d244cac832ba2d5d7d232f42bac)