### PR TITLE
Prevent activities snapshot data loss: metadata, fallback, and stable RowIDs

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -3400,12 +3400,15 @@ function allActivitiesSummary_() {
       list = list.concat(cachedRows);
       return;
     }
-    var rows = readRowsProjected_(sheetName, cols).map(function(row) {
+    var rawRows = readRowsProjected_(sheetName, cols);
+    Logger.log('[activities] source=' + sheetName + ' read_rows=' + rawRows.length);
+    var rows = rawRows.map(function(row) {
       var startIso = normalizeDateTextToIso_(row.start_date) || '';
       var endIso = normalizeDateTextToIso_(row.end_date) || startIso || '';
+      var stableRowId = text_(row.RowID) || ((sheetName === CONFIG.SHEETS.DATA_LONG ? 'LONG-' : 'SHORT-') + text_(row.__row_number));
       return {
         source_sheet: sheetName,
-        RowID: text_(row.RowID),
+        RowID: stableRowId,
         activity_manager: text_(row.activity_manager),
         authority: text_(row.authority),
         school: text_(row.school),
@@ -3441,6 +3444,7 @@ function allActivitiesSummary_() {
   });
 
   enrichRowsWithMeetings_(list);
+  Logger.log('[activities] combined rows before filters=' + list.length);
   if (__rqCache_) {
     __rqCache_.allActivitiesSummary = list;
   }

--- a/backend/activities-snapshot.gs
+++ b/backend/activities-snapshot.gs
@@ -47,9 +47,9 @@ function safeCellValue_(value, fieldName, maxLength) {
  */
 function safeJsonArrayCell_(arr, fieldName, maxLength) {
   maxLength = maxLength || 45000;
-  if (!Array.isArray(arr) || arr.length === 0) return '[]';
+  if (!Array.isArray(arr) || arr.length === 0) return { json: '[]', truncated: false, original_rows_count: 0, kept_rows_count: 0 };
   var full = JSON.stringify(arr);
-  if (full.length <= maxLength) return full;
+  if (full.length <= maxLength) return { json: full, truncated: false, original_rows_count: arr.length, kept_rows_count: arr.length };
   var lo = 0;
   var hi = arr.length;
   while (lo < hi) {
@@ -67,7 +67,7 @@ function safeJsonArrayCell_(arr, fieldName, maxLength) {
     ' kept=' + kept.length + ' rows (' + JSON.stringify(kept).length + ' chars)' +
     ' maxLength=' + maxLength
   );
-  return JSON.stringify(kept);
+  return { json: JSON.stringify(kept), truncated: true, original_rows_count: arr.length, kept_rows_count: kept.length };
 }
 
 function activitiesSnapshotSheetName_() {
@@ -102,10 +102,21 @@ function readActivitiesSnapshotRow_() {
   var sheetName = activitiesSnapshotSheetName_();
   try {
     var rows = readRowsProjected_(sheetName, activitiesSnapshotHeaders_());
-    return rows.find(function(r) { return text_(r.snapshot_key) === 'all'; }) || null;
+    var row = rows.find(function(r) { return text_(r.snapshot_key) === 'all'; }) || null;
+    if (!row) return null;
+    row._rows_meta = parseActivitiesSnapshotJson_(row.rows_meta_json, {});
+    return row;
   } catch (_err) {
     return null;
   }
+}
+
+function isActivitiesSnapshotTruncated_(snap) {
+  var meta = (snap && snap._rows_meta) || parseActivitiesSnapshotJson_(snap && snap.rows_meta_json, {}) || {};
+  if (yesNo_(meta.truncated || 'no') === 'yes') return true;
+  var originalCount = parseInt(meta.original_rows_count, 10);
+  var keptCount = parseInt(meta.kept_rows_count, 10);
+  return originalCount > 0 && keptCount >= 0 && keptCount < originalCount;
 }
 
 function parseActivitiesSnapshotJson_(raw, fallback) {
@@ -267,10 +278,21 @@ function actionActivitiesSnapshotFirst_(user, payload) {
     fallback._activities_fallback_used = true;
     return fallback;
   }
+  if (isActivitiesSnapshotTruncated_(snap)) {
+    Logger.log('[activities_snapshot] truncated rows_json detected; fallback to legacy');
+    var fullFallback = actionActivitiesLegacy_(user, payload || {});
+    fullFallback._is_snapshot = false;
+    fullFallback._activities_fallback_used = true;
+    fullFallback._snapshot_truncated = true;
+    return fullFallback;
+  }
 
   var counts = parseActivitiesSnapshotJson_(snap.activity_type_counts_json, {});
   var rows = parseActivitiesSnapshotJson_(snap.rows_json, []).map(normalizeActivitiesSnapshotRow_);
+  Logger.log('[activities_snapshot] rows before filter=' + rows.length);
   var filtered = filterActivitiesSnapshotRows_(rows, payload || {});
+  Logger.log('[activities_snapshot] rows after filter=' + filtered.length + ' month=' + text_((payload || {}).month || ''));
+  Logger.log('[activities_snapshot] missing RowID rows=' + filtered.filter(function(row) { return !text_(row && row.RowID); }).length);
   var snapStats = activitiesInstructorCoverageStats_(filtered);
 
   var needsFallbackMerge = filtered.some(function(row) {
@@ -318,13 +340,23 @@ function refreshActivitiesSnapshot_() {
 
   try {
     var payload = actionActivitiesLegacy_(SNAPSHOT_ADMIN_USER_, { activity_type: 'all' });
+    Logger.log('[activities_snapshot] read rows data_short=' + text_(payload._data_short_rows_read) + ' data_long=' + text_(payload._data_long_rows_read));
+    Logger.log('[activities_snapshot] payload rows before snapshot=' + (payload.rows || []).length);
     var sheet = ensureActivitiesSnapshotSheet_();
     var now = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), "yyyy-MM-dd'T'HH:mm:ss");
+    var rowsCell = safeJsonArrayCell_(payload.rows || [], 'rows_json');
+    var rowsMeta = {
+      truncated: rowsCell.truncated ? 'yes' : 'no',
+      original_rows_count: rowsCell.original_rows_count,
+      kept_rows_count: rowsCell.kept_rows_count
+    };
+    Logger.log('[activities_snapshot] rows_json truncated=' + rowsMeta.truncated + ' original=' + rowsMeta.original_rows_count + ' kept=' + rowsMeta.kept_rows_count);
     var row = [
       'all',
       now,
       safeCellValue_(payload.activity_type_counts || {}, 'activity_type_counts_json'),
-      safeJsonArrayCell_(payload.rows || [], 'rows_json')
+      rowsCell.json,
+      safeCellValue_(rowsMeta, 'rows_meta_json')
     ];
     sheet.getRange(CONFIG.DATA_START_ROW, 1, 1, activitiesSnapshotHeaders_().length).setValues([row]);
     var lastRow = sheet.getLastRow();

--- a/backend/read-models.gs
+++ b/backend/read-models.gs
@@ -362,7 +362,7 @@ function refreshDashboardReadModel_() {
 
 function refreshActivitiesReadModel_() {
   return refreshSingleReadModel_('activities', {}, function() {
-    return actionActivitiesSnapshotFirst_(READ_MODEL_ADMIN_USER_, { activity_type: 'all' });
+    return actionActivitiesLegacy_(READ_MODEL_ADMIN_USER_, { activity_type: 'all' });
   });
 }
 

--- a/backend/sheet-schema.gs
+++ b/backend/sheet-schema.gs
@@ -111,8 +111,8 @@ function getSystemSheetSchema_() {
   },
   activities_snapshot: {
     sheetName: 'activities_snapshot', required: true, type: 'snapshot',
-    headers: ['snapshot_key','updated_at','activity_type_counts_json','rows_json'],
-    hebrewLabels: ['מפתח snapshot','עודכן בתאריך','ספירות לפי סוג פעילות','שורות פעילות לתצוגה'],
+    headers: ['snapshot_key','updated_at','activity_type_counts_json','rows_json','rows_meta_json'],
+    hebrewLabels: ['מפתח snapshot','עודכן בתאריך','ספירות לפי סוג פעילות','שורות פעילות לתצוגה','מטא נתוני שורות snapshot'],
     dataStartRow: 3, allowExtraColumns: false, preserveExistingData: false, legacyFinanceColumns: false
   },
   read_models: {

--- a/backend/sheets.gs
+++ b/backend/sheets.gs
@@ -189,15 +189,15 @@ function readRowsProjected_(sheetName, projectedHeaders) {
   var readStartMs = perfNowMs_();
   var values = sheet.getRange(dataStart, 1, lastRow - dataStart + 1, maxIdx + 1).getValues();
   var readDurationMs = perfNowMs_() - readStartMs;
-  var projected = values.filter(function(row) {
-    return row.some(function(cell) { return text_(cell) !== ''; });
-  }).map(function(row) {
+  var projected = values.map(function(row, idx) {
+    if (!row.some(function(cell) { return text_(cell) !== ''; })) return null;
     var item = {};
     projectedIndexes.forEach(function(idx) {
       item[headers[idx]] = row[idx];
     });
+    item.__row_number = dataStart + idx;
     return item;
-  });
+  }).filter(Boolean);
   if (__rqCache_) {
     __rqCache_.readRows[cacheKey] = projected;
   }
@@ -243,15 +243,15 @@ function readRows_(sheetName) {
   var values = sheet.getRange(dataStart, 1, lastRow - dataStart + 1, lastCol).getValues();
   var readDurationMs = perfNowMs_() - readStartMs;
 
-  var result = values.filter(function(row) {
-    return row.some(function(cell) { return text_(cell) !== ''; });
-  }).map(function(row) {
+  var result = values.map(function(row, idx) {
+    if (!row.some(function(cell) { return text_(cell) !== ''; })) return null;
     var item = {};
     headers.forEach(function(header, idx) {
       item[header] = row[idx];
     });
+    item.__row_number = dataStart + idx;
     return item;
-  });
+  }).filter(Boolean);
 
   if (__rqCache_) {
     __rqCache_.readRows[cacheKey] = result;

--- a/tests/activities-snapshot-cell-safety.test.mjs
+++ b/tests/activities-snapshot-cell-safety.test.mjs
@@ -62,7 +62,7 @@ test('safeJsonArrayCell_: calls Logger.log on truncation', () => {
 });
 
 test('safeJsonArrayCell_: returns [] for empty input', () => {
-  assert.match(src, /if \(!Array\.isArray\(arr\) \|\| arr\.length === 0\) return '\[\]'/, 'empty-array guard must be present');
+  assert.match(src, /if \(!Array\.isArray\(arr\) \|\| arr\.length === 0\) return \{ json: '\[\]'/, 'empty-array guard must be present');
 });
 
 test('refreshActivitiesSnapshot_: uses safeCellValue_ for activity_type_counts', () => {
@@ -107,9 +107,9 @@ function safeCellValue(value, fieldName, maxLength) {
 
 function safeJsonArrayCell(arr, fieldName, maxLength) {
   maxLength = maxLength || MAX;
-  if (!Array.isArray(arr) || arr.length === 0) return '[]';
+  if (!Array.isArray(arr) || arr.length === 0) return { json: '[]', truncated: false, original_rows_count: 0, kept_rows_count: 0 };
   var full = JSON.stringify(arr);
-  if (full.length <= maxLength) return full;
+  if (full.length <= maxLength) return { json: full, truncated: false, original_rows_count: arr.length, kept_rows_count: arr.length };
   var lo = 0;
   var hi = arr.length;
   while (lo < hi) {
@@ -120,7 +120,7 @@ function safeJsonArrayCell(arr, fieldName, maxLength) {
       hi = mid - 1;
     }
   }
-  return JSON.stringify(arr.slice(0, lo));
+  return { json: JSON.stringify(arr.slice(0, lo)), truncated: true, original_rows_count: arr.length, kept_rows_count: lo };
 }
 
 function bigRow(id) {
@@ -166,25 +166,29 @@ test('sim safeCellValue_: output exactly at limit is NOT truncated', () => {
 
 // --- safeJsonArrayCell simulation tests ---
 
-test('sim safeJsonArrayCell_: empty array returns "[]"', () => {
-  assert.strictEqual(safeJsonArrayCell([], 'test'), '[]');
+test('sim safeJsonArrayCell_: empty array returns metadata with []', () => {
+  const out = safeJsonArrayCell([], 'test');
+  assert.strictEqual(out.json, '[]');
+  assert.equal(out.truncated, false);
 });
 
-test('sim safeJsonArrayCell_: null returns "[]"', () => {
-  assert.strictEqual(safeJsonArrayCell(null, 'test'), '[]');
+test('sim safeJsonArrayCell_: null returns metadata with []', () => {
+  const out = safeJsonArrayCell(null, 'test');
+  assert.strictEqual(out.json, '[]');
+  assert.equal(out.truncated, false);
 });
 
 test('sim safeJsonArrayCell_: small array returned unchanged', () => {
   const arr = [{ id: 1 }, { id: 2 }, { id: 3 }];
   const out = safeJsonArrayCell(arr, 'test');
-  assert.deepStrictEqual(JSON.parse(out), arr);
+  assert.deepStrictEqual(JSON.parse(out.json), arr);
 });
 
 test('sim safeJsonArrayCell_: large array (1000 big rows) output never > HARD_MAX', () => {
   const arr = Array.from({ length: 1000 }, (_, i) => bigRow(i));
   const out = safeJsonArrayCell(arr, 'rows_json');
-  assert.ok(out.length <= HARD_MAX,
-    'safeJsonArrayCell_ result must be <= 50000 chars, got ' + out.length
+  assert.ok(out.json.length <= HARD_MAX,
+    'safeJsonArrayCell_ result must be <= 50000 chars, got ' + out.json.length
   );
 });
 
@@ -192,14 +196,14 @@ test('sim safeJsonArrayCell_: output is always valid JSON', () => {
   const arr = Array.from({ length: 500 }, (_, i) => bigRow(i));
   const out = safeJsonArrayCell(arr, 'rows_json');
   let parsed;
-  assert.doesNotThrow(() => { parsed = JSON.parse(out); }, 'output must be valid JSON');
+  assert.doesNotThrow(() => { parsed = JSON.parse(out.json); }, 'output must be valid JSON');
   assert.ok(Array.isArray(parsed), 'parsed result must be an array');
 });
 
 test('sim safeJsonArrayCell_: kept rows are a prefix of the original array', () => {
   const arr = Array.from({ length: 400 }, (_, i) => bigRow(i));
   const out = safeJsonArrayCell(arr, 'rows_json');
-  const parsed = JSON.parse(out);
+  const parsed = JSON.parse(out.json);
   for (let i = 0; i < parsed.length; i++) {
     assert.strictEqual(parsed[i].RowID, arr[i].RowID,
       'kept rows must be a prefix of the original array'
@@ -210,20 +214,20 @@ test('sim safeJsonArrayCell_: kept rows are a prefix of the original array', () 
 test('sim safeJsonArrayCell_: all rows kept when total fits within limit', () => {
   const arr = Array.from({ length: 10 }, (_, i) => ({ id: i, name: 'row' + i }));
   const out = safeJsonArrayCell(arr, 'rows_json');
-  const parsed = JSON.parse(out);
+  const parsed = JSON.parse(out.json);
   assert.strictEqual(parsed.length, arr.length, 'all rows must be kept when under the limit');
 });
 
 test('sim safeJsonArrayCell_: binary search finds maximum fitting rows', () => {
   const arr = Array.from({ length: 2000 }, (_, i) => bigRow(i));
   const out = safeJsonArrayCell(arr, 'rows_json', 10000);
-  const parsed = JSON.parse(out);
+  const parsed = JSON.parse(out.json);
   // Verify exactly one more row would exceed the limit
   const oneMore = JSON.stringify(arr.slice(0, parsed.length + 1));
   assert.ok(oneMore.length > 10000,
     'adding one more row must exceed the limit (binary search is tight)'
   );
-  assert.ok(out.length <= 10000,
+  assert.ok(out.json.length <= 10000,
     'output must be within the limit'
   );
 });
@@ -236,6 +240,6 @@ test('sim full snapshot write: both cells within HARD_MAX', () => {
   const countsCell = safeCellValue(payload.activity_type_counts, 'activity_type_counts_json');
   const rowsCell   = safeJsonArrayCell(payload.rows, 'rows_json');
   assert.ok(countsCell.length <= HARD_MAX, 'activity_type_counts_json must be <= 50000 chars');
-  assert.ok(rowsCell.length   <= HARD_MAX, 'rows_json must be <= 50000 chars');
-  assert.doesNotThrow(() => JSON.parse(rowsCell), 'rows_json must remain valid JSON');
+  assert.ok(rowsCell.json.length   <= HARD_MAX, 'rows_json must be <= 50000 chars');
+  assert.doesNotThrow(() => JSON.parse(rowsCell.json), 'rows_json must remain valid JSON');
 });


### PR DESCRIPTION
### Motivation
- Prevent silent data loss when `activities_snapshot.rows_json` is too large for a single Sheets cell and ensure the UI never uses a truncated snapshot as authoritative data.
- Make read-model refresh resilient so a truncated snapshot cannot poison the Drive read-model payload.
- Provide stable row identifiers and diagnostic logs so missing `RowID` and row-count regressions are detectable and reproducible.

### Description
- Change `safeJsonArrayCell_` to return an object `{ json, truncated, original_rows_count, kept_rows_count }` instead of just the JSON string, and keep `safeCellValue_` behavior for simple cells (`backend/activities-snapshot.gs`).
- Add `rows_meta_json` column to the `activities_snapshot` sheet schema and persist snapshot metadata when writing the snapshot in `refreshActivitiesSnapshot_` (`backend/sheet-schema.gs`, `backend/activities-snapshot.gs`).
- Detect truncated snapshots via `isActivitiesSnapshotTruncated_` and make `actionActivitiesSnapshotFirst_` immediately fall back to `actionActivitiesLegacy_` when the snapshot is truncated, avoiding use of partial rows; add logging for row counts, truncation state and missing `RowID`s (`backend/activities-snapshot.gs`).
- Build the activities read-model from the full legacy path by switching `refreshActivitiesReadModel_` to call `actionActivitiesLegacy_` (instead of snapshot-first), preventing truncated snapshots from being persisted into read-model storage (`backend/read-models.gs`).
- Add stable physical row numbering (`__row_number`) in `readRows_` and `readRowsProjected_` and use it to synthesize stable fallback `RowID`s (`SHORT-<row_number>` / `LONG-<row_number>`) when `RowID` is missing (`backend/sheets.gs`, `backend/actions.gs`).
- Add diagnostic `Logger.log` entries for source read counts and combined row counts so drops can be traced (`backend/actions.gs`, `backend/activities-snapshot.gs`).
- Update unit tests that simulate `safeJsonArrayCell_` so they follow the new metadata contract and validate the JSON part remains valid (`tests/activities-snapshot-cell-safety.test.mjs`).

### Testing
- Ran the snapshot-safety and read-model hardening tests with `node --test tests/activities-snapshot-cell-safety.test.mjs tests/read-model-hardening.test.mjs` and they passed. 
- Executed the modified test suite and verified the `safeJsonArrayCell_` simulation asserts JSON validity and metadata (`tests/activities-snapshot-cell-safety.test.mjs`), and read-model tests validated the `refreshActivitiesReadModel_` change; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f589b6e468832bbdc0e2900f02f35f)