### PR TITLE
Rebuild week read-model from source when month-bundle is empty and add week debug metrics

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -1516,6 +1516,29 @@ function actionWeek_(user, payload) {
   }
   weekPayload = normalizeWeekPayloadShape_(weekPayload);
 
+  // Safety-net: if cached month bundle produced empty week items, rebuild from source
+  // rows using Date1–Date35/start_date + activity_meetings (in addition, not במקום).
+  var hasWeekItems = Object.keys(weekPayload.items_by_id || {}).length > 0;
+  var hasDayItems = (weekPayload.days || []).some(function(day) {
+    return Array.isArray(day.item_ids) && day.item_ids.length > 0;
+  });
+  var debugWeek = buildWeekSourceDebug_(user, anchor);
+  if (!hasWeekItems || !hasDayItems) {
+    var rebuilt = normalizeWeekPayloadShape_(actionWeekLegacy_(user, payload));
+    rebuilt.debug = Object.assign({}, rebuilt.debug || {}, debugWeek, {
+      items_count: Object.keys(rebuilt.items_by_id || {}).length,
+      days_with_items: (rebuilt.days || []).filter(function(day) { return (day.item_ids || []).length > 0; }).length,
+      fallback_rebuild_used: true
+    });
+    weekPayload = rebuilt;
+  } else {
+    weekPayload.debug = Object.assign({}, weekPayload.debug || {}, debugWeek, {
+      items_count: Object.keys(weekPayload.items_by_id || {}).length,
+      days_with_items: (weekPayload.days || []).filter(function(day) { return (day.item_ids || []).length > 0; }).length,
+      fallback_rebuild_used: false
+    });
+  }
+
   setRequestPerfField_('week_used_view', true);
   setRequestPerfField_('week_used_cache', !!ensured.usedCacheOnly);
   setRequestPerfField_('week_fallback_used', false);
@@ -1526,6 +1549,47 @@ function actionWeek_(user, payload) {
   markRequestPerf_(ensured.usedCacheOnly ? 'week:used_cache:true' : 'week:used_cache:false');
   markRequestPerf_('week:fallback_used:false');
   return weekPayload;
+}
+
+function buildWeekSourceDebug_(user, anchor) {
+  var fromDate = formatDate_(anchor);
+  var toDate = formatDate_(shiftDate_(anchor, 6));
+  var calRows = visibleActivitiesSummaryForUser_(user) || [];
+  var meetingsMap = buildMeetingsMap_() || {};
+  var rowsWithAnyDate = 0;
+  var rowsWithDateInWeek = 0;
+
+  calRows.forEach(function(row) {
+    var rowId = text_(row && row.RowID);
+    var hasAnyDate = false;
+    var hasDateInWeek = false;
+    var seen = {};
+
+    var addDate = function(dateKey) {
+      if (!dateKey || seen[dateKey]) return;
+      seen[dateKey] = true;
+      hasAnyDate = true;
+      if (dateKey >= fromDate && dateKey <= toDate) hasDateInWeek = true;
+    };
+
+    if (rowId && meetingsMap[rowId] && meetingsMap[rowId].length) {
+      meetingsMap[rowId].forEach(function(d) { addDate(normalizeDateTextToIso_(d)); });
+    }
+    var rowDates = collectActivityDatesFromSourceRow_(row);
+    rowDates.forEach(addDate);
+    if (!hasAnyDate) addDate(normalizeDateTextToIso_(row && row.start_date));
+
+    if (hasAnyDate) rowsWithAnyDate++;
+    if (hasDateInWeek) rowsWithDateInWeek++;
+  });
+
+  return {
+    total_source_rows: calRows.length,
+    rows_with_any_date: rowsWithAnyDate,
+    rows_with_date_in_week: rowsWithDateInWeek,
+    week_start: fromDate,
+    week_end: toDate
+  };
 }
 
 function buildMonthResponseFromMeetingViewRows_(rows, year, month) {


### PR DESCRIPTION
### Motivation
- The week screen sometimes showed days but zero activities because the month-bundle / cached view produced an empty `items_by_id` or days with empty `item_ids` while source rows still contained dates.  
- The code must consider dates coming from `Date1`–`Date35`, `start_date`, and `activity_meetings` (as additional source), so items that occur in the week are not lost.  
- Add debug counters to make it easier to diagnose why a week payload is empty without manual inspection of sheets.

### Description
- Added a safety-net in `actionWeek_` that detects when `weekPayload.items_by_id` is empty or no day has `item_ids` and then rebuilds the week payload using the legacy calendar/index logic via `actionWeekLegacy_`.  
- Implemented `buildWeekSourceDebug_` which collects metrics from source rows and meetings (uses `visibleActivitiesSummaryForUser_`, `buildMeetingsMap_`, and `collectActivityDatesFromSourceRow_`) and returns `total_source_rows`, `rows_with_any_date`, `rows_with_date_in_week`, `week_start`, and `week_end`.  
- The final `weekPayload.debug` now includes `items_count`, `days_with_items`, and `fallback_rebuild_used` in addition to the metrics collected by `buildWeekSourceDebug_`.  
- The fallback rebuild preserves `activity_meetings` support and collects `Date1..Date35` and `start_date` (via existing helpers) so source-date coverage is additive (not replacing meetings data).

### Testing
- Performed repository inspections and diffs with `rg`/`sed` and validated the patch via `git add` + `git commit`, all commands succeeded.  
- No automated unit/integration tests were added or executed in this change.  
- Recommended post-deploy verification: run `refreshAllReadModels` and inspect `week?week_offset=0` to confirm `items_by_id` is non-empty when activities exist and at least one day has non-empty `item_ids`, and check the new `debug` fields for the reported counters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a8398160832bb890fea059c3d4b3)