### PR TITLE
Update Apps Script deployment URL to new Web App endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbyRgPaytGRBYT2_6p-qvXsU5oZYV-mV9FPd6uNhWifBOlKFDnWdJd2aVB4GQIoeH00H/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyRgPaytGRBYT2_6p-qvXsU5oZYV-mV9FPd6uNhWifBOlKFDnWdJd2aVB4GQIoeH00H/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec
+- API URL: https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec
 - Samples per screen requested: 20
 
 ## Status

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbxGgH1aR9EM8P_v43miHScvvGfHPtjlPhExZYyj_2ridyKwFIoVVdn_mWpPB-__5uXO/exec';
+  'https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbxTD4nRJtgs3Yd9OwYDyDAaavJQij94cLmumx4IrCQ3KhKs9-l0S5bLIHFA9NRRF3r-/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);


### PR DESCRIPTION
### Motivation
- להחליף כתובת Web App ישנה של Google Apps Script בכל המקומות הרלוונטיים כדי שה־frontend, סקריפטי הבדיקות ותיעוד ישתמשו בפריסה החדשה.

### Description
- עדכנתי את ברירת המחדל של ה־API ב־`frontend/src/config.js` לכתובת החדשה `https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec`.
- עדכנתי דוגמאות ההגדרה ב־`README.md` (`window.__DASHBOARD_CONFIG__.apiUrl` ו־`?apiUrl=`) לשימוש באותה כתובת.
- עדכנתי את כתובת ה־fallback ב־`scripts/collect_baseline_stage0_real.mjs` ואת ה־API URL במסמך `docs/architecture/read-models-stage0-real-baseline.md` לשאת את הפריסה החדשה.

### Testing
- הרצתי את סקריפט העדכון ששינה את מחרוזות ה־URL בקבצים המיועדים והאישור שהקבצים עודכנו הצליח.
- ווידאתי עם `rg -n "script.google.com/macros/s/.*/exec" frontend/src/config.js README.md scripts/collect_baseline_stage0_real.mjs docs/architecture/read-models-stage0-real-baseline.md` שכל ההפניות עודכנו לכתובת החדשה.
- בדקתי שורות מעודכנות באמצעות `nl` כדי לאשר שה־`DEFAULT_API_URL` ו־הדוגמאות בתיעוד מצביעות כעת על הכתובת החדשה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54bb28af4832bafa8d65c62c1ef35)