### PR TITLE
תמיכה במנהלי פעילות לא-פעילים

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,7 @@
 import { state, setSession, clearScreenDataCache } from './state.js';
 import { deletePersistedCacheByPrefixes } from './cache-persist.js';
 import { hebrewRole } from './screens/shared/ui-hebrew.js';
+import { cleanActivityManagerName, NO_ACTIVITY_MANAGER_LABEL } from './screens/shared/activity-options.js';
 import { supabase, supabaseConfig } from './supabase-client.js';
 
 /**
@@ -381,7 +382,7 @@ async function readListsFromSupabase() {
       const label = String(row.label ?? row.item_label ?? row.display ?? value).trim() || value;
       if (!value) continue;
       if (!catMap.has(cat)) catMap.set(cat, []);
-      catMap.get(cat).push({ label, value, _row: row });
+      catMap.get(cat).push({ label, value, _row: row, is_active: row.is_active, active: row.active });
     }
     const categories = [...catMap.entries()].map(([category, items]) => ({ category, items }));
     return { categories, _source: 'supabase' };
@@ -447,7 +448,22 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
     parent_value:  String(i._row?.parent_value  || i._row?.activity_type || i._row?.type || '').trim()
   }));
 
-  const managerNames = managerItems.map((i) => i.value || i.label).filter(Boolean);
+  const managerIsActive = (item) => {
+    const row = item?._row && typeof item._row === 'object' ? item._row : item;
+    const raw = row && Object.prototype.hasOwnProperty.call(row, 'is_active') ? row.is_active : row?.active;
+    if (raw === false || raw === 0) return false;
+    const clean = String(raw ?? '').trim().toLowerCase();
+    return !['false', '0', 'no', 'n', 'inactive', 'לא', 'לא פעיל', 'כבוי'].includes(clean);
+  };
+  const managerNames = managerItems
+    .filter(managerIsActive)
+    .map((i) => cleanActivityManagerName(i.value || i.label))
+    .filter(Boolean);
+  const managerUsers = managerItems.map((i) => ({
+    name: cleanActivityManagerName(i.value || i.label),
+    is_active: managerIsActive(i),
+    active: i.active,
+  })).filter((user) => user.name);
 
   return {
     dropdown_options: {
@@ -461,7 +477,7 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
       authorities:              authorityValues,
       activity_manager:         managerNames,
       activity_managers:        managerNames,
-      activities_manager_users: managerNames.map((name) => ({ name })),
+      activities_manager_users: managerUsers,
       instructor_name:          instructorUsers.map((u) => u.name),
       instructor_names:         instructorUsers.map((u) => u.name),
       instructor_users:         instructorUsers,
@@ -840,7 +856,7 @@ async function dashboardReadModelFromSupabase(month) {
     const byManagerMap = new Map();
 
     function managerStats(manager) {
-      const key = String(manager || 'unassigned').trim() || 'unassigned';
+      const key = cleanActivityManagerName(manager) || NO_ACTIVITY_MANAGER_LABEL;
       if (!byManagerMap.has(key)) {
         byManagerMap.set(key, {
           activity_manager: key,
@@ -990,7 +1006,7 @@ function buildExceptionsModelFromRows(activityRows = [], month = '', opts = {}) 
     if (!activityOverlapsMonthForExceptions(row, month)) continue;
     const types = rowExceptionTypesFromActivity(row);
     if (!types.length) continue;
-    const manager = nullStr(row?.activity_manager) || 'unassigned';
+    const manager = cleanActivityManagerName(row?.activity_manager) || NO_ACTIVITY_MANAGER_LABEL;
     byManager[manager] = (byManager[manager] || 0) + 1;
     for (const type of types) counts[type] = (counts[type] || 0) + 1;
     if (includeRows) {

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -23,19 +23,21 @@ import {
   splitVisibleRows
 } from './shared/activity-list-filters.js';
 import {
+  activityManagerDisplayName,
   getActivityCatalog,
   getActivityTypesByFamily,
   getActivityNamesForType,
   getRosterUsers,
   getManagerUsers,
   getFilterOptionOverrides,
-  cleanUnique
+  cleanUnique,
+  NO_ACTIVITY_MANAGER_LABEL
 } from './shared/activity-options.js';
 
 const inflightActivityDetailRequests = new Map();
 const ACTIVITIES_SCOPE = 'activities';
 const ACTIVITY_FILTER_FIELDS = [
-  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
   { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
   { key: 'activity_name', label: 'תוכנית' },
   { key: 'authority', label: 'רשות' },
@@ -180,7 +182,7 @@ function addActivityModalHtml(settings) {
       </div>
       <input type="hidden" name="source" value="long">
       <div class="ds-activity-add-grid">
-        <label class="ds-activity-add-field"><span>מנהל פעילות</span><select class="ds-input" name="activity_manager">${optionsHtml(managerOptions)}</select></label>
+        <label class="ds-activity-add-field"><span>מנהל פעילות</span><select class="ds-input" name="activity_manager">${optionsHtml(managerOptions, '', NO_ACTIVITY_MANAGER_LABEL)}</select></label>
         ${authorityField}
         ${schoolField}
         <label class="ds-activity-add-field"><span>שכבה</span><select class="ds-input" name="grade">${optionsHtml(gradeOptions)}</select></label>

--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -15,7 +15,7 @@ import {
   bindLocalFilters,
   splitVisibleRows
 } from './shared/activity-list-filters.js';
-import { getRosterUsers } from './shared/activity-options.js';
+import { activityManagerDisplayName, getRosterUsers } from './shared/activity-options.js';
 
 const ARCHIVE_SCOPE = 'archive';
 
@@ -38,7 +38,7 @@ function archiveTypeKpiHtml(rows) {
 }
 
 const ARCHIVE_FILTER_FIELDS = [
-  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
   { key: 'activity_type', label: 'סוג הפעילות', getOptionLabel: (value) => visibleActivityCategoryLabel(value) },
   { key: 'authority', label: 'רשות' }
 ];
@@ -124,7 +124,7 @@ export const archiveScreen = {
       const authority = escapeHtml(row.authority || '—');
       const school = escapeHtml(row.school || '—');
       const instructor = escapeHtml(instructorText(row));
-      const manager = escapeHtml(row.activity_manager || '—');
+      const manager = escapeHtml(activityManagerDisplayName(row.activity_manager));
       const endRaw = String(row?.end_date || row?.start_date || '').trim();
       const endHe = endRaw ? (formatDateHe(endRaw) || endRaw) : '—';
       const startRaw = String(row?.start_date || '').trim();

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -9,6 +9,7 @@ import {
   filtersToolbarHtml,
   bindLocalFilters
 } from './shared/activity-list-filters.js';
+import { getManagerUsers } from './shared/activity-options.js';
 
 const AVATAR_COLORS = [
   '#ef4444', '#f97316', '#eab308', '#22c55e',
@@ -333,9 +334,7 @@ export const contactsScreen = {
     const instrRows = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows) ? data.school_rows : [];
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
-    const managerOptions = (Array.isArray(state?.clientSettings?.dropdown_options?.activities_manager_users)
-      ? state.clientSettings.dropdown_options.activities_manager_users.map((u) => String(u?.name || '').trim())
-      : []).filter(Boolean);
+    const managerOptions = getManagerUsers(state?.clientSettings || {});
 
     root.querySelectorAll('[data-contacts-tab]').forEach((btn) => {
       btn.addEventListener('click', () => {

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -2,6 +2,7 @@ import { escapeHtml } from './shared/html.js';
 import { dsCard, dsScreenStack, dsEmptyState } from './shared/layout.js';
 import { formatDateHe } from './shared/format-date.js';
 import { triggerExcelDownload } from './shared/excel-export.js';
+import { activityManagerDisplayName } from './shared/activity-options.js';
 
 function asIso(value) {
   const text = String(value || '').trim().slice(0, 10);
@@ -74,7 +75,7 @@ function renderMonthTable(month, monthIdx) {
       <tr class="ds-end-expand-row" id="ds-end-expand-${escapeHtml(rowId)}" hidden>
         <td colspan="5" class="ds-end-expand-td">
           <div class="ds-end-dates__dates-list">${pillsHtml}</div>
-          <p class="ds-end-dates__meta"><strong>מנהל פעילויות:</strong> ${escapeHtml(String(row.activity_manager || '—'))}</p>
+          <p class="ds-end-dates__meta"><strong>מנהל פעילויות:</strong> ${escapeHtml(activityManagerDisplayName(row.activity_manager))}</p>
         </td>
       </tr>`;
   }).join('');

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -17,7 +17,7 @@ import {
   bindLocalFilters,
   splitVisibleRows
 } from './shared/activity-list-filters.js';
-import { getFilterOptionOverrides } from './shared/activity-options.js';
+import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 
 const EXCEPTIONS_SCOPE = 'exceptions';
 
@@ -30,7 +30,7 @@ function hebrewMonthLabel(ym) {
 }
 
 const EXCEPTION_FILTER_FIELDS = [
-  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
   { key: 'authority', label: 'רשות' },
   { key: 'funding', label: 'מימון' },
   { key: 'school', label: 'בית ספר' },
@@ -79,7 +79,7 @@ function exceptionDrawerHtml(row, hideRowId) {
     ${fieldRow(hebrewColumn('authority'),        row.authority)}
     ${fieldRow(hebrewColumn('school'),           row.school)}
     ${classDisplay ? fieldRow('שכבה/כיתה', classDisplay) : ''}
-    ${fieldRow(hebrewColumn('activity_manager'), row.activity_manager)}
+    ${fieldRow(hebrewColumn('activity_manager'), activityManagerDisplayName(row.activity_manager))}
     ${fieldRow('מדריך',
         instructor  ? (row.emp_id  ? `${instructor} (${row.emp_id})`  : instructor)  : '')}
     ${instructor2 ? fieldRow('מדריך 2',

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -11,14 +11,14 @@ import {
   filtersToolbarHtml,
   bindLocalFilters
 } from './shared/activity-list-filters.js';
-import { getFilterOptionOverrides } from './shared/activity-options.js';
+import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { calendarMonthStorageKey } from '../state.js';
 
 const inflightActivityDetailRequests = new Map();
 const inflightMonthRequests = new Map();
 const MONTH_SCOPE = 'calendar';
 const CALENDAR_FILTER_FIELDS = [
-  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
   { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
   { key: 'activity_name', label: 'תוכנית' },
   { key: 'authority', label: 'רשות' },

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -1,5 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatTimeShort, formatTimeRangeShort, formatActivityDateColumnsHe } from './format-date.js';
+import { activityManagerDisplayName, cleanActivityManagerName, getManagerUsers, NO_ACTIVITY_MANAGER_LABEL } from './activity-options.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
 
@@ -29,6 +30,10 @@ function activityNameLabel(type) {
 
 function fallback(v) {
   return String(v || '').trim() || '—';
+}
+
+function managerFallback(v) {
+  return activityManagerDisplayName(v);
 }
 
 function todayStr() {
@@ -299,7 +304,7 @@ function headerHtml(row, { mode = 'single', summaryDate = '', exportAction = tru
 
 function blockPeople(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
-  const managers = mergeListStrings(options, ['activity_manager', 'activity_managers']);
+  const managers = getManagerUsers(settings || {});
   const instructors = mergeListStrings(options, ['instructor_name', 'instructor_names']);
   const authorities = mergeListStrings(options, ['authority', 'authorities']);
   const grades = mergeListStrings(options, ['grade', 'grades']);
@@ -328,7 +333,7 @@ function blockPeople(row, { settings = {} } = {}) {
   return `
     <section class="activity-drawer__section">
       <div class="activity-drawer__grid activity-drawer__grid--three" data-mode="view">
-        ${fieldViewOnly('מנהל פעילות', escapeHtml(fallback(row.activity_manager)))}
+        ${fieldViewOnly('מנהל פעילות', escapeHtml(managerFallback(row.activity_manager)))}
         ${fieldViewOnly(instructorLabel, escapeHtml(fallback(instructor1Display)))}
         ${fieldViewOnly('סוג פעילות', escapeHtml(activityTypeLabel(activityType)))}
         ${fieldViewOnly('סטטוס', escapeHtml(statusText(row.status)))}
@@ -339,7 +344,7 @@ function blockPeople(row, { settings = {} } = {}) {
       <div class="activity-drawer__details-edit-grid" data-mode="edit" hidden>
         ${fieldEditOnly(
           'מנהל פעילות',
-          selectHtml({ name: 'activity_manager', value: row.activity_manager, options: managers })
+          selectHtml({ name: 'activity_manager', value: cleanActivityManagerName(row.activity_manager), options: managers, placeholder: NO_ACTIVITY_MANAGER_LABEL })
         )}
         ${fieldEditOnly('מדריך/ה', instructorEditHtml)}
         ${fieldEditOnly(

--- a/frontend/src/screens/shared/activity-list-filters.js
+++ b/frontend/src/screens/shared/activity-list-filters.js
@@ -127,7 +127,8 @@ export function filtersToolbarHtml(scope, rows, state, config = {}) {
   if (config.optionsOverrides && typeof config.optionsOverrides === 'object') {
     Object.keys(config.optionsOverrides).forEach((k) => {
       if (Array.isArray(config.optionsOverrides[k]) && config.optionsOverrides[k].length) {
-        optionsMap[k] = config.optionsOverrides[k];
+        optionsMap[k] = Array.from(new Set([...(optionsMap[k] || []), ...config.optionsOverrides[k]]))
+          .sort((a, b) => a.localeCompare(b, 'he'));
       }
     });
   }

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -1,5 +1,32 @@
+export const NO_ACTIVITY_MANAGER_LABEL = 'ללא מנהל';
+
 function text(value) {
   return String(value == null ? '' : value).trim();
+}
+
+export function cleanActivityManagerName(value) {
+  const clean = text(value);
+  const upper = clean.toUpperCase();
+  if (!clean || clean === NO_ACTIVITY_MANAGER_LABEL || upper === 'NULL' || upper === 'UNDEFINED' || upper === 'NONE' || upper === 'N/A' || upper === 'UNASSIGNED' || clean === '-') return '';
+  return clean;
+}
+
+export function activityManagerDisplayName(value) {
+  return cleanActivityManagerName(value) || NO_ACTIVITY_MANAGER_LABEL;
+}
+
+function isExplicitlyInactive(value) {
+  if (value === false || value === 0) return true;
+  const clean = text(value).toLowerCase();
+  return ['false', '0', 'no', 'n', 'inactive', 'לא', 'לא פעיל', 'כבוי'].includes(clean);
+}
+
+function isActiveManagerItem(item) {
+  const row = item?._row && typeof item._row === 'object' ? item._row : item;
+  if (!row || typeof row !== 'object') return true;
+  if ('is_active' in row) return !isExplicitlyInactive(row.is_active);
+  if ('active' in row) return !isExplicitlyInactive(row.active);
+  return true;
 }
 
 function uniqueSorted(values) {
@@ -66,12 +93,13 @@ export function getRosterUsers(settings) {
     });
 }
 
-export function getManagerUsers(settings) {
+export function getManagerUsers(settings, { activeOnly = true } = {}) {
   const raw = Array.isArray(settings?.dropdown_options?.activities_manager_users)
     ? settings.dropdown_options.activities_manager_users
     : [];
-  const names = raw.map((user) => text(user?.name));
-  return uniqueSorted(names.length ? names : settings?.dropdown_options?.activity_manager);
+  const managerRows = activeOnly ? raw.filter(isActiveManagerItem) : raw;
+  const names = managerRows.map((user) => cleanActivityManagerName(user?.name));
+  return uniqueSorted(raw.length ? names : settings?.dropdown_options?.activity_manager);
 }
 
 export function getFilterOptionOverrides(settings) {

--- a/frontend/src/screens/shared/excel-export.js
+++ b/frontend/src/screens/shared/excel-export.js
@@ -1,5 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatActivityDateColumnsHe } from './format-date.js';
+import { activityManagerDisplayName } from './activity-options.js';
 
 function safeFilePart(value, fallback = 'export') {
   const clean = String(value || fallback).replace(/[\\/?%*:|"<>]/g, '_').trim();
@@ -43,7 +44,7 @@ export function activityExportRow(row = {}) {
     'רשות': row.authority || '',
     'שכבה': row.grade || '',
     'קבוצה / כיתה': row.class_group || '',
-    'מנהל פעילות': row.activity_manager || '',
+    'מנהל פעילות': activityManagerDisplayName(row.activity_manager),
     'מדריך 1': row.instructor_name || row.emp_id || '',
     'מדריך 2': row.instructor_name_2 || row.emp_id_2 || '',
     'תאריך התחלה': formatDateHe(row.start_date) || row.start_date || '',

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -11,14 +11,14 @@ import {
   filtersToolbarHtml,
   bindLocalFilters
 } from './shared/activity-list-filters.js';
-import { getFilterOptionOverrides } from './shared/activity-options.js';
+import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { bindActNavGrid } from './shared/act-nav-grid.js';
 
 const inflightActivityDetailRequests = new Map();
 const inflightWeekRequests = new Map();
 const WEEK_SCOPE = 'calendar';
 const CALENDAR_FILTER_FIELDS = [
-  { key: 'activity_manager', label: 'מנהל פעילות' },
+  { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
   { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
   { key: 'activity_name', label: 'תוכנית' },
   { key: 'authority', label: 'רשות' },

--- a/supabase/migrations/20260508_add_lists_is_active.sql
+++ b/supabase/migrations/20260508_add_lists_is_active.sql
@@ -1,0 +1,21 @@
+alter table public.lists
+  add column if not exists is_active boolean not null default true;
+
+-- Backfill the new boolean flag from legacy text columns when they exist.
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'lists'
+      and column_name = 'active'
+  ) then
+    update public.lists
+    set is_active = false
+    where lower(trim(coalesce(active::text, ''))) in ('false', '0', 'no', 'n', 'inactive', 'לא', 'לא פעיל', 'כבוי');
+  end if;
+end $$;
+
+create index if not exists lists_category_is_active_idx
+  on public.lists(category, is_active);

--- a/tests/activity-manager-active-state.test.mjs
+++ b/tests/activity-manager-active-state.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  activityManagerDisplayName,
+  getManagerUsers,
+  NO_ACTIVITY_MANAGER_LABEL
+} from '../frontend/src/screens/shared/activity-options.js';
+import { activityWorkDrawerHtml } from '../frontend/src/screens/shared/activity-detail-html.js';
+import { collectFilterOptions } from '../frontend/src/screens/shared/activity-list-filters.js';
+
+test('activity manager options include only active managers', () => {
+  const settings = {
+    dropdown_options: {
+      activities_manager_users: [
+        { name: 'מנהלת פעילה', is_active: true },
+        { name: 'מנהל שעזב', is_active: false },
+        { name: 'מנהלת פעילה 2', active: 'yes' },
+        { name: 'מנהל כבוי', active: 'no' },
+        { name: NO_ACTIVITY_MANAGER_LABEL, is_active: true },
+        { name: 'unassigned', is_active: true }
+      ]
+    }
+  };
+
+  assert.deepEqual(getManagerUsers(settings), ['מנהלת פעילה', 'מנהלת פעילה 2']);
+});
+
+test('blank and textual null manager values are displayed as no manager', () => {
+  for (const value of ['', '   ', null, undefined, 'NULL', 'null', 'undefined', 'unassigned', NO_ACTIVITY_MANAGER_LABEL]) {
+    assert.equal(activityManagerDisplayName(value), NO_ACTIVITY_MANAGER_LABEL);
+  }
+});
+
+test('existing inactive manager stays visible in the activity drawer history', () => {
+  const html = activityWorkDrawerHtml(
+    {
+      RowID: 'A-1',
+      activity_manager: 'מנהל שעזב',
+      activity_type: 'course',
+      status: 'active'
+    },
+    {
+      settings: {
+        dropdown_options: {
+          activities_manager_users: [
+            { name: 'מנהלת פעילה', is_active: true },
+            { name: 'מנהל שעזב', is_active: false }
+          ]
+        }
+      }
+    }
+  );
+
+  assert.match(html, />מנהל שעזב</);
+  assert.match(html, /<option value="מנהל שעזב" selected>מנהל שעזב<\/option>/);
+  assert.match(html, /<option value="מנהלת פעילה">מנהלת פעילה<\/option>/);
+});
+
+test('no manager is collected as a separate filter category', () => {
+  const rows = [{ activity_manager: 'מנהלת פעילה' }, { activity_manager: '   ' }, { activity_manager: 'null' }];
+  const options = collectFilterOptions(rows, [
+    { key: 'activity_manager', getValues: (row) => [activityManagerDisplayName(row.activity_manager)] }
+  ]);
+
+  assert.deepEqual(options.activity_manager, [NO_ACTIVITY_MANAGER_LABEL, 'מנהלת פעילה']);
+});


### PR DESCRIPTION
### Motivation
- לתמוך במצב שבו מנהל פעילות עזב את הארגון מבלי למחוק את שמו מההיסטוריה, ולהציג ברשימות בחירה רק מנהלים פעילים תוך שמירת שמו של מנהל לא פעיל בפעילויות קיימות.

### Description
- הוספתי נירמול מרכזי עבור שמות מנהל פעילות עם `cleanActivityManagerName` ו־`activityManagerDisplayName` כך שערכים ריקים/טקסטואליים של null/`unassigned` ו־`ללא מנהל` מטופלים כקטגוריית "ללא מנהל" ולא כשם מנהל אמיתי (קובץ: `frontend/src/screens/shared/activity-options.js`).
- רשימות הבחירה וה־`clientSettings` בנויות עכשיו מתוך שדות `lists` של Supabase הכוללים `is_active`, ו־`getManagerUsers` מסננת כברירת מחדל רק מנהלים פעילים; מבנה `activities_manager_users` הותאם לשאת גם מידע `is_active` (שינויים ב־`frontend/src/api.js`).
- עדכנתי תצוגות ופילטרים כך שהמחברות/דשבורד/חריגות וסקרינרים משתמשים ב־`activityManagerDisplayName` (כולל `activities`, `week`, `month`, `exceptions`, `archive`, `end-dates`) כדי לשמור היסטוריה של מנהלים לא פעילים אך להציג בבחירה רק מנהלים פעילים; נוספה טיפול בברירת מחדל להוספת פעילות עם `NO_ACTIVITY_MANAGER_LABEL` (קבצים: `frontend/src/screens/*`, `frontend/src/screens/shared/activity-detail-html.js`, `frontend/src/screens/shared/excel-export.js`).
- הוספתי migration שמוסיף את העמודה `is_active` לטבלת `public.lists` עם backfill מהעמודה הטקסטואלית `active` ואינדקס לקטגוריה (קובץ: `supabase/migrations/20260508_add_lists_is_active.sql`).
- הוספו בדיקות רגרסיה חדשות לכיסוי סינון מנהלים פעילים, נירמול "ללא מנהל", שמירת מנהל לא פעיל בתצוגת היסטוריה ואיסוף קטגוריית "ללא מנהל" בפילטרים (קובץ: `tests/activity-manager-active-state.test.mjs`).

### Testing
- הרצת המבחן החדש עם `node --test tests/activity-manager-active-state.test.mjs` — כל המבחנים החדשים עברו בהצלחה.
- ביצעתי בנייה לקוחית עם `npm run build` כדי לאשר שהבנדל מתבנה ללא שגיאות, והבניה הושלמה בהצלחה.
- ניסיון ראשוני להריץ `npm test -- --test-name-pattern="activity manager"` הריץ גם סוויטות לא קשורות שכוללות כשלים חיצוניים והופסק; לאחר מכן הורצו המבחנים הממוקדים שהעבודה הוסיפה והם עברו בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6bbc3fa0832b8f8920db42a3ab98)