### PR TITLE
Fix operational exception summary

### DIFF
--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -45,6 +45,42 @@ function fieldRow(label, value) {
   return `<p><strong>${escapeHtml(label)}:</strong> ${display}</p>`;
 }
 
+function normalizedExceptionTypes(row) {
+  if (Array.isArray(row?.exception_types)) return row.exception_types.map((type) => String(type || '').trim()).filter(Boolean);
+  return [row?.exception_type].map((type) => String(type || '').trim()).filter(Boolean);
+}
+
+function numericCount(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function exceptionCountFromRows(rows, type) {
+  return (Array.isArray(rows) ? rows : []).reduce(
+    (sum, row) => sum + (normalizedExceptionTypes(row).includes(type) ? 1 : 0),
+    0
+  );
+}
+
+function exceptionsOperationalSummaryHtml(data, rows) {
+  const counts = data?.counts && typeof data.counts === 'object' ? data.counts : {};
+  const missingInstructor = counts.missing_instructor !== undefined
+    ? numericCount(counts.missing_instructor)
+    : exceptionCountFromRows(rows, 'missing_instructor');
+  const missingStartDate = counts.missing_start_date !== undefined
+    ? numericCount(counts.missing_start_date)
+    : exceptionCountFromRows(rows, 'missing_start_date');
+  const operationalTotal = missingInstructor + missingStartDate;
+
+  return dsCard({
+    title: `חריגות תפעוליות: ${escapeHtml(String(operationalTotal))}`,
+    body: `<div class="ds-summary-panel__structured" dir="rtl">
+      <p class="ds-summary-panel__text">חסר מדריך: <strong>${escapeHtml(String(missingInstructor))}</strong></p>
+      <p class="ds-summary-panel__text">חסר תאריך התחלה: <strong>${escapeHtml(String(missingStartDate))}</strong></p>
+    </div>`
+  });
+}
+
 function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
   const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
   return activityWorkDrawerHtml(row, {
@@ -61,7 +97,7 @@ function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, 
 }
 
 function exceptionDrawerHtml(row, hideRowId) {
-  const exceptionTypes = Array.isArray(row.exception_types) ? row.exception_types : [row.exception_type].filter(Boolean);
+  const exceptionTypes = normalizedExceptionTypes(row);
   const chips = exceptionTypes.map((et) => dsStatusChip(hebrewExceptionType(String(et || '').trim()), 'neutral')).join(' ');
 
   const instructor  = isEmptyValue(row.instructor_name) ? '' : String(row.instructor_name).trim();
@@ -122,12 +158,11 @@ export const exceptionsScreen = {
         ? dsEmptyState('לא נמצאו חריגות')
         : `<div class="ds-compact-list">${visibleRows
             .map((row, idx) => {
-              const et = String(row.exception_type || '').trim();
               const subtitleParts = [row.authority, row.school].filter(Boolean);
               const subtitleHtml  = subtitleParts.length
                 ? `<p class="ds-interactive-card__subtitle">${escapeHtml(subtitleParts.join(' · '))}</p>`
                 : '';
-              const exTypes = Array.isArray(row.exception_types) ? row.exception_types : [et].filter(Boolean);
+              const exTypes = normalizedExceptionTypes(row);
               const chips = exTypes.map((type) => dsStatusChip(hebrewExceptionType(type), 'neutral')).join(' ');
               const multiBadge = exTypes.length > 1 ? `<span class="ds-badge" aria-label="${escapeHtml(String(exTypes.length))} חריגות">${escapeHtml(String(exTypes.length))}</span>` : '';
               const chipHtml = `<p class="ds-interactive-card__meta">${chips} ${multiBadge}</p>`;
@@ -146,6 +181,7 @@ export const exceptionsScreen = {
 
     return dsScreenStack(`
       ${toolbarHtml}
+      <section class="ds-screen-compact-90">${exceptionsOperationalSummaryHtml(data, allRows)}</section>
       <section class="ds-screen-compact-90">${dsCard({
         title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''} · סה״כ חריגות: ${escapeHtml(String(data?.totalExceptionRows ?? total))}`,
         body: compact,
@@ -201,7 +237,7 @@ export const exceptionsScreen = {
     }
 
     function exceptionTypeHeader(summaryRow) {
-      const exTypes = Array.isArray(summaryRow?.exception_types) ? summaryRow.exception_types : [summaryRow?.exception_type].filter(Boolean);
+      const exTypes = normalizedExceptionTypes(summaryRow);
       if (!exTypes.length) return '';
       const chips = exTypes.map((et) => dsStatusChip(hebrewExceptionType(String(et || '').trim()), 'neutral')).join(' ');
       const multiBadge = exTypes.length > 1 ? `<span class="ds-badge" aria-label="${escapeHtml(String(exTypes.length))} חריגות">${escapeHtml(String(exTypes.length))}</span>` : '';

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -78,8 +78,8 @@ export function exceptionTypeVariant(exceptionType) {
 }
 
 export const HEBREW_EXCEPTION_TYPE = {
-  missing_instructor:       'מדריך',
-  missing_start_date:       'תאריך התחלה',
+  missing_instructor:       'חסר מדריך',
+  missing_start_date:       'חסר תאריך התחלה',
   late_end_date:            'תאריך סיום',
   dangerous_end_date:       'תאריך סיום',
   missing_activity_manager: 'חסר מנהל פעילות',

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -342,6 +342,26 @@ test('frontend exceptions title uses totalExceptionRows', async () => {
   );
 });
 
+test('frontend exceptions screen renders operational summary as parent total with child counts', async () => {
+  const src = await read('frontend/src/screens/exceptions.js');
+  assert.match(src, /function exceptionsOperationalSummaryHtml\(data, rows\)/,
+    'exceptions screen must render an operational summary block');
+  assert.match(src, /const operationalTotal = missingInstructor \+ missingStartDate/,
+    'operational parent count must be the sum of missing instructor and missing start date instances');
+  assert.match(src, /חריגות תפעוליות: \$\{escapeHtml\(String\(operationalTotal\)\)\}/,
+    'operational summary must display the parent category count');
+  assert.match(src, /חסר מדריך: <strong>\$\{escapeHtml\(String\(missingInstructor\)\)\}<\/strong>/,
+    'operational summary must display missing instructor as a separate exception count');
+  assert.match(src, /חסר תאריך התחלה: <strong>\$\{escapeHtml\(String\(missingStartDate\)\)\}<\/strong>/,
+    'operational summary must display missing start date as a separate exception count');
+});
+
+test('frontend exception Hebrew labels describe the missing operational details', async () => {
+  const src = await read('frontend/src/screens/shared/ui-hebrew.js');
+  assert.match(src, /missing_instructor:\s+'חסר מדריך'/);
+  assert.match(src, /missing_start_date:\s+'חסר תאריך התחלה'/);
+});
+
 test('frontend drawer shows exception type chip when opening activity detail', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
   assert.match(src, /exceptionTypeHeader/,


### PR DESCRIPTION
### Motivation
- The exceptions page showed only a generic "חריגות תפעוליות" label and did not expose the internal exception types or aggregate them correctly.
- The goal is to have "חריגות תפעוליות" act as a parent summary whose value is the sum of the internal operational exceptions, while still showing the internal types separately.

### Description
- Added `normalizedExceptionTypes`, counting helpers, and `exceptionsOperationalSummaryHtml` to `frontend/src/screens/exceptions.js` and render the operational summary card above the exceptions list so the parent total equals the sum of internal counts.
- Normalized usage of `exception_types` across list items and drawer via `normalizedExceptionTypes` so activities with multiple exceptions show all types and are counted per-type.
- Updated Hebrew labels in `frontend/src/screens/shared/ui-hebrew.js` to show `missing_instructor` as `חסר מדריך` and `missing_start_date` as `חסר תאריך התחלה`.
- Added regression tests in `tests/exceptions-all-types.test.mjs` to assert the operational summary parent total, child counts, and updated Hebrew labels.

### Testing
- Ran `node --test tests/exceptions-all-types.test.mjs` and the focused test file passed: 16 tests ✅.
- Ran `npm run build` and the production build completed successfully ✅.
- Attempted `npm test -- tests/exceptions-all-types.test.mjs` but the `npm test` script expands to the full suite which hit unrelated environment-dependent failures before it was stopped, so the focused test file was executed directly instead (see above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7278c0d8832bb3425307a1ac524e)