### PR TITLE
Scope instructors page table borders to neutral color

### DIFF
--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -133,7 +133,7 @@ function buildPopupHtml(name, items) {
       <tbody>${rows}</tbody>
     </table>`;
   }
-  return `<div class="instr-popup-overlay" id="instr-popup-overlay" role="dialog" aria-modal="true" dir="rtl">
+  return `<div class="instr-popup-overlay ds-instructors-screen" id="instr-popup-overlay" role="dialog" aria-modal="true" dir="rtl">
     <div class="instr-popup" id="instr-popup">
       <div class="instr-popup__head">
         <span class="instr-popup__name">${name}</span>
@@ -240,7 +240,7 @@ export const instructorsScreen = {
     const pageHeader = `<div class="instr-page-header" dir="rtl"><span class="instr-page-header__title">מדריכים פעילים</span><span class="instr-page-header__count">${filtered.length} מדריכים</span></div>`;
 
     return dsScreenStack(`
-      <section class="ds-screen-compact-90 instr-page">
+      <section class="ds-screen-compact-90 instr-page ds-instructors-screen">
       ${pageHeader}
       <div class="ds-screen-top-row">
         ${toolbarHtml}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9108,6 +9108,15 @@ select.ds-activity-add-field .ds-input,
   display: none;
 }
 
+.ds-instructors-screen .ds-table,
+.ds-instructors-screen .ds-table th,
+.ds-instructors-screen .ds-table td,
+.ds-instructors-screen .instr-popup-table,
+.ds-instructors-screen .instr-popup-table th,
+.ds-instructors-screen .instr-popup-table td {
+  border-color: #d8dee8;
+}
+
 .instr-page .ci-list--instr-grid {
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 8px;


### PR DESCRIPTION
### Motivation
- Ensure the instructors screen tables (and its popup table) keep a fixed, neutral border color regardless of the global accent chosen in the color picker.

### Description
- Added the page-scope class `ds-instructors-screen` to the main instructors container and to the instructor popup overlay in `frontend/src/screens/instructors.js` so styling can be targeted only on that screen.
- Added scoped CSS rules in `frontend/src/styles/main.css` that set `border-color: #d8dee8` for `.ds-instructors-screen .ds-table`, its `th`/`td`, and the popup table selectors, without modifying any global color variables such as `--ds-accent`, `--ds-accent-hover`, or `--ds-accent-soft`.
- The change is narrowly scoped to avoid affecting tables on other screens (activities, exceptions, archive, month, week, contacts, etc.) and does not change color picker behavior.

### Testing
- Ran `git diff --check` which produced no issues and passed successfully.
- Ran `npm run build` which completed successfully (Vite build emitted a chunk-size advisory but build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe68ecb418832b8d544b89b7b55a12)