### PR TITLE
Dashboard: route through read-model, re-enable conservative persistent cache, and add route perf logs

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -710,6 +710,15 @@ export const api = {
   },
   dashboardSnapshot: (filters) => request('dashboardSnapshot', filters || {}),
   dashboardSheet: (filters) => request('dashboardSheet', filters || {}),
+  dashboardReadModel: (filters, options) => {
+    const resolved = (filters && typeof filters === 'object') ? filters : {};
+    const candidate = String(resolved.month || resolved.ym || '').trim();
+    const now = new Date();
+    const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const month = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
+    const canonical = { ...resolved, month };
+    return requestReadModel('dashboard', canonical, 'dashboardSheet', canonical, options || {});
+  },
   activities: (filters, options) => requestReadModel('activities', filters || {}, 'activities', filters || {}, options || {}),
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
   activityDates: (source_row_id, source_sheet) => request('activityDates', { source_row_id, source_sheet }),

--- a/frontend/src/cache-persist.js
+++ b/frontend/src/cache-persist.js
@@ -13,8 +13,6 @@ function storageKey() {
 }
 
 export function persistCacheEntry(key, entry) {
-  return;
-  // Hotfix: persistent localStorage cache is disabled system-wide.
   if (PERSIST_BLOCKED_PREFIXES.some((p) => key.startsWith(p))) return;
   try {
     const serialized = JSON.stringify(entry);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -839,28 +839,62 @@ function maybePersistScreenCacheEntry(key, entry) {
  */
 async function loadScreenDataWithCache(screen) {
   if (!screen.load) return {};
+  const routeName = String(state.route || '');
+  const routePerfEnabled = routeName === 'dashboard' || routeName === 'activities' || routeName === 'week' || routeName === 'month';
+  const routePerfStart = routePerfEnabled ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0;
   const key = screenDataCacheKey();
   const hit = state.screenDataCache[key];
   const ttl = screenCacheTtl();
   const age = hit ? Date.now() - hit.t : 0;
   const serverMarkedStale = !!(hit && hit.data && hit.data._is_stale === true);
-  if (hit && age < ttl && !serverMarkedStale) return hit.data;
+  if (hit && age < ttl && !serverMarkedStale) {
+    if (routePerfEnabled) {
+      const dur = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routePerfStart);
+      console.info('[route-load]', { route: routeName, duration_ms: dur, cache_hit: true, fallback_used: false, source: 'memory-cache-fresh' });
+    }
+    return hit.data;
+  }
 
   if (hit) {
-    if (STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH) return hit.data;
+    if (STABILITY_HOTFIX_DISABLE_BACKGROUND_REFRESH) {
+      if (routePerfEnabled) {
+        const dur = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routePerfStart);
+        console.info('[route-load]', { route: routeName, duration_ms: dur, cache_hit: true, fallback_used: false, source: 'memory-cache-stale-bg-disabled' });
+      }
+      return hit.data;
+    }
     if (!inflightRequests.has(key)) {
       backgroundRefreshScreen(screen, key);
+    }
+    if (routePerfEnabled) {
+      const dur = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routePerfStart);
+      console.info('[route-load]', { route: routeName, duration_ms: dur, cache_hit: true, fallback_used: false, source: 'memory-cache-swr' });
     }
     return hit.data;
   }
 
   if (inflightRequests.has(key)) {
     pushDuplicateRequestPerf(key, state.route);
-    return inflightRequests.get(key);
+    const inflight = inflightRequests.get(key);
+    if (routePerfEnabled) {
+      const dur = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routePerfStart);
+      console.info('[route-load]', { route: routeName, duration_ms: dur, cache_hit: false, fallback_used: false, source: 'inflight-dedup' });
+    }
+    return inflight;
   }
 
   const p = screen.load({ api, state })
     .then((data) => {
+      if (routePerfEnabled) {
+        const dur = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - routePerfStart);
+        console.info('[route-load]', {
+          route: routeName,
+          duration_ms: dur,
+          cache_hit: false,
+          fallback_used: !!(data && (data._snapshot_unavailable === true || data._read_model_stale === true || data._is_stale === true)),
+          source: 'network'
+        });
+      }
       const entry = { data, t: Date.now() };
       state.screenDataCache[key] = entry;
       maybePersistScreenCacheEntry(key, entry);

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -219,7 +219,7 @@ export const dashboardScreen = {
 
     try {
       const data = await Promise.race([
-        api.dashboardSheet({ month: ym }),
+        api.dashboardReadModel({ month: ym }),
         guardPromise
       ]);
       clearTimeout(guardTimer);
@@ -228,7 +228,7 @@ export const dashboardScreen = {
       );
       // eslint-disable-next-line no-console
       console.info('[dashboard-load]', {
-        action: 'dashboardSheet',
+        action: 'dashboardReadModel',
         duration_ms: durationMs,
         is_snapshot: data?._is_snapshot !== false,
         is_stale: data?._is_stale === true,
@@ -246,7 +246,7 @@ export const dashboardScreen = {
         String(err?.message || '').includes('timeout');
       // eslint-disable-next-line no-console
       console.warn('[dashboard-load] failed', {
-        action: 'dashboardSheet',
+        action: 'dashboardReadModel',
         duration_ms: durationMs,
         is_timeout: isTimeout,
         error: err?.message || String(err),
@@ -444,7 +444,7 @@ export const dashboardScreen = {
         }
         showDataAreaLoading();
         try {
-          const snapshotData = await api.dashboardSheet({ month: nextYm });
+          const snapshotData = await api.dashboardReadModel({ month: nextYm });
           putDashboardCache(cacheKey, snapshotData);
         } catch (_err) {
           // Keep currently rendered dashboard content when refresh fails.


### PR DESCRIPTION
### Motivation
- לשפר בצורה שמרנית את מהירות המעבר למסכי הדשבורד והמעבר מ־dashboard ל־activities/week/month על ידי שימוש בנתיב ה־read-model במקום קריאה ישירה כבדת `dashboardSheet` ולהפעיל cache מקומי שמרני. 
- למנוע הופעת נתונים של חודש שונה ע"י הבטחת cache key חודשי ספציפי (`dashboard:YYYY-MM`).
- לאפשר מדידה פשוטה של זמני טעינה ומקורות נתונים כדי לאתר צווארי בקבוק בלי refactor רחב.

### Description
- הוספתי את ה־API שמרני `api.dashboardReadModel(...)` שמנרמל את `month` כ־`YYYY-MM` ומקורו הוא `requestReadModel('dashboard', ...)` עם fallback ל־`dashboardSheet` כדי לשמור על הצורה הקיימת של התשובה ולא לשנות שמות actions או מבני נתונים (`frontend/src/api.js`).
- עדכנתי את `dashboardScreen` כדי לטעון באמצעות `api.dashboardReadModel` גם בעומס ראשוני וגם בעדכון ניווט חודשי, ושמתי לב שה־cache key נשאר `dashboard:YYYY-MM` כפי שנדרש (`frontend/src/screens/dashboard.js`).
- החזרתי להפעלה את מנגנון ה־persistent screen cache על ידי הסרת ה־`return` המוקדם ב־`persistCacheEntry`, תוך שמירה על החסימות וההגבלות הקיימות (חסימת `activityDetail:*`, גודל מקסימלי), כדי לאפשר `stale-while-revalidate` שמרני (`frontend/src/cache-persist.js`, `frontend/src/main.js`).
- הוספתי instrumentation קונסול ב־`loadScreenDataWithCache` עבור המסלולים `dashboard`, `activities`, `week`, `month` שמדווחת לכל קונסול את `duration_ms`, `cache_hit`, `fallback_used` ו־`source` (`memory-cache-fresh` / `memory-cache-swr` / `inflight-dedup` / `network`) כדי למדוד לפני/אחרי ולנתח התנהגות טעינה (`frontend/src/main.js`).
- לא שיניתי TTLs, שמות actions, מבני תשובות, הרשאות, חישובים עסקיים או פילטרים; התנהגות stale-while-revalidate, prefetch וה־cache-key עבור `activities/week/month` נשארה עקבית.

### Testing
- רצתה בדיקה של ה־diff באמצעות `git diff` וההבדלים הוצגו כנכון עבור הקבצים: `frontend/src/api.js`, `frontend/src/cache-persist.js`, `frontend/src/main.js`, `frontend/src/screens/dashboard.js` (הצלחה).
- ניסיתי להריץ `npm -C frontend run -s build` אך זה נכשל בסביבת הריפו הנוכחית עקב העדר `frontend/package.json` (כשלון אוטומטי בניית קרקע, לא שקשור לשינויים בקוד המקור שנערכו).
- בדקתי סטטוס git עם `git status --short` והקבצים ששונו הוצגו; ביצעתי commit באמצעות `git commit` והפעולה הושלמה בהצלחה (שינויים מקומיים נעו ל־commit).
- לא הופעלו בדיקות אוטומטיות נוספות (linters/builds) בסביבה זו בגלל חוסר תשתית build ב־repo; מומלץ להריץ את ה־build/CI בפרויקט המלא כדי לאמת חבילות וביצועים בשדה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b23f555c832bbacad83d67ed3928)