### PR TITLE
Unify empty-value detection and treat textual NULL as empty (fix exceptions detection)

### DIFF
--- a/OLD-GAS/actions.gs
+++ b/OLD-GAS/actions.gs
@@ -54,9 +54,9 @@ function shiftYm_(ym, deltaMonths) {
 /** פעילות עם טווח תאריכים שחופף לחודש ym (כולל קצה) */
 function activityOverlapsYm_(row, ym) {
   var b = ymBounds_(ym);
-  var s = text_(row.start_date);
-  var e = text_(row.end_date || row.start_date);
-  if (!s) return false;
+  var s = normalizeDateTextToIso_(row && row.start_date);
+  var e = normalizeDateTextToIso_(row && row.end_date) || s;
+  if (isEmptyValue_(row && row.start_date) || !s) return false;
   if (!e) e = s;
   return s <= b.last && e >= b.first;
 }
@@ -101,8 +101,8 @@ function countActiveByTypeInYm_(rows, ym, activityType) {
 function rowExceptionTypes_(row) {
   var out = [];
   if (isExcludedStatusForControl_(row && row.status)) return out;
-  var hasInstructor1 = !isNormalizedEmptyValue_(row && row.instructor_name) || !isNormalizedEmptyValue_(row && row.emp_id);
-  var hasInstructor2 = !isNormalizedEmptyValue_(row && row.instructor_name_2) || !isNormalizedEmptyValue_(row && row.emp_id_2);
+  var hasInstructor1 = !isEmptyValue_(row && row.instructor_name) || !isEmptyValue_(row && row.emp_id);
+  var hasInstructor2 = !isEmptyValue_(row && row.instructor_name_2) || !isEmptyValue_(row && row.emp_id_2);
   if (!hasInstructor1 && !hasInstructor2) out.push('missing_instructor');
   if (isDataShortRow_(row)) {
     if (!normalizeDateTextToIso_(row && row.start_date)) out.push('missing_start_date');
@@ -136,7 +136,7 @@ function computeExceptionsModel_(rows, ym, opts) {
     // active: the missing date is itself an exception and we cannot determine
     // overlap from an absent field.  Only skip overlap check when start_date
     // exists and the range does not intersect the requested month.
-    var rowHasStart = !!text_(row && row.start_date);
+    var rowHasStart = !isEmptyValue_(row && row.start_date) && !!normalizeDateTextToIso_(row && row.start_date);
     if (month && rowHasStart && !activityOverlapsYm_(row, month)) return;
     if (isExcludedStatusForControl_(row && row.status)) return;
 
@@ -4231,9 +4231,9 @@ function isActivityActiveBySpec_(row, todayIso) {
   if (settingYes_('use_status_with_dates') && st === 'ended') {
     return false;
   }
-  var s = text_(row.start_date);
-  var e = text_(row.end_date || row.start_date);
-  if (!s) return false;
+  var s = normalizeDateTextToIso_(row && row.start_date);
+  var e = normalizeDateTextToIso_(row && row.end_date) || s;
+  if (isEmptyValue_(row && row.start_date) || !s) return false;
   return todayIso >= s && todayIso <= e;
 }
 

--- a/OLD-GAS/activities-snapshot.gs
+++ b/OLD-GAS/activities-snapshot.gs
@@ -164,8 +164,8 @@ function activitiesInstructorCoverageStats_(rows) {
   var withEmpId = 0;
   var missingInstructor = 0;
   list.forEach(function(row) {
-    var hasName = !!(text_(row && row.instructor_name) || text_(row && row.instructor_name_2));
-    var hasEmp = !!(text_(row && row.emp_id) || text_(row && row.emp_id_2));
+    var hasName = !isEmptyValue_(row && row.instructor_name) || !isEmptyValue_(row && row.instructor_name_2);
+    var hasEmp = !isEmptyValue_(row && row.emp_id) || !isEmptyValue_(row && row.emp_id_2);
     if (hasName) withInstructorName++;
     if (hasEmp) withEmpId++;
     if (!hasName && !hasEmp) missingInstructor++;
@@ -219,8 +219,8 @@ function filterActivitiesSnapshotRows_(rows, payload) {
 }
 
 function rowHasInstructorData_(row) {
-  var hasName = !!(text_(row && row.instructor_name) || text_(row && row.instructor_name_2) || text_(row && row.Employee) || text_(row && row.Employee2));
-  var hasEmp = !!(text_(row && row.emp_id) || text_(row && row.emp_id_2) || text_(row && row.EmployeeID) || text_(row && row.EmployeeID2));
+  var hasName = !isEmptyValue_(row && row.instructor_name) || !isEmptyValue_(row && row.instructor_name_2) || !isEmptyValue_(row && row.Employee) || !isEmptyValue_(row && row.Employee2);
+  var hasEmp = !isEmptyValue_(row && row.emp_id) || !isEmptyValue_(row && row.emp_id_2) || !isEmptyValue_(row && row.EmployeeID) || !isEmptyValue_(row && row.EmployeeID2);
   return hasName || hasEmp;
 }
 

--- a/OLD-GAS/helpers.gs
+++ b/OLD-GAS/helpers.gs
@@ -12,11 +12,11 @@ function text_(value) {
 }
 
 /**
- * Unified empty-value normalization for control metrics.
- * Values such as null/undefined/blank/whitespace/"-"/"—"/"לא שובץ"/"טרם שובץ"/"לא נקבע"
- * are treated as empty.
+ * Unified empty-value normalization for control metrics and exception detection.
+ * Values such as null/undefined/blank/whitespace/"NULL"/"null"/"undefined"/"-"/"—"/
+ * "לא שובץ"/"טרם שובץ"/"לא נקבע" are treated as empty.
  */
-function isNormalizedEmptyValue_(value) {
+function isEmptyValue_(value) {
   if (value === null || value === undefined) return true;
   var raw = text_(value);
   if (!raw) return true;
@@ -33,6 +33,11 @@ function isNormalizedEmptyValue_(value) {
     compact === 'none' ||
     compact === 'null' ||
     compact === 'undefined';
+}
+
+
+function isNormalizedEmptyValue_(value) {
+  return isEmptyValue_(value);
 }
 
 function isValidIsoDateString_(value) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,6 +2,7 @@ import { state, setSession, clearScreenDataCache } from './state.js';
 import { deletePersistedCacheByPrefixes } from './cache-persist.js';
 import { hebrewRole } from './screens/shared/ui-hebrew.js';
 import { supabase, supabaseConfig } from './supabase-client.js';
+import { isEmptyValue, nonEmptyString } from './utils/empty-value.js';
 
 /**
  * Actions that modify server-side data.
@@ -237,7 +238,7 @@ function activityHasDateInMonth(row, monthPrefix) {
   const dates = getActivityDateColumns(row);
   if (dates.some((dateKey) => dateKey.startsWith(monthPrefix))) return true;
   // start_date is only a fallback when the activity has no meeting date columns.
-  return dates.length === 0 && String(row?.start_date || '').slice(0, 7) === monthPrefix;
+  return dates.length === 0 && normalizeSupabaseDate(row?.start_date).slice(0, 7) === monthPrefix;
 }
 
 async function selectActivitiesFromSupabase(select = '*') {
@@ -632,10 +633,10 @@ const HEBREW_WEEKDAY_LABELS = ['ראשון', 'שני', 'שלישי', 'רביעי
  * מונע מהמחרוזת הטקסטואלית "NULL" להיחשב כערך תקין.
  */
 function nullStr(val) {
-  if (val === null || val === undefined) return '';
-  const s = String(val).trim();
+  if (isEmptyValue(val)) return '';
+  const s = nonEmptyString(val);
   const u = s.toUpperCase();
-  if (u === 'NULL' || u === 'NONE' || u === 'UNDEFINED' || u === 'N/A' || u === '-') return '';
+  if (u === 'NONE' || u === 'N/A' || u === '-') return '';
   return s;
 }
 
@@ -643,8 +644,8 @@ function nullStr(val) {
  * Normalize a date value to YYYY-MM-DD string, or '' if invalid.
  */
 function normalizeSupabaseDate(val) {
-  if (!val) return '';
-  const s = String(val).trim();
+  if (isEmptyValue(val)) return '';
+  const s = nonEmptyString(val);
   if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
   const m = /^(\d{4}-\d{2}-\d{2})/.exec(s);
   return m ? m[1] : '';
@@ -1043,14 +1044,14 @@ async function readExceptionsFromSupabase(params = {}) {
         .select('*')
         .in('activity_type', COURSE_TYPE_VALUES)
         .neq('status', CLOSED_STATUS)
-        .or('start_date.is.null,start_date.eq.'),
+        .or('start_date.is.null,start_date.eq.,start_date.eq.NULL,start_date.eq.null'),
       supabase
         .from('activities')
         .select('*')
         .in('activity_type', COURSE_TYPE_VALUES)
         .neq('status', CLOSED_STATUS)
-        .or('emp_id.is.null,emp_id.eq.')
-        .or('instructor_name.is.null,instructor_name.eq.')
+        .or('emp_id.is.null,emp_id.eq.,emp_id.eq.NULL,emp_id.eq.null')
+        .or('instructor_name.is.null,instructor_name.eq.,instructor_name.eq.NULL,instructor_name.eq.null')
     ]);
 
     const missingStartRows  = (Array.isArray(missingStartResult.data)      ? missingStartResult.data      : []).map(normalizeActivityRow);

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -18,6 +18,7 @@ import {
   splitVisibleRows
 } from './shared/activity-list-filters.js';
 import { getFilterOptionOverrides } from './shared/activity-options.js';
+import { isEmptyValue } from '../utils/empty-value.js';
 
 const EXCEPTIONS_SCOPE = 'exceptions';
 
@@ -38,8 +39,8 @@ const EXCEPTION_FILTER_FIELDS = [
 ];
 
 function fieldRow(label, value) {
-  const display = (value !== undefined && value !== null && value !== '')
-    ? escapeHtml(String(value))
+  const display = !isEmptyValue(value)
+    ? escapeHtml(String(value).trim())
     : '<em style="color:var(--ds-text-muted)">—</em>';
   return `<p><strong>${escapeHtml(label)}:</strong> ${display}</p>`;
 }
@@ -63,10 +64,10 @@ function exceptionDrawerHtml(row, hideRowId) {
   const exceptionTypes = Array.isArray(row.exception_types) ? row.exception_types : [row.exception_type].filter(Boolean);
   const chips = exceptionTypes.map((et) => dsStatusChip(hebrewExceptionType(String(et || '').trim()), 'neutral')).join(' ');
 
-  const instructor  = row.instructor_name  || '';
-  const instructor2 = row.instructor_name_2 || '';
-  const startDate   = formatDateHe(row.start_date) || row.start_date || '';
-  const endDate     = formatDateHe(row.end_date)   || row.end_date   || '';
+  const instructor  = isEmptyValue(row.instructor_name) ? '' : String(row.instructor_name).trim();
+  const instructor2 = isEmptyValue(row.instructor_name_2) ? '' : String(row.instructor_name_2).trim();
+  const startDate   = isEmptyValue(row.start_date) ? '' : (formatDateHe(row.start_date) || String(row.start_date).trim());
+  const endDate     = isEmptyValue(row.end_date)   ? '' : (formatDateHe(row.end_date)   || String(row.end_date).trim());
   const grade = String(row.grade || '').trim();
   const classGroup = String(row.class_group || '').trim();
   const classDisplay = [grade, classGroup].filter(Boolean).join(' ');

--- a/frontend/src/utils/empty-value.js
+++ b/frontend/src/utils/empty-value.js
@@ -1,0 +1,16 @@
+/**
+ * Returns true for values that should be treated as empty across the app.
+ * Covers actual null/undefined, blank strings, whitespace-only strings, and
+ * textual null markers that can arrive from spreadsheets or Supabase.
+ */
+export function isEmptyValue(value) {
+  if (value === null || value === undefined) return true;
+  const normalized = String(value).replace(/\u00A0/g, ' ').trim();
+  if (!normalized) return true;
+  const compact = normalized.replace(/\s+/g, ' ').toLowerCase();
+  return compact === 'null' || compact === 'undefined';
+}
+
+export function nonEmptyString(value) {
+  return isEmptyValue(value) ? '' : String(value).trim();
+}

--- a/tests/empty-value-helper.test.mjs
+++ b/tests/empty-value-helper.test.mjs
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { isEmptyValue, nonEmptyString } from '../frontend/src/utils/empty-value.js';
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), 'utf8');
+
+test('frontend isEmptyValue covers null-like spreadsheet values', () => {
+  for (const value of [null, undefined, '', '   ', '\t', 'NULL', 'null', ' undefined ', '\u00A0']) {
+    assert.equal(isEmptyValue(value), true, `${String(value)} should be empty`);
+    assert.equal(nonEmptyString(value), '');
+  }
+  assert.equal(isEmptyValue('0'), false);
+  assert.equal(nonEmptyString(' value '), 'value');
+});
+
+test('backend exposes a single isEmptyValue_ helper and keeps backward-compatible alias', async () => {
+  const src = await read('OLD-GAS/helpers.gs');
+  assert.match(src, /function isEmptyValue_\(value\)/);
+  assert.match(src, /function isNormalizedEmptyValue_\(value\) \{\n  return isEmptyValue_\(value\);\n\}/);
+  assert.match(src, /compact === 'null'/);
+  assert.match(src, /compact === 'undefined'/);
+});
+
+test('exception calculations use isEmptyValue_ for instructors and start dates', async () => {
+  const actions = await read('OLD-GAS/actions.gs');
+  const api = await read('frontend/src/api.js');
+  assert.match(actions, /!isEmptyValue_\(row && row\.instructor_name\)/);
+  assert.match(actions, /var rowHasStart = !isEmptyValue_\(row && row\.start_date\)/);
+  assert.match(api, /function nullStr\(val\) \{\n  if \(isEmptyValue\(val\)\) return '';/);
+  assert.match(api, /start_date\.eq\.NULL/);
+});

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -25,12 +25,24 @@ function ymBounds(ym) {
   return { first, last };
 }
 
+function isEmptyValue(value) {
+  if (value === null || value === undefined) return true;
+  const normalized = String(value).replace(/\u00A0/g, ' ').trim();
+  if (!normalized) return true;
+  const compact = normalized.replace(/\s+/g, ' ').toLowerCase();
+  return compact === 'null' || compact === 'undefined';
+}
+
+function nonEmptyString(value) {
+  return isEmptyValue(value) ? '' : String(value).trim();
+}
+
 function activityOverlapsYm(row, ym) {
   const b = ymBounds(ym);
-  const s = String(row.start_date || '');
-  const e = String(row.end_date || row.start_date || '');
+  const s = nonEmptyString(row.start_date);
+  const e = nonEmptyString(row.end_date) || s;
   if (!s) return false;
-  return s <= b.last && (e || s) >= b.first;
+  return s <= b.last && e >= b.first;
 }
 
 function rowExceptionTypes(row) {
@@ -41,10 +53,10 @@ function rowExceptionTypes(row) {
   const out = [];
   if (row.status === 'ארכיון' || row.status === 'canceled') return out;
   const hasInstructor =
-    (String(row.instructor_name || '').trim() !== '' || String(row.emp_id || '').trim() !== '' ||
-     String(row.instructor_name_2 || '').trim() !== '' || String(row.emp_id_2 || '').trim() !== '');
+    (!isEmptyValue(row.instructor_name) || !isEmptyValue(row.emp_id) ||
+     !isEmptyValue(row.instructor_name_2) || !isEmptyValue(row.emp_id_2));
   if (!hasInstructor) out.push('missing_instructor');
-  if (!String(row.start_date || '').trim()) out.push('missing_start_date');
+  if (isEmptyValue(row.start_date)) out.push('missing_start_date');
   if (String(row.end_date || '') > LATE_CUTOFF) out.push('late_end_date');
   return out;
 }
@@ -59,7 +71,7 @@ function computeExceptionsModel(sourceRows, ym, opts) {
   sourceRows.forEach((row) => {
     if (String(row.activity_type || '') !== 'course') return;
     // KEY FIX: activities without start_date are always included
-    const rowHasStart = !!String(row.start_date || '').trim();
+    const rowHasStart = !isEmptyValue(row.start_date);
     if (ym && rowHasStart && !activityOverlapsYm(row, ym)) return;
     if (row.status === 'ארכיון') return;
 
@@ -116,9 +128,9 @@ const rowAllThree = {
   RowID: 'LONG-001',
   activity_type: 'course',
   activity_manager: 'mgr_a',
-  instructor_name: '',
-  emp_id: '',
-  start_date: '',
+  instructor_name: 'NULL',
+  emp_id: ' null ',
+  start_date: 'NULL',
   end_date: '2026-07-31',  // after cutoff → late_end_date
   status: 'פעיל'
 };
@@ -197,6 +209,13 @@ const rowOutOfMonth = {
 };
 
 // ─── Numeric tests ────────────────────────────────────────────────────────────
+
+test('isEmptyValue treats textual NULL markers as empty', () => {
+  for (const value of ['', '   ', null, undefined, 'NULL', 'null', ' undefined ']) {
+    assert.equal(isEmptyValue(value), true, `${String(value)} should be empty`);
+  }
+  assert.equal(isEmptyValue('actual value'), false);
+});
 
 test('activity with all 3 exception types counts as one row and keeps details', () => {
   const result = computeExceptionsModel([rowAllThree], '', { include_rows: true });
@@ -278,10 +297,10 @@ test('non-course activities are never included in exceptions', () => {
 test('backend computeExceptionsModel_ guards month filter only when start_date exists', async () => {
   const src = await read('OLD-GAS/actions.gs');
   // The fix: rowHasStart is defined and used as a guard
-  assert.match(src, /var rowHasStart = !!text_\(row && row\.start_date\)/,
-    'computeExceptionsModel_ must compute rowHasStart');
+  assert.match(src, /var rowHasStart = !isEmptyValue_\(row && row\.start_date\) && !!normalizeDateTextToIso_\(row && row\.start_date\)/,
+    'computeExceptionsModel_ must compute rowHasStart with the unified empty-value helper');
   assert.match(src, /if \(month && rowHasStart && !activityOverlapsYm_\(row, month\)\) return;/,
-    'overlap check must be guarded by rowHasStart so no-start_date rows are always included');
+    'overlap check must be guarded by rowHasStart so no-start_date/NULL rows are always included');
   // The old unconditional check must NOT appear
   assert.doesNotMatch(src, /if \(month && !activityOverlapsYm_\(row, month\)\) return;/,
     'unconditional activityOverlapsYm_ check must be removed from computeExceptionsModel_');


### PR DESCRIPTION
### Motivation

- Empty spreadsheet/Supabase cells sometimes contain literal text like `NULL`/`null`/`undefined` and the app treated those as present values, causing the exceptions logic to miss missing-instructor / missing-start-date cases.
- Exception detection and several date/coverage checks need a single canonical definition of “empty” to behave consistently across frontend and GAS backend.

### Description

- Added a frontend helper `isEmptyValue(value)` and `nonEmptyString(value)` at `frontend/src/utils/empty-value.js` and imported it into the API and exceptions screen to normalize null-like markers before display or logic.
- Added a GAS helper `isEmptyValue_(value)` in `OLD-GAS/helpers.gs` and kept `isNormalizedEmptyValue_` as a backward-compatible alias so server-side logic uses a single empty-value definition.
- Updated exception and date-related logic to use the unified helper: `OLD-GAS/actions.gs` (exceptions computation, `activityOverlapsYm_`, `isActivityActiveBySpec_`), `OLD-GAS/activities-snapshot.gs` (instructor coverage / rowHasInstructorData_), and frontend `frontend/src/screens/exceptions.js` (drawer display and field rendering).
- Tightened Supabase-side normalization in `frontend/src/api.js` by using `isEmptyValue`/`nonEmptyString`, normalizing date checks via `normalizeSupabaseDate`, and expanding the Supabase `.or()` filters to include textual `NULL`/`null` matches for `start_date`, `emp_id`, and `instructor_name` so missing rows are returned by the backend queries.
- Added tests and test updates that exercise the new empty-value rules and exception behavior: `tests/empty-value-helper.test.mjs` and updates to `tests/exceptions-all-types.test.mjs` to cover textual `NULL` values.

### Testing

- Ran targeted unit tests: `node --test tests/empty-value-helper.test.mjs tests/exceptions-all-types.test.mjs` — all tests passed (17 passing assertions across those files).
- Built the frontend: `npm run build` — build completed successfully.
- Ran the full test suite with `npm test` but the run hit pre-existing unrelated failures and stalled in other suites (activities-snapshot / api-mutations / perf checks); I aborted after observing the unrelated failures — the changes themselves are validated by the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6ad1f3f8832b8ddc62d6f3995428)