### PR TITLE
Serve built Vite `dist` on GitHub Pages; keep Supabase-first dashboard read model

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,16 +2,21 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,10 +25,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build
         env:
@@ -32,9 +37,18 @@ jobs:
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact (dist)
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          publish_branch: gh-pages
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Ensure GitHub Pages serves the production `dist` output (not source files) to avoid runtime module-resolution errors such as failing to resolve `@supabase/supabase-js` when index.html referenced source modules.  
- Use Supabase as the primary source for dashboard KPIs while preserving the existing GAS read-model as a safe fallback.  

### Description
- Updated `.github/workflows/deploy.yml` to run `npm install` and `npm run build`, upload the `dist` artifact with `actions/upload-pages-artifact@v3`, and deploy via `actions/deploy-pages@v4`, added `workflow_dispatch`, adjusted `permissions` and added `concurrency`.  
- Left frontend code unchanged because `frontend/src/api.js` already implements `dashboardReadModelFromSupabase` and `api.dashboardReadModel` prefers the Supabase path and falls back to GAS on `null`/error.  
- KPIs computed from Supabase are `short`, `long`, `active_courses`, `active_workshops`, `active_tours`, `active_after_school`, `active_escape_room`, `instructors`, and `endings` (rows sourced from `data_long` and `data_short`, and `data_long` for endings).  
- Files changed: `.github/workflows/deploy.yml` (only).  

### Testing
- Attempted `npm run build` locally but it failed during Rollup because `@supabase/supabase-js` could not be resolved prior to installing dependencies, so full build verification did not complete.  
- Attempted `npm install` locally and it failed with `403 Forbidden` from the npm registry (`ws-8.20.0.tgz`), so the environment prevented completing the build.  
- Committed the workflow change (`git commit`) successfully; no automated unit tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa20d59a80832b9630c536d020d6d3)