### PR TITLE
apps-script: expose workbook maintenance wrappers

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -31,6 +31,22 @@ function refreshDashboardSnapshots() {
   return refreshDashboardSnapshots_();
 }
 
+function refreshDataViews() {
+  return refreshDataViews_();
+}
+
+function refreshActivitiesSnapshot() {
+  return refreshActivitiesSnapshot_();
+}
+
+function ensureSystemWorkbookScaffold() {
+  return ensureSystemWorkbookScaffold_();
+}
+
+function repairSystemWorkbookStructure() {
+  return repairSystemWorkbookStructure_();
+}
+
 /**
  * Time-driven trigger entrypoint for rebuilding dashboard snapshots.
  * Set up as a separate trigger — do not add snapshot logic inside keepWarm.
@@ -154,9 +170,13 @@ function installProductionAutomation() {
   };
   if (typeof ensureSystemWorkbookScaffold_ === 'function') {
     try { result.scaffold = ensureSystemWorkbookScaffold_(); } catch (e) { result.scaffold = { skipped: true, reason: String(e) }; }
+  } else {
+    result.scaffold = { skipped: true, reason: 'missing_function_ensureSystemWorkbookScaffold_' };
   }
   if (typeof repairSystemWorkbookStructure_ === 'function') {
     try { result.repair = repairSystemWorkbookStructure_(); } catch (e2) { result.repair = { skipped: true, reason: String(e2) }; }
+  } else {
+    result.repair = { skipped: true, reason: 'missing_function_repairSystemWorkbookStructure_' };
   }
   [
     { fn: 'refreshDataViews_', label: 'data_views' },

--- a/tests/production-automation.test.mjs
+++ b/tests/production-automation.test.mjs
@@ -10,6 +10,14 @@ test('production automation entrypoints exist', async () => {
   assert.match(source, /function\s+getProductionAutomationStatus\s*\(/);
 });
 
+test('manual workbook and refresh wrappers are publicly exposed', async () => {
+  const source = await readFile(CODE_GS, 'utf8');
+  assert.match(source, /function\s+repairSystemWorkbookStructure\s*\(/);
+  assert.match(source, /function\s+ensureSystemWorkbookScaffold\s*\(/);
+  assert.match(source, /function\s+refreshActivitiesSnapshot\s*\(/);
+  assert.match(source, /function\s+refreshDataViews\s*\(/);
+});
+
 test('installProductionAutomation installs required production automation triggers including end-dates', async () => {
   const source = await readFile(CODE_GS, 'utf8');
   assert.match(source, /newTrigger\('keepWarm'\)[\s\S]*everyMinutes\(5\)/);


### PR DESCRIPTION
### Motivation
- Make key Apps Script maintenance routines available for manual execution from the Apps Script function dropdown by exposing public wrappers (no trailing underscore) for workbook scaffold/repair and refresh flows.
- Harden initial production automation installation so missing internal functions do not leave ambiguous nulls or crash the install flow and instead report `skipped` with a reason.

### Description
- Added public wrapper functions in `backend/Code.gs`: `ensureSystemWorkbookScaffold`, `repairSystemWorkbookStructure`, `refreshDataViews`, and `refreshActivitiesSnapshot` that call the corresponding internal functions with trailing underscores.
- Hardened `installProductionAutomation()` so missing `ensureSystemWorkbookScaffold_` or `repairSystemWorkbookStructure_` produce `{ skipped: true, reason: 'missing_function_...' }` entries in the bootstrap `result` instead of leaving nulls or failing.
- Added assertions in `tests/production-automation.test.mjs` to verify the new public wrappers (`repairSystemWorkbookStructure`, `ensureSystemWorkbookScaffold`, `refreshActivitiesSnapshot`, `refreshDataViews`) are present in `backend/Code.gs`.
- No duplicate public entrypoints were created for functions already public (e.g., `refreshDashboardSnapshots`, `refreshAllReadModels`, `diagnosticsSheetStructure`).

### Testing
- Ran `npm test`, which executed the full test suite; the suite run failed due to pre-existing unrelated failures (5 failing tests) and not because of the added wrappers.
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56ac476d4832bbe2aac4cbf180611)