### PR TITLE
Fix Supabase env resolution for Vite / GitHub Pages deployment

### DIFF
--- a/frontend/src/supabase-client.js
+++ b/frontend/src/supabase-client.js
@@ -1,7 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const FALLBACK_SUPABASE_URL = 'https://szinlhjuwyiyszdpsdop.supabase.co';
+const FALLBACK_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_k0IbDJlgPA9KTVuDWrCyFw_Zsa5kZIM';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || import.meta.env.NEXT_PUBLIC_SUPABASE_URL || FALLBACK_SUPABASE_URL;
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  FALLBACK_SUPABASE_PUBLISHABLE_KEY;
 
 let supabase = null;
 
@@ -9,7 +15,9 @@ if (supabaseUrl && supabaseAnonKey) {
   supabase = createClient(supabaseUrl, supabaseAnonKey);
 } else {
   // eslint-disable-next-line no-console
-  console.error('[supabase] Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.');
+  console.error(
+    '[supabase] Missing configuration. Expected VITE_SUPABASE_URL/VITE_SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+  );
 }
 
 export { supabase };


### PR DESCRIPTION
### Motivation
- Ensure the frontend can connect to Supabase when deployed as a static site on GitHub Pages (or other Vite builds) where a normal runtime `.env` injection may not be available. 
- Preserve existing guarantees: do not add or modify database tables, do not use secret keys, and keep the `activities` schema and existing data untouched.

### Description
- Updated `frontend/src/supabase-client.js` to resolve environment variables in this priority: `import.meta.env.VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`, then `import.meta.env.NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`, then a safe publishable fallback. 
- Added `FALLBACK_SUPABASE_URL` and `FALLBACK_SUPABASE_PUBLISHABLE_KEY` constants using the provided publishable-only values so static builds can still create a client when runtime env injection is unavailable. 
- Kept the existing behavior of creating `supabase` only when both URL and anon key are present and retained a null-client fallback with a clearer `console.error` message when configuration is missing. 
- Files changed: `frontend/src/supabase-client.js`.

### Testing
- Ran the automated test suite with `npm test`.
- Result: `283` tests passed and `35` tests failed out of `318`, where failures are caused by `ERR_MODULE_NOT_FOUND` for `@supabase/supabase-js` when the test environment attempted to import `frontend/src/supabase-client.js`, indicating a dependency/environment issue rather than a logic regression. 
- No other automated tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d56fa1bc832ba833e45333ea69ca)