### PR TITLE
Add end-dates automation trigger to production schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,14 +285,19 @@ npm test
 - `installProductionAutomation()`
 
 הפונקציה:
-- מתקינה trigger ל־`keepWarm` כל 10 דקות.
+- מתקינה trigger ל־`keepWarm` כל 5 דקות.
 - מתקינה trigger ל־`runDataMaintenanceTrigger` כל שעה.
+- מתקינה trigger ל־`refreshAllReadModelsTrigger` כל שעה.
+- מתקינה trigger ל־`refreshDataViewsTrigger` כל שעה.
+- מתקינה trigger ל־`refreshActivitiesSnapshotTrigger` כל 10 דקות.
+- מתקינה trigger ל־`refreshDashboardSnapshotsTrigger` כל 10 דקות.
+- מתקינה trigger ל־`syncEndDatesTrigger` כל שעה (כולל רענון אוטומטי של עמוד תאריכי סיום).
 - מוחקת/מחליפה טריגרים קיימים לאותן פונקציות כדי למנוע כפילויות.
-- לא מתקינה `refreshAllReadModelsTrigger` כברירת מחדל (כי `READ_MODELS_ENABLED` בפרונט כבוי).
 
 לאחר ההתקנה אין צורך בהרצות ידניות שוטפות של:
 - `runRefreshDataViewsManually`
 - `runDataMaintenance`
+- `syncEndDates`
 
 לבדיקת מצב האוטומציה:
 - `getProductionAutomationStatus()`
@@ -300,6 +305,11 @@ npm test
 מה אמור להופיע במסך Triggers:
 - trigger אחד עבור `keepWarm` (Time-driven).
 - trigger אחד עבור `runDataMaintenanceTrigger` (Time-driven).
+- trigger אחד עבור `refreshAllReadModelsTrigger` (Time-driven).
+- trigger אחד עבור `refreshDataViewsTrigger` (Time-driven).
+- trigger אחד עבור `refreshActivitiesSnapshotTrigger` (Time-driven).
+- trigger אחד עבור `refreshDashboardSnapshotsTrigger` (Time-driven).
+- trigger אחד עבור `syncEndDatesTrigger` (Time-driven).
 - בלי כפילויות עבור אותן פונקציות.
 
 ## Cache וביצועים

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -51,6 +51,25 @@ function runDataMaintenanceTrigger() {
   runDataMaintenance_('time_trigger');
 }
 
+function syncEndDatesTrigger() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(1000)) {
+    console.info('[end_dates] skipped: lock busy');
+    return { skipped: true, reason: 'lock_busy' };
+  }
+  try {
+    if (typeof actionSyncEndDates_ === 'function') {
+      return actionSyncEndDates_({ user_id: 'end_dates_trigger', display_role: 'admin' }, {});
+    }
+    if (typeof refreshEndDatesReadModel_ === 'function') {
+      return refreshEndDatesReadModel_();
+    }
+    return { skipped: true, reason: 'no_end_dates_refresh_function' };
+  } finally {
+    lock.releaseLock();
+  }
+}
+
 function installDataMaintenanceTrigger() {
   var triggers = ScriptApp.getProjectTriggers();
   var exists = triggers.some(function(t) {
@@ -76,6 +95,18 @@ function installProductionAutomation() {
     }},
     { handler: 'refreshAllReadModelsTrigger', frequency: 'hourly', install: function() {
       ScriptApp.newTrigger('refreshAllReadModelsTrigger').timeBased().everyHours(1).create();
+    }},
+    { handler: 'refreshDataViewsTrigger', frequency: 'hourly', install: function() {
+      ScriptApp.newTrigger('refreshDataViewsTrigger').timeBased().everyHours(1).create();
+    }},
+    { handler: 'refreshActivitiesSnapshotTrigger', frequency: 'every_10_minutes', install: function() {
+      ScriptApp.newTrigger('refreshActivitiesSnapshotTrigger').timeBased().everyMinutes(10).create();
+    }},
+    { handler: 'refreshDashboardSnapshotsTrigger', frequency: 'every_10_minutes', install: function() {
+      ScriptApp.newTrigger('refreshDashboardSnapshotsTrigger').timeBased().everyMinutes(10).create();
+    }},
+    { handler: 'syncEndDatesTrigger', frequency: 'hourly', install: function() {
+      ScriptApp.newTrigger('syncEndDatesTrigger').timeBased().everyHours(1).create();
     }}
   ];
   var existing = ScriptApp.getProjectTriggers();
@@ -123,6 +154,10 @@ function installProductionAutomation() {
   return result;
 }
 
+function ensureProductionAutomationTriggers_() {
+  return installProductionAutomation();
+}
+
 function getProductionAutomationStatus() {
   var triggers = ScriptApp.getProjectTriggers();
   var byHandler = {};
@@ -147,12 +182,23 @@ function getProductionAutomationStatus() {
   var keepWarm = summarize('keepWarm', 'every_5_minutes');
   var maintenance = summarize('runDataMaintenanceTrigger', 'hourly');
   var readModels = summarize('refreshAllReadModelsTrigger', 'hourly');
+  var dataViews = summarize('refreshDataViewsTrigger', 'hourly');
+  var activitiesSnapshot = summarize('refreshActivitiesSnapshotTrigger', 'every_10_minutes');
+  var dashboardSnapshots = summarize('refreshDashboardSnapshotsTrigger', 'every_10_minutes');
+  var endDates = summarize('syncEndDatesTrigger', 'hourly');
+  var workbookRepair = summarize('repairSystemWorkbookStructureTrigger', 'daily_optional');
   var hasDuplicates =
-    keepWarm.duplicate || maintenance.duplicate || readModels.duplicate;
+    keepWarm.duplicate || maintenance.duplicate || readModels.duplicate ||
+    dataViews.duplicate || activitiesSnapshot.duplicate || dashboardSnapshots.duplicate ||
+    endDates.duplicate || workbookRepair.duplicate;
   var missing = [];
   if (!keepWarm.exists) missing.push('keepWarm');
   if (!maintenance.exists) missing.push('runDataMaintenanceTrigger');
   if (!readModels.exists) missing.push('refreshAllReadModelsTrigger');
+  if (!dataViews.exists) missing.push('refreshDataViewsTrigger');
+  if (!activitiesSnapshot.exists) missing.push('refreshActivitiesSnapshotTrigger');
+  if (!dashboardSnapshots.exists) missing.push('refreshDashboardSnapshotsTrigger');
+  if (!endDates.exists) missing.push('syncEndDatesTrigger');
 
   var recommendation = missing.length === 0 && !hasDuplicates
     ? 'automation_is_healthy'
@@ -162,6 +208,11 @@ function getProductionAutomationStatus() {
     keepWarm: keepWarm,
     runDataMaintenanceTrigger: maintenance,
     refreshAllReadModelsTrigger: readModels,
+    refreshDataViewsTrigger: dataViews,
+    refreshActivitiesSnapshotTrigger: activitiesSnapshot,
+    refreshDashboardSnapshotsTrigger: dashboardSnapshots,
+    syncEndDatesTrigger: endDates,
+    repairSystemWorkbookStructureTrigger: workbookRepair,
     duplicates_detected: hasDuplicates,
     missing_handlers: missing,
     recommendation: recommendation

--- a/tests/api-mutations.test.mjs
+++ b/tests/api-mutations.test.mjs
@@ -113,10 +113,12 @@ test('api mutation cache invalidation map includes required keys', async () => {
 test('read-model rollout excludes finance from normal paths and keeps end-dates', async () => {
   const fs = await import('node:fs/promises');
   const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  const mainSource = await fs.readFile(new URL('../frontend/src/main.js', import.meta.url), 'utf8');
   assert.match(source, /const READ_MODELS_ENABLED = true/);
   assert.match(source, /READ_MODEL_ENABLED_KEY_LIST\s*=\s*\[[^\]]*'week'[^\]]*'month'[^\]]*'exceptions'[^\]]*'end-dates'[^\]]*\]/);
   assert.doesNotMatch(source, /READ_MODEL_ENABLED_KEY_LIST\s*=\s*\[[^\]]*'finance'[^\]]*\]/);
   assert.match(source, /endDates:\s*\(options\)\s*=>\s*requestReadModel\('end-dates'/);
+  assert.match(mainSource, /const screenLoaders = \{[\s\S]*'end-dates': \(\) => import\('\.\/screens\/end-dates\.js'\)/);
 });
 
 test('perf request marks slow=true for API calls longer than 3000ms', async () => {

--- a/tests/production-automation.test.mjs
+++ b/tests/production-automation.test.mjs
@@ -10,11 +10,15 @@ test('production automation entrypoints exist', async () => {
   assert.match(source, /function\s+getProductionAutomationStatus\s*\(/);
 });
 
-test('installProductionAutomation installs keepWarm, maintenance, and read models triggers', async () => {
+test('installProductionAutomation installs required production automation triggers including end-dates', async () => {
   const source = await readFile(CODE_GS, 'utf8');
   assert.match(source, /newTrigger\('keepWarm'\)[\s\S]*everyMinutes\(5\)/);
   assert.match(source, /newTrigger\('runDataMaintenanceTrigger'\)[\s\S]*everyHours\(1\)/);
   assert.match(source, /newTrigger\('refreshAllReadModelsTrigger'\)[\s\S]*everyHours\(1\)/);
+  assert.match(source, /newTrigger\('refreshDataViewsTrigger'\)[\s\S]*everyHours\(1\)/);
+  assert.match(source, /newTrigger\('refreshActivitiesSnapshotTrigger'\)[\s\S]*everyMinutes\(10\)/);
+  assert.match(source, /newTrigger\('refreshDashboardSnapshotsTrigger'\)[\s\S]*everyMinutes\(10\)/);
+  assert.match(source, /newTrigger\('syncEndDatesTrigger'\)[\s\S]*everyHours\(1\)/);
 });
 
 test('installProductionAutomation avoids duplicate triggers by replacing existing ones', async () => {
@@ -28,4 +32,11 @@ test('read models trigger can be normalized to hourly via installReadModelsTrigg
   assert.match(source, /function\s+installReadModelsTriggers\s*\(/);
   assert.match(source, /function\s+ensureReadModelsRefreshTrigger_\s*\(/);
   assert.match(source, /newTrigger\('refreshAllReadModelsTrigger'\)[\s\S]*everyHours\(1\)/);
+});
+
+test('production automation status includes end-dates trigger health', async () => {
+  const source = await readFile(CODE_GS, 'utf8');
+  assert.match(source, /var endDates = summarize\('syncEndDatesTrigger', 'hourly'\)/);
+  assert.match(source, /syncEndDatesTrigger: endDates/);
+  assert.match(source, /if \(!endDates\.exists\) missing\.push\('syncEndDatesTrigger'\)/);
 });

--- a/tests/read-model-hardening.test.mjs
+++ b/tests/read-model-hardening.test.mjs
@@ -27,6 +27,7 @@ test('read-model refresh batch includes adjacent week and month models', () => {
   assert.match(readModelsSource, /refreshMonthReadModelForYm_\(shiftYm_\(curYm, -1\)\)/);
   assert.match(readModelsSource, /refreshMonthReadModelForYm_\(curYm\)/);
   assert.match(readModelsSource, /refreshMonthReadModelForYm_\(shiftYm_\(curYm, 1\)\)/);
+  assert.match(readModelsSource, /refreshEndDatesReadModel_\(\)/);
 });
 
 test('end-dates refresh uses internal payload builder and api action keeps permission checks', () => {


### PR DESCRIPTION
### Motivation

- Ensure the End Dates page stays up-to-date automatically by adding a scheduled trigger so `end-dates` read models are refreshed without manual intervention. 
- Keep End Dates as an active, non-finance read-model and avoid reintroducing finance into the read-model refresh path. 

### Description

- Added a dedicated hourly entrypoint `syncEndDatesTrigger()` with a script lock and fallback behavior that calls `actionSyncEndDates_` if present or `refreshEndDatesReadModel_` otherwise. 
- Extended `installProductionAutomation()` to install a fuller production trigger set including `refreshDataViewsTrigger`, `refreshActivitiesSnapshotTrigger`, `refreshDashboardSnapshotsTrigger`, and `syncEndDatesTrigger` (plus existing `keepWarm`, `runDataMaintenanceTrigger`, `refreshAllReadModelsTrigger`). 
- Added `ensureProductionAutomationTriggers_()` wrapper and expanded `getProductionAutomationStatus()` to report health for `syncEndDatesTrigger` and the other production triggers. 
- Updated tests and docs to cover the new automation: updated/added assertions in `tests/production-automation.test.mjs`, `tests/read-model-hardening.test.mjs`, and `tests/api-mutations.test.mjs`, and updated `README.md` automation documentation. 

### Testing

- Ran `npm test`; the new/updated automation and read-model assertions passed (production automation/read-model tests succeeded). 
- The full test run surfaced unrelated pre-existing failures in other suites (some `consistency` tests), so overall `npm test` completed with failures not caused by these changes. 
- Verified `refreshAllReadModels_` still calls `refreshEndDatesReadModel_` and the frontend `READ_MODEL_ENABLED_KEY_LIST` and `screenLoaders` retain `end-dates` while `finance` remains excluded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5626f46e4832b82267dd69c40bc7d)