### PR TITLE
Fix Apps Script read-model coverage and end-dates refresh

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -2192,13 +2192,7 @@ function actionInstructorContacts_(user) {
   };
 }
 
-function actionEndDates_(user) {
-  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
-  var permission = getPermissionRow_(user.user_id);
-  if (!endDatesViewYes_(permission)) {
-    throw new Error('Forbidden');
-  }
-
+function buildEndDatesPayload_() {
   var meetingsMap = buildMeetingsMap_();
   var activityRows = enrichRowsWithMeetings_(allActivitiesSummary_().slice());
   var rows = activityRows
@@ -2237,6 +2231,15 @@ function actionEndDates_(user) {
   });
 
   return { rows: rows };
+}
+
+function actionEndDates_(user) {
+  requireAnyRole_(user, ['admin', 'operation_manager', 'authorized_user']);
+  var permission = getPermissionRow_(user.user_id);
+  if (!endDatesViewYes_(permission)) {
+    throw new Error('Forbidden');
+  }
+  return buildEndDatesPayload_();
 }
 
 function actionMyData_(user) {

--- a/backend/read-models.gs
+++ b/backend/read-models.gs
@@ -431,7 +431,7 @@ function refreshFinanceReadModel_() {
 
 function refreshEndDatesReadModel_() {
   return refreshSingleReadModel_('end-dates', {}, function() {
-    return actionEndDates_(READ_MODEL_ADMIN_USER_);
+    return buildEndDatesPayload_();
   });
 }
 
@@ -442,6 +442,9 @@ function refreshAllReadModels_() {
   if (!hadCache) beginRequestCache_();
   var batchStarted = perfNowMs_();
   try {
+    try {
+      console.info('[read_models] refreshAllReadModels_version', 'adjacent-week-month-v2');
+    } catch (_vlogErr) {}
     var results = [];
     results.push(refreshDashboardReadModel_());
     results.push(refreshActivitiesReadModel_());

--- a/tests/read-model-hardening.test.mjs
+++ b/tests/read-model-hardening.test.mjs
@@ -20,12 +20,29 @@ test('requestReadModel fallback metadata includes reason and explicit fallback f
 });
 
 test('read-model refresh batch includes adjacent week and month models', () => {
+  assert.match(readModelsSource, /refreshAllReadModels_version',\s*'adjacent-week-month-v2'/);
   assert.match(readModelsSource, /refreshWeekReadModelForOffset_\(-1\)/);
   assert.match(readModelsSource, /refreshWeekReadModelForOffset_\(0\)/);
   assert.match(readModelsSource, /refreshWeekReadModelForOffset_\(1\)/);
   assert.match(readModelsSource, /refreshMonthReadModelForYm_\(shiftYm_\(curYm, -1\)\)/);
   assert.match(readModelsSource, /refreshMonthReadModelForYm_\(curYm\)/);
   assert.match(readModelsSource, /refreshMonthReadModelForYm_\(shiftYm_\(curYm, 1\)\)/);
+});
+
+test('end-dates refresh uses internal payload builder and api action keeps permission checks', () => {
+  const refreshFn = readModelsSource.match(/function refreshEndDatesReadModel_\(\)\s*\{[\s\S]*?\n\}/);
+  assert.ok(refreshFn, 'refreshEndDatesReadModel_ function exists');
+  assert.match(refreshFn[0], /return buildEndDatesPayload_\(\);/);
+  assert.doesNotMatch(refreshFn[0], /actionEndDates_/);
+  assert.match(readModelsSource, /if \(key === 'end-dates'\) return function\(\) \{ return actionEndDates_\(user\); \};/);
+  assert.match(readModelsSource, /function refreshAllReadModels_/);
+  assert.equal((readModelsSource.match(/function refreshAllReadModels_/g) || []).length, 1);
+});
+
+test('actionEndDates_ remains protected and delegates to payload builder', () => {
+  const actionsSource = fs.readFileSync(new URL('../backend/actions.gs', import.meta.url), 'utf8');
+  assert.match(actionsSource, /function buildEndDatesPayload_\(\)/);
+  assert.match(actionsSource, /function actionEndDates_\(user\)\s*\{[\s\S]*requireAnyRole_\([^)]*'authorized_user'[^)]*\)[\s\S]*endDatesViewYes_\([\s\S]*throw new Error\('Forbidden'\)[\s\S]*return buildEndDatesPayload_\(\);[\s\S]*\}/);
 });
 
 test('materializeScreenDataFromReadModel supports adjacent week/month and keeps outer fallback', () => {


### PR DESCRIPTION
### Motivation
- Production read-model batch was missing adjacent week/month refreshes and reported a low `model_count` because the refresh flow was outdated.  
- `end-dates` internal refresh failed with `Forbidden` because it invoked the public permission-protected route instead of an internal builder.  
- A verifiable version marker was required so production can be validated after deploy.  
- Ensure there is only one `refreshAllReadModels_` definition and keep user-facing permission checks intact for API routes.  

### Description
- Added an internal payload builder `buildEndDatesPayload_()` in `backend/actions.gs` and made `actionEndDates_(user)` delegate to it while preserving permission checks.  
- Updated `refreshEndDatesReadModel_()` in `backend/read-models.gs` to call `buildEndDatesPayload_()` directly so internal refresh bypasses the public permission path.  
- Inserted a version marker log at the start of `refreshAllReadModels_()`: `console.info('[read_models] refreshAllReadModels_version', 'adjacent-week-month-v2');`.  
- Confirmed `refreshAllReadModels_()` includes adjacent week offsets (`-1, 0, 1`) and month previous/current/next via `shiftYm_()`.  
- Updated tests in `tests/read-model-hardening.test.mjs` to assert the version marker, adjacent refresh calls, internal end-dates builder usage, that `actionEndDates_` remains protected, and that there is a single `refreshAllReadModels_` definition.  
- Files changed: `backend/actions.gs`, `backend/read-models.gs`, `tests/read-model-hardening.test.mjs`.  

### Testing
- Ran targeted unit tests with `node --test tests/read-model-hardening.test.mjs tests/api-mutations.test.mjs` and the targeted suite passed (all relevant tests for read-model hardening and API mutations succeeded).  
- Running the full test script via `npm test` earlier exercised the whole test suite and surfaced unrelated pre-existing failures in other tests; those are not caused by this change.  
- The added/updated tests specifically asserting: adjacent week/month refreshes, the version log, internal `end-dates` builder usage for refresh, and preserved `actionEndDates_` permission checks all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54ff4b6d0832b98ec79dbd0cef669)