### PR TITLE
config: update Apps Script API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@
 ```html
 <script>
   window.__DASHBOARD_CONFIG__ = {
-    apiUrl: 'https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec'
+    apiUrl: 'https://script.google.com/macros/s/AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu/exec'
   };
 </script>
 ```
@@ -189,7 +189,7 @@
 לבדיקות:
 
 ```text
-http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec
+http://localhost:5000/?apiUrl=https://script.google.com/macros/s/AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu/exec
 ```
 
 ### 3. DEFAULT_API_URL

--- a/docs/architecture/read-models-stage0-real-baseline.md
+++ b/docs/architecture/read-models-stage0-real-baseline.md
@@ -1,7 +1,7 @@
 # Stage 0B Real Environment Baseline (Blocked)
 
 - Generated at (UTC): 2026-04-25T23:02:46.813Z
-- API URL: https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec
+- API URL: https://script.google.com/macros/s/AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu/exec
 - Samples per screen requested: 20
 
 ## Status

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -19,7 +19,7 @@ const runtimeConfig = (typeof globalThis !== 'undefined' && globalThis.__DASHBOA
  * ניתן לדרוס ב-`window.__DASHBOARD_CONFIG__.apiUrl` או ב-`?apiUrl=` בלא שינוי קוד.
  */
 const DEFAULT_API_URL =
-  'https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec';
+  'https://script.google.com/macros/s/AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu/exec';
 
 function resolveApiUrl() {
   if (runtimeConfig.apiUrl) return String(runtimeConfig.apiUrl).trim();

--- a/replit.md
+++ b/replit.md
@@ -11,7 +11,7 @@ Preserve: RTL, Hebrew, dark shell + light panels. Communication with user: Hebre
 ## Key identifiers
 - `SPREADSHEET_ID = '1odLLnhpm7gLwSsDrgzxjIy2cuHXZGNNQYXCkuhAt52s'`
 - GAS deployment URL (DEFAULT_API_URL in `frontend/src/config.js`):
-  `AKfycbysqMOYDnPXDeTiU1R0qBr5Kp84E_q2m6kkMVk6CLXZX9akgvE4zKGPmm_h7CJjfnys`
+  `AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu`
 
 ## Test suite
 - `node --test tests/*.test.mjs`

--- a/scripts/collect_baseline_stage0_real.mjs
+++ b/scripts/collect_baseline_stage0_real.mjs
@@ -11,7 +11,7 @@ import { instructorsScreen } from '../frontend/src/screens/instructors.js';
 import { contactsScreen } from '../frontend/src/screens/contacts.js';
 import { endDatesScreen } from '../frontend/src/screens/end-dates.js';
 
-const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbw0MssmmGZyjGBW41AhKHSjaOWOmJhUle9O3CJRBMVGXjzqcYpZHZibBkml2wRGz1dr/exec';
+const API_URL = process.env.DASHBOARD_API_URL || 'https://script.google.com/macros/s/AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu/exec';
 const USER_ID = process.env.DASHBOARD_USER_ID || '';
 const ENTRY_CODE = process.env.DASHBOARD_ENTRY_CODE || '';
 const SAMPLES_PER_SCREEN = Number(process.env.STAGE0B_SAMPLES || 20);

--- a/tests/dashboard-load-guard.test.mjs
+++ b/tests/dashboard-load-guard.test.mjs
@@ -52,7 +52,7 @@ test('dashboard load logs perf data on failure', async () => {
 
 test('config.js DEFAULT_API_URL matches the active GAS deployment', async () => {
   const src = await read(CONFIG_FILE);
-  assert.match(src, /AKfycbxGgH1aR9EM8P_v43miHScvvGfHPtjlPhExZYyj_2ridyKwFIoVVdn_mWpPB-__5uXO/,
+  assert.match(src, /AKfycbyxuO4hGXwAvMsR4tljCy-ADBApSY3c6YPWXc17DAzgjzV7-rjgLzir08XvPUN6BGUu/,
     'DEFAULT_API_URL should use the current active GAS deployment URL');
 });
 


### PR DESCRIPTION
### Motivation
- Update the Apps Script API endpoint used by the frontend to the new deployment URL so runtime defaults and documentation point to the active GAS deployment.
- Keep a single source of truth for the API URL in `frontend/src/config.js` and avoid any behavioral or routing changes.
- Remove references to the old hardcoded deployment ID across docs/scripts/tests to prevent accidental use of the outdated endpoint.

### Description
- Set `DEFAULT_API_URL` in `frontend/src/config.js` to the new Apps Script URL.
- Updated runtime examples and documentation in `README.md` and `replit.md` to reference the new URL.
- Updated `scripts/collect_baseline_stage0_real.mjs` and `docs/architecture/read-models-stage0-real-baseline.md` to use the new URL, and adjusted the assertion in `tests/dashboard-load-guard.test.mjs` that validates the active deployment ID.
- No application logic, routes, read models, finance, snapshots or authentication behavior was changed; this is an endpoint-only update.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm test` which produced `144` passing tests and `5` failing tests; the failures are pre-existing read-model/storage-guard issues and are unrelated to this endpoint-only change.
- Verified runtime overrides via `window.__DASHBOARD_CONFIG__.apiUrl` and `?apiUrl=` continue to work and were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5643269fc832b9e475fc1cfefa13e)