### PR TITLE
Connect activities data source to Supabase with graceful fallback

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 import { config } from './config.js';
 import { state, setSession, clearScreenDataCache } from './state.js';
 import { translateApiErrorForUser } from './screens/shared/ui-hebrew.js';
+import { supabase } from './supabase-client.js';
 
 /**
  * Actions that modify server-side data.
@@ -117,6 +118,41 @@ function warnHeavyLegacyReadWithoutIntentionalFlag(action, perfMeta) {
     }));
   } catch {
     /* ignore */
+  }
+}
+
+
+function rowMatchesActivitiesFilters(row, filters = {}) {
+  const activityType = String(filters?.activity_type || '').trim();
+  const month = String(filters?.month || '').trim();
+
+  if (activityType && activityType !== 'all' && String(row?.activity_type || '').trim() !== activityType) return false;
+
+  if (/^\d{4}-\d{2}$/.test(month)) {
+    const start = String(row?.date_start || row?.start_date || '').trim();
+    if (/^\d{4}-\d{2}/.test(start) && !start.startsWith(month)) return false;
+  }
+
+  return true;
+}
+
+async function readActivitiesFromSupabase(filters = {}) {
+  if (!supabase) return null;
+
+  try {
+    const { data, error } = await supabase.from('activities').select('*');
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error('[supabase] Failed to load activities:', error);
+      return null;
+    }
+
+    const rows = Array.isArray(data) ? data.filter((row) => rowMatchesActivitiesFilters(row, filters)) : [];
+    return { rows };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[supabase] Unexpected activities fetch error:', error);
+    return null;
   }
 }
 
@@ -719,7 +755,12 @@ export const api = {
     const canonical = { ...resolved, month };
     return requestReadModel('dashboard', canonical, 'dashboardSheet', canonical, options || {});
   },
-  activities: (filters, options) => requestReadModel('activities', filters || {}, 'activities', filters || {}, options || {}),
+  activities: async (filters, options) => {
+    const resolvedFilters = filters || {};
+    const supabaseData = await readActivitiesFromSupabase(resolvedFilters);
+    if (supabaseData) return normalizeData(supabaseData);
+    return requestReadModel('activities', resolvedFilters, 'activities', resolvedFilters, options || {});
+  },
   activityDetail: (source_row_id, source_sheet) => request('activityDetail', { source_row_id, source_sheet }),
   activityDates: (source_row_id, source_sheet) => request('activityDates', { source_row_id, source_sheet }),
   week: (params, options) => {

--- a/frontend/src/supabase-client.js
+++ b/frontend/src/supabase-client.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+let supabase = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
+} else {
+  // eslint-disable-next-line no-console
+  console.error('[supabase] Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.');
+}
+
+export { supabase };

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "jsdom": "^29.0.2",
     "vite": "^6.0.3",
     "xlsx": "^0.18.5"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.49.8"
   }
 }


### PR DESCRIPTION
### Motivation
- להחליף את מקור הנתונים המקומי של מסך ה־`activities` בנתונים אמיתיים מ‑Supabase בלי לשבש את המערכת הקיימת. 
- לשמור על חוויית המשתמש כשה‑Supabase לא זמין על‑ידי fallback לזרימת ה‑read‑model הקיימת.

### Description
- הוספתי לקוח Supabase ב־`frontend/src/supabase-client.js` שמשתמש ב־`@supabase/supabase-js` ובמשתני הסביבה `NEXT_PUBLIC_SUPABASE_URL` ו־`NEXT_PUBLIC_SUPABASE_ANON_KEY`.
- עדכנתי את `api.activities` ב־`frontend/src/api.js` כך שיצטט נתונים מטבלת `activities` עם `select('*')` דרך Supabase לפני שהוא נופל חזרה ל־`requestReadModel` אם Supabase לא זמין או מחזיר שגיאה.
- הוספתי סינון פשוט בצד הלקוח (`activity_type` ו־`month`) על תוצאות Supabase כדי לשמר את התנהגות המסך הנוכחית מבלי לשנות את מבנה הטבלה או למחוק נתונים.
- טיפול בשגיאות קריאה ל‑Supabase מתבצע באמצעות `console.error` בלבד כדי לא להפיל את האפליקציה; אין יצירת טבלאות, שינויים בסכימה או מחיקה של נתונים.
- הוספתי את התלות `@supabase/supabase-js` ל־`package.json`.

### Testing
- הרצתי `node --test tests/activities-screen.test.mjs` וכולם עברו בהצלחה.
- ניסיתי להריץ `npm install @supabase/supabase-js` אבל התקנה נחסמה בסביבת הריצה עם `403 Forbidden`, לכן הוספתי את החבילה ל־`package.json` אך לא התקנתי אותה אוטומטית.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cae01dfc832b99875058340a49a9)