### PR TITLE
Align Supabase activities fetch with real source tables

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -140,18 +140,34 @@ async function readActivitiesFromSupabase(filters = {}) {
   if (!supabase) return null;
 
   try {
-    const { data, error } = await supabase.from('activities').select('*');
-    if (error) {
+    const [longResult, shortResult] = await Promise.all([
+      supabase.from('data_long').select('*'),
+      supabase.from('data_short').select('*')
+    ]);
+
+    if (longResult.error) {
       // eslint-disable-next-line no-console
-      console.error('[supabase] Failed to load activities:', error);
+      console.error('[supabase] Failed to load data_long:', longResult.error);
+      return null;
+    }
+    if (shortResult.error) {
+      // eslint-disable-next-line no-console
+      console.error('[supabase] Failed to load data_short:', shortResult.error);
       return null;
     }
 
-    const rows = Array.isArray(data) ? data.filter((row) => rowMatchesActivitiesFilters(row, filters)) : [];
+    const longRows = Array.isArray(longResult.data)
+      ? longResult.data.map((row) => ({ ...row, source_sheet: row?.source_sheet || 'data_long' }))
+      : [];
+    const shortRows = Array.isArray(shortResult.data)
+      ? shortResult.data.map((row) => ({ ...row, source_sheet: row?.source_sheet || 'data_short' }))
+      : [];
+
+    const rows = [...longRows, ...shortRows].filter((row) => rowMatchesActivitiesFilters(row, filters));
     return { rows };
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error('[supabase] Unexpected activities fetch error:', error);
+    console.error('[supabase] Unexpected data_long/data_short fetch error:', error);
     return null;
   }
 }


### PR DESCRIPTION
### Motivation
- The system’s canonical activity sources are `data_long` and `data_short`, and the frontend must stop treating `activities` as a source table and instead read the real source tables. 
- Keep the existing fallback to the backend/read-model path when Supabase is unavailable and improve error visibility when a table read fails.

### Description
- Replaced the single `supabase.from('activities').select('*')` query with parallel queries to `data_long` and `data_short` inside `readActivitiesFromSupabase(filters)` in `frontend/src/api.js`.
- Normalized and merged results into a single in-code `activities` layer by mapping `source_sheet` to `data_long`/`data_short` when absent and then applying the existing `rowMatchesActivitiesFilters` filtering logic.
- Added explicit `console.error` logging for failures of each source-table fetch and for unexpected fetch errors, kept the function returning `null` on failure so the existing read-model/backend fallback remains.
- No schema changes, no new or deleted tables, no new ids added, and row identity semantics are preserved (existing `RowID` is used by the application).

### Testing
- Ran the test command `npm test -- tests/activities-screen.test.mjs` which invoked the project’s test runner and related test files.
- Test run summary: 318 tests executed, 283 passed and 35 failed; failures are due to environment/test issues such as a missing `@supabase/supabase-js` package and unrelated assertion mismatches rather than the change to `readActivitiesFromSupabase`.
- The modified code path returns `null` on Supabase/unexpected errors to preserve existing fallback behavior observed by the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9dc06efc0832bbddf4d7ce309ff64)