### PR TITLE
Count course exceptions by course row

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -146,12 +146,14 @@ function computeExceptionsModel_(rows, ym, opts) {
     if (!byManager[manager]) byManager[manager] = 0;
 
     totalExceptionRows += 1;
-    byManager[manager] += types.length;
+    byManager[manager] += 1;
 
     types.forEach(function(type) {
       if (!counts[type]) counts[type] = 0;
       counts[type] += 1;
-      if (!includeRows) return;
+    });
+
+    if (includeRows) {
       exceptionRows.push({
         RowID: text_(row && row.RowID),
         source_sheet: text_(row && row.source_sheet),
@@ -173,9 +175,12 @@ function computeExceptionsModel_(rows, ym, opts) {
         end_date: row && row.end_date,
         sessions: row && row.sessions,
         notes: row && row.notes,
-        exception_type: type
+        exception_type: types[0] || '',
+        exception_types: types.slice(),
+        exception_count: types.length,
+        has_multiple_exceptions: types.length > 1 ? 'yes' : 'no'
       });
-    });
+    }
 
     if (includeDebug && sampleRows.length < 25) {
       sampleRows.push({
@@ -528,7 +533,7 @@ function actionDiagnosticsConsistency_(user, payload) {
     Logger.log('finished exceptions + duration=' + timings.exceptionsMs + 'ms');
     guardRuntime_('after_getExceptionsSummary_');
 
-    var exceptionsTotal = Number(exceptionSummary.totalExceptionInstances || 0);
+    var exceptionsTotal = Number(exceptionSummary.totalExceptionRows || 0);
     var byManager = exceptionSummary.byManager || {};
     var sumByManager = Object.keys(byManager).reduce(function(sum, manager) {
       return sum + Number(byManager[manager] || 0);
@@ -574,7 +579,8 @@ function actionDiagnosticsConsistency_(user, payload) {
       month: month,
       dashboard: dashboard,
       exceptions: {
-        totalExceptionInstances: exceptionsTotal,
+        totalExceptionRows: exceptionsTotal,
+        totalExceptionInstances: Number(exceptionSummary.totalExceptionInstances || 0),
         byManager: byManager,
         sumByManager: sumByManager
       },
@@ -603,8 +609,8 @@ function actionDiagnosticsConsistency_(user, payload) {
       diagnostics.mismatches.push(mismatch);
     }
 
-    if (dashboard.exceptions_count !== diagnostics.exceptions.totalExceptionInstances) {
-      pushMismatch_('exceptions_count', dashboard.exceptions_count, diagnostics.exceptions.totalExceptionInstances, 'exceptions_direct', 'getExceptionsSummary_');
+    if (dashboard.exceptions_count !== diagnostics.exceptions.totalExceptionRows) {
+      pushMismatch_('exceptions_count', dashboard.exceptions_count, diagnostics.exceptions.totalExceptionRows, 'exceptions_direct', 'getExceptionsSummary_');
     }
     if (dashboard.exceptions_count !== diagnostics.exceptions.sumByManager) {
       pushMismatch_('exceptions_count_vs_byManager_sum', dashboard.exceptions_count, diagnostics.exceptions.sumByManager, 'exceptions_direct.byManager', 'computeExceptionsModel_');
@@ -836,7 +842,7 @@ function actionDashboard_(user, payload) {
   missingInstructorCount = exceptionSummary.counts.missing_instructor || 0;
   missingStartDateCount = exceptionSummary.counts.missing_start_date || 0;
   lateEndDateCount = exceptionSummary.counts.late_end_date || 0;
-  var exceptionSum = exceptionSummary.totalExceptionInstances || 0;
+  var exceptionSum = exceptionSummary.totalExceptionRows || 0;
 
   var shortActivitiesByType = {};
   shortRowsBySource.forEach(function(row) {

--- a/backend/views.gs
+++ b/backend/views.gs
@@ -313,7 +313,7 @@ function buildViewDashboardMonthlyRows_(activitiesSummaryRows, meetingsViewRows)
 
     var monthExceptionSummary = computeExceptionsModel_(monthActivities, ym, { include_rows: false });
     managerExceptions = monthExceptionSummary.byManager || {};
-    primaryExceptionRowCount = monthExceptionSummary.totalExceptionInstances || 0;
+    primaryExceptionRowCount = monthExceptionSummary.totalExceptionRows || 0;
 
     monthMeetings.forEach(function(row) {
       var i1 = text_(row.instructor_name || row.emp_id);

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -60,8 +60,8 @@ function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, 
 }
 
 function exceptionDrawerHtml(row, hideRowId) {
-  const et = String(row.exception_type || '').trim();
-  const typeChip = dsStatusChip(hebrewExceptionType(et), 'neutral');
+  const exceptionTypes = Array.isArray(row.exception_types) ? row.exception_types : [row.exception_type].filter(Boolean);
+  const chips = exceptionTypes.map((et) => dsStatusChip(hebrewExceptionType(String(et || '').trim()), 'neutral')).join(' ');
 
   const instructor  = row.instructor_name  || '';
   const instructor2 = row.instructor_name_2 || '';
@@ -73,7 +73,7 @@ function exceptionDrawerHtml(row, hideRowId) {
 
   return `<div class="ds-details-grid" dir="rtl">
     ${hideRowId ? '' : `<p><strong>${escapeHtml(hebrewColumn('RowID'))}:</strong> ${escapeHtml(String(row.RowID || '—'))}</p>`}
-    <p><strong>סוג חריגה:</strong> ${typeChip}</p>
+    <p><strong>סוגי חריגה:</strong> ${chips || "—"}</p>
     ${fieldRow(hebrewColumn('activity_name'),    row.activity_name)}
     ${fieldRow(hebrewColumn('activity_type'),    row.activity_type)}
     ${fieldRow(hebrewColumn('authority'),        row.authority)}
@@ -103,7 +103,7 @@ export const exceptionsScreen = {
     const rawRows   = Array.isArray(data?.rows) ? data.rows : [];
     const allRows   = rawRows.filter((row) => String(row?.activity_type || '').trim() === 'course');
     const filterState = ensureActivityListFilters(state, EXCEPTIONS_SCOPE);
-    prepareRowsForSearch(allRows, ['RowID', 'activity_name', 'activity_manager', 'authority', 'school', 'funding', 'exception_type']);
+    prepareRowsForSearch(allRows, ['RowID', 'activity_name', 'activity_manager', 'authority', 'school', 'funding', 'exception_type', 'exception_types']);
     const filteredRows = applyLocalFilters(allRows, filterState, { filterFields: EXCEPTION_FILTER_FIELDS });
     const { visible: visibleRows, hasMore, nextCount, total } = splitVisibleRows(filteredRows, filterState);
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
@@ -126,12 +126,15 @@ export const exceptionsScreen = {
               const subtitleHtml  = subtitleParts.length
                 ? `<p class="ds-interactive-card__subtitle">${escapeHtml(subtitleParts.join(' · '))}</p>`
                 : '';
-              const chipHtml = `<p class="ds-interactive-card__meta">${dsStatusChip(hebrewExceptionType(et), 'neutral')}</p>`;
+              const exTypes = Array.isArray(row.exception_types) ? row.exception_types : [et].filter(Boolean);
+              const chips = exTypes.map((type) => dsStatusChip(hebrewExceptionType(type), 'neutral')).join(' ');
+              const multiBadge = exTypes.length > 1 ? `<span class="ds-badge">${escapeHtml(String(exTypes.length))} חריגות</span>` : '';
+              const chipHtml = `<p class="ds-interactive-card__meta">${chips} ${multiBadge}</p>`;
 
               return `<div data-list-item>
                 <button type="button"
                   class="ds-interactive-card ds-interactive-card--session"
-                  data-card-action="${escapeHtml(`exception:${row.RowID}:${row.exception_type || ''}`)}">
+                  data-card-action="${escapeHtml(`exception:${row.RowID}`)}">
                   <p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p>
                   ${subtitleHtml}
                   ${chipHtml}
@@ -143,7 +146,7 @@ export const exceptionsScreen = {
     return dsScreenStack(`
       ${toolbarHtml}
       <section class="ds-screen-compact-90">${dsCard({
-        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''} · סה״כ חריגות: ${escapeHtml(String(data?.totalExceptionInstances ?? total))}`,
+        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''} · סה״כ חריגות: ${escapeHtml(String(data?.totalExceptionRows ?? total))}`,
         body: compact,
         padded: visibleRows.length === 0
       })}</section>
@@ -197,9 +200,11 @@ export const exceptionsScreen = {
     }
 
     function exceptionTypeHeader(summaryRow) {
-      const et = String(summaryRow?.exception_type || '').trim();
-      if (!et) return '';
-      return `<div style="margin-bottom:10px;direction:rtl">${dsStatusChip(hebrewExceptionType(et), 'neutral')}</div>`;
+      const exTypes = Array.isArray(summaryRow?.exception_types) ? summaryRow.exception_types : [summaryRow?.exception_type].filter(Boolean);
+      if (!exTypes.length) return '';
+      const chips = exTypes.map((et) => dsStatusChip(hebrewExceptionType(String(et || '').trim()), 'neutral')).join(' ');
+      const multiBadge = exTypes.length > 1 ? `<span class="ds-badge">${escapeHtml(String(exTypes.length))} חריגות</span>` : '';
+      return `<div style="margin-bottom:10px;direction:rtl">${chips} ${multiBadge}</div>`;
     }
 
     async function openActivityDetail(summaryRow) {
@@ -263,16 +268,8 @@ export const exceptionsScreen = {
 
     ui?.bindInteractiveCards(root, (action) => {
       if (!action.startsWith('exception:')) return;
-      // Action format: "exception:<RowID>:<exception_type>"
-      // RowID may itself contain ":" only in legacy formats; exception_type never does.
-      const rest = action.slice('exception:'.length);
-      const lastColon = rest.lastIndexOf(':');
-      const rowId  = lastColon >= 0 ? rest.slice(0, lastColon) : rest;
-      const exType = lastColon >= 0 ? rest.slice(lastColon + 1) : '';
-      const idx = allRows.findIndex((row) =>
-        String(row.RowID) === rowId &&
-        (!exType || String(row.exception_type || '') === exType)
-      );
+      const rowId = action.slice('exception:'.length);
+      const idx = allRows.findIndex((row) => String(row.RowID) === rowId);
       openAt(idx);
     });
   }

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -68,14 +68,15 @@ function computeExceptionsModel(sourceRows, ym, opts) {
     const manager = String(row.activity_manager || '') || 'unassigned';
     if (!byManager[manager]) byManager[manager] = 0;
     totalExceptionRows += 1;
-    byManager[manager] += types.length;
+    byManager[manager] += 1;
 
     types.forEach((type) => {
       if (!counts[type]) counts[type] = 0;
       counts[type] += 1;
-      if (!includeRows) return;
-      exceptionRows.push({ RowID: String(row.RowID || ''), activity_type: row.activity_type, exception_type: type });
     });
+    if (includeRows) {
+      exceptionRows.push({ RowID: String(row.RowID || ''), activity_type: row.activity_type, exception_type: types[0] || '', exception_types: types.slice() });
+    }
   });
 
   const totalExceptionInstances = counts.missing_instructor + counts.missing_start_date + counts.late_end_date;
@@ -160,15 +161,13 @@ const rowOutOfMonth = {
 
 // ─── Numeric tests ────────────────────────────────────────────────────────────
 
-test('activity with all 3 exception types produces 3 exception instances', () => {
+test('activity with all 3 exception types counts as one row and keeps details', () => {
   const result = computeExceptionsModel([rowAllThree], '', { include_rows: true });
   assert.equal(result.totalExceptionInstances, 3,
     'one activity with missing_instructor + missing_start_date + late_end_date → 3 instances');
-  assert.equal(result.rows.length, 3, 'should produce 3 rows (one per exception type)');
-  const types = result.rows.map((r) => r.exception_type);
-  assert.ok(types.includes('missing_instructor'),  'should include missing_instructor');
-  assert.ok(types.includes('missing_start_date'),  'should include missing_start_date');
-  assert.ok(types.includes('late_end_date'),        'should include late_end_date');
+  assert.equal(result.rows.length, 1, 'should produce one row per course');
+  const types = result.rows[0].exception_types || [];
+  assert.deepEqual(types.sort(), ['late_end_date','missing_instructor','missing_start_date'].sort());
 });
 
 test('activity without start_date (missing_start_date) is included in month-filtered results', () => {
@@ -192,16 +191,14 @@ test('activity outside month with start_date is excluded when month filter is ac
   assert.equal(result.totalExceptionInstances, 0);
 });
 
-test('count by manager is by exception instances not by activity count', () => {
+test('count by manager is by course rows, not instances', () => {
   const allRows = [rowAllThree, rowMissingInstructor];
   const result = computeExceptionsModel(allRows, YM, { include_rows: false });
   // rowAllThree (no start_date): 3 exceptions → mgr_a gets 3
   // rowMissingInstructor: 1 exception → mgr_b gets 1
-  assert.equal(result.byManager['mgr_a'], 3,
-    'mgr_a should count 3 exception instances from rowAllThree');
-  assert.equal(result.byManager['mgr_b'], 1,
-    'mgr_b should count 1 exception instance from rowMissingInstructor');
-  assert.equal(result.totalExceptionInstances, 4);
+  assert.equal(result.byManager['mgr_a'], 1, 'mgr_a should count one problematic course');
+  assert.equal(result.byManager['mgr_b'], 1, 'mgr_b should count one problematic course');
+  assert.equal(result.totalExceptionRows, 2);
 });
 
 test('non-course activities are never included in exceptions', () => {
@@ -231,23 +228,14 @@ test('backend has all 3 exception type keys in counts object', async () => {
   assert.match(src, /late_end_date:\s*0/);
 });
 
-test('frontend exceptions screen uses composite card action (RowID + exception_type)', async () => {
+test('frontend exceptions screen uses single row action by RowID', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
-  assert.match(src, /data-card-action.*exception:\$\{row\.RowID\}:\$\{row\.exception_type/,
-    'card action must include exception_type so cards for same activity are uniquely keyed');
-  assert.doesNotMatch(
-    src,
-    /data-card-action.*`exception:\$\{row\.RowID\}`/,
-    'card action must NOT use RowID-only key (would conflate multiple exception types)'
-  );
+  assert.match(src, /data-card-action.*`exception:\$\{row\.RowID\}`/);
 });
 
-test('frontend bind parses exception_type from card action for correct row lookup', async () => {
+test('frontend bind resolves row by RowID only', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
-  assert.match(src, /lastIndexOf\(':'\)/,
-    'bind must split action by lastIndexOf to extract exception_type');
-  assert.match(src, /row\.exception_type/,
-    'findIndex must compare exception_type');
+  assert.match(src, /findIndex\(\(row\) => String\(row\.RowID\) === rowId\)/);
 });
 
 test('frontend exceptions screen filter fields include exception_type', async () => {
@@ -258,13 +246,13 @@ test('frontend exceptions screen filter fields include exception_type', async ()
     'exception_type filter must use hebrewExceptionType for option labels');
 });
 
-test('frontend exceptions title uses totalExceptionInstances not totalExceptionRows', async () => {
+test('frontend exceptions title uses totalExceptionRows', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
-  assert.match(src, /data\?\.totalExceptionInstances/,
+  assert.match(src, /data\?\.totalExceptionRows/,
     'title count must use totalExceptionInstances from API response');
   assert.doesNotMatch(
     src,
-    /totalExceptionRows.*סה.{0,5}כ חריגות/,
+    /totalExceptionInstances.*סה.{0,5}כ חריגות/,
     'title must not use totalExceptionRows for the count'
   );
 });

--- a/tests/exceptions-single-source.test.mjs
+++ b/tests/exceptions-single-source.test.mjs
@@ -13,6 +13,6 @@ test('dashboard and manager summary read exceptions from shared summary object',
   const source = await fs.readFile(new URL('../backend/actions.gs', import.meta.url), 'utf8');
   assert.match(source, /missingInstructorCount = exceptionSummary\.counts\.missing_instructor \|\| 0;/);
   assert.match(source, /missingStartDateCount = exceptionSummary\.counts\.missing_start_date \|\| 0;/);
-  assert.match(source, /var exceptionSum = exceptionSummary\.totalExceptionInstances \|\| 0;/);
+  assert.match(source, /var exceptionSum = exceptionSummary\.totalExceptionRows \|\| 0;/);
   assert.match(source, /managerExceptions = exceptionSummary\.byManager \|\| \{\};/);
 });


### PR DESCRIPTION
### Motivation
- The exceptions/dashboard logic counted exception *instances*, causing a single problematic course with multiple issue types to be counted multiple times; the dashboard and manager KPIs must instead reflect the number of courses with at least one exception.
- The UI must show one card/row per course and surface multiple exception types on that single card with a badge when applicable.

### Description
- Backend: `computeExceptionsModel_` was changed to increment `byManager[manager]` by `1` per problematic course row and to increment `totalExceptionRows` per course, while preserving per-type `counts` and `totalExceptionInstances` for diagnostics; the returned row object now includes `exception_type` (primary), `exception_types`, `exception_count`, and `has_multiple_exceptions` and only one `rows` entry is emitted per course row.
- Dashboard/Views: dashboard logic now sources the KPI from `totalExceptionRows` (course count) instead of `totalExceptionInstances`, and `views` code uses `totalExceptionRows` for the dashboard summary display.
- Frontend: `frontend/src/screens/exceptions.js` now renders one card per course keyed by `RowID`, shows all exception chips for a course, displays a multiple-issues badge like `"N חריגות"` when >1 type exists, and uses `totalExceptionRows` for the header count.
- Tests: targeted tests were updated to assert row-based counting and multi-type details and to expect the frontend source to use RowID-only card actions and `totalExceptionRows` in the title.

### Testing
- Ran targeted unit tests `tests/exceptions-all-types.test.mjs`, `tests/exceptions-single-source.test.mjs`, and `tests/consistency-stage2b-numeric.test.mjs` with `node --test`, and the updated tests passed (20 tests, all OK).
- A prior full `npm test` run surfaced unrelated pre-existing failures in other areas (external to these changes), but the focused exception/dashboard tests and numeric consistency tests for this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55299a30c832b816bb6e9794e6537)