### PR TITLE
Fix authenticated refresh route correction

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BdvI2Brb.js",
+  "./assets/index-ByTLKxRO.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BdvI2Brb.js"></script>
+  <script type="module" crossorigin src="./assets/index-ByTLKxRO.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-RcHmWAKz.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BdvI2Brb.js",
+  "./assets/index-ByTLKxRO.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -731,6 +731,15 @@ function resolveAllowedDefaultRoute(preferred, routes) {
   return knownRoutes[0] || 'my-data';
 }
 
+function resolveAuthenticatedRoute(preferred, routes = effectiveRoutes()) {
+  const knownRoutes = Array.isArray(routes)
+    ? routes.filter((r) => !!screenLoaders[r] && !PERMANENTLY_DISABLED_ROUTES.has(r))
+    : [];
+  if (preferred && preferred !== 'login' && knownRoutes.includes(preferred)) return preferred;
+  if (knownRoutes.includes('dashboard')) return 'dashboard';
+  return resolveAllowedDefaultRoute('', knownRoutes);
+}
+
 function bootstrapSupabaseReadonlySession() {
   if (!SUPABASE_READONLY_CUTOVER) return;
   if (!state.token) {
@@ -1473,7 +1482,7 @@ async function restoreSession() {
 
 async function mountScreen() {
   redirectIfDisabledRoute();
-  const requestedRoute = state.route;
+  let requestedRoute = state.route;
   const transitionToken = ++navigationToken;
   activeNavigationToken = transitionToken;
   latestNavigationRoute = requestedRoute;
@@ -1494,7 +1503,20 @@ async function mountScreen() {
       await restoreSession();
     }
   }
-  if (!isAllowedRoute(state.route)) state.route = resolveAllowedDefaultRoute('', state.routes);
+  if (!isAllowedRoute(state.route)) state.route = resolveAuthenticatedRoute(state.route, state.routes);
+
+  if (requestedRoute !== state.route) {
+    const previousRequestedRoute = requestedRoute;
+    requestedRoute = state.route;
+    latestNavigationRoute = requestedRoute;
+    // eslint-disable-next-line no-console
+    console.info('[route-load:corrected]', {
+      previousRequestedRoute,
+      requestedRoute,
+      stateRoute: state.route,
+      reason: previousRequestedRoute === 'login' ? 'authenticated-login-redirect' : 'route-state-correction'
+    });
+  }
 
   if (transitionToken !== activeNavigationToken || requestedRoute !== latestNavigationRoute) {
     finishRouteTransition(transitionLabel, requestedRoute, screenDataCacheKey(), mountStartMs, transitionToken);
@@ -1513,6 +1535,8 @@ async function mountScreen() {
     const fallback = effectiveRoutes().find((r) => !!screenLoaders[r]);
     if (fallback) {
       state.route = fallback;
+      requestedRoute = fallback;
+      latestNavigationRoute = fallback;
       screen = await getScreen(fallback);
     }
   }


### PR DESCRIPTION
### Motivation
- After a full refresh the UI could remain on a `login` requested route while the session and dashboard had already been restored, leaving the dashboard stuck on the loading spinner; this change fixes the route/auth guard/render state reconciliation after refresh.

### Description
- Add `resolveAuthenticatedRoute(preferred, routes)` to prefer a safe authenticated route (avoid `login`, prefer `dashboard`) when restoring routes. (`frontend/src/main.js`)
- Change `mountScreen()` to use a mutable `requestedRoute`, and if bootstrapping/restore changes `state.route` update `requestedRoute` and `latestNavigationRoute` and emit a `[route-load:corrected]` info log to document the correction. (`frontend/src/main.js`)
- Ensure fallback screen selection also updates `requestedRoute`/`latestNavigationRoute` so the navigation guard and render flow remain consistent when `state.route` is adjusted. (`frontend/src/main.js`)
- Rebuild distribution artifacts so `dist/index.html` and service-worker precache reference the new bundle. (`dist/*`)

### Testing
- Ran `npm run build`, which completed successfully and produced updated `dist` assets. (passed)
- Ran the test suite with `npm test`; test run started but multiple unrelated test failures were observed and the process was terminated to avoid a long hang, so full test pass was not recorded. (partial / interrupted)
- Manual smoke checks exercised the updated `mountScreen` path via the build to ensure the corrected route sync and the new log entry appear during an authenticated refresh. (manual verification)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6281a644832b8e4b22afa7a67e94)