### PR TITLE
Redesign instructors page: compact 2×2 icon-grid cards with accent th…

### DIFF
--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -46,32 +46,39 @@ function globalDateRange(rows) {
   return { min, max };
 }
 
+function instructorTypeIcon(icon) {
+  const S = (d) => `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${d}</svg>`;
+  const map = {
+    book:        S('<path d="M3 2.5C4.5 2 6.5 2 8 3V14C6.5 13 4.5 13 3 13.5V2.5z"/><path d="M13 2.5C11.5 2 9.5 2 8 3V14C9.5 13 11.5 13 13 13.5V2.5z"/>'),
+    pin:         S('<path d="M8 1.5a4 4 0 0 1 4 4c0 4-4 9-4 9s-4-5-4-9a4 4 0 0 1 4-4z"/><circle cx="8" cy="5.5" r="1.4"/>'),
+    bulb:        S('<path d="M8 2a4 4 0 0 1 2.8 6.8L11 10H5l.2-1.2A4 4 0 0 1 8 2z"/><line x1="6.5" y1="12" x2="9.5" y2="12"/><line x1="7" y1="14" x2="9" y2="14"/>'),
+    schoolClock: S('<circle cx="8" cy="8" r="6"/><polyline points="8 4.5 8 8 10.5 9.5"/>'),
+  };
+  return map[icon] || '';
+}
+
+const TYPE_ITEMS = [
+  { keys: ['course', 'קורס', 'קורסים'],                                                  label: 'קורסים',    icon: 'book'        },
+  { keys: ['tour', 'סיור', 'סיורים'],                                                     label: 'סיורים',    icon: 'pin'         },
+  { keys: ['workshop', 'סדנה', 'סדנאות'],                                                 label: 'סדנאות',    icon: 'bulb'        },
+  { keys: ['after_school', 'after school', 'afterschool', 'חוג אפטרסקול', 'אפטרסקול'], label: 'אפטרסקול', icon: 'schoolClock' },
+];
+
 function renderInstructorRow(row) {
   const name       = escapeHtml(row.full_name || row.emp_id || '—');
   const empId      = String(row.emp_id || '').trim();
   const typeCounts = row.activity_type_counts || {};
 
-  const TYPE_LABELS = [
-    [['course', 'קורס', 'קורסים'], 'קורסים'],
-    [['tour', 'סיור', 'סיורים'], 'סיורים'],
-    [['workshop', 'סדנה', 'סדנאות'], 'סדנאות'],
-    [['after_school', 'after school', 'afterschool', 'חוג אפטרסקול', 'אפטרסקול'], 'חוג אפטרסקול'],
-  ];
-  const typeStats = TYPE_LABELS.map(([keys, label]) => ({
-    label,
-    count: keys.reduce((sum, key) => sum + Number(typeCounts[key] || 0), 0)
-  }));
-  const typeStatParts = typeStats
-    .map(({ count, label }) => `<span class="instr-stat"><span class="instr-stat__lbl">${label}</span><span class="instr-stat__num">${count}</span></span>`)
-    .join('');
-
-  const statsHtml = `<span class="instr-stats">${typeStatParts}</span>`;
+  const statCells = TYPE_ITEMS.map(({ keys, label, icon }) => {
+    const count = keys.reduce((sum, key) => sum + Number(typeCounts[key] || 0), 0);
+    return `<span class="instr-stat" title="${escapeHtml(label)}" aria-label="${escapeHtml(label)}: ${count}"><span class="instr-stat__icon">${instructorTypeIcon(icon)}</span><span class="instr-stat__num">${count}</span></span>`;
+  }).join('');
 
   return `<article class="instr-card" data-instructor-item="${escapeHtml(empId)}">
     <button type="button" class="ci-row instr-summary-row" dir="rtl" data-instructor-card="${escapeHtml(empId)}" data-instructor-name="${name}">
       <div class="ci-row__main">
         <span class="ci-row__name">${name}</span>
-        ${statsHtml}
+        <span class="instr-stats">${statCells}</span>
       </div>
     </button>
   </article>`;
@@ -207,15 +214,16 @@ export const instructorsScreen = {
         hasMore ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${INSTRUCTORS_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>` : ''
       }`;
 
-    const subtitle = `מדריכים פעילים (${filtered.length})`;
+    const pageHeader = `<div class="instr-page-header" dir="rtl"><span class="instr-page-header__title">מדריכים פעילים</span><span class="instr-page-header__count">${filtered.length} מדריכים</span></div>`;
 
     return dsScreenStack(`
-      <section class="ds-screen-compact-90">
+      <section class="ds-screen-compact-90 instr-page">
+      ${pageHeader}
       <div class="ds-screen-top-row">
         ${toolbarHtml}
       </div>
       ${dateFilterBarHtml(dateFrom, dateTo, globalMin, globalMax)}
-      ${dsCard({ title: subtitle, body: bodyHtml, padded: filtered.length === 0 })}
+      ${dsCard({ title: '', body: bodyHtml, padded: filtered.length === 0 })}
       </section>
     `);
   },

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8970,3 +8970,123 @@ select.ds-activity-add-field .ds-input,
     font-size: 0.68rem;
   }
 }
+
+/* ============================================================
+   Instructors page redesign – 2026-05
+   Compact 2×2 icon-grid cards, accent-responsive
+   ============================================================ */
+
+.instr-page-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  margin-bottom: 6px;
+  border-radius: var(--ds-radius-md);
+  background: color-mix(in srgb, var(--ds-accent) 6%, #fff);
+  border: 1px solid color-mix(in srgb, var(--ds-accent) 14%, transparent);
+}
+
+.instr-page-header__title {
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: var(--ds-accent);
+}
+
+.instr-page-header__count {
+  font-size: 0.78rem;
+  color: var(--ds-text-muted);
+}
+
+.instr-page .ds-card .ds-card__head {
+  display: none;
+}
+
+.instr-page .ci-list--instr-grid {
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 8px;
+  padding: 6px;
+}
+
+@media (max-width: 480px) {
+  .instr-page .ci-list--instr-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.instr-page .ci-list--instr-grid .instr-summary-row,
+.instr-page .instr-card .instr-summary-row {
+  min-height: unset;
+  padding: 8px 8px 7px;
+  background: color-mix(in srgb, var(--ds-accent) 5%, #fff);
+  border: 1px solid color-mix(in srgb, var(--ds-accent) 12%, transparent);
+  border-inline-start-width: 1px;
+  border-radius: 10px;
+  box-shadow: none;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+}
+
+.instr-page .ci-list--instr-grid .instr-summary-row:hover,
+.instr-page .instr-card .instr-summary-row:hover {
+  background: color-mix(in srgb, var(--ds-accent) 10%, #fff);
+  border-color: color-mix(in srgb, var(--ds-accent) 28%, transparent);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--ds-accent) 10%, transparent);
+}
+
+.instr-page .ci-row__main {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 5px;
+  padding: 0;
+}
+
+.instr-page .ci-row__name {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--ds-text);
+  text-align: center;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ds-accent) 12%, transparent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.instr-page .instr-stats {
+  display: grid !important;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
+  width: 100%;
+  margin-inline-start: 0;
+}
+
+.instr-page .instr-stat {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 28px;
+  min-height: unset;
+  background: color-mix(in srgb, var(--ds-accent) 7%, transparent);
+  border-radius: 6px;
+  padding: 0;
+  width: 100%;
+}
+
+.instr-stat__icon {
+  display: flex;
+  align-items: center;
+  color: var(--ds-accent);
+  flex-shrink: 0;
+}
+
+.instr-page .instr-stat__num {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--ds-text);
+}
+
+.instr-page .instr-stat__lbl {
+  display: none;
+}


### PR DESCRIPTION
…eming

- Add instructorTypeIcon() with inline SVGs (book/pin/bulb/clock)
- Replace TYPE_LABELS with TYPE_ITEMS; stats render as 2×2 icon+number grid
- Remove visible text labels; accessibility via title/aria-label only
- Add .instr-page-header ("מדריכים פעילים" + count) scoped to .instr-page wrapper
- All card backgrounds, borders, icon colors respond to color picker via CSS vars
- Cards target ~106px height; auto-fill grid packs many per row
- Scoped to .instr-page to avoid cascade side-effects on other screens

https://claude.ai/code/session_0135cWdHrMjBdVhNKyntPXNT