### PR TITLE
Restore dashboard fallback for stale snapshots

### DIFF
--- a/backend/dashboard-snapshot.gs
+++ b/backend/dashboard-snapshot.gs
@@ -563,18 +563,14 @@ function actionDashboardSnapshot_(user, payload) {
 
     var stalePayload;
     if (!persistedStale.snap || !persistedStale.hasSummarySnapshotSheet) {
-      stalePayload = {
-        month: ym,
-        can_view_finance: canViewFinance,
-        totals: {},
-        summary: {},
-        by_activity_manager: [],
-        kpi_cards: [],
-        show_only_nonzero_kpis: showOnlyFromControl,
-        _is_snapshot: true,
-        _is_stale: true,
-        _snapshot_fallback_reason: staleReason
-      };
+      stalePayload = actionDashboard_(user, payload || {});
+      if (stalePayload && typeof stalePayload === 'object') {
+        stalePayload._is_snapshot = false;
+        stalePayload._is_stale = true;
+        stalePayload._snapshot_fallback_reason = staleReason || 'missing_snapshot';
+      }
+      setRequestPerfField_('dashboard_fallback_used', true);
+      markRequestPerf_('dashboard:fallback_used:true');
     } else {
       markRequestPerf_('dashboardSnapshot:build kpi cards:start');
       stalePayload = composeDashboardPayloadFromSummarySnapshot_(
@@ -587,16 +583,16 @@ function actionDashboardSnapshot_(user, payload) {
       markRequestPerf_('dashboardSnapshot:build kpi cards:end');
       stalePayload._is_stale = true;
       stalePayload._snapshot_fallback_reason = staleReason;
+      setRequestPerfField_('dashboard_fallback_used', false);
+      markRequestPerf_('dashboard:fallback_used:false');
     }
 
     setRequestPerfField_('dashboard_used_view', false);
     setRequestPerfField_('dashboard_cache_hit', false);
-    setRequestPerfField_('dashboard_fallback_used', false);
     setRequestPerfField_('dashboard_view_rows_read', 0);
     setRequestPerfField_('payload_bytes', JSON.stringify(stalePayload || {}).length);
     markRequestPerf_('dashboard:force_fallback_by_freshness:true');
     markRequestPerf_('dashboard:stale_snapshot:true');
-    markRequestPerf_('dashboard:fallback_used:false');
     markRequestPerf_('dashboardSnapshot:total actionDashboardSnapshot:end');
     return stalePayload;
   }
@@ -647,24 +643,19 @@ function actionDashboardSnapshot_(user, payload) {
       markRequestPerf_('dashboardSnapshot:total actionDashboardSnapshot:end');
       return fullData;
     }
-    setRequestPerfField_('dashboard_fallback_used', false);
+    var fallbackData = actionDashboard_(user, payload || {});
+    if (fallbackData && typeof fallbackData === 'object') {
+      fallbackData._is_snapshot = false;
+      fallbackData._is_stale = true;
+      fallbackData._snapshot_fallback_reason = 'missing_snapshot';
+    }
+    setRequestPerfField_('dashboard_fallback_used', true);
     setRequestPerfField_('dashboard_view_rows_read', 0);
-    var stubPayload = {
-      month: ym,
-      _is_snapshot: false,
-      _is_snapshot_missing: true,
-      can_view_finance: canViewFinance,
-      totals: {},
-      summary: {},
-      by_activity_manager: [],
-      kpi_cards: [],
-      show_only_nonzero_kpis: true
-    };
-    setRequestPerfField_('payload_bytes', JSON.stringify(stubPayload).length);
-    markRequestPerf_('dashboard:fallback_used:false');
+    setRequestPerfField_('payload_bytes', JSON.stringify(fallbackData || {}).length);
+    markRequestPerf_('dashboard:fallback_used:true');
     markRequestPerf_('dashboard:used_view:false');
     markRequestPerf_('dashboardSnapshot:total actionDashboardSnapshot:end');
-    return stubPayload;
+    return fallbackData;
   }
 
   markRequestPerf_('dashboardSnapshot:settings/show_only_nonzero_kpis:start');

--- a/backend/router.gs
+++ b/backend/router.gs
@@ -145,8 +145,10 @@ function handlePost_(e) {
         }
         if (action === 'addActivity' || action === 'saveActivity' || action === 'submitEditRequest' || action === 'reviewEditRequest') {
           try {
+            refreshActivitiesSnapshot_();
+          } catch (_activitiesSnapshotErr) {
             bumpDataViewsCacheVersion_();
-          } catch (_activitiesSnapshotErr) {}
+          }
         }
       }
       markRequestPerf_('action_done');

--- a/tests/backend-write-flows-guard.test.mjs
+++ b/tests/backend-write-flows-guard.test.mjs
@@ -40,10 +40,9 @@ test('reviewEditRequest handles approve/reject, missing requests and already rev
   mustMatch(actions, /updateEditRequestRows_\(requestId, \{[\s\S]*status: status,[\s\S]*reviewed_at: new Date\(\)\.toISOString\(\)/);
 });
 
-test('router write flow avoids synchronous snapshot rebuild and only bumps cache version', () => {
+test('router write flow tries activity snapshot refresh and falls back to cache bump on failure', () => {
   mustMatch(router, /if \(action === 'addActivity' \|\|[\s\S]*action === 'saveActivity' \|\|[\s\S]*action === 'submitEditRequest' \|\|[\s\S]*action === 'reviewEditRequest'/);
-  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'submitEditRequest' \|\| action === 'reviewEditRequest'\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);/);
-  assert.doesNotMatch(router, /refreshActivitiesSnapshot_\(\)/);
+  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'submitEditRequest' \|\| action === 'reviewEditRequest'\) \{[\s\S]*try \{[\s\S]*refreshActivitiesSnapshot_\(\);[\s\S]*\} catch \(_activitiesSnapshotErr\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);[\s\S]*\}/);
 });
 
 test('addActivity requires core fields but does not force notes/end_date when derivable', () => {

--- a/tests/dashboard-snapshot-hotfix.test.mjs
+++ b/tests/dashboard-snapshot-hotfix.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const read = (p) => fs.readFile(new URL(`../${p}`, import.meta.url), 'utf8');
+
+function mustMatch(src, re, msg) {
+  assert.match(src, re, msg || String(re));
+}
+
+test('dashboard snapshot stale/missing falls back to actionDashboard_ instead of empty payload', async () => {
+  const snapshot = await read('backend/dashboard-snapshot.gs');
+
+  mustMatch(snapshot, /if \(!persistedStale\.snap \|\| !persistedStale\.hasSummarySnapshotSheet\) \{[\s\S]*stalePayload = actionDashboard_\(user, payload \|\| \{\}\);/);
+  mustMatch(snapshot, /stalePayload\._is_snapshot = false;/);
+  mustMatch(snapshot, /stalePayload\._is_stale = true;/);
+  mustMatch(snapshot, /stalePayload\._snapshot_fallback_reason = staleReason \|\| 'missing_snapshot';/);
+
+  mustMatch(snapshot, /if \(!snap \|\| !hasSummarySnapshotSheet\) \{[\s\S]*fallbackData = actionDashboard_\(user, payload \|\| \{\}\);[\s\S]*fallbackData\._snapshot_fallback_reason = 'missing_snapshot';/);
+});
+
+test('dashboard manager mapping keeps display-only district labels', async () => {
+  const snapshot = await read('backend/dashboard-snapshot.gs');
+
+  mustMatch(snapshot, /var SNAPSHOT_MANAGER_DISPLAY_NAMES_ = \{[\s\S]*'גיל נאמן'\s*:\s*'מחוז צפון',[\s\S]*'לינוי שמואל מזרחי'\s*:\s*'מחוז דרום'[\s\S]*\};/);
+});


### PR DESCRIPTION
### Motivation
- Prevent the dashboard from returning an empty payload when snapshot data is stale or missing so the frontend no longer shows "אין נתונים להצגה".
- Reintroduce a safe synchronous attempt to rebuild activity snapshots after activity/edit writes and fall back to a cache bump on error to improve stability.
- Keep finance behavior and UI untouched and only revert unsafe defaults that directly cause missing dashboard data.
- Ensure display-only mapping for specific manager names to district labels for dashboard summaries.

### Description
- Change `actionDashboardSnapshot_` in `backend/dashboard-snapshot.gs` so that when snapshot freshness is stale or persisted snapshot rows are missing it falls back to calling `actionDashboard_(user, payload || {})` instead of returning an empty stub, and annotate the fallback result with `_is_snapshot = false`, `_is_stale = true` and `_snapshot_fallback_reason = staleReason || 'missing_snapshot'`.
- Adjust `backend/router.gs` write flow for `addActivity` / `saveActivity` / `submitEditRequest` / `reviewEditRequest` to try `refreshActivitiesSnapshot_()` first and only call `bumpDataViewsCacheVersion_()` inside the `catch` block.
- Preserve the display-only manager-to-district mapping in `SNAPSHOT_MANAGER_DISPLAY_NAMES_` with `גיל נאמן -> מחוז צפון` and `לינוי שמואל מזרחי -> מחוז דרום` and do not change internal manager keys or calculations.
- Update tests: modify `tests/backend-write-flows-guard.test.mjs` to assert the new write-flow try/fallback behavior and add `tests/dashboard-snapshot-hotfix.test.mjs` to validate the stale/missing snapshot fallback and the manager display mapping.
- Files changed: `backend/dashboard-snapshot.gs`, `backend/router.gs`, `tests/backend-write-flows-guard.test.mjs`, and `tests/dashboard-snapshot-hotfix.test.mjs`.

### Testing
- Ran `node --test tests/dashboard-snapshot-hotfix.test.mjs` and it passed (2 tests, 0 failures).
- Ran `node --test tests/backend-write-flows-guard.test.mjs` and it passed (10 tests, 0 failures).
- No other tests were modified; the changes are targeted and unit tests covering the hotfix assertions succeeded.
- Apps Script sync/deploy is required for these backend `.gs` changes to take effect in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f545fad758832bbe4918b823b09047)