### PR TITLE
Align allowed user roles (supabase + frontend), canonicalize instructor_manager, and update UI labels

### DIFF
--- a/OLD-GAS/helpers.gs
+++ b/OLD-GAS/helpers.gs
@@ -87,7 +87,7 @@ function isPermissionsSheetRoleCodeToken_(value) {
     'instructor_admin',
     'activities_manager',
     'domain_manager',
-    'manager_instructor'
+    'instructor_manager'
   ];
   return codes.indexOf(t) >= 0;
 }
@@ -103,7 +103,7 @@ function normalizeRole_(value) {
     case 'authorized_user':    return 'authorized_user';
     case 'activities_manager': return 'activities_manager';
     case 'domain_manager':     return 'domain_manager';
-    case 'manager_instructor': return 'manager_instructor';
+    case 'instructor_manager': return 'instructor_manager';
     case 'instructor':         return 'instructor';
     case 'instructor_admin':   return 'instructor';
   }
@@ -124,8 +124,8 @@ function normalizeRole_(value) {
     case 'מנהל פעילויות':      return 'activities_manager';
     case 'מנהל/ת תחום':
     case 'מנהל תחום':          return 'domain_manager';
-    case 'מדריך/ת-מנהל/ת':
-    case 'מדריך-מנהל':         return 'manager_instructor';
+    case 'מנהל/ת הדרכה / מדריך/ת מנהל/ת':
+    case 'מדריך-מנהל':         return 'instructor_manager';
     default:                   throw new Error('invalid_role');
   }
 }
@@ -146,7 +146,7 @@ function isAuthorizedUserTier_(role) {
     role === 'operation_manager' ||
     role === 'activities_manager' ||
     role === 'domain_manager' ||
-    role === 'manager_instructor';
+    role === 'instructor_manager';
 }
 
 function normalizeFinance_(value) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -997,12 +997,16 @@ function normalizeData(data) {
 }
 
 const USER_PUBLIC_COLUMNS = 'user_id,email,name,role,display_role,emp_id,is_active,permissions,auth_user_id,created_at,updated_at';
-const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor']);
+const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
   admin: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
   operation_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  domain_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   instructor: ['dashboard', 'activities', 'archive', 'week', 'month', 'instructor-contacts', 'my-data']
 };
 
@@ -1431,6 +1435,10 @@ export const api = {
         admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes' },
         operation_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'no' },
         authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
+        finance: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
+        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
+        domain_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
+        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
         instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' }
       }
     };

--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -14,6 +14,25 @@ const KEY_PERM_FLAGS = [
   'view_permissions'
 ];
 
+const PERMISSION_ROLE_OPTIONS = [
+  'admin',
+  'operation_manager',
+  'authorized_user',
+  'instructor',
+  'finance',
+  'activities_manager',
+  'domain_manager',
+  'instructor_manager'
+];
+
+function renderRoleOptionsHtml(selectedRole = '') {
+  const selected = String(selectedRole || '').trim();
+  return PERMISSION_ROLE_OPTIONS.map((role) => {
+    const attr = role === selected ? ' selected' : '';
+    return `<option value="${escapeHtml(role)}"${attr}>${escapeHtml(hebrewRole(role))}</option>`;
+  }).join('');
+}
+
 /** Normalized role code from API (`role`). */
 function permRowRoleCode(row) {
   const code = String(row?.role != null && row.role !== '' ? row.role : row?.display_role || '').trim();
@@ -117,10 +136,7 @@ function buildAddUserDrawerHtml(roleDefaults) {
       <div class="ds-perm-field">
         <span class="ds-muted">תפקיד</span>
         <select class="ds-input ds-input--sm" id="new-display-role">
-          <option value="instructor">מדריך/ה</option>
-          <option value="authorized_user">משתמש/ת מורשה</option>
-          <option value="operation_manager">בקר/ת תפעול</option>
-          <option value="admin">מנהל/ת</option>
+          ${renderRoleOptionsHtml('instructor')}
         </select>
       </div>
       <div data-role-preview>${buildRolePreviewHtml('instructor', roleDefaults)}</div>
@@ -173,10 +189,7 @@ function buildEditDrawerHtml(row) {
       <div class="ds-perm-field">
         <span class="ds-muted">${escapeHtml(hebrewColumn('display_role'))}</span>
         <select data-role-select data-user-id="${uid}" class="ds-input ds-input--sm">
-          <option value="admin" ${permRowRoleCode(row) === 'admin' ? 'selected' : ''}>מנהל/ת</option>
-          <option value="operation_manager" ${permRowRoleCode(row) === 'operation_manager' ? 'selected' : ''}>בקר/ת תפעול</option>
-          <option value="authorized_user" ${permRowRoleCode(row) === 'authorized_user' ? 'selected' : ''}>משתמש/ת מורשה</option>
-          <option value="instructor" ${permRowRoleCode(row) === 'instructor' ? 'selected' : ''}>מדריך/ה</option>
+          ${renderRoleOptionsHtml(permRowRoleCode(row))}
         </select>
       </div>
       <div class="ds-perm-field">

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -6,14 +6,13 @@ export const UI_ACTIVITY_FAMILY_LONG = 'תוכניות';
 
 export const HEBREW_ROLE = {
   admin: 'מנהל/ת',
-  operation_manager: 'בקר/ת תפעול',
+  operation_manager: 'מנהל/ת תפעול',
   authorized_user: 'משתמש/ת מורשה',
   instructor: 'מדריך/ה',
   finance: 'כספים',
-  operation_manager: 'מנהל/ת תפעול',
   activities_manager: 'מנהל/ת פעילויות',
   domain_manager: 'מנהל/ת תחום',
-  manager_instructor: 'מדריך/ת-מנהל/ת'
+  instructor_manager: 'מנהל/ת הדרכה / מדריך/ת מנהל/ת'
 };
 
 export function hebrewRole(role) {

--- a/supabase/migrations/20260507_expand_users_role_set.sql
+++ b/supabase/migrations/20260507_expand_users_role_set.sql
@@ -1,0 +1,97 @@
+-- Keep public.users.role aligned with the role codes used by imported user data.
+-- instructor_manager is the canonical internal code; legacy manager_instructor values
+-- are migrated before the constraint is tightened.
+update public.users
+set role = 'instructor_manager'
+where role = 'manager_instructor';
+
+alter table public.users
+  drop constraint if exists users_role_check;
+
+alter table public.users
+  add constraint users_role_check check (
+    role in (
+      'admin',
+      'operation_manager',
+      'authorized_user',
+      'instructor',
+      'finance',
+      'activities_manager',
+      'domain_manager',
+      'instructor_manager'
+    )
+  );
+
+-- Login validates entry_code server-side and allows the same canonical role set
+-- as the users_role_check constraint.
+drop function if exists public.login_user_by_entry_code(text, text);
+create function public.login_user_by_entry_code(p_login text, p_entry_code text)
+returns table (
+  status text,
+  user_id text,
+  email text,
+  name text,
+  role text,
+  emp_id text,
+  is_active boolean,
+  permissions jsonb,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with input as (
+    select trim(coalesce(p_login, '')) as login, trim(coalesce(p_entry_code, '')) as code
+  ), candidate as (
+    select u.*
+    from public.users u
+    cross join input i
+    where u.user_id = i.login
+       or u.email = i.login
+       or u.emp_id = i.login
+    order by case
+      when u.user_id = i.login then 1
+      when u.email = i.login then 2
+      when u.emp_id = i.login then 3
+      else 4
+    end, u.created_at desc
+    limit 1
+  ), diagnostic as (
+    select
+      case
+        when (select i.login from input i) = '' or (select i.code from input i) = '' then 'missing_user_id_or_entry_code'
+        when not exists (select 1 from candidate) then 'user_not_found'
+        when not (select c.is_active from candidate c) then 'inactive_user'
+        when trim(coalesce((select c.entry_code from candidate c), '')) <> (select i.code from input i) then 'entry_code_mismatch'
+        when coalesce((select c.role from candidate c), '') not in (
+          'admin',
+          'operation_manager',
+          'authorized_user',
+          'instructor',
+          'finance',
+          'activities_manager',
+          'domain_manager',
+          'instructor_manager'
+        ) then 'invalid_role'
+        else 'ok'
+      end as status
+  )
+  select
+    d.status,
+    case when d.status = 'ok' then c.user_id end as user_id,
+    case when d.status = 'ok' then c.email end as email,
+    case when d.status = 'ok' then c.name end as name,
+    case when d.status = 'ok' then c.role end as role,
+    case when d.status = 'ok' then c.emp_id end as emp_id,
+    case when d.status = 'ok' then c.is_active end as is_active,
+    case when d.status = 'ok' then c.permissions end as permissions,
+    case when d.status = 'ok' then c.created_at end as created_at,
+    case when d.status = 'ok' then c.updated_at end as updated_at
+  from diagnostic d
+  left join candidate c on true;
+$$;
+
+revoke all on function public.login_user_by_entry_code(text, text) from public;
+grant execute on function public.login_user_by_entry_code(text, text) to anon, authenticated;

--- a/tests/normalize-role-regression.test.mjs
+++ b/tests/normalize-role-regression.test.mjs
@@ -1,7 +1,7 @@
 /**
  * normalize-role-regression.test.mjs
  *
- * Regression tests for normalizeRole_ in backend/helpers.gs.
+ * Regression tests for normalizeRole_ in OLD-GAS/helpers.gs.
  *
  * Covers:
  *  - All internal role codes (including the previously-missing authorized_user)
@@ -16,7 +16,7 @@ import { readFile } from 'fs/promises';
 import { strict as assert } from 'assert';
 import { test } from 'node:test';
 
-const HELPERS_PATH = 'backend/helpers.gs';
+const HELPERS_PATH = 'OLD-GAS/helpers.gs';
 let src;
 
 test('load helpers.gs', async () => {
@@ -52,7 +52,7 @@ function normalizeRole(value) {
     case 'authorized_user':    return 'authorized_user';
     case 'activities_manager': return 'activities_manager';
     case 'domain_manager':     return 'domain_manager';
-    case 'manager_instructor': return 'manager_instructor';
+    case 'instructor_manager': return 'instructor_manager';
     case 'instructor':         return 'instructor';
     case 'instructor_admin':   return 'instructor';
   }
@@ -71,8 +71,8 @@ function normalizeRole(value) {
     case 'מנהל פעילויות':      return 'activities_manager';
     case 'מנהל/ת תחום':
     case 'מנהל תחום':          return 'domain_manager';
-    case 'מדריך/ת-מנהל/ת':
-    case 'מדריך-מנהל':         return 'manager_instructor';
+    case 'מנהל/ת הדרכה / מדריך/ת מנהל/ת':
+    case 'מדריך-מנהל':         return 'instructor_manager';
     default:                   throw new Error('invalid_role');
   }
 }
@@ -107,8 +107,8 @@ test('sim normalizeRole_: domain_manager', () => {
   assert.strictEqual(normalizeRole('domain_manager'), 'domain_manager');
 });
 
-test('sim normalizeRole_: manager_instructor', () => {
-  assert.strictEqual(normalizeRole('manager_instructor'), 'manager_instructor');
+test('sim normalizeRole_: instructor_manager', () => {
+  assert.strictEqual(normalizeRole('instructor_manager'), 'instructor_manager');
 });
 
 test('sim normalizeRole_: instructor', () => {
@@ -191,12 +191,12 @@ test('sim normalizeRole_: "מנהל תחום" → domain_manager', () => {
   assert.strictEqual(normalizeRole('מנהל תחום'), 'domain_manager');
 });
 
-test('sim normalizeRole_: "מדריך/ת-מנהל/ת" → manager_instructor', () => {
-  assert.strictEqual(normalizeRole('מדריך/ת-מנהל/ת'), 'manager_instructor');
+test('sim normalizeRole_: "מנהל/ת הדרכה / מדריך/ת מנהל/ת" → instructor_manager', () => {
+  assert.strictEqual(normalizeRole('מנהל/ת הדרכה / מדריך/ת מנהל/ת'), 'instructor_manager');
 });
 
-test('sim normalizeRole_: "מדריך-מנהל" → manager_instructor', () => {
-  assert.strictEqual(normalizeRole('מדריך-מנהל'), 'manager_instructor');
+test('sim normalizeRole_: "מדריך-מנהל" → instructor_manager', () => {
+  assert.strictEqual(normalizeRole('מדריך-מנהל'), 'instructor_manager');
 });
 
 // --- Unknown / invalid values must still throw ---


### PR DESCRIPTION
### Motivation
- Fix login failures caused by a mismatch between the actual `role` values present in the `users` table and the smaller allow-list used by the login function and frontend validation which returned `invalid_role` for many legitimate users. 
- Ensure the system accepts the full set of real roles (`admin`, `operation_manager`, `authorized_user`, `instructor`, `finance`, `activities_manager`, `domain_manager`, `instructor_manager`) throughout backend and frontend. 
- Unify the instructor/manager naming by choosing a single canonical internal code and provide Hebrew display labels for the UI only.

### Description
- Added a Supabase migration `supabase/migrations/20260507_expand_users_role_set.sql` that migrates legacy `manager_instructor` values to `instructor_manager`, expands the `users_role_check` constraint to include the full role set, and re-creates `public.login_user_by_entry_code` to validate against the same canonical set. 
- Updated frontend role validation and routing in `frontend/src/api.js` by expanding `VALID_SUPABASE_ROLES`, adding routes/roleDefaults for the new roles, and keeping `normalizeSupabaseRole` behavior consistent with the new set. 
- Updated the permissions UI in `frontend/src/screens/permissions.js` to render a unified role dropdown (`PERMISSION_ROLE_OPTIONS` + `renderRoleOptionsHtml`) that uses English internal values and Hebrew labels from `hebrewRole`. 
- Updated Hebrew display mappings in `frontend/src/screens/shared/ui-hebrew.js` to include `finance`, `activities_manager`, `domain_manager` and the requested label for `instructor_manager` without changing internal English `role` values. 
- Canonized the legacy name in backend code and tooling: replaced `manager_instructor` with `instructor_manager` in `OLD-GAS/helpers.gs` and updated the role-normalization regression test `tests/normalize-role-regression.test.mjs` accordingly.

### Testing
- Ran the role normalization regression test with `node --test tests/normalize-role-regression.test.mjs`, which passed (`✅`).
- Built the frontend with `npm run build` to ensure the UI compiles after the changes (`✅`).
- Performed static checks to confirm the new role tokens appear in `supabase/migrations`, `frontend/src/api.js`, `frontend/src/screens/permissions.js`, and `frontend/src/screens/shared/ui-hebrew.js` (`✅`).
- Ran the full test suite via `npm test`; the broader suite surfaced unrelated existing failures and did not fully complete, so unrelated failures were not blocked by these changes (`❌ unrelated test-suite failures`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfdfa829c832b82c67ed40d536e8f)