### PR TITLE
Allow foreground fallback rebuild for week read-model and add source debug info

### DIFF
--- a/backend/actions.gs
+++ b/backend/actions.gs
@@ -1516,6 +1516,32 @@ function actionWeek_(user, payload) {
   }
   weekPayload = normalizeWeekPayloadShape_(weekPayload);
 
+  // Read-model build safety-net only: during scheduled/background refresh we may
+  // rebuild from source if bundle output is unexpectedly empty.
+  var hasWeekItems = Object.keys(weekPayload.items_by_id || {}).length > 0;
+  var hasDayItems = (weekPayload.days || []).some(function(day) {
+    return Array.isArray(day.item_ids) && day.item_ids.length > 0;
+  });
+  var debugWeek = buildWeekSourceDebug_(user, anchor);
+  var allowForegroundRebuild = yesNo_(payload && payload.allow_foreground_rebuild) === 'yes';
+  var shouldRebuild = (!hasWeekItems || !hasDayItems) && allowForegroundRebuild;
+  if (shouldRebuild) {
+    var rebuilt = normalizeWeekPayloadShape_(actionWeekLegacy_(user, payload));
+    rebuilt.debug = Object.assign({}, rebuilt.debug || {}, debugWeek, {
+      items_count: Object.keys(rebuilt.items_by_id || {}).length,
+      days_with_items: (rebuilt.days || []).filter(function(day) { return (day.item_ids || []).length > 0; }).length,
+      fallback_rebuild_used: true
+    });
+    weekPayload = rebuilt;
+  } else {
+    weekPayload.debug = Object.assign({}, weekPayload.debug || {}, debugWeek, {
+      items_count: Object.keys(weekPayload.items_by_id || {}).length,
+      days_with_items: (weekPayload.days || []).filter(function(day) { return (day.item_ids || []).length > 0; }).length,
+      fallback_rebuild_used: false,
+      fallback_rebuild_allowed: allowForegroundRebuild
+    });
+  }
+
   setRequestPerfField_('week_used_view', true);
   setRequestPerfField_('week_used_cache', !!ensured.usedCacheOnly);
   setRequestPerfField_('week_fallback_used', false);
@@ -1526,6 +1552,47 @@ function actionWeek_(user, payload) {
   markRequestPerf_(ensured.usedCacheOnly ? 'week:used_cache:true' : 'week:used_cache:false');
   markRequestPerf_('week:fallback_used:false');
   return weekPayload;
+}
+
+function buildWeekSourceDebug_(user, anchor) {
+  var fromDate = formatDate_(anchor);
+  var toDate = formatDate_(shiftDate_(anchor, 6));
+  var calRows = visibleActivitiesSummaryForUser_(user) || [];
+  var meetingsMap = buildMeetingsMap_() || {};
+  var rowsWithAnyDate = 0;
+  var rowsWithDateInWeek = 0;
+
+  calRows.forEach(function(row) {
+    var rowId = text_(row && row.RowID);
+    var hasAnyDate = false;
+    var hasDateInWeek = false;
+    var seen = {};
+
+    var addDate = function(dateKey) {
+      if (!dateKey || seen[dateKey]) return;
+      seen[dateKey] = true;
+      hasAnyDate = true;
+      if (dateKey >= fromDate && dateKey <= toDate) hasDateInWeek = true;
+    };
+
+    if (rowId && meetingsMap[rowId] && meetingsMap[rowId].length) {
+      meetingsMap[rowId].forEach(function(d) { addDate(normalizeDateTextToIso_(d)); });
+    }
+    var rowDates = collectActivityDatesFromSourceRow_(row);
+    rowDates.forEach(addDate);
+    if (!hasAnyDate) addDate(normalizeDateTextToIso_(row && row.start_date));
+
+    if (hasAnyDate) rowsWithAnyDate++;
+    if (hasDateInWeek) rowsWithDateInWeek++;
+  });
+
+  return {
+    total_source_rows: calRows.length,
+    rows_with_any_date: rowsWithAnyDate,
+    rows_with_date_in_week: rowsWithDateInWeek,
+    week_start: fromDate,
+    week_end: toDate
+  };
 }
 
 function buildMonthResponseFromMeetingViewRows_(rows, year, month) {

--- a/backend/read-models.gs
+++ b/backend/read-models.gs
@@ -387,7 +387,10 @@ function refreshWeekReadModel_() {
 function refreshWeekReadModelForOffset_(offset) {
   var wo = parseInt(offset, 10) || 0;
   return refreshSingleReadModel_('week', { week_offset: wo }, function() {
-    return actionWeek_(READ_MODEL_ADMIN_USER_, { week_offset: wo });
+    return actionWeek_(READ_MODEL_ADMIN_USER_, {
+      week_offset: wo,
+      allow_foreground_rebuild: 'yes'
+    });
   });
 }
 


### PR DESCRIPTION
### Motivation

- Prevent returning an empty week view when the read-model bundle unexpectedly contains no items by enabling a controlled foreground rebuild from source.
- Surface diagnostic counters to help understand why a bundle produced no week items by summarizing source rows and meeting dates for the requested week.

### Description

- Added a foreground rebuild safety-net in `actionWeek_` that optionally calls the legacy builder when the week payload has no items or no day items, gated by the `allow_foreground_rebuild` payload flag and attaching debug metadata to the response. 
- Introduced `buildWeekSourceDebug_` which scans visible activity rows and meetings to produce `total_source_rows`, `rows_with_any_date`, `rows_with_date_in_week`, `week_start`, and `week_end` for inclusion in the `week` response `debug` field. 
- Populated request performance and payload size fields as before and annotated the `debug` object with `items_count`, `days_with_items`, `fallback_rebuild_used`, and `fallback_rebuild_allowed`. 
- Updated the read-model refresher `refreshWeekReadModelForOffset_` to set `allow_foreground_rebuild: 'yes'` when building the week read-model so background refreshes can produce a non-empty bundle if needed.

### Testing

- Ran the existing automated test suite for the backend (unit/integration tests) and all tests passed. 
- Exercised `refreshWeekReadModelForOffset_` to ensure the `allow_foreground_rebuild` flag is passed through and the `week` response contains expected `debug` counters when source rows are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a8398160832bb890fea059c3d4b3)