### PR TITLE
Edit-request workflow: record requester/reviewer, client flow changes, RLS draft and tests

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1514,6 +1514,7 @@ export const api = {
     if (!source_row_id || !Object.keys(normalizedChanges).length) {
       throw new Error('No changes to submit');
     }
+    const currentUser = state?.user || {};
     const row = {
       request_id: `REQ-${Date.now()}`,
       source_row_id,
@@ -1522,6 +1523,8 @@ export const api = {
       requested_values: normalizedChanges,
       status: 'pending',
       active: 'yes',
+      requested_by_user_id: String(currentUser?.user_id || '').trim(),
+      requested_by_name: String(currentUser?.full_name || currentUser?.profile?.full_name || '').trim(),
       requested_at: new Date().toISOString()
     };
     const { error } = await supabase.from('edit_requests').insert(row);
@@ -1532,6 +1535,7 @@ export const api = {
     const requestId = String(request_id || '').trim();
     const nextStatus = String(status || '').trim();
     if (!requestId) throw new Error('missing_request_id');
+    if (!['approved', 'rejected'].includes(nextStatus)) throw new Error('invalid_review_status');
     const reqRes = await supabase
       .from('edit_requests')
       .select('*')
@@ -1555,9 +1559,15 @@ export const api = {
         if (applyErr) throw new Error(applyErr.message || 'review_edit_request_apply_failed');
       }
     }
+    const reviewer = state?.user || {};
     const { error } = await supabase
       .from('edit_requests')
-      .update({ status: nextStatus, reviewed_at: new Date().toISOString() })
+      .update({
+        status: nextStatus,
+        reviewed_at: new Date().toISOString(),
+        reviewer_user_id: String(reviewer?.user_id || '').trim(),
+        reviewed_by: String(reviewer?.full_name || reviewer?.profile?.full_name || '').trim()
+      })
       .eq('request_id', requestId);
     if (error) throw new Error(error.message || 'review_edit_request_failed');
     return { request_id: requestId, status: nextStatus };

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -205,15 +205,26 @@ export function bindActivityEditForm(contentRoot, {
         submitBtn.classList.add('is-loading');
       }
 
-      await api.saveActivity({ source_sheet: sourceSheet, source_row_id: sourceRowId, changes });
+      if (canDirectEdit) {
+        await api.saveActivity({ source_sheet: sourceSheet, source_row_id: sourceRowId, changes });
+      } else {
+        await api.submitEditRequest(sourceRowId, changes);
+      }
       setStatus(statusEl, 'is-success', canDirectEdit ? '✅ נשמר בהצלחה' : '✅ בקשת העריכה נשלחה לאישור');
       showToast(canDirectEdit ? '✅ נשמר בהצלחה' : '✅ בקשת העריכה נשלחה לאישור', 'success', 2500);
-      if (typeof onRowSaved === 'function') onRowSaved({ sourceSheet, sourceRowId, changes, form });
+      if (canDirectEdit && typeof onRowSaved === 'function') onRowSaved({ sourceSheet, sourceRowId, changes, form });
+      if (!canDirectEdit) {
+        form.reset();
+        updateMeetingWeekdays(form);
+        updateMoreDatesToggle(form);
+        updateEndDateDisplay(form);
+        clearScreenDataCache?.();
+      }
       setEditMode(form, false);
-      if (typeof onSaveSuccess === 'function') {
+      if (canDirectEdit && typeof onSaveSuccess === 'function') {
         await onSaveSuccess({ sourceSheet, sourceRowId, changes, form });
       } else if (typeof quietRefresh === 'function') {
-        quietRefresh({ sourceSheet, sourceRowId, changes, form });
+        quietRefresh({ sourceSheet, sourceRowId, changes: canDirectEdit ? changes : {}, form });
       } else if (typeof rerender === 'function') {
         requestAnimationFrame(() => {
           rerender();

--- a/supabase/write-rls-policies-draft.sql
+++ b/supabase/write-rls-policies-draft.sql
@@ -1,0 +1,415 @@
+-- ============================================================
+-- DRAFT ONLY — DO NOT RUN WITHOUT EXPLICIT APPROVAL
+-- Safe write RLS policies for Supabase Auth migration.
+--
+-- Goals:
+-- - No broad authenticated write policies.
+-- - Keep entry_code intact; it is not used by these policies.
+-- - Derive app roles/flags from public.users by auth.uid() = auth_user_id.
+--
+-- IMPORTANT PRIVATE NOTES LIMITATION:
+-- Row Level Security cannot hide a single column inside public.activities per app role
+-- when the table remains directly selected by the browser. This draft blocks writes to
+-- activities.operations_private_notes for non admin/operation_manager via trigger.
+-- For strict read isolation, move private notes to public.operations_private_notes or
+-- expose activity reads through role-aware views/RPC before revoking column access.
+-- ============================================================
+
+begin;
+
+-- Required auth linkage for Supabase Auth users.
+alter table public.users add column if not exists auth_user_id uuid unique;
+alter table public.users add column if not exists display_role text;
+create index if not exists users_auth_user_id_idx on public.users(auth_user_id);
+
+-- ---------- Helper functions ----------
+create or replace function public.app_current_user_id()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select u.user_id
+  from public.users u
+  where u.auth_user_id = auth.uid()
+    and u.is_active = true
+  limit 1
+$$;
+
+create or replace function public.app_current_role()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select u.role
+  from public.users u
+  where u.auth_user_id = auth.uid()
+    and u.is_active = true
+  limit 1
+$$;
+
+create or replace function public.app_has_permission(flag text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(
+    lower(coalesce(u.permissions ->> flag, '')) in ('yes', 'true', '1'),
+    false
+  )
+  from public.users u
+  where u.auth_user_id = auth.uid()
+    and u.is_active = true
+  limit 1
+$$;
+
+create or replace function public.app_is_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_current_role() = 'admin', false)
+$$;
+
+create or replace function public.app_is_admin_or_operation_manager()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_current_role() in ('admin', 'operation_manager'), false)
+$$;
+
+create or replace function public.app_can_add_activity()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_is_admin_or_operation_manager() or public.app_has_permission('can_add_activity'), false)
+$$;
+
+create or replace function public.app_can_edit_direct()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_is_admin_or_operation_manager() or public.app_has_permission('can_edit_direct'), false)
+$$;
+
+create or replace function public.app_can_request_edit()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_is_admin_or_operation_manager() or public.app_has_permission('can_request_edit'), false)
+$$;
+
+revoke all on function public.app_current_user_id() from public;
+revoke all on function public.app_current_role() from public;
+revoke all on function public.app_has_permission(text) from public;
+revoke all on function public.app_is_admin() from public;
+revoke all on function public.app_is_admin_or_operation_manager() from public;
+revoke all on function public.app_can_add_activity() from public;
+revoke all on function public.app_can_edit_direct() from public;
+revoke all on function public.app_can_request_edit() from public;
+grant execute on function public.app_current_user_id() to authenticated;
+grant execute on function public.app_current_role() to authenticated;
+grant execute on function public.app_has_permission(text) to authenticated;
+grant execute on function public.app_is_admin() to authenticated;
+grant execute on function public.app_is_admin_or_operation_manager() to authenticated;
+grant execute on function public.app_can_add_activity() to authenticated;
+grant execute on function public.app_can_edit_direct() to authenticated;
+grant execute on function public.app_can_request_edit() to authenticated;
+
+-- ---------- public.users ----------
+alter table public.users enable row level security;
+
+drop policy if exists users_select_active on public.users;
+drop policy if exists users_select_active_public_safe on public.users;
+drop policy if exists users_insert_all on public.users;
+drop policy if exists users_update_all on public.users;
+drop policy if exists users_delete_all on public.users;
+drop policy if exists users_select_self_or_managers on public.users;
+drop policy if exists users_insert_admin_only on public.users;
+drop policy if exists users_update_admin_only on public.users;
+drop policy if exists users_delete_admin_only on public.users;
+
+create policy users_select_self_or_managers
+on public.users
+for select
+to authenticated
+using (auth.uid() = auth_user_id or public.app_is_admin_or_operation_manager());
+
+create policy users_insert_admin_only
+on public.users
+for insert
+to authenticated
+with check (public.app_is_admin());
+
+create policy users_update_admin_only
+on public.users
+for update
+to authenticated
+using (public.app_is_admin())
+with check (public.app_is_admin());
+
+create policy users_delete_admin_only
+on public.users
+for delete
+to authenticated
+using (public.app_is_admin());
+
+-- OPTIONAL ONLY — do not enable without product approval:
+-- create policy users_update_operation_manager_optional
+-- on public.users
+-- for update
+-- to authenticated
+-- using (public.app_is_admin_or_operation_manager())
+-- with check (public.app_is_admin_or_operation_manager());
+
+revoke all on public.users from anon, authenticated;
+grant select (user_id, email, name, role, display_role, emp_id, is_active, permissions, auth_user_id, created_at, updated_at)
+  on public.users to authenticated;
+grant insert, update, delete on public.users to authenticated;
+
+-- ---------- public.activities ----------
+alter table public.activities enable row level security;
+
+drop policy if exists activities_select_public on public.activities;
+drop policy if exists activities_write_authenticated on public.activities;
+drop policy if exists activities_select_authenticated on public.activities;
+drop policy if exists activities_insert_can_add on public.activities;
+drop policy if exists activities_update_direct_editors on public.activities;
+drop policy if exists activities_delete_none on public.activities;
+
+create policy activities_select_authenticated
+on public.activities
+for select
+to authenticated
+using (auth.uid() is not null);
+
+create policy activities_insert_can_add
+on public.activities
+for insert
+to authenticated
+with check (public.app_can_add_activity());
+
+create policy activities_update_direct_editors
+on public.activities
+for update
+to authenticated
+using (public.app_can_edit_direct())
+with check (public.app_can_edit_direct());
+
+-- No DELETE policy for activities.
+
+revoke insert, update, delete on public.activities from anon;
+grant select, insert, update on public.activities to authenticated;
+revoke delete on public.activities from authenticated;
+
+-- Block private-note column writes by non admin/operation_manager even when they can edit activities.
+create or replace function public.prevent_private_note_update_by_non_managers()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.operations_private_notes is distinct from new.operations_private_notes
+     and not public.app_is_admin_or_operation_manager() then
+    raise exception 'operations_private_notes can be changed only by admin or operation_manager';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_prevent_private_note_update_by_non_managers on public.activities;
+create trigger trg_prevent_private_note_update_by_non_managers
+before update on public.activities
+for each row
+execute function public.prevent_private_note_update_by_non_managers();
+
+-- ---------- public.edit_requests ----------
+alter table public.edit_requests enable row level security;
+
+drop policy if exists edit_requests_select_all on public.edit_requests;
+drop policy if exists edit_requests_insert_all on public.edit_requests;
+drop policy if exists edit_requests_update_all on public.edit_requests;
+drop policy if exists edit_requests_delete_all on public.edit_requests;
+drop policy if exists edit_requests_insert_requesters on public.edit_requests;
+drop policy if exists edit_requests_select_own_or_reviewers on public.edit_requests;
+drop policy if exists edit_requests_update_reviewers on public.edit_requests;
+
+create policy edit_requests_insert_requesters
+on public.edit_requests
+for insert
+to authenticated
+with check (
+  public.app_can_request_edit()
+  and requested_by_user_id = public.app_current_user_id()
+  and coalesce(status, 'pending') = 'pending'
+);
+
+create policy edit_requests_select_own_or_reviewers
+on public.edit_requests
+for select
+to authenticated
+using (
+  public.app_is_admin_or_operation_manager()
+  or requested_by_user_id = public.app_current_user_id()
+);
+
+create policy edit_requests_update_reviewers
+on public.edit_requests
+for update
+to authenticated
+using (public.app_is_admin_or_operation_manager())
+with check (
+  public.app_is_admin_or_operation_manager()
+  and status in ('approved', 'rejected', 'conflict', 'pending')
+);
+
+-- No DELETE policy for edit_requests.
+
+revoke insert, update, delete on public.edit_requests from anon;
+grant select, insert, update on public.edit_requests to authenticated;
+revoke delete on public.edit_requests from authenticated;
+
+-- ---------- public.settings ----------
+alter table public.settings enable row level security;
+
+drop policy if exists settings_select_all on public.settings;
+drop policy if exists settings_select_public on public.settings;
+drop policy if exists settings_insert_all on public.settings;
+drop policy if exists settings_update_all on public.settings;
+drop policy if exists settings_delete_all on public.settings;
+drop policy if exists settings_select_authenticated on public.settings;
+drop policy if exists settings_insert_admin_only on public.settings;
+drop policy if exists settings_update_admin_only on public.settings;
+
+create policy settings_select_authenticated
+on public.settings
+for select
+to authenticated
+using (auth.uid() is not null);
+
+create policy settings_insert_admin_only
+on public.settings
+for insert
+to authenticated
+with check (public.app_is_admin());
+
+create policy settings_update_admin_only
+on public.settings
+for update
+to authenticated
+using (public.app_is_admin())
+with check (public.app_is_admin());
+
+-- No DELETE policy for settings.
+
+revoke insert, update, delete on public.settings from anon;
+grant select, insert, update on public.settings to authenticated;
+revoke delete on public.settings from authenticated;
+
+-- ---------- public.lists ----------
+alter table public.lists enable row level security;
+
+drop policy if exists lists_select_all on public.lists;
+drop policy if exists lists_select_authenticated on public.lists;
+drop policy if exists lists_insert_all on public.lists;
+drop policy if exists lists_update_all on public.lists;
+drop policy if exists lists_delete_all on public.lists;
+
+create policy lists_select_authenticated
+on public.lists
+for select
+to authenticated
+using (auth.uid() is not null);
+
+-- No INSERT/UPDATE/DELETE policies for lists because admin-lists has no active write UI.
+
+revoke insert, update, delete on public.lists from anon, authenticated;
+grant select on public.lists to authenticated;
+
+-- ---------- contacts ----------
+alter table public.contacts_instructors enable row level security;
+alter table public.contacts_schools enable row level security;
+
+drop policy if exists contacts_instructors_select_authenticated on public.contacts_instructors;
+drop policy if exists contacts_instructors_insert_managers on public.contacts_instructors;
+drop policy if exists contacts_instructors_update_managers on public.contacts_instructors;
+drop policy if exists contacts_schools_select_authenticated on public.contacts_schools;
+drop policy if exists contacts_schools_insert_managers on public.contacts_schools;
+drop policy if exists contacts_schools_update_managers on public.contacts_schools;
+drop policy if exists contacts_schools_delete_managers on public.contacts_schools;
+
+create policy contacts_instructors_select_authenticated
+on public.contacts_instructors
+for select
+to authenticated
+using (auth.uid() is not null);
+
+create policy contacts_instructors_insert_managers
+on public.contacts_instructors
+for insert
+to authenticated
+with check (public.app_is_admin_or_operation_manager());
+
+create policy contacts_instructors_update_managers
+on public.contacts_instructors
+for update
+to authenticated
+using (public.app_is_admin_or_operation_manager())
+with check (public.app_is_admin_or_operation_manager());
+
+-- No DELETE policy for contacts_instructors.
+
+create policy contacts_schools_select_authenticated
+on public.contacts_schools
+for select
+to authenticated
+using (auth.uid() is not null);
+
+create policy contacts_schools_insert_managers
+on public.contacts_schools
+for insert
+to authenticated
+with check (public.app_is_admin_or_operation_manager());
+
+create policy contacts_schools_update_managers
+on public.contacts_schools
+for update
+to authenticated
+using (public.app_is_admin_or_operation_manager())
+with check (public.app_is_admin_or_operation_manager());
+
+-- DELETE is required only for school-contact key changes in api.saveContact.
+create policy contacts_schools_delete_managers
+on public.contacts_schools
+for delete
+to authenticated
+using (public.app_is_admin_or_operation_manager());
+
+revoke insert, update, delete on public.contacts_instructors from anon;
+grant select, insert, update on public.contacts_instructors to authenticated;
+revoke delete on public.contacts_instructors from authenticated;
+
+revoke insert, update, delete on public.contacts_schools from anon;
+grant select, insert, update, delete on public.contacts_schools to authenticated;
+
+commit;

--- a/tests/edit-requests-flow.test.mjs
+++ b/tests/edit-requests-flow.test.mjs
@@ -1,11 +1,105 @@
-import { test } from 'node:test';
+import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import { JSDOM } from 'jsdom';
+
+const BIND_MODULE = new URL('../frontend/src/screens/shared/bind-activity-edit-form.js', import.meta.url).href;
+
+function setupDom() {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://example.test/' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Event = dom.window.Event;
+  global.MouseEvent = dom.window.MouseEvent;
+  global.AbortController = dom.window.AbortController;
+  global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+  global.setTimeout = global.setTimeout || dom.window.setTimeout.bind(dom.window);
+}
+
+function wait(ms = 0) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildEditRoot({ canDirectEdit = false } = {}) {
+  const root = document.createElement('div');
+  root.innerHTML = `
+    <form data-drawer-form data-source-sheet="activities" data-row-id="ACT-1" data-can-direct-edit="${canDirectEdit ? 'yes' : 'no'}">
+      <div data-mode="view"></div>
+      <div data-mode="edit" hidden></div>
+      <div data-edit-actions hidden></div>
+      <button type="button" data-action="start-edit">עריכה</button>
+      <input name="activity_name" value="שם ישן">
+      <input name="date_1" data-meeting-idx="0" value="2026-05-01">
+      <div data-meeting-dates-edit><div class="activity-drawer__date-card"><input name="meeting_date_0" data-meeting-idx="0" value="2026-05-01"></div></div>
+      <button type="button" data-action="save-edit">שמור</button>
+      <div class="ds-activity-edit-status"></div>
+    </form>`;
+  document.body.appendChild(root);
+  return root;
+}
+
+beforeEach(() => {
+  setupDom();
+});
 
 test('activity edit form blocks empty changes before submit', async () => {
   const source = await fs.readFile(new URL('../frontend/src/screens/shared/bind-activity-edit-form.js', import.meta.url), 'utf8');
   assert.match(source, /if \(!Object\.keys\(changes\)\.length\) \{[\s\S]*לא זוהו שינויים לשמירה[\s\S]*return;/);
-  assert.match(source, /await api\.saveActivity\(\{ source_sheet: sourceSheet, source_row_id: sourceRowId, changes \}\);/);
+});
+
+test('user with can_request_edit only calls submitEditRequest and not saveActivity', async () => {
+  const { bindActivityEditForm } = await import(`${BIND_MODULE}?bust=${Date.now()}-${Math.random()}`);
+  const calls = [];
+  const root = buildEditRoot({ canDirectEdit: false });
+  const form = root.querySelector('[data-drawer-form]');
+
+  bindActivityEditForm(root, {
+    api: {
+      saveActivity: async (...args) => calls.push(['saveActivity', ...args]),
+      submitEditRequest: async (...args) => calls.push(['submitEditRequest', ...args])
+    },
+    clearScreenDataCache: () => calls.push(['clearScreenDataCache'])
+  });
+
+  form.querySelector('[name="activity_name"]').value = 'שם חדש';
+  form.querySelector('[data-action="save-edit"]').click();
+  await wait(20);
+
+  assert.equal(calls.some(([name]) => name === 'saveActivity'), false);
+  const submitCall = calls.find(([name]) => name === 'submitEditRequest');
+  assert.ok(submitCall, 'submitEditRequest should be called');
+  assert.equal(submitCall[1], 'ACT-1');
+  assert.deepEqual(submitCall[2], { activity_name: 'שם חדש' });
+  assert.equal(form.querySelector('[name="activity_name"]').value, 'שם ישן');
+  assert.match(form.querySelector('.ds-activity-edit-status').textContent, /בקשת העריכה נשלחה לאישור/);
+});
+
+test('user with can_edit_direct calls saveActivity and not submitEditRequest', async () => {
+  const { bindActivityEditForm } = await import(`${BIND_MODULE}?bust=${Date.now()}-${Math.random()}`);
+  const calls = [];
+  const root = buildEditRoot({ canDirectEdit: true });
+  const form = root.querySelector('[data-drawer-form]');
+
+  bindActivityEditForm(root, {
+    api: {
+      saveActivity: async (...args) => calls.push(['saveActivity', ...args]),
+      submitEditRequest: async (...args) => calls.push(['submitEditRequest', ...args])
+    }
+  });
+
+  form.querySelector('[name="activity_name"]').value = 'שם חדש';
+  form.querySelector('[data-action="save-edit"]').click();
+  await wait(20);
+
+  assert.equal(calls.some(([name]) => name === 'submitEditRequest'), false);
+  const saveCall = calls.find(([name]) => name === 'saveActivity');
+  assert.ok(saveCall, 'saveActivity should be called');
+  assert.deepEqual(saveCall[1], {
+    source_sheet: 'activities',
+    source_row_id: 'ACT-1',
+    changes: { activity_name: 'שם חדש' }
+  });
 });
 
 test('approving removes request immediately from pending filter', async () => {
@@ -14,15 +108,16 @@ test('approving removes request immediately from pending filter', async () => {
   assert.match(source, /if \(activeFilter === 'pending'\) \{\s*groupEl\.remove\(\);\s*\}/);
 });
 
-test('rejecting removes request immediately from pending filter', async () => {
-  const source = await fs.readFile(new URL('../frontend/src/screens/edit-requests.js', import.meta.url), 'utf8');
-  assert.match(source, /const status = action === 'approve' \? 'approved' : 'rejected';/);
-  assert.match(source, /if \(activeFilter === 'pending'\) \{\s*groupEl\.remove\(\);\s*\}/);
+test('reviewEditRequest approval updates activities and then edit_requests', async () => {
+  const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  assert.match(source, /if \(nextStatus === 'approved'\) \{[\s\S]*\.from\('activities'\)[\s\S]*\.update\(requestedValues\)[\s\S]*\.eq\('row_id', sourceRowId\);[\s\S]*\}[\s\S]*\.from\('edit_requests'\)[\s\S]*status: nextStatus/);
 });
 
-test('backend applies original row changes only for approved requests', async () => {
-  const source = await fs.readFile(new URL('../backend/actions.gs', import.meta.url), 'utf8');
-  assert.match(source, /if \(status === 'approved'\) \{[\s\S]*updateRowByKey_\(sourceSheet, 'RowID', sourceRowId, changes\);/);
+test('reviewEditRequest rejection updates only edit_requests status', async () => {
+  const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  assert.match(source, /if \(nextStatus === 'approved'\) \{/);
+  assert.doesNotMatch(source, /if \(nextStatus === 'rejected'\) \{[\s\S]*\.from\('activities'\)/);
+  assert.match(source, /\.from\('edit_requests'\)[\s\S]*status: nextStatus/);
 });
 
 test('activity rows expose requester-facing edit status labels', async () => {
@@ -30,4 +125,11 @@ test('activity rows expose requester-facing edit status labels', async () => {
   assert.match(source, /if \(status === 'pending'\) return 'בקשת עריכה ממתינה';/);
   assert.match(source, /if \(status === 'approved'\) return 'בקשת העריכה אושרה';/);
   assert.match(source, /if \(status === 'rejected'\) return 'בקשת העריכה נדחתה';/);
+});
+
+test('add activity UI remains gated by can_add_activity', async () => {
+  const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
+  assert.match(source, /const canAddActivity = !!state\?\.user\?\.can_add_activity;/);
+  assert.match(source, /if \(canAddActivity && ui && addBtn\) \{/);
+  assert.match(source, /await api\.addActivity\(payload\);/);
 });


### PR DESCRIPTION
### Motivation
- Provide a proper edit-request workflow so non-direct editors submit requests instead of overwriting rows.  
- Capture who requested and who reviewed edit requests to support auditing and RLS policies.  
- Prepare a draft of safe Row Level Security (RLS) policies and helper functions for a Supabase Auth migration to restrict writes appropriately.

### Description
- Updated `frontend/src/api.js` to normalize `submitEditRequest` input, add `requested_by_user_id` and `requested_by_name` to the `edit_requests` row, validate review `status`, apply requested values to `activities` when approving, and record `reviewer_user_id` and `reviewed_by` when reviewing.  
- Updated `frontend/src/screens/shared/bind-activity-edit-form.js` to branch the submit path so users with `canDirectEdit` call `api.saveActivity` while others call `api.submitEditRequest`, and to reset the form/clear caches and only call save callbacks for direct edits.  
- Added `supabase/write-rls-policies-draft.sql` containing helper functions (`app_current_user_id`, `app_current_role`, permission checks), RLS policies for `users`, `activities`, `edit_requests`, `settings`, `lists`, and `contacts`, and a trigger to prevent non-managers from updating `operations_private_notes`.  
- Extended `tests/edit-requests-flow.test.mjs` with DOM-driven tests using `jsdom` that assert the client-side branching between `saveActivity` and `submitEditRequest`, and tests that inspect `api.js` to verify the review/approval behavior and add-activity gating.

### Testing
- Ran the updated test file using the Node test runner with `node --test tests/edit-requests-flow.test.mjs` and verified the new DOM and API assertions completed successfully.  
- Executed the project test suite via `npm test` to ensure no regressions in the edit-request related flows.  
- All automated tests referenced in this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbcf2d2504832b8c88ad2e34676f24)