### PR TITLE
Fix dashboard KPI failure handling

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -495,7 +495,7 @@ async function readInstructorsFromSupabase() {
 
 /**
  * Builds KPI card array for the dashboard from computed Supabase values.
- * KPIs that cannot be computed from Supabase columns are set to 0 and noted as GAS-only.
+ * Only metrics computed from the same Supabase dashboard path are emitted.
  */
 function buildDashboardKpiCardsFromSupabase(totals, activeTypeCounts, exceptionCount, uniqueInstructorCount, courseEndings) {
   return [
@@ -843,223 +843,62 @@ async function readMonthFromSupabase(ym) {
 /**
  * Queries Supabase to build a dashboard payload for the given month (YYYY-MM).
  *
- * KPIs computable from Supabase: short, long, active_courses, active_workshops,
- * active_tours, active_after_school, active_escape_room, instructors, endings.
- *
- * KPIs that cannot yet be computed (no equivalent column): exceptions,
- * operational_gaps_count, late_end_date_count, active_courses_next_month.
- * These are set to 0 — GAS fallback is authoritative for them.
- *
- * Returns null on any failure so the caller can fall through to GAS.
+ * Reads the dashboard source-of-truth table populated by the trusted backend/sync job.
+ * Supabase errors, missing rows, invalid months, and payload debug errors return null so
+ * callers never treat fabricated KPI=0 values as real dashboard data.
  */
+function warnDashboardSupabasePathFailed(reason, extra = {}) {
+  try {
+    console.warn('[supabase][dashboard] path failed', { reason: String(reason || 'unknown'), ...extra });
+  } catch { /* ignore */ }
+}
+
 async function dashboardReadModelFromSupabase(month) {
-  if (!supabase) return buildSupabaseErrorPayload({ month, requested_month: month }, 'no_supabase_client');
+  if (!supabase) {
+    warnDashboardSupabasePathFailed('no_supabase_client', { month });
+    return null;
+  }
   try {
     const monthPrefix = String(month || '').slice(0, 7);
     if (!/^\d{4}-\d{2}$/.test(monthPrefix)) {
-      return buildSupabaseErrorPayload({ month, requested_month: month }, 'invalid_month_format', { month });
+      warnDashboardSupabasePathFailed('invalid_month_format', { month });
+      return null;
     }
 
-    const monthStart = `${monthPrefix}-01`;
-    const [yStr, mStr] = monthPrefix.split('-');
-    const y = Number(yStr);
-    const m = Number(mStr);
-    const lastDay = new Date(y, m, 0).getDate();
-    const monthEnd = `${monthPrefix}-${String(lastDay).padStart(2, '0')}`;
-
-    const [longResult, shortResult] = await Promise.all([
-      supabase.from('data_long')
-        .select('activity_type,activity_manager,start_date,end_date,date_end,emp_id,emp_id_2,instructor_name,instructor_name_2,school,authority,activity_name,status,RowID')
-        .lte('start_date', monthEnd)
-        .neq('status', 'סגור'),
-      supabase.from('data_short')
-        .select('activity_type,activity_manager,start_date,emp_id,emp_id_2,instructor_name,instructor_name_2,school,authority,activity_name,status,RowID')
-        .gte('start_date', monthStart)
-        .lte('start_date', monthEnd)
-        .neq('status', 'סגור'),
-    ]);
-
-    if (longResult.error) {
-      // eslint-disable-next-line no-console
-      console.error('[supabase][dashboard] data_long fetch failed:', longResult.error);
-      return buildSupabaseErrorPayload({ month, requested_month: month }, longResult.error);
+    const sourceResult = await supabase
+      .from('dashboard_monthly_read_models')
+      .select('month,payload,source,updated_at')
+      .eq('month', monthPrefix)
+      .maybeSingle();
+    if (sourceResult.error) {
+      console.error('[supabase][dashboard] dashboard_monthly_read_models fetch failed:', sourceResult.error);
+      warnDashboardSupabasePathFailed(sourceResult.error?.message || 'dashboard_source_fetch_failed', { month: monthPrefix });
+      return null;
     }
-    if (shortResult.error) {
-      // eslint-disable-next-line no-console
-      console.error('[supabase][dashboard] data_short fetch failed:', shortResult.error);
-      return buildSupabaseErrorPayload({ month, requested_month: month }, shortResult.error);
+    if (!sourceResult.data || !sourceResult.data.payload || typeof sourceResult.data.payload !== 'object') {
+      warnDashboardSupabasePathFailed('dashboard_source_month_missing', { month: monthPrefix });
+      return null;
     }
 
-    const allLongRows = Array.isArray(longResult.data) ? longResult.data : [];
-    const shortRows = Array.isArray(shortResult.data) ? shortResult.data : [];
-
-    // Filter long activities active during this month: started <= monthEnd AND
-    // (no end date → still active, OR end_date/date_end >= monthStart)
-    const longRows = allLongRows.filter((r) => {
-      const ed = String(r.end_date || r.date_end || '').slice(0, 10);
-      return !ed || ed >= monthStart;
-    });
-
-    // Course endings: long activities whose end falls within this month
-    const courseEndingRows = allLongRows.filter((r) => {
-      const ed = String(r.end_date || r.date_end || '').slice(0, 10);
-      return ed && ed >= monthStart && ed <= monthEnd;
-    });
-
-    const total_long_activities = longRows.length;
-    const total_short_activities = shortRows.length;
-    const course_endings = courseEndingRows.length;
-
-    const HEB_TYPE_MAP = {
-      'קורס': 'course', 'סדנה': 'workshop', 'סדנאות': 'workshop',
-      'טיול': 'tour', 'סיור': 'tour', 'צהרון': 'after_school', 'חוג': 'after_school',
-      'חדר בריחה': 'escape_room',
-      'course': 'course', 'workshop': 'workshop', 'tour': 'tour',
-      'after_school': 'after_school', 'escape_room': 'escape_room'
-    };
-    const activeTypeCounts = { course: 0, after_school: 0, workshop: 0, tour: 0, escape_room: 0 };
-    for (const r of [...longRows, ...shortRows]) {
-      const t = String(r.activity_type || '').trim();
-      const key = HEB_TYPE_MAP[t] || t;
-      if (Object.prototype.hasOwnProperty.call(activeTypeCounts, key)) activeTypeCounts[key] += 1;
+    const sourcePayload = sourceResult.data.payload;
+    if (sourcePayload?.error || sourcePayload?._debug?.error) {
+      warnDashboardSupabasePathFailed(sourcePayload.error || sourcePayload._debug.error, { month: monthPrefix });
+      return null;
     }
-
-    const instructorIds = new Set();
-    const instructorNames = new Set();
-    for (const r of longRows) {
-      const id = String(r.emp_id || '').trim();
-      const n = String(r.instructor_name || '').trim();
-      if (id) instructorIds.add(id);
-      if (n) instructorNames.add(n);
-    }
-    for (const r of shortRows) {
-      const id1 = String(r.emp_id || '').trim();
-      const id2 = String(r.emp_id_2 || '').trim();
-      const n1 = String(r.instructor_name || '').trim();
-      const n2 = String(r.instructor_name_2 || '').trim();
-      if (id1) instructorIds.add(id1);
-      if (id2) instructorIds.add(id2);
-      if (n1) instructorNames.add(n1);
-      if (n2) instructorNames.add(n2);
-    }
-    const active_instructors_count = instructorIds.size;
-    const exceptions_count = buildExceptionsFromRows(longRows, shortRows, []).length;
-
-    const managerMap = new Map();
-    function ensureManager(name) {
-      const k = String(name || '').trim();
-      if (!k) return null;
-      if (!managerMap.has(k)) managerMap.set(k, { total_long: 0, total_short: 0, instructors: new Set(), endings: 0 });
-      return managerMap.get(k);
-    }
-    for (const r of longRows) {
-      const mg = ensureManager(r.activity_manager);
-      if (!mg) continue;
-      mg.total_long += 1;
-      const id = String(r.emp_id || '').trim();
-      if (id) mg.instructors.add(id);
-    }
-    for (const r of shortRows) {
-      const mg = ensureManager(r.activity_manager);
-      if (!mg) continue;
-      mg.total_short += 1;
-      const id1 = String(r.emp_id || '').trim();
-      const id2 = String(r.emp_id_2 || '').trim();
-      if (id1) mg.instructors.add(id1);
-      if (id2) mg.instructors.add(id2);
-    }
-    for (const r of courseEndingRows) {
-      const mg = ensureManager(r.activity_manager);
-      if (!mg) continue;
-      mg.endings += 1;
-    }
-
-    const by_activity_manager = [...managerMap.entries()].map(([activity_manager, s]) => ({
-      activity_manager,
-      total_long: s.total_long,
-      total_short: s.total_short,
-      total: s.total_long + s.total_short,
-      num_instructors: s.instructors.size,
-      course_endings: s.endings,
-      exceptions: 0
-    }));
-
-    const totals = {
-      total_short_activities,
-      total_long_activities,
-      total_instructors: active_instructors_count,
-      total_course_endings_current_month: course_endings,
-      exceptions_count,
-      short: total_short_activities,
-      long: total_long_activities
-    };
-
-    const kpi_cards = buildDashboardKpiCardsFromSupabase(
-      totals,
-      activeTypeCounts,
-      exceptions_count,
-      active_instructors_count,
-      course_endings
-    );
 
     return {
-      month,
+      ...sourcePayload,
+      month: sourcePayload.month || sourceResult.data.month || monthPrefix,
       requested_month: month,
       month_fallback_used: false,
-      totals,
-      by_activity_manager,
-      summary: {
-        active_courses_current_month: total_long_activities,
-        ending_courses_current_month: course_endings,
-        active_courses_next_month: 0,
-        exceptions_count,
-        active_instructors: [...instructorNames].sort(),
-        operational_gaps_count: 0,
-        missing_instructor_count: 0,
-        missing_start_date_count: 0,
-        late_end_date_count: 0,
-        short_activities: [],
-        active_type_counts: { ...activeTypeCounts }
-      },
-      kpi_cards,
-      show_only_nonzero_kpis: false,
-      _source: 'supabase'
+      _source: sourceResult.data.source || 'supabase_dashboard_monthly_read_models',
+      _dashboard_source_table: 'dashboard_monthly_read_models',
+      _dashboard_source_updated_at: sourceResult.data.updated_at || null
     };
   } catch (err) {
-    return buildSupabaseErrorPayload({
-      month,
-      requested_month: month,
-      totals: {
-        total_short_activities: 0,
-        total_long_activities: 0,
-        total_instructors: 0,
-        total_course_endings_current_month: 0,
-        exceptions_count: 0,
-        short: 0,
-        long: 0
-      },
-      by_activity_manager: [],
-      summary: {
-        active_courses_current_month: 0,
-        ending_courses_current_month: 0,
-        active_courses_next_month: 0,
-        exceptions_count: 0,
-        active_instructors: [],
-        operational_gaps_count: 0,
-        missing_instructor_count: 0,
-        missing_start_date_count: 0,
-        late_end_date_count: 0,
-        short_activities: []
-      },
-      kpi_cards: buildDashboardKpiCardsFromSupabase(
-        { total_short_activities: 0, total_long_activities: 0 },
-        { course: 0, after_school: 0, workshop: 0, tour: 0, escape_room: 0 },
-        0,
-        0,
-        0
-      ),
-      show_only_nonzero_kpis: false
-    }, err);
+    console.error('[supabase][dashboard] unexpected error:', err);
+    warnDashboardSupabasePathFailed(err?.message || err || 'unexpected_error', { month });
+    return null;
   }
 }
 
@@ -1828,6 +1667,8 @@ async function request(action, payload = {}, perfMeta = {}) {
   throw new Error('legacy_gas_api_disabled');
 }
 
+const USER_PUBLIC_COLUMNS = 'user_id,email,name,role,emp_id,is_active,permissions,created_at,updated_at';
+
 const SUPABASE_ROLE_ROUTES = {
   admin: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'permissions', 'admin-lists'],
   operation_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
@@ -1845,7 +1686,6 @@ function flattenUserRow(userRow = {}) {
     display_role_label: hebrewRole(String(userRow.role || 'authorized_user')),
     display_role2: String(permissions.display_role2 || ''),
     emp_id: String(userRow.emp_id || ''),
-    entry_code: String(userRow.entry_code || ''),
     active: userRow.is_active ? 'yes' : 'no',
     ...permissions
   };
@@ -1875,14 +1715,13 @@ async function getActiveUserByLogin(user_id, entry_code) {
   const uid = String(user_id || '').trim();
   const code = String(entry_code || '').trim();
   if (!uid || !code) throw new Error('invalid_credentials');
-  const { data, error } = await supabase
-    .from('users')
-    .select('*')
-    .eq('is_active', true)
-    .or(`user_id.eq.${uid},email.eq.${uid},emp_id.eq.${uid}`)
-    .limit(20);
+  const { data, error } = await supabase.rpc('login_user_by_entry_code', {
+    p_login: uid,
+    p_entry_code: code
+  });
   if (error) throw new Error(error.message || 'auth_query_failed');
-  const hit = (Array.isArray(data) ? data : []).find((r) => String(r.entry_code || '').trim() === code);
+  const rows = Array.isArray(data) ? data : (data ? [data] : []);
+  const hit = rows[0];
   if (!hit) throw new Error('invalid_credentials');
   return hit;
 }
@@ -1903,7 +1742,7 @@ async function readCurrentUserBySession() {
   if (!userId) throw new Error('unauthorized');
   const { data, error } = await supabase
     .from('users')
-    .select('*')
+    .select(USER_PUBLIC_COLUMNS)
     .eq('user_id', userId)
     .single();
   if (error || !data) throw new Error('unauthorized');
@@ -2114,17 +1953,28 @@ export const api = {
   dashboardSnapshot: (filters) => api.dashboardReadModel(filters || {}),
   dashboardSheet: (filters) => api.dashboardReadModel(filters || {}),
   dashboardReadModel: async (filters, options) => {
+    void options;
     const resolved = (filters && typeof filters === 'object') ? filters : {};
     const candidate = String(resolved.month || resolved.ym || '').trim();
     const now = new Date();
     const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    const month = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
+    let month = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
+    if (candidate && candidate !== month) {
+      console.warn('[dashboard] fallback month returned', { requested_month: candidate, fallback_month: month, reason: 'invalid_month_format' });
+    }
     const canonical = { ...resolved, month };
     const supabasePayload = await dashboardReadModelFromSupabase(month);
-    if (!supabasePayload || typeof supabasePayload !== 'object') {
-      return buildSupabaseErrorPayload({ month, requested_month: month, ...canonical }, 'dashboard_null_payload');
+    const supabaseError = supabasePayload?.error || supabasePayload?._debug?.error;
+    if (!supabasePayload || typeof supabasePayload !== 'object' || supabaseError) {
+      warnDashboardSupabasePathFailed(supabaseError || 'dashboard_null_payload', { month, requested_month: candidate || month });
+      // Legacy GAS/read-model fallback is disabled in this Supabase-only client. Do not fabricate KPI=0 payloads.
+      throw new Error('טעינת נתוני לוח הבקרה נכשלה. מקור Supabase לא החזיר נתונים תקינים ואין fallback פעיל.');
     }
-    return { ...supabasePayload, ...canonical };
+    if (supabasePayload.month && supabasePayload.month !== month) {
+      console.warn('[dashboard] fallback month returned', { requested_month: month, returned_month: supabasePayload.month });
+      month = supabasePayload.month;
+    }
+    return { ...supabasePayload, ...canonical, month };
   },
   archiveActivities: async () => {
     const data = await readArchiveActivitiesFromSupabase();
@@ -2200,7 +2050,7 @@ export const api = {
     return buildEditRequestGroups(rows, canReview);
   },
   permissions: async () => {
-    const { data, error } = await supabase.from('users').select('*').order('created_at', { ascending: false });
+    const { data, error } = await supabase.from('users').select(USER_PUBLIC_COLUMNS).order('created_at', { ascending: false });
     if (error) throw new Error(error.message || 'permissions_read_failed');
     const rows = (Array.isArray(data) ? data : []).map(flattenUserRow);
     return {
@@ -2361,7 +2211,7 @@ export const api = {
   savePermission: async (row) => {
     const userId = String(row?.user_id || '').trim();
     if (!userId) throw new Error('missing_user_id');
-    const existing = await supabase.from('users').select('*').eq('user_id', userId).single();
+    const existing = await supabase.from('users').select(USER_PUBLIC_COLUMNS).eq('user_id', userId).single();
     if (existing.error || !existing.data) throw new Error('user_not_found');
     const permissions = { ...(existing.data.permissions || {}) };
     Object.entries(row || {}).forEach(([k, v]) => {
@@ -2373,7 +2223,6 @@ export const api = {
       is_active: String(row.active || '').toLowerCase() !== 'no',
       name: row.full_name ?? existing.data.name,
       emp_id: row.emp_id ?? existing.data.emp_id,
-      entry_code: row.entry_code ?? existing.data.entry_code,
       permissions: {
         ...permissions,
         display_role2: row.display_role2 ?? permissions.display_role2 ?? ''

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -164,6 +164,11 @@ function goActivitiesDrill(state, patch) {
 const ALLOWED_KPI_ACTIONS = new Set([
   'kpi|long',
   'kpi|short',
+  'kpi|active_courses',
+  'kpi|active_workshops',
+  'kpi|active_tours',
+  'kpi|active_after_school',
+  'kpi|active_escape_room',
   'kpi|exceptions',
   'kpi|instructors',
   'kpi|endings'
@@ -174,6 +179,42 @@ function filterKpiCards(cards, showOnlyNonzero) {
   const allowed = list.filter((c) => c && c.action && ALLOWED_KPI_ACTIONS.has(c.action));
   if (!showOnlyNonzero) return allowed;
   return allowed.filter((c) => c.id === 'exceptions' || Number(c.value || 0) > 0);
+}
+
+function dashboardSourceError(data) {
+  return data?.error || data?._debug?.error || '';
+}
+
+function dashboardTotalsAllZero(totals = {}) {
+  const values = [
+    totals.total_short_activities,
+    totals.total_long_activities,
+    totals.total_instructors,
+    totals.total_course_endings_current_month,
+    totals.exceptions_count,
+    totals.short,
+    totals.long
+  ].filter((v) => v !== undefined && v !== null && v !== '');
+  return values.length > 0 && values.every((v) => Number(v || 0) === 0);
+}
+
+function dashboardErrorHtml(data, ym) {
+  const errorText = dashboardSourceError(data) || 'dashboard_source_failed';
+  return dsScreenStack(`
+    <div class="ds-dashboard-wrap">
+      <header class="ds-dash-header" dir="rtl">
+        <h1 class="ds-dash-header__title">לוח בקרה</h1>
+        <div class="ds-dash-month-nav" dir="rtl" aria-label="בחירת חודש לתצוגה">
+          <span class="ds-dash-month-nav__label">${escapeHtml(hebrewMonthTitle(ym))}</span>
+        </div>
+      </header>
+      ${dsCard({
+        title: 'לא ניתן לטעון את נתוני לוח הבקרה',
+        body: `<p class="ds-empty__msg">מקור הנתונים נכשל ולכן לא מוצגים כרטיסי KPI עם ערכי 0 שאינם מאומתים.</p><p class="ds-muted" dir="ltr">${escapeHtml(errorText)}</p>`,
+        padded: true
+      })}
+    </div>
+  `);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -239,7 +280,7 @@ export const dashboardScreen = {
 
     try {
       const data = await Promise.race([
-        api.dashboardReadModel({ month: ym }),
+        api.dashboardSnapshot({ month: ym }),
         guardPromise
       ]);
       clearTimeout(guardTimer);
@@ -248,7 +289,7 @@ export const dashboardScreen = {
       );
       // eslint-disable-next-line no-console
       console.info('[dashboard-load]', {
-        action: 'dashboardReadModel',
+        action: 'dashboardSnapshot',
         duration_ms: durationMs,
         is_snapshot: data?._is_snapshot !== false,
         is_stale: data?._is_stale === true,
@@ -266,7 +307,7 @@ export const dashboardScreen = {
         String(err?.message || '').includes('timeout');
       // eslint-disable-next-line no-console
       console.warn('[dashboard-load] failed', {
-        action: 'dashboardReadModel',
+        action: 'dashboardSnapshot',
         duration_ms: durationMs,
         is_timeout: isTimeout,
         error: err?.message || String(err),
@@ -277,6 +318,14 @@ export const dashboardScreen = {
   },
   render(data, { state } = {}) {
     const ym = data?.month || currentMonthYm();
+    const sourceError = dashboardSourceError(data);
+    if (sourceError) {
+      console.warn('[dashboard] source error; KPI cards suppressed', { month: ym, error: sourceError });
+      if (dashboardTotalsAllZero(data?.totals || {})) {
+        console.warn('[dashboard] totals are all zero while source error exists', { month: ym, error: sourceError });
+      }
+      return dashboardErrorHtml(data, ym);
+    }
 
     const _seenMgr = new Set();
     const managers = (Array.isArray(data.by_activity_manager) ? data.by_activity_manager : []).filter(
@@ -290,17 +339,13 @@ export const dashboardScreen = {
     const showOnly = !!data?.show_only_nonzero_kpis;
     let _kpiSource = data?.kpi_cards;
     if (!Array.isArray(_kpiSource) || _kpiSource.filter(c => c && ALLOWED_KPI_ACTIONS.has(c.action)).length === 0) {
-      const t = data?.totals || {};
-      const s = data?.summary || {};
-      _kpiSource = [
-        { id: 'short',       action: 'kpi|short',       subtitle: 'חד-יומי',           value: t.total_short_activities ?? t.short ?? 0 },
-        { id: 'long',        action: 'kpi|long',        subtitle: 'תוכניות',            value: t.total_long_activities  ?? t.long  ?? 0 },
-        { id: 'exceptions',  action: 'kpi|exceptions',  subtitle: 'חריגות (קורסים)',    value: s.exceptions_count       ?? t.exceptions_count ?? 0 },
-        { id: 'instructors', action: 'kpi|instructors', subtitle: 'מדריכים פעילים',     value: Array.isArray(s.active_instructors) ? s.active_instructors.length : (t.total_instructors ?? 0) },
-        { id: 'endings',     action: 'kpi|endings',     subtitle: 'סיומי קורסים',       value: t.total_course_endings_current_month ?? s.ending_courses_current_month ?? 0 },
-      ];
+      console.warn('[dashboard] KPI cards empty', { month: ym, has_totals: !!data?.totals, has_summary: !!data?.summary });
+      _kpiSource = [];
     }
     const kpiCards = filterKpiCards(_kpiSource, showOnly);
+    if (kpiCards.length === 0) {
+      console.warn('[dashboard] KPI cards empty after filtering', { month: ym, show_only_nonzero_kpis: showOnly });
+    }
 
     const managerCards = managers
       .map((row) => {
@@ -468,7 +513,7 @@ export const dashboardScreen = {
         }
         showDataAreaLoading();
         try {
-          const snapshotData = await api.dashboardReadModel({ month: nextYm });
+          const snapshotData = await api.dashboardSnapshot({ month: nextYm });
           putDashboardCache(cacheKey, snapshotData);
         } catch (_err) {
           // Keep currently rendered dashboard content when refresh fails.

--- a/frontend/src/supabase-client.js
+++ b/frontend/src/supabase-client.js
@@ -3,10 +3,11 @@ import { createClient } from '@supabase/supabase-js';
 const FALLBACK_SUPABASE_URL = 'https://szinlhjuwyiyszdpsdop.supabase.co';
 const FALLBACK_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_k0IbDJlgPA9KTVuDWrCyFw_Zsa5kZIM';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || import.meta.env.NEXT_PUBLIC_SUPABASE_URL || FALLBACK_SUPABASE_URL;
+const viteEnv = import.meta.env || {};
+const supabaseUrl = viteEnv.VITE_SUPABASE_URL || viteEnv.NEXT_PUBLIC_SUPABASE_URL || FALLBACK_SUPABASE_URL;
 const supabaseAnonKey =
-  import.meta.env.VITE_SUPABASE_ANON_KEY ||
-  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  viteEnv.VITE_SUPABASE_ANON_KEY ||
+  viteEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
   FALLBACK_SUPABASE_PUBLISHABLE_KEY;
 
 let supabase = null;

--- a/supabase/migrations/20260506_lock_down_client_rls_and_dashboard_source.sql
+++ b/supabase/migrations/20260506_lock_down_client_rls_and_dashboard_source.sql
@@ -1,0 +1,103 @@
+-- Migration: lock down client-facing RLS/grants and define a Supabase dashboard source table.
+-- The anon key may read only the public data needed by the app. Writes must be performed
+-- by a trusted backend/service-role process, not directly from the browser.
+
+-- A Supabase-only dashboard should be populated from the same fixed dashboard sheet/read-model
+-- contract by a backend sync job. The frontend may read this table by month; it must not
+-- synthesize KPI=0 payloads when this source is missing or unreadable.
+create table if not exists public.dashboard_monthly_read_models (
+  month text primary key check (month ~ '^[0-9]{4}-[0-9]{2}$'),
+  payload jsonb not null,
+  source text not null default 'dashboard_sheet',
+  updated_at timestamptz not null default now()
+);
+
+alter table public.dashboard_monthly_read_models enable row level security;
+
+drop policy if exists dashboard_monthly_read_models_select_public on public.dashboard_monthly_read_models;
+create policy dashboard_monthly_read_models_select_public
+on public.dashboard_monthly_read_models
+for select
+to anon, authenticated
+using (true);
+
+drop policy if exists dashboard_monthly_read_models_insert_public on public.dashboard_monthly_read_models;
+drop policy if exists dashboard_monthly_read_models_update_public on public.dashboard_monthly_read_models;
+drop policy if exists dashboard_monthly_read_models_delete_public on public.dashboard_monthly_read_models;
+
+grant select on public.dashboard_monthly_read_models to anon, authenticated;
+revoke insert, update, delete on public.dashboard_monthly_read_models from anon, authenticated;
+
+-- Undo the broad anon write grants from 20260505_grant_anon_all_tables.sql for sensitive/core data.
+revoke insert, update, delete on public.data_long from anon;
+revoke insert, update, delete on public.data_short from anon;
+revoke insert, update, delete on public.users from anon;
+revoke insert, update, delete on public.settings from anon;
+
+-- Keep browser reads explicit. entry_code is intentionally excluded from users column grants.
+revoke all on public.users from anon, authenticated;
+grant select (user_id, email, name, role, emp_id, is_active, permissions, created_at, updated_at)
+on public.users to anon, authenticated;
+
+revoke all on public.settings from anon, authenticated;
+grant select on public.settings to anon, authenticated;
+
+-- Data tables are readable by the client screens but not writable with the anon key.
+grant select on public.data_long to anon, authenticated;
+grant select on public.data_short to anon, authenticated;
+revoke insert, update, delete on public.data_long from authenticated;
+revoke insert, update, delete on public.data_short from authenticated;
+
+-- Replace permissive users write policies with read-only public access to active users.
+drop policy if exists users_insert_all on public.users;
+drop policy if exists users_update_all on public.users;
+drop policy if exists users_delete_all on public.users;
+drop policy if exists users_select_active on public.users;
+create policy users_select_active_public_safe
+on public.users
+for select
+to anon, authenticated
+using (is_active = true);
+
+-- Replace permissive settings write policies with read-only public access.
+drop policy if exists settings_insert_all on public.settings;
+drop policy if exists settings_update_all on public.settings;
+drop policy if exists settings_delete_all on public.settings;
+drop policy if exists settings_select_all on public.settings;
+create policy settings_select_public
+on public.settings
+for select
+to anon, authenticated
+using (true);
+
+-- Login validates entry_code server-side and returns only non-secret user fields.
+create or replace function public.login_user_by_entry_code(p_login text, p_entry_code text)
+returns table (
+  user_id text,
+  email text,
+  name text,
+  role text,
+  emp_id text,
+  is_active boolean,
+  permissions jsonb,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select u.user_id, u.email, u.name, u.role, u.emp_id, u.is_active, u.permissions, u.created_at, u.updated_at
+  from public.users u
+  where u.is_active = true
+    and trim(coalesce(u.entry_code, '')) = trim(coalesce(p_entry_code, ''))
+    and (
+      u.user_id = trim(coalesce(p_login, ''))
+      or u.email = trim(coalesce(p_login, ''))
+      or u.emp_id = trim(coalesce(p_login, ''))
+    )
+  limit 1;
+$$;
+
+revoke all on function public.login_user_by_entry_code(text, text) from public;
+grant execute on function public.login_user_by_entry_code(text, text) to anon, authenticated;


### PR DESCRIPTION
### Motivation
- Prevent the UI from fabricating `KPI=0` when Supabase reads fail, the month is invalid, or the Supabase payload signals an error so users are not shown misleading metrics.
- Make Supabase the explicit frontend source-of-truth for the dashboard (monthly read-model table) and ensure the client surfaces clear failure messages instead of silent zero fallbacks.
- Harden client-surface security by removing `entry_code` from public user reads and routing login validation to a DB-side RPC, and tighten anon RLS/grants for sensitive tables.

### Description
- Replaced the in-client dashboard aggregation path in `dashboardReadModelFromSupabase` with a dedicated monthly source lookup from `dashboard_monthly_read_models` and added `warnDashboardSupabasePathFailed` so invalid months, missing rows, `_debug.error` or Supabase errors return `null` (no fabricated KPI payload). (`frontend/src/api.js`)
- Made `api.dashboardReadModel` treat a missing/errored Supabase payload as a hard failure and throw an explicit error when no legacy/GAS fallback is active, avoiding constructed zero-values returned to the UI. (`frontend/src/api.js`)
- Updated dashboard UI (`frontend/src/screens/dashboard.js`) to suppress building KPI cards with zeros when `data.error`/`data._debug.error` exist and instead show a clear error/card explaining the data source failure; added `console.warn` traces for source failures, fallback-months, empty KPI cards, and all-zero totals with source errors.
- Allowed the `active_*` KPI actions through `ALLOWED_KPI_ACTIONS` so those cards are not silently filtered out when they are present; removed constructing a zero-filled fallback KPI list. (`frontend/src/screens/dashboard.js`)
- Locked down client RLS/grants and added a migration `20260506_lock_down_client_rls_and_dashboard_source.sql` to: create `dashboard_monthly_read_models`, restrict anon insert/update/delete on sensitive tables, grant explicit public read columns (excluding `entry_code`), and add a secure `login_user_by_entry_code` RPC to validate credentials server-side. (`supabase/migrations/20260506_lock_down_client_rls_and_dashboard_source.sql`)
- Hid `entry_code` from client-side `flattenUserRow` and switched the frontend login flow to call the new server-side RPC (`supabase.rpc('login_user_by_entry_code', ...)`) so secrets are never exposed to the browser. (`frontend/src/api.js`)
- Guarded `import.meta.env` access in `supabase-client.js` for Node/test environments so `@supabase/supabase-js` imports no longer fail when Vite env is not present. (`frontend/src/supabase-client.js`)

### Testing
- Ran `npm install` which completed successfully.
- Ran `npm run build` which succeeded and produced the production build without `@supabase/supabase-js` import errors.
- Performed static checks with `node --check frontend/src/api.js && node --check frontend/src/screens/dashboard.js && node --check frontend/src/supabase-client.js` which passed.
- Ran `npm test`; the repository test suite reported multiple failures but the failures are due to missing backend `backend/*.gs` files and legacy GAS/read-model contract tests (expected given the shift to a Supabase monthly read-model and tightened RLS), and not from the `@supabase/supabase-js` import issue.
- Ran focused dashboard test files (`tests/dashboard-readmodel-guard.test.mjs`, `tests/dashboard-stability.test.mjs`, `tests/dashboard-sheet-contract.test.mjs`, `tests/calendar-navigation.test.mjs`); dashboard snapshot-path assertions passed but some backend-contract tests failed due to absent GAS backend files as noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb34d90e7c832bb0d62f130f1fa1e6)