### PR TITLE
perf: block implicit heavy legacy fallback and decouple write path from sync snapshot refresh

### DIFF
--- a/backend/router.gs
+++ b/backend/router.gs
@@ -11,6 +11,33 @@ function handleGet_() {
   });
 }
 
+
+function shouldAllowLegacyFallbackForHeavyAction_(action, payload, user) {
+  var a = text_(action);
+  var heavy = {
+    dashboard: true,
+    dashboardSnapshot: true,
+    month: true,
+    week: true,
+    activities: true,
+    exceptions: true,
+    endDates: true
+  };
+  if (!heavy[a]) return true;
+  var forceLegacy = yesNo_(payload && payload.force_legacy) === 'yes' || payload && payload.force_legacy === true;
+  var debugEnabled = yesNo_(payload && payload.debug) === 'yes' || yesNo_(payload && payload.debug_perf) === 'yes';
+  var isAdmin = !!(user && (user.display_role === 'admin' || user.display_role === 'operation_manager'));
+  if (forceLegacy || debugEnabled) {
+    try { console.warn('[perf][legacy_fallback_explicit]', JSON.stringify({ action: a, force_legacy: !!forceLegacy, debug: !!debugEnabled, is_admin: !!isAdmin })); } catch (_e) {}
+    setRequestPerfField_('legacy_fallback_explicit', true);
+    return true;
+  }
+  try { console.warn('[perf][legacy_fallback_blocked]', JSON.stringify({ action: a, reason: 'read_model_missing_or_stale' })); } catch (_e2) {}
+  setRequestPerfField_('legacy_fallback_blocked', true);
+  setRequestPerfField_('legacy_fallback_reason', 'read_model_missing_or_stale');
+  return false;
+}
+
 function handlePost_(e) {
   try {
     beginRequestCache_();
@@ -97,18 +124,21 @@ function handlePost_(e) {
         if (readData !== null) {
           markRequestPerf_('action_done');
           setRequestPerfField_('read_model_screen_hit', true);
-          scriptCachePutJson_(readKey, readData, CONFIG.SCRIPT_CACHE_SECONDS || 90);
+          scriptCachePutJson_(readKey, readData, CONFIG.SCRIPT_CACHE_SECONDS || 900);
           opsHealthAfterReadResponse_(action, false, readData);
           return jsonResponse_({ ok: true, data: readData }, {
             action: action,
             cache_hit: false
           });
         }
-        /* Persisted read-model miss: heavy handler runs only for actions on LEGACY_READ_DISPATCH_ALLOWLIST_
-           (see api_read_write.gs); non-listed actions log [legacy-allowlist]. */
+        /* Persisted read-model miss: block implicit heavy legacy fallback in normal flow. */
+        if (!shouldAllowLegacyFallbackForHeavyAction_(action, payload, user)) {
+          markRequestPerf_('action_done');
+          throw new Error('READ_MODEL_UNAVAILABLE_TRY_AGAIN');
+        }
         readData = runReadApiHandler_(action, user, payload);
         markRequestPerf_('action_done');
-        scriptCachePutJson_(readKey, readData, CONFIG.SCRIPT_CACHE_SECONDS || 90);
+        scriptCachePutJson_(readKey, readData, CONFIG.SCRIPT_CACHE_SECONDS || 900);
         opsHealthAfterReadResponse_(action, false, readData);
         return jsonResponse_({ ok: true, data: readData }, {
           action: action,
@@ -143,13 +173,9 @@ function handlePost_(e) {
             );
           } catch (_e) {}
         }
-        if (action === 'addActivity' || action === 'saveActivity' || action === 'submitEditRequest' || action === 'reviewEditRequest') {
-          try {
-            refreshActivitiesSnapshot_();
-          } catch (_activitiesSnapshotErr) {
-            bumpDataViewsCacheVersion_();
-          }
-        }
+        try {
+          bumpDataViewsCacheVersion_();
+        } catch (_bumpErr) {}
       }
       markRequestPerf_('action_done');
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -344,6 +344,21 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
           params,
           error: _refreshErr?.message || String(_refreshErr)
         });
+        const staleData = hit?.data && typeof hit.data === 'object' ? { ...hit.data, _read_model_stale: true } : hit?.data;
+        if (staleData) {
+          pushPerfRequest({
+            action: fallbackAction,
+            duration_ms: 0,
+            slow: false,
+            payload_size: JSON.stringify(staleData || {}).length,
+            used_read_model: true,
+            fallback_used: false,
+            cache_hit: true,
+            stale_cache_used: true,
+            sheet_reads_count: null
+          });
+          return staleData;
+        }
         throw _refreshErr;
       }
     }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -344,14 +344,7 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
           params,
           error: _refreshErr?.message || String(_refreshErr)
         });
-        return request(fallbackAction, fallbackPayload, {
-          ...perfBase,
-          fallback_used: true,
-          legacy_fallback_reason: 'read_model_refresh_failed',
-          legacy_intentional: true,
-          read_model_screen_key: key,
-          ...options
-        });
+        throw _refreshErr;
       }
     }
 
@@ -361,14 +354,18 @@ async function requestReadModel(key, params = {}, fallbackAction, fallbackPayloa
       params,
       error: err?.message || String(err)
     });
-    return request(fallbackAction, fallbackPayload, {
-      ...perfBase,
-      fallback_used: true,
-      legacy_fallback_reason: 'read_model_get_failed',
-      legacy_intentional: true,
-      read_model_screen_key: key,
-      ...options
-    });
+    const explicitLegacy = options?.forceLegacy === true || params?.force_legacy === true || String(params?.force_legacy || '').toLowerCase() === 'yes' || options?.debug === true;
+    if (explicitLegacy) {
+      return request(fallbackAction, { ...(fallbackPayload || {}), force_legacy: true }, {
+        ...perfBase,
+        fallback_used: true,
+        legacy_fallback_reason: 'read_model_get_failed_explicit',
+        legacy_intentional: true,
+        read_model_screen_key: key,
+        ...options
+      });
+    }
+    throw new Error('הנתונים מתעדכנים כעת. נסו שוב בעוד מספר רגעים.');
   }
 }
 

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -282,6 +282,7 @@ export const dashboardScreen = {
       : '<p class="ds-muted">אין כרטיסי KPI להצגה.</p>';
 
     const navLoading = !!state?.dashboardNavLoading;
+    const staleBanner = data?._read_model_stale ? '<div class="ds-muted" style="margin-bottom:var(--ds-space-2)">הנתונים מתעדכנים כעת. מוצגים נתוני מטמון אחרונים.</div>' : ''; 
     const monthNav = `<div class="ds-dash-month-nav${navLoading ? ' is-nav-loading' : ''}" dir="rtl" aria-label="בחירת חודש לתצוגה">
       <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-dash-month-prev aria-label="חודש קודם" title="חודש קודם" ${navLoading ? 'disabled' : ''}>▶</button>
       <span class="ds-dash-month-nav__label">${escapeHtml(hebrewMonthTitle(ym))} ${navLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>
@@ -292,6 +293,7 @@ export const dashboardScreen = {
       <div class="ds-dashboard-wrap">
         ${dsPageHeader('לוח בקרה')}
         ${monthNav}
+        ${staleBanner}
         <div data-dash-data-area>
           <div class="ds-dashboard-summary-row">
             <button type="button" class="ds-summary-btn" data-summary-target="national" aria-label="סיכום">סיכום</button>

--- a/tests/backend-write-flows-guard.test.mjs
+++ b/tests/backend-write-flows-guard.test.mjs
@@ -40,9 +40,11 @@ test('reviewEditRequest handles approve/reject, missing requests and already rev
   mustMatch(actions, /updateEditRequestRows_\(requestId, \{[\s\S]*status: status,[\s\S]*reviewed_at: new Date\(\)\.toISOString\(\)/);
 });
 
-test('router write flow tries activity snapshot refresh and falls back to cache bump on failure', () => {
+test('router write flow marks read models dirty and bumps cache version without synchronous snapshot refresh', () => {
   mustMatch(router, /if \(action === 'addActivity' \|\|[\s\S]*action === 'saveActivity' \|\|[\s\S]*action === 'submitEditRequest' \|\|[\s\S]*action === 'reviewEditRequest'/);
-  mustMatch(router, /if \(action === 'addActivity' \|\| action === 'saveActivity' \|\| action === 'submitEditRequest' \|\| action === 'reviewEditRequest'\) \{[\s\S]*try \{[\s\S]*refreshActivitiesSnapshot_\(\);[\s\S]*\} catch \(_activitiesSnapshotErr\) \{[\s\S]*bumpDataViewsCacheVersion_\(\);[\s\S]*\}/);
+  mustMatch(router, /markReadModelsDirtyByMutation_\(action, payload \|\| \{\}\)/);
+  mustMatch(router, /bumpDataViewsCacheVersion_\(\);/);
+  assert.doesNotMatch(router, /refreshActivitiesSnapshot_\(\);/);
 });
 
 test('addActivity requires core fields but does not force notes/end_date when derivable', () => {

--- a/tests/dashboard-readmodel-guard.test.mjs
+++ b/tests/dashboard-readmodel-guard.test.mjs
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const dashboard = fs.readFileSync(new URL('../frontend/src/screens/dashboard.js', import.meta.url), 'utf8');
+
+test('dashboard screen load uses dashboardSnapshot and not legacy dashboard api', () => {
+  assert.match(dashboard, /api\.dashboardSnapshot\(\{ month: ym \}\)/);
+  assert.doesNotMatch(dashboard, /api\.dashboard\(/);
+});
+
+test('dashboard month navigation uses dashboardSnapshot for next month', () => {
+  assert.match(dashboard, /api\.dashboardSnapshot\(\{ month: nextYm \}\)/);
+});

--- a/tests/readmodel-resilience.test.mjs
+++ b/tests/readmodel-resilience.test.mjs
@@ -24,7 +24,7 @@ async function freshModules() {
   return { ...stateMod, ...apiMod };
 }
 
-test('activities read-model path falls back to legacy action when readModelGet fails', async () => {
+test('activities read-model path does not auto-fallback without explicit legacy flag', async () => {
   const { api, state } = await freshModules();
   state.token = 'token';
   const calls = [];
@@ -36,14 +36,13 @@ test('activities read-model path falls back to legacy action when readModelGet f
     if (body.action === 'readModelManifest') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{} }); } };
     throw new Error('unexpected action');
   };
-  const data = await api.activities({});
-  assert.ok(Array.isArray(data?.rows));
+  await assert.rejects(() => api.activities({}), /הנתונים מתעדכנים כעת/);
   assert.ok(calls.includes('readModelGet'));
-  assert.ok(calls.includes('activities'));
+  assert.equal(calls.includes('activities'), false);
 });
 
 
-test('dashboardSnapshot tries read model then falls back to legacy on readModelGet failure', async () => {
+test('dashboardSnapshot blocks implicit legacy fallback on readModelGet failure', async () => {
   const { api, state } = await freshModules();
   state.token = 'token';
   const calls = [];
@@ -55,13 +54,12 @@ test('dashboardSnapshot tries read model then falls back to legacy on readModelG
     if (body.action === 'readModelManifest') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{} }); } };
     throw new Error('unexpected action');
   };
-  const data = await api.dashboardSnapshot({});
-  assert.equal(data?.totals?.active, 7);
+  await assert.rejects(() => api.dashboardSnapshot({}), /הנתונים מתעדכנים כעת/);
   assert.ok(calls.includes('readModelGet'));
-  assert.ok(calls.includes('dashboardSnapshot'));
+  assert.equal(calls.includes('dashboardSnapshot'), false);
 });
 
-test('read-model fallback emits perf metadata visibility flags', async () => {
+test('explicit force_legacy still allows legacy fallback when requested', async () => {
   const { api, state } = await freshModules();
   state.token = 'token';
   global.fetch = async (_url, req) => {
@@ -70,9 +68,6 @@ test('read-model fallback emits perf metadata visibility flags', async () => {
     if (body.action === 'activities') return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{ rows: [] } }); } };
     return { status: 200, async text(){ return JSON.stringify({ ok:true, data:{} }); } };
   };
-  await api.activities({});
-  const reqs = global.window.__dsPerf?.requests || [];
-  const last = reqs[reqs.length - 1] || {};
-  assert.equal(last.fallback_used, true);
-  assert.equal(last.used_read_model, false);
+  const data = await api.activities({ force_legacy: true }, { forceLegacy: true });
+  assert.ok(Array.isArray(data?.rows));
 });


### PR DESCRIPTION
### Motivation
- Prevent interactive users from triggering heavy legacy computations for dashboard/month/week/activities/exceptions/endDates when Read Models / Snapshots are missing or stale. 
- Keep write responses fast by avoiding synchronous snapshot rebuilds inside user requests and let background triggers perform read-model refreshes. 
- Improve cache stability for heavy read paths by using a longer read-cache TTL and clearer perf visibility when fallbacks are blocked or explicit.

### Description
- Added `shouldAllowLegacyFallbackForHeavyAction_` and gating logic in `backend/router.gs` to block implicit legacy fallback for heavy actions (`dashboard`, `dashboardSnapshot`, `month`, `week`, `activities`, `exceptions`, `endDates`) unless `force_legacy`/debug is explicitly provided, and emit perf warnings/fields on blocked or explicit fallbacks. 
- Changed router read-path cache writes to use a larger default TTL when storing read responses (`scriptCachePutJson_` fallback from `90`s → `900`s) for heavy screen reads. 
- Removed synchronous `refreshActivitiesSnapshot_()` from write request flow and replaced it with marking read models dirty + `bumpDataViewsCacheVersion_()` so background triggers perform refreshes and writes return quickly. 
- Updated client `requestReadModel` in `frontend/src/api.js` to stop performing a silent legacy fallback on read-model failures; it now throws a controlled error unless an explicit `force_legacy` / debug flag is provided, in which case legacy action is invoked. 
- Adjusted tests to assert the new behaviour: `readmodel-resilience` tests now expect blocked implicit fallbacks and verify explicit `force_legacy` still works; `backend-write-flows-guard` checks that no synchronous snapshot refresh call remains.

### Testing
- Ran the test suite with `npm test` (node --test tests/*.test.mjs); overall run in this environment reported 208 tests, 196 passed and 12 failed, with failures caused by missing environment deps (`jsdom`) required by multiple tests and an existing regex assertion mismatch in a read-model storage test. 
- Ran `npm run build`; it failed in this environment because the `vite` binary is not available (`sh: 1: vite: not found`). 
- Updated/added unit assertions in `tests/readmodel-resilience.test.mjs` and `tests/backend-write-flows-guard.test.mjs` to cover: blocking implicit fallback, allowing explicit `force_legacy`, and ensuring write flows no longer run a synchronous snapshot refresh.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5937d3aa0832b91d0a0d8e757d3ae)