### PR TITLE
Fix Supabase login RPC diagnostics

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -988,14 +988,16 @@ async function readExceptionsFromSupabase(params = {}) {
   const end = `${month}-${String(lastDay).padStart(2, '0')}`;
   try {
     const [longRes, shortRes, meetRes] = await Promise.all([
-      supabase.from('data_long').select('*').lte('start_date', end).or(`end_date.gte.${start},date_end.gte.${start}`),
+      supabase.from('data_long').select('*').lte('start_date', end),
       supabase.from('data_short').select('*').gte('start_date', start).lte('start_date', end),
       supabase.from('activity_meetings').select('*').gte('meeting_date', start).lte('meeting_date', end)
     ]);
     if (longRes.error) return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0 }, longRes.error);
     if (shortRes.error) return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0 }, shortRes.error);
     if (meetRes.error) return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0 }, meetRes.error);
-    const longRows = Array.isArray(longRes.data) ? longRes.data : [];
+    const longRows = Array.isArray(longRes.data)
+      ? longRes.data.filter((row) => String(row?.end_date || row?.date_end || '').trim() >= start)
+      : [];
     const shortRows = Array.isArray(shortRes.data) ? shortRes.data : [];
     const meetingsRows = Array.isArray(meetRes.data) ? meetRes.data : [];
     const rows = buildExceptionsFromRows(longRows, shortRows, meetingsRows);
@@ -1683,7 +1685,7 @@ function normalizeSupabaseRole(role) {
 }
 
 function getLoginStatus(row) {
-  return String(row?.login_status || row?.status || '').trim();
+  return String(row?.status || '').trim();
 }
 
 function throwLoginError(code, details = {}) {
@@ -1748,7 +1750,6 @@ async function getActiveUserByLogin(user_id, entry_code) {
   if (!supabase) throwLoginError('no_supabase_client');
   const uid = String(user_id || '').trim();
   const code = String(entry_code || '').trim();
-  if (!uid || !code) throwLoginError('missing_user_id_or_entry_code', { has_user_id: Boolean(uid), has_entry_code: Boolean(code) });
 
   const { data, error } = await supabase.rpc('login_user_by_entry_code', {
     p_login: uid,
@@ -1761,12 +1762,10 @@ async function getActiveUserByLogin(user_id, entry_code) {
   const rows = Array.isArray(data) ? data : (data ? [data] : []);
   const hit = rows[0];
   const status = getLoginStatus(hit);
-  if (!hit) throwLoginError('user_not_found', { login: uid });
-  if (status && status !== 'ok') {
-    const allowedStatuses = new Set(['user_not_found', 'inactive_user', 'entry_code_mismatch', 'invalid_role']);
-    throwLoginError(allowedStatuses.has(status) ? status : 'users_query_failed', { login: uid, status });
+  if (!hit || !status) throwLoginError('users_query_failed', { login: uid, reason: 'missing_rpc_status' });
+  if (status !== 'ok') {
+    throwLoginError(status, { login: uid, status });
   }
-  if (!hit.is_active) throwLoginError('inactive_user', { login: uid });
   assertValidLoginUserRow(hit);
   return hit;
 }

--- a/supabase/migrations/20260506_lock_down_client_rls_and_dashboard_source.sql
+++ b/supabase/migrations/20260506_lock_down_client_rls_and_dashboard_source.sql
@@ -74,7 +74,7 @@ using (true);
 drop function if exists public.login_user_by_entry_code(text, text);
 create function public.login_user_by_entry_code(p_login text, p_entry_code text)
 returns table (
-  login_status text,
+  status text,
   user_id text,
   email text,
   name text,
@@ -108,24 +108,25 @@ as $$
   ), diagnostic as (
     select
       case
+        when (select i.login from input i) = '' or (select i.code from input i) = '' then 'missing_user_id_or_entry_code'
         when not exists (select 1 from candidate) then 'user_not_found'
         when not (select c.is_active from candidate c) then 'inactive_user'
         when trim(coalesce((select c.entry_code from candidate c), '')) <> (select i.code from input i) then 'entry_code_mismatch'
         when coalesce((select c.role from candidate c), '') not in ('admin', 'operation_manager', 'authorized_user', 'instructor') then 'invalid_role'
         else 'ok'
-      end as login_status
+      end as status
   )
   select
-    d.login_status,
-    case when d.login_status = 'ok' then c.user_id end as user_id,
-    case when d.login_status = 'ok' then c.email end as email,
-    case when d.login_status = 'ok' then c.name end as name,
-    case when d.login_status = 'ok' then c.role end as role,
-    case when d.login_status = 'ok' then c.emp_id end as emp_id,
-    case when d.login_status = 'ok' then c.is_active end as is_active,
-    case when d.login_status = 'ok' then c.permissions end as permissions,
-    case when d.login_status = 'ok' then c.created_at end as created_at,
-    case when d.login_status = 'ok' then c.updated_at end as updated_at
+    d.status,
+    case when d.status = 'ok' then c.user_id end as user_id,
+    case when d.status = 'ok' then c.email end as email,
+    case when d.status = 'ok' then c.name end as name,
+    case when d.status = 'ok' then c.role end as role,
+    case when d.status = 'ok' then c.emp_id end as emp_id,
+    case when d.status = 'ok' then c.is_active end as is_active,
+    case when d.status = 'ok' then c.permissions end as permissions,
+    case when d.status = 'ok' then c.created_at end as created_at,
+    case when d.status = 'ok' then c.updated_at end as updated_at
   from diagnostic d
   left join candidate c on true;
 $$;


### PR DESCRIPTION
### Motivation
- לקוד חשוב ש-RPC של ההתחברות יחזיר דיאגנוסטיקה מפורשת כדי לאפשר ל-frontend להבדיל בין סיבות כשל (חסר קלט, משתמש לא נמצא, משתמש לא פעיל, קוד כניסה לא תואם, תפקיד לא חוקי) ללא חשיפת `entry_code`.

### Description
- עדכנתי את ה-SQL של `public.login_user_by_entry_code(p_login text, p_entry_code text)` כדי שיחזיר עמודה `status text` עם הערכים המבוקשים כולל `missing_user_id_or_entry_code`, ושמרתי את `security definer` ו-`grant execute to anon, authenticated`.
- שיניתי את ה-frontend (`frontend/src/api.js`) כך שיקרא ל-`supabase.rpc('login_user_by_entry_code')`, ישתמש ב-`result.status`, ויזרוק `Error` עם אותו `status` כאשר הוא אינו `ok`, ובמקרה `ok` יבנה את ה-session/user/bootstrap מהשורה שחזרה.
- הסרתי שימוש ב-PostgREST `.or(...)` בשאילתת פעילויות ארוכות והעברתי את בדיקת חפיפת התאריכים לסינון בצד הלקוח כדי להשאיר את הנתיב Supabase-only פשוט יותר.
- הקבצים ששונו: `supabase/migrations/20260506_lock_down_client_rls_and_dashboard_source.sql` ו-`frontend/src/api.js`.

### Testing
- הרצת `npm run build` הצליחה ללא שגיאות והארכיבה את ה-dist بنجاح.
- ביצעתי בדיקות סטטיות/grep ו-`git diff --check` כדי לוודא שהשינויים ב-SQL וב-API יישרו קו עם השימוש ב-`status` (`rg`/`diff` נוספו ברולאוט).
- ניסיתי להריץ `npm test` אך הבדיקות נכשלו בקבצי legacy של GAS (קבצים חסרים כמו `backend/activities-snapshot.gs`) שהן לא קשורות לתיקון זה, לכן לא כל בדיקות ה-TAP עברו.
- לא ניתן לבצע את בדיקות ה-SQL הידניות על מסד הנתונים כי אין `psql` או Supabase CLI בסביבת הבניה; מומלץ להריץ את הפקודות הבאות בסביבת Supabase אמתית: `select * from public.login_user_by_entry_code('USER_ID_VALID','CODE_VALID');` ו-דוגמאות נוספות לפי הדרישה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4264a7a8832b828afdd3119a3fc7)