### PR TITLE
הוספת ייצוא לאקסל בחלון פעילות + כפתור ייצוא אדמין ותיקוני תצוגה/נתונים

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "/assets/favicon-32.png",
   "/assets/favicon-D0Y9bj5H.ico",
   "/assets/favicon.ico",
-  "/assets/index-MySTRkUc.js",
+  "/assets/index-CR4vK8Yz.js",
   "/assets/logo1-sNrSbLi9.png",
   "/assets/logo1.png",
   "/assets/logo2.png",
@@ -29,7 +29,7 @@ const PRECACHE_URLS = [
   "/assets/pwa/icon-72.png",
   "/assets/pwa/icon-96.png",
   "/assets/pwa/icon-maskable-512.png",
-  "/assets/style-yLozzbt3.css",
+  "/assets/style-C40MIE1y.css",
   "/index.html",
   "/manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-MySTRkUc.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-yLozzbt3.css">
+  <script type="module" crossorigin src="./assets/index-CR4vK8Yz.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-C40MIE1y.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -439,7 +439,8 @@ async function readInstructorsFromSupabase() {
       const manager = String(row.activity_manager || '').trim();
       const actType = String(row.activity_type || '').trim();
       for (const [id, name] of pairs) {
-        const stats = ensureStats(id, name);
+        const fallbackId = String(id || name || '').trim();
+        const stats = ensureStats(fallbackId, name || id);
         if (!stats) continue;
         const cleanName = String(name || '').trim();
         if (cleanName && (!stats.full_name || stats.full_name === stats.emp_id)) {
@@ -796,7 +797,6 @@ function buildExceptionsFromRows(activityRows = []) {
   const rows = [];
   for (const row of activityRows) {
     if (isActivityClosed(row)) continue;
-    if (String(row?.activity_type || '').trim() !== 'course') continue;
     const types = [];
     const emp1        = nullStr(row?.emp_id);
     const emp2        = nullStr(row?.emp_id_2);
@@ -825,7 +825,18 @@ async function readExceptionsFromSupabase(params = {}) {
   const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
   const month = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
   try {
-    const activityRows = (await selectActivitiesFromSupabase('*')).filter((row) => activityHasDateInMonth(row, month) || String(row?.end_date || '').startsWith(month));
+    const activityRows = (await selectActivitiesFromSupabase('*')).filter((row) => {
+      const emp1 = nullStr(row?.emp_id);
+      const emp2 = nullStr(row?.emp_id_2);
+      const instructor1 = nullStr(row?.instructor_name);
+      const instructor2 = nullStr(row?.instructor_name_2);
+      const missingInstructor = !emp1 && !emp2 && !instructor1 && !instructor2;
+      const missingStartDate = !nullStr(row?.start_date);
+      return activityHasDateInMonth(row, month)
+        || String(row?.end_date || '').startsWith(month)
+        || missingInstructor
+        || missingStartDate;
+    });
     const rows = buildExceptionsFromRows(activityRows);
     return { month, rows, totalExceptionRows: rows.length, _source: 'supabase' };
   } catch (error) {
@@ -1336,6 +1347,10 @@ export const api = {
     const data = await readArchiveActivitiesFromSupabase();
     if (data) return data;
     return buildSupabaseErrorPayload({ rows: [] }, 'archive_supabase_failed');
+  },
+  allActivities: async () => {
+    const rows = await readAllActivitiesRowsSupabase();
+    return { rows, _source: 'supabase' };
   },
   activities: async (filters, options) => {
     const resolvedFilters = filters || {};

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -55,6 +55,8 @@ function accentNameFromStorage() {
   try {
     return normalizeAccentName(localStorage.getItem(ACCENT_LS_KEY))
       || normalizeAccentName(localStorage.getItem(LEGACY_STRIPE_LS_KEY))
+      || normalizeAccentName(state?.clientSettings?.accent_color)
+      || normalizeAccentName(state?.clientSettings?.theme_accent)
       || 'blue';
   } catch {
     return 'blue';
@@ -95,6 +97,7 @@ function bindAccentPickerOnce() {
         localStorage.setItem(ACCENT_LS_KEY, selected);
         localStorage.setItem(LEGACY_STRIPE_LS_KEY, selected);
       } catch {}
+      state.clientSettings = { ...(state.clientSettings || {}), accent_color: selected };
       pop.hidden = true;
       return;
     }

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -373,6 +373,7 @@ export const activitiesScreen = {
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canAddActivity = !!state?.user?.can_add_activity;
+    const isAdmin = state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
 
     const rosterUsers = getRosterUsers(state?.clientSettings || {});
     const instructorByEmpId = rosterUsers.reduce((acc, user) => {
@@ -472,6 +473,7 @@ export const activitiesScreen = {
       ${bareFilters}
       <div class="ds-activities-main-toolbar__actions">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
+        ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activities-export-all title="ייצוא כל הפעילויות לאקסל">ייצוא כל הפעילויות לאקסל</button>` : ''}
         ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">+</button>` : ''}
       </div>
     </div>`;
@@ -500,6 +502,7 @@ export const activitiesScreen = {
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canAddActivity = !!state?.user?.can_add_activity;
+    const isAdmin = state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
 
     const rerenderLocal = () => {
       if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
@@ -659,6 +662,22 @@ export const activitiesScreen = {
         rerenderLocal();
       }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
+
+    root.querySelector('[data-activities-export-all]')?.addEventListener('click', async (ev) => {
+      if (!isAdmin) return;
+      const btn = ev.currentTarget;
+      btn.disabled = true;
+      const originalText = btn.textContent;
+      btn.textContent = 'מייצא…';
+      try {
+        const res = await (typeof api.allActivities === 'function' ? api.allActivities() : api.activities({ activity_type: 'all' }));
+        exportActivitiesToExcel(Array.isArray(res?.rows) ? res.rows : [], 'כל_הפעילויות');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
+      }
+    });
+
     root.querySelector('[data-activities-month-prev]')?.addEventListener('click', () => runMonthShift(-1));
     root.querySelector('[data-activities-month-next]')?.addEventListener('click', () => runMonthShift(1));
     root.querySelector(`[data-list-show-more="${ACTIVITIES_SCOPE}"]`)?.addEventListener('click', (ev) => {

--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -246,7 +246,7 @@ export const archiveScreen = {
         const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
         const reopenBtn = canReopen
           ? `<div style="padding:12px 16px 0;text-align:right">
-               <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-archive-reopen="${escapeHtml(String(row.RowID || ''))}">
+               <button type="button" class="ds-btn ds-btn--sm ds-archive-reopen-btn" data-archive-reopen="${escapeHtml(String(row.RowID || ''))}">
                  🔓 פתח מחדש
                </button>
              </div>`

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -1,6 +1,7 @@
 import { escapeHtml } from './shared/html.js';
 import { dsCard, dsScreenStack, dsEmptyState } from './shared/layout.js';
 import { formatDateHe } from './shared/format-date.js';
+import { triggerExcelDownload } from './shared/excel-export.js';
 
 function asIso(value) {
   const text = String(value || '').trim().slice(0, 10);
@@ -98,7 +99,7 @@ function renderMonthTable(month, monthIdx) {
 
 function buildExcelBlob(rows) {
   const maxMeetingDates = rows.reduce((max, row) => Math.max(max, Array.isArray(row?._dates) ? row._dates.length : 0), 0);
-  const dateHeaders = Array.from({ length: maxMeetingDates }, (_, idx) => `תאריך סיום ${idx + 1}`);
+  const dateHeaders = Array.from({ length: maxMeetingDates }, (_, idx) => `תאריך ${idx + 1}`);
   const headers = ['שם פעילות', 'בית ספר', 'רשות', 'תאריך סיום', ...dateHeaders];
   const tableRows = rows.map((row) => {
     const dateCells = Array.from({ length: maxMeetingDates }, (_, idx) => {
@@ -120,17 +121,6 @@ function buildExcelBlob(rows) {
     <tbody>${tableRows}</tbody></table></body></html>`;
 
   return new Blob(['\uFEFF' + html], { type: 'application/vnd.ms-excel;charset=utf-8' });
-}
-
-function triggerDownload(blob, filename) {
-  const url = URL.createObjectURL(blob);
-  const a   = document.createElement('a');
-  a.href     = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
 }
 
 export const endDatesScreen = {
@@ -170,7 +160,7 @@ export const endDatesScreen = {
 
     root.querySelector('[data-end-dates-export]')?.addEventListener('click', () => {
       const stamp = new Date().toISOString().slice(0, 10);
-      triggerDownload(buildExcelBlob(allRows), `תאריכי_סיום_${stamp}.xls`);
+      triggerExcelDownload(buildExcelBlob(allRows), `תאריכי_סיום_${stamp}.xls`);
     });
 
     root.querySelectorAll('[data-end-row]').forEach((tr) => {
@@ -194,7 +184,7 @@ export const endDatesScreen = {
         const name  = String(row.activity_name || 'פעילות')
           .replace(/[/\\?%*:|"<>]/g, '_').slice(0, 40);
         const stamp = new Date().toISOString().slice(0, 10);
-        triggerDownload(buildExcelBlob([row]), `${name}_${stamp}.xls`);
+        triggerExcelDownload(buildExcelBlob([row]), `${name}_${stamp}.xls`);
       });
     });
   }

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -109,7 +109,7 @@ function normalizeActivityNameOptions(raw) {
 }
 
 function selectHtml({ name, value, options, klass = 'ds-input', placeholder = '—', attrs = '' }) {
-  const safeValue = String(value || '');
+  const safeValue = String(value || '').trim();
   const normalized = toOptions(options);
   const all = normalized.includes(safeValue) || !safeValue ? normalized : [safeValue, ...normalized];
   const opts = [`<option value="">${escapeHtml(placeholder)}</option>`]
@@ -204,7 +204,7 @@ function fieldViewOnly(label, viewHtml) {
   `;
 }
 
-function headerHtml(row, { mode = 'single', summaryDate = '' } = {}) {
+function headerHtml(row, { mode = 'single', summaryDate = '', exportAction = true } = {}) {
   if (mode === 'summary') {
     const rows = Array.isArray(row) ? row : [];
     const main = rows[0] || {};
@@ -222,6 +222,7 @@ function headerHtml(row, { mode = 'single', summaryDate = '' } = {}) {
     const dateLabel = formatDateHe(summaryDate) || fallback(summaryDate);
     return `
       <div class="activity-drawer__header">
+        ${exportAction ? '<button type="button" class="activity-drawer__export" data-action="export-activity-excel" title="ייצוא פעילות לאקסל" aria-label="ייצוא פעילות לאקסל">⇩</button>' : ''}
         <button type="button" class="activity-drawer__close" data-action="close-drawer" data-ui-close-drawer aria-label="סגירה">✕</button>
         <h2 class="activity-drawer__title">${escapeHtml(instructorName)}</h2>
         <div class="activity-drawer__meta">${escapeHtml(`${dateLabel} · ${rows.length} פעילויות`)}</div>
@@ -232,6 +233,7 @@ function headerHtml(row, { mode = 'single', summaryDate = '' } = {}) {
     <div class="activity-drawer__header">
       <div class="activity-drawer__header-top">
         <span class="activity-drawer__pill">${escapeHtml(activityTypeLabel(row?.activity_type))}</span>
+        ${exportAction ? '<button type="button" class="activity-drawer__export" data-action="export-activity-excel" title="ייצוא פעילות לאקסל" aria-label="ייצוא פעילות לאקסל">⇩</button>' : ''}
         <button type="button" class="activity-drawer__close" data-action="close-drawer" data-ui-close-drawer aria-label="סגירה">✕</button>
       </div>
       <h2 class="activity-drawer__title">${escapeHtml(fallback(row?.activity_name))}</h2>
@@ -257,18 +259,18 @@ function blockPeople(row, { settings = {} } = {}) {
       ${fieldViewEdit(
         'מדריך/ה 1',
         `${escapeHtml(fallback(instructor1Display))}`,
-        selectHtml({ name: 'instructor_name', value: row.instructor_name, options: instructors })
+        selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors })
       )}
       ${fieldViewEdit(
         'מדריך/ה 2',
         `${escapeHtml(fallback(instructor2Display))}`,
-        selectHtml({ name: 'instructor_name_2', value: row.instructor_name_2, options: instructors })
+        selectHtml({ name: 'instructor_name_2', value: instructor2Display, options: instructors })
       )}
     `
     : fieldViewEdit(
         'מדריך/ה',
         `${escapeHtml(fallback(instructor1Display))}`,
-        selectHtml({ name: 'instructor_name', value: row.instructor_name, options: instructors })
+        selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors })
       );
   return `
     <section class="activity-drawer__section">
@@ -565,6 +567,14 @@ function blockNotes(row, { privateNote = null, showPrivateNote = false } = {}) {
   `;
 }
 
+function jsonAttr(value) {
+  try {
+    return escapeHtml(JSON.stringify(value || {}));
+  } catch {
+    return '{}';
+  }
+}
+
 function singleForm(row, { settings = {}, privateNote = null, canEdit = false, canDirectEdit = false, showPrivateNote = false, idx = 0, datesLoading = false } = {}) {
   const computedEnd = autoEndDate(row);
   const activityType = String(row.activity_type || '').trim();
@@ -579,6 +589,7 @@ function singleForm(row, { settings = {}, privateNote = null, canEdit = false, c
     : '';
   return `
     <form class="activity-drawer__form" data-drawer-form data-editing="no"
+      data-export-row="${jsonAttr(row)}"
       data-source-sheet="${escapeHtml(String(row.source_sheet || ''))}"
       data-row-id="${escapeHtml(String(row.RowID || ''))}"
       data-can-direct-edit="${canDirectEdit ? 'yes' : 'no'}"
@@ -610,7 +621,7 @@ export function activityRowDetailHtml(row, { privateNote = null, hideActivityNo 
 }
 
 export function activityWorkDrawerHtml(row, opts = {}) {
-  const { mode = 'single', summaryDate = '', privateNote = null, canEdit = false, canDirectEdit = false, settings = {}, datesLoading = false } = opts;
+  const { mode = 'single', summaryDate = '', privateNote = null, canEdit = false, canDirectEdit = false, settings = {}, datesLoading = false, exportAction = true } = opts;
   if (mode === 'summary') {
     const rows = Array.isArray(row) ? row : [];
     const body = rows
@@ -635,7 +646,7 @@ export function activityWorkDrawerHtml(row, opts = {}) {
       `)
       .join('');
     return `
-      ${headerHtml(rows, { mode: 'summary', summaryDate })}
+      ${headerHtml(rows, { mode: 'summary', summaryDate, exportAction })}
       <div class="activity-drawer__body">
         ${body || '<div class="activity-drawer__empty">אין נתונים</div>'}
       </div>
@@ -643,7 +654,7 @@ export function activityWorkDrawerHtml(row, opts = {}) {
   }
   const one = row || {};
   return `
-    ${headerHtml(one)}
+    ${headerHtml(one, { exportAction })}
     <div class="activity-drawer__body">
       ${singleForm(one, {
         settings,

--- a/frontend/src/screens/shared/excel-export.js
+++ b/frontend/src/screens/shared/excel-export.js
@@ -1,0 +1,90 @@
+import { escapeHtml } from './html.js';
+import { formatDateHe, formatActivityDateColumnsHe } from './format-date.js';
+
+function safeFilePart(value, fallback = 'export') {
+  const clean = String(value || fallback).replace(/[\\/?%*:|"<>]/g, '_').trim();
+  return (clean || fallback).slice(0, 48);
+}
+
+export function triggerExcelDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function buildHtmlExcelBlob(headers, rows) {
+  const safeHeaders = Array.isArray(headers) ? headers : [];
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const htmlRows = safeRows.map((row) => `<tr>${safeHeaders.map((header) => `<td>${escapeHtml(String(row?.[header] ?? ''))}</td>`).join('')}</tr>`).join('');
+  const html = `<!doctype html><html dir="rtl" xmlns:x="urn:schemas-microsoft-com:office:excel">
+    <head><meta charset="UTF-8"></head><body>
+    <table border="1"><thead><tr>${safeHeaders.map((h) => `<th>${escapeHtml(h)}</th>`).join('')}</tr></thead>
+    <tbody>${htmlRows}</tbody></table></body></html>`;
+  return new Blob(['\uFEFF' + html], { type: 'application/vnd.ms-excel;charset=utf-8' });
+}
+
+export function activityExportRow(row = {}) {
+  const meetingDates = Array.isArray(row.meeting_dates) && row.meeting_dates.length
+    ? row.meeting_dates
+    : Array.isArray(row.date_cols) && row.date_cols.length
+      ? row.date_cols
+      : Array.from({ length: 35 }, (_, idx) => row[`date_${idx + 1}`] || row[`Date${idx + 1}`]).filter(Boolean);
+  return {
+    'מספר שורה': row.RowID || row.row_id || '',
+    'שם פעילות': row.activity_name || '',
+    'סוג פעילות': row.activity_type || '',
+    'סטטוס': row.status || '',
+    'בית ספר': row.school || '',
+    'רשות': row.authority || '',
+    'שכבה': row.grade || '',
+    'קבוצה / כיתה': row.class_group || '',
+    'מנהל פעילות': row.activity_manager || '',
+    'מדריך 1': row.instructor_name || row.emp_id || '',
+    'מדריך 2': row.instructor_name_2 || row.emp_id_2 || '',
+    'תאריך התחלה': formatDateHe(row.start_date) || row.start_date || '',
+    'תאריך סיום': formatDateHe(row.end_date) || row.end_date || '',
+    'תאריכי מפגשים': meetingDates.map((d) => formatDateHe(d) || d).join(', ') || formatActivityDateColumnsHe(row),
+    'שעת התחלה': row.start_time || '',
+    'שעת סיום': row.end_time || '',
+    'מימון': row.funding || '',
+    'מחיר': row.price || '',
+    'הערות': row.notes || ''
+  };
+}
+
+export const ACTIVITY_EXPORT_HEADERS = [
+  'מספר שורה',
+  'שם פעילות',
+  'סוג פעילות',
+  'סטטוס',
+  'בית ספר',
+  'רשות',
+  'שכבה',
+  'קבוצה / כיתה',
+  'מנהל פעילות',
+  'מדריך 1',
+  'מדריך 2',
+  'תאריך התחלה',
+  'תאריך סיום',
+  'תאריכי מפגשים',
+  'שעת התחלה',
+  'שעת סיום',
+  'מימון',
+  'מחיר',
+  'הערות'
+];
+
+export function exportActivitiesToExcel(rows, filenameBase = 'פעילויות') {
+  const normalizedRows = (Array.isArray(rows) ? rows : [rows]).filter(Boolean).map(activityExportRow);
+  const stamp = new Date().toISOString().slice(0, 10);
+  triggerExcelDownload(buildHtmlExcelBlob(ACTIVITY_EXPORT_HEADERS, normalizedRows), `${safeFilePart(filenameBase, 'פעילויות')}_${stamp}.xls`);
+}
+
+export function exportSingleActivityToExcel(row) {
+  exportActivitiesToExcel([row], row?.activity_name || 'פעילות');
+}

--- a/frontend/src/screens/shared/interactions.js
+++ b/frontend/src/screens/shared/interactions.js
@@ -1,4 +1,5 @@
 import { escapeHtml } from './html.js';
+import { exportSingleActivityToExcel } from './excel-export.js';
 
 const UI_LAYER_ID = 'ds-shared-ui-layer';
 
@@ -25,6 +26,22 @@ const HOST_MARKUP = `
         <footer class="ds-modal__footer" hidden></footer>
       </section>
     `;
+
+
+function bindDrawerExport(contentNode) {
+  if (!contentNode || contentNode.dataset.exportBound === '1') return;
+  contentNode.dataset.exportBound = '1';
+  contentNode.addEventListener('click', (event) => {
+    const target = event.target instanceof Element ? event.target.closest('[data-action="export-activity-excel"]') : null;
+    if (!target) return;
+    event.preventDefault();
+    const form = contentNode.querySelector('[data-drawer-form]');
+    if (!form) return;
+    let row = {};
+    try { row = JSON.parse(form.dataset.exportRow || '{}'); } catch { row = {}; }
+    exportSingleActivityToExcel(row);
+  });
+}
 
 function asHtml(content) {
   if (content == null) return '';
@@ -164,11 +181,18 @@ export function createSharedInteractionLayer() {
 
     titleNode.innerHTML = defaultDrawerTitle(title);
     contentNode.innerHTML = asHtml(content);
+    bindDrawerExport(contentNode);
+    drawer.scrollTop = 0;
+    contentNode.scrollTop = 0;
     onDrawerClose = typeof onClose === 'function' ? onClose : null;
 
     drawerOpen = true;
     drawer.setAttribute('aria-hidden', 'false');
     syncLayerClasses();
+    requestAnimationFrame(() => {
+      drawer.scrollTop = 0;
+      contentNode.scrollTop = 0;
+    });
     if (typeof onOpen === 'function') onOpen(contentNode);
   }
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8716,3 +8716,45 @@ select.ds-activity-add-field .ds-input,
 .ds-table--archive .ds-archive-meeting-dates {
   white-space: normal;
 }
+
+/* Targeted fixes: instructors density + drawer actions */
+@media (min-width: 1281px) {
+  .ci-list--instr-grid {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1001px) and (max-width: 1280px) {
+  .ci-list--instr-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+.activity-drawer__header-top {
+  gap: 8px;
+}
+.activity-drawer__export {
+  width: 28px;
+  height: 28px;
+  border: 1px solid color-mix(in srgb, var(--ds-accent) 28%, var(--ds-border));
+  border-radius: 999px;
+  background: #fff;
+  color: var(--ds-accent);
+  font-weight: 800;
+  cursor: pointer;
+}
+.activity-drawer__export:hover,
+.activity-drawer__export:focus-visible {
+  background: var(--ds-accent-soft);
+  outline: none;
+}
+.ds-archive-reopen-btn {
+  background: var(--ds-accent) !important;
+  border-color: var(--ds-accent) !important;
+  color: #fff !important;
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--ds-accent) 24%, transparent);
+}
+.ds-archive-reopen-btn:hover,
+.ds-archive-reopen-btn:focus-visible {
+  background: var(--ds-accent-hover) !important;
+  border-color: var(--ds-accent-hover) !important;
+}


### PR DESCRIPTION
### Motivation

- לשפר מנגנון הייצוא לאקסל (קובץ שורות פעילות וייצוא שורה בודדת) ולספק כפתור ייצוא זמין בחלון הצד של פעילות ולכפתור אדמין לייצוא כל הפעילויות. 
- לתקן מספר באגים שטכניים וויזואליים הקשורים ברשימות dropdown, בחישובי מדריכים ובעמודי drawer/ארכיון ללא שינוי מבני במסד הנתונים.

### Description

- הוספה של מודול שיתוף לייצוא אקסל `frontend/src/screens/shared/excel-export.js` שמייצר Blob HTML מותאם ל־Excel ומספק `exportActivitiesToExcel` ו־`exportSingleActivityToExcel` לשימוש מכל מקום. 
- שונו כותרות עמודות שדות מפגשים ב־End Dates לייצוא בלבד מ־`תאריך סיום ${i}` ל־`תאריך ${i}` מבלי לשנות שמות שדות במסד הנתונים, וההורדה עוברת ל־`triggerExcelDownload`. (`frontend/src/screens/end-dates.js`, `frontend/src/screens/shared/excel-export.js`).
- הוספת אייקון ייצוא בחלון הצד של פעילות ופתירת מסלול הייצוא של שורה בודדת דרך טופס ה־drawer; שורת ה־form מכילה כעת `data-export-row` עם מידע activity כדי לאפשר ייצוא מה־drawer המשותף. (`frontend/src/screens/shared/activity-detail-html.js`, `frontend/src/screens/shared/interactions.js`).
- חיבור הייצוא לממשק המשותף של ה־drawer כך שהפונקציונליות עובדת בכל מסכי פתיחת פעילות; וקשירת אירוע הלחיצה לייצוא בפנים ה־drawer. (`frontend/src/screens/shared/interactions.js`).
- הוספת כפתור אדמין בלבד במסך פעילויות שמבצע ייצוא של כל הפעילויות דרך `api.allActivities` וקורא ל־`exportActivitiesToExcel`. (`frontend/src/screens/activities.js`, `frontend/src/api.js`).
- שיפורי אמינות תצוגת select/ערכים: `selectHtml` מטפל ב־trim לערכי default והאפשרויות של שדות מדריכים משתמשות ב־display name המוסדר (מ־emp_id fallback) כדי למנוע שדות ריקים בעת עריכה. (`frontend/src/screens/shared/activity-detail-html.js`).
- הרחבת לוגיקת חריגות כדי לכלול רשומות חסרות מדריך או חסרות תאריך התחלה גם כאשר הן מחוץ לחודש המדווח, כך שהעמוד יציג את כל סוגי החריגות הרלוונטיים. (`frontend/src/api.js`).
- שיפור חישובי סטטיסטיקות מדריכים כך שגם כאשר יש רק שם ללא `emp_id` המדריך לא יאבד מספירות (fallback id/name). (`frontend/src/api.js`).
- תיקון UX: בילטון לאיפוס גלילה של החלון הישיר (drawer) לראש בעת פתיחה/החלפת תוכן, ושיפור נראות כפתור "פתח מחדש" בארכיון עם class ייעודי וצבע אטום. (`frontend/src/screens/shared/interactions.js`, `frontend/src/screens/archive.js`, `frontend/src/styles/main.css`).
- שמירת בחירת צבע הממשק גם ב־`state.clientSettings.accent_color` בנוסף ל־localStorage כדי להבטיח התנהגות עקבית. (`frontend/src/main.js`).

(קבצים עיקריים ששונו: `frontend/src/screens/end-dates.js`, `frontend/src/screens/shared/excel-export.js`, `frontend/src/screens/shared/activity-detail-html.js`, `frontend/src/screens/shared/interactions.js`, `frontend/src/screens/activities.js`, `frontend/src/api.js`, `frontend/src/styles/main.css`, ועוד עדכונים בנקודות הנוגעות ל־drawer/ייצוא)

### Testing

- בנייה: הרצת `npm run build` — build עבר בהצלחה (Vite built assets). 
- בדיקות יחידה: הרצת `npm test` — חלק מהבדיקות עברו בהצלחה (למשל בדיקות של accent picker, rendering/activities, חלק מ־safeCellValue/safeJsonArrayCell ועוד), אך היו כשלונות בריצת הבדיקות האוטומטיות المتعلقة ב־api-mutations / Supabase-mocked tests (לדוגמה: בדיקות `addActivity`/`saveActivity`/`submitEditRequest` וקריאות Supabase בדיקות snapshot/rollout שדיווחו על שגיאות בקריאת Supabase). 
- סטטוס: `build` — מוצלח; `test` — מעורב: מספר יחידות עברו, מספר בדיקות אינטגרציה/mocking של Supabase לא עברו ונדרשת בדיקה בסביבת בדיקות המחקה Supabase מלאה או התאמות ל־mocks כדי לסגור את הכשלים.

אם תרצו, אוכל להכין רשימת קבצים מדויקת יותר עם הסבר שורה-שורה לכל שינוי, או לפרק את ה־PR למספר PR-ים קטנים יותר לפי תחום (ייצוא, drawer, exceptions, instructors) כדי להקל על סקירה ו־QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfc0ca34c832b90a54d3e3cbfd8d5)