### PR TITLE
Add `ui_accent_color` support, compact activity-drawer edit UI, and update built asset references

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CKNPwGxg.js",
+  "./assets/index-Bu5RAkRI.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CKNPwGxg.js"></script>
+  <script type="module" crossorigin src="./assets/index-Bu5RAkRI.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DZE6SILU.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CKNPwGxg.js",
+  "./assets/index-Bu5RAkRI.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -467,7 +467,7 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
     },
     one_day_activity_types: shortTypes,
     program_activity_types: longTypes,
-    ...(accentColor ? { accent_color: accentColor, theme_accent: accentColor } : {}),
+    ...(accentColor ? { accent_color: accentColor, theme_accent: accentColor, ui_accent_color: accentColor } : {}),
   };
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -57,6 +57,7 @@ function accentNameFromStorage() {
       || normalizeAccentName(localStorage.getItem(LEGACY_STRIPE_LS_KEY))
       || normalizeAccentName(state?.clientSettings?.accent_color)
       || normalizeAccentName(state?.clientSettings?.theme_accent)
+      || normalizeAccentName(state?.clientSettings?.ui_accent_color)
       || 'blue';
   } catch {
     return 'blue';
@@ -102,11 +103,19 @@ function bindAccentPickerOnce() {
         localStorage.setItem(ACCENT_LS_KEY, selected);
         localStorage.setItem(LEGACY_STRIPE_LS_KEY, selected);
       } catch {}
-      state.clientSettings = { ...(state.clientSettings || {}), accent_color: selected, theme_accent: selected };
+      state.clientSettings = {
+        ...(state.clientSettings || {}),
+        accent_color: selected,
+        theme_accent: selected,
+        ui_accent_color: selected
+      };
+      saveRoutesToStorage(state.routes, state.route, state.clientSettings);
       if (typeof api.saveClientSetting === 'function') {
-        api.saveClientSetting({ key: 'accent_color', value: selected }).catch((err) => {
-          console.warn('[accent-picker] Supabase accent save failed; local choice remains active:', err);
-        });
+        Promise.all(['accent_color', 'theme_accent', 'ui_accent_color']
+          .map((key) => api.saveClientSetting({ key, value: selected })))
+          .catch((err) => {
+            console.warn('[accent-picker] Supabase accent save failed; local choice remains active:', err);
+          });
       }
       pop.hidden = true;
       if (pop.parentElement === document.body) {

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -214,6 +214,26 @@ function fieldViewEdit(label, viewHtml, editHtml) {
   `;
 }
 
+function fieldEditOnly(label, editHtml, extraClass = '') {
+  const cls = ['activity-drawer__field', extraClass].filter(Boolean).join(' ');
+  return `
+    <div class="${escapeHtml(cls)}">
+      <label class="activity-drawer__label">${escapeHtml(label)}</label>
+      ${editHtml}
+    </div>
+  `;
+}
+
+function resolveAllActivityTypes(settings) {
+  const seen = new Set();
+  const out = [];
+  [...(settings?.one_day_activity_types || []), ...(settings?.program_activity_types || [])].forEach((v) => {
+    const s = String(v || '').trim();
+    if (s && !seen.has(s)) { seen.add(s); out.push(s); }
+  });
+  return out;
+}
+
 function fieldViewOnly(label, viewHtml) {
   return `
     <div class="activity-drawer__field">
@@ -281,6 +301,8 @@ function blockPeople(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
   const managers = mergeListStrings(options, ['activity_manager', 'activity_managers']);
   const instructors = mergeListStrings(options, ['instructor_name', 'instructor_names']);
+  const authorities = mergeListStrings(options, ['authority', 'authorities']);
+  const grades = mergeListStrings(options, ['grade', 'grades']);
   const instructorLookup = buildInstructorLookup(settings);
   const instructor1Display = resolveInstructorDisplayName(row.instructor_name, row.emp_id, instructorLookup);
   const instructor2Display = resolveInstructorDisplayName(row.instructor_name_2, row.emp_id_2, instructorLookup);
@@ -294,24 +316,15 @@ function blockPeople(row, { settings = {} } = {}) {
     String(row.start_time || '').trim() && String(row.end_time || '').trim()
       ? formatTimeRangeShort(row.start_time, row.end_time)
       : '—';
-  const instructorFields = twoInstructors
-    ? `
-      ${fieldViewEdit(
-        'מדריך/ה 1',
-        `${escapeHtml(fallback(instructor1Display))}`,
-        selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors })
-      )}
-      ${fieldViewEdit(
-        'מדריך/ה 2',
-        `${escapeHtml(fallback(instructor2Display))}`,
-        selectHtml({ name: 'instructor_name_2', value: instructor2Display, options: instructors })
-      )}
-    `
-    : fieldViewEdit(
-        'מדריך/ה',
-        `${escapeHtml(fallback(instructor1Display))}`,
-        selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors })
-      );
+  const statusOptions = ['פעיל', 'סגור'];
+  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : 'פעיל';
+  const instructorEditHtml = twoInstructors
+    ? `<div class="activity-drawer__field-controls activity-drawer__field-controls--stacked">
+        ${selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors })}
+        ${selectHtml({ name: 'instructor_name_2', value: instructor2Display, options: instructors })}
+      </div>`
+    : selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors });
+
   return `
     <section class="activity-drawer__section">
       <div class="activity-drawer__grid activity-drawer__grid--three" data-mode="view">
@@ -323,13 +336,41 @@ function blockPeople(row, { settings = {} } = {}) {
         ${fieldViewOnly('כיתה', escapeHtml(classLabel))}
         ${fieldViewOnly('שעות', escapeHtml(hoursLabel))}
       </div>
-      <div class="activity-drawer__grid activity-drawer__grid--two" data-mode="edit" hidden>
-        ${fieldViewEdit(
+      <div class="activity-drawer__details-edit-grid" data-mode="edit" hidden>
+        ${fieldEditOnly(
           'מנהל פעילות',
-          `${escapeHtml(fallback(row.activity_manager))}`,
           selectHtml({ name: 'activity_manager', value: row.activity_manager, options: managers })
         )}
-        ${instructorFields}
+        ${fieldEditOnly('מדריך/ה', instructorEditHtml)}
+        ${fieldEditOnly(
+          'סוג פעילות',
+          selectHtml({ name: 'activity_type', value: activityType, options: resolveAllActivityTypes(settings), placeholder: 'בחרו סוג פעילות' })
+        )}
+        ${fieldEditOnly(
+          'סטטוס',
+          selectHtml({ name: 'status', value: normalizedStatus, options: statusOptions, placeholder: 'פעיל' })
+        )}
+        ${fieldEditOnly(
+          'רשות',
+          authorities.length
+            ? selectHtml({ name: 'authority', value: row.authority, options: authorities })
+            : inputHtml({ name: 'authority', value: row.authority })
+        )}
+        ${fieldEditOnly(
+          'כיתה',
+          `<div class="activity-drawer__field-controls activity-drawer__field-controls--inline">
+            ${selectHtml({ name: 'grade', value: row.grade, options: grades })}
+            ${inputHtml({ name: 'class_group', value: row.class_group, attrs: 'placeholder="כיתה"' })}
+          </div>`
+        )}
+        ${fieldEditOnly(
+          'שעות',
+          `<div class="activity-drawer__field-controls activity-drawer__field-controls--inline">
+            ${inputHtml({ name: 'start_time', value: formatTimeShort(row.start_time), type: 'time' })}
+            ${inputHtml({ name: 'end_time', value: formatTimeShort(row.end_time), type: 'time' })}
+          </div>`,
+          'activity-drawer__field--hours'
+        )}
       </div>
     </section>
   `;
@@ -337,49 +378,18 @@ function blockPeople(row, { settings = {} } = {}) {
 
 function blockContent(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
-  const constrainDropdowns = settings.constrained_fields_use_dropdown !== false;
   const fundings = mergeListStrings(options, ['funding', 'fundings']);
-  const grades = mergeListStrings(options, ['grade', 'grades']);
   const schools = mergeListStrings(options, ['school', 'schools']);
-  const authorities = mergeListStrings(options, ['authority', 'authorities']);
   const activityType = String(row.activity_type || '').trim();
-  const allActivityTypes = (() => {
-    const seen = new Set();
-    const out = [];
-    [...(settings.one_day_activity_types || []), ...(settings.program_activity_types || [])].forEach((v) => {
-      const s = String(v || '').trim();
-      if (s && !seen.has(s)) { seen.add(s); out.push(s); }
-    });
-    return out;
-  })();
   const allActivityNames = resolveActivityNameOptions(settings, activityType);
   if (!allActivityNames.length) {
     // eslint-disable-next-line no-console
     console.warn('[activity-edit] activity name options missing from client settings');
   }
   const nameLabel = activityNameLabel(activityType);
-  const gradeVal = String(row.grade || '').trim();
-  const classGroupVal = String(row.class_group || '').trim();
-  const classLabel = [gradeVal, classGroupVal].filter(Boolean).join(' / ') || '—';
-  const firstMeetingDate = Array.isArray(row.meeting_schedule) && row.meeting_schedule.length
-    ? String(row.meeting_schedule[0]?.date || '').trim()
-    : String(row.start_date || '').trim();
-  const hoursLabel =
-    String(row.start_time || '').trim() && String(row.end_time || '').trim()
-      ? formatTimeRangeShort(row.start_time, row.end_time)
-      : '—';
-  const statusOptions = [
-    { value: 'פעיל', label: 'פעיל' },
-    { value: 'סגור', label: 'סגור' }
-  ];
-  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : 'פעיל';
   return `
     <section class="activity-drawer__section">
       <div class="activity-drawer__edit-grid activity-drawer__grid activity-drawer__grid--two" data-mode="edit" hidden>
-        <div class="activity-drawer__field activity-drawer__field--full">
-          <div class="activity-drawer__label">סוג פעילות</div>
-          ${selectHtml({ name: 'activity_type', value: activityType, options: allActivityTypes, placeholder: 'בחרו סוג פעילות' })}
-        </div>
         <div class="activity-drawer__field activity-drawer__field--full">
           <div class="activity-drawer__label">${escapeHtml(nameLabel)}</div>
           ${activityNameSelectHtml('activity_name', row.activity_name, allActivityNames, activityType)}
@@ -393,15 +403,6 @@ function blockContent(row, { settings = {} } = {}) {
           }
         </div>
         <div class="activity-drawer__field">
-          <div class="activity-drawer__label">סטטוס</div>
-          ${selectHtml({
-            name: 'status',
-            value: normalizedStatus,
-            options: statusOptions.map((o) => o.value),
-            placeholder: 'פעיל'
-          })}
-        </div>
-        <div class="activity-drawer__field">
           <div class="activity-drawer__label">מחיר</div>
           ${inputHtml({ name: 'price', value: row.price })}
         </div>
@@ -412,30 +413,6 @@ function blockContent(row, { settings = {} } = {}) {
               ? selectHtml({ name: 'school', value: row.school, options: schools })
               : inputHtml({ name: 'school', value: row.school })
           }
-        </div>
-        <div class="activity-drawer__field">
-          <div class="activity-drawer__label">רשות</div>
-          ${
-            authorities.length
-              ? selectHtml({ name: 'authority', value: row.authority, options: authorities })
-              : inputHtml({ name: 'authority', value: row.authority })
-          }
-        </div>
-        <div class="activity-drawer__field">
-          <div class="activity-drawer__label">שכבה</div>
-          ${selectHtml({ name: 'grade', value: row.grade, options: grades })}
-        </div>
-        <div class="activity-drawer__field">
-          <div class="activity-drawer__label">קבוצה / כיתה</div>
-          ${inputHtml({ name: 'class_group', value: row.class_group })}
-        </div>
-        <div class="activity-drawer__field">
-          <div class="activity-drawer__label">שעת התחלה</div>
-          ${inputHtml({ name: 'start_time', value: formatTimeShort(row.start_time), type: 'time' })}
-        </div>
-        <div class="activity-drawer__field">
-          <div class="activity-drawer__label">שעת סיום</div>
-          ${inputHtml({ name: 'end_time', value: formatTimeShort(row.end_time), type: 'time' })}
         </div>
       </div>
     </section>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7113,9 +7113,57 @@ select.ds-input {
   gap: 8px 12px;
 }
 
-@media (max-width: 480px) {
-  .activity-drawer__grid--three {
+.activity-drawer__details-edit-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px 10px;
+  align-items: start;
+}
+
+.activity-drawer__details-edit-grid .activity-drawer__field {
+  min-width: 0;
+  gap: 3px;
+}
+
+.activity-drawer__details-edit-grid .ds-input,
+.activity-drawer__details-edit-grid select,
+.activity-drawer__details-edit-grid input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  min-height: 34px;
+}
+
+.activity-drawer__field-controls {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.activity-drawer__field-controls--inline {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.activity-drawer__field-controls--stacked {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (max-width: 640px) {
+  .activity-drawer__details-edit-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .activity-drawer__grid--three,
+  .activity-drawer__details-edit-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 360px) {
+  .activity-drawer__details-edit-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/tests/accent-picker.test.mjs
+++ b/tests/accent-picker.test.mjs
@@ -29,3 +29,20 @@ test('accent picker records current accent on the button and root dataset', () =
   assert.match(src, /btn\.style\.backgroundColor = colors\.accent/);
   assert.match(src, /btn\.dataset\.currentAccent = selected/);
 });
+
+
+test('accent picker keeps all settings accent keys in sync locally and remotely', () => {
+  const src = read('frontend/src/main.js');
+  assert.match(src, /ui_accent_color: selected/);
+  assert.match(src, /saveRoutesToStorage\(state\.routes, state\.route, state\.clientSettings\)/);
+  assert.match(src, /\['accent_color', 'theme_accent', 'ui_accent_color'\]/);
+  assert.match(src, /api\.saveClientSetting\(\{ key, value: selected \}\)/);
+});
+
+test('bootstrap accent fallback reads and returns all supported settings keys', () => {
+  const main = read('frontend/src/main.js');
+  const api = read('frontend/src/api.js');
+  assert.match(main, /normalizeAccentName\(state\?\.clientSettings\?\.ui_accent_color\)/);
+  assert.match(api, /settingValue\('accent_color'\) \|\| settingValue\('theme_accent'\) \|\| settingValue\('ui_accent_color'\)/);
+  assert.match(api, /accent_color: accentColor, theme_accent: accentColor, ui_accent_color: accentColor/);
+});

--- a/tests/ui-fixes-regression.test.mjs
+++ b/tests/ui-fixes-regression.test.mjs
@@ -56,3 +56,16 @@ test('instructors screen counts normalized activity_type keys', () => {
   assert.match(screenSrc, /typeStats = TYPE_LABELS\.map/);
   assert.match(screenSrc, /keys\.reduce\(\(sum, key\) => sum \+ Number\(typeCounts\[key\] \|\| 0\), 0\)/);
 });
+
+test('activity drawer edit details use compact three-column field wrappers', () => {
+  const htmlSrc = read('frontend/src/screens/shared/activity-detail-html.js');
+  const css = read('frontend/src/styles/main.css');
+  assert.match(htmlSrc, /function fieldEditOnly\(label, editHtml, extraClass = ''\)[\s\S]*<label class="activity-drawer__label">\$\{escapeHtml\(label\)\}<\/label>[\s\S]*\$\{editHtml\}/);
+  assert.match(htmlSrc, /activity-drawer__details-edit-grid/);
+  assert.match(htmlSrc, /name: 'activity_manager'/);
+  assert.match(htmlSrc, /name: 'instructor_name'/);
+  assert.match(htmlSrc, /name: 'activity_type'/);
+  assert.match(htmlSrc, /'סטטוס'[\s\S]*name: 'status'[\s\S]*'רשות'[\s\S]*name: 'authority'[\s\S]*'כיתה'[\s\S]*name: 'grade'[\s\S]*name: 'class_group'[\s\S]*'שעות'[\s\S]*name: 'start_time'[\s\S]*name: 'end_time'/);
+  assert.match(css, /\.activity-drawer__details-edit-grid \{[\s\S]*grid-template-columns: repeat\(3, minmax\(0, 1fr\)\)/);
+  assert.match(css, /\.activity-drawer__details-edit-grid \.ds-input,[\s\S]*width: 100%;[\s\S]*height: 34px;/);
+});


### PR DESCRIPTION
### Motivation

- Keep accent configuration consistent across legacy and new keys and persist the full set of accent settings both locally and to the backend.
- Improve the activity drawer edit UI by introducing a compact, three-column edit layout and clearer field wrappers.
- Ensure built distribution references the new hashed `index` asset after a build.

### Description

- Add `ui_accent_color` to client settings handling in `frontend/src/api.js` so `buildClientSettingsFromLists` emits `ui_accent_color` alongside `accent_color` and `theme_accent`.
- Read and prefer `ui_accent_color` as a fallback in `frontend/src/main.js`, persist it into `state.clientSettings`, call `saveRoutesToStorage`, and save all three keys (`accent_color`, `theme_accent`, `ui_accent_color`) via `api.saveClientSetting` when the accent picker is used.
- Introduce new helpers and markup in `frontend/src/screens/shared/activity-detail-html.js`: `fieldEditOnly`, `resolveAllActivityTypes`, and a reworked edit-state layout for the activity drawer that groups fields into a compact `activity-drawer__details-edit-grid` with inline/stacked field controls and normalized status handling.
- Add CSS rules in `frontend/src/styles/main.css` for `.activity-drawer__details-edit-grid`, `.activity-drawer__field-controls`, responsive behavior, and input sizing to support the new edit layout.
- Update built distribution files `dist/index.html`, `dist/sw.js`, and `dist/frontend/sw.js` to reference the new `index-Bu5RAkRI.js` hashed asset.
- Update tests to validate the new accent key behavior and the activity-drawer edit UI structure in `tests/accent-picker.test.mjs` and `tests/ui-fixes-regression.test.mjs`.

### Testing

- Ran the test suite including `tests/accent-picker.test.mjs` and `tests/ui-fixes-regression.test.mjs`, and all tests passed.
- Static distribution files were updated to reference the new built asset name and were included in the commit for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5b1626ac832b88c6158f257efd06)