### PR TITLE
Fix activities RLS role helpers and save diagnostics

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1409,6 +1409,47 @@ function buildSupabaseMutationError(operation, error, fallback = 'server_error')
   return apiError;
 }
 
+async function buildActivityMutationAuthContext() {
+  const context = {
+    auth_uid: '',
+    user_id: '',
+    role: '',
+    can_edit_direct: null,
+    can_add_activity: null
+  };
+  if (!supabase) return context;
+  try {
+    const { data: authData } = await supabase.auth.getUser();
+    context.auth_uid = String(authData?.user?.id || '').trim();
+  } catch {
+    /* ignore */
+  }
+  if (!context.auth_uid) return context;
+  try {
+    const [{ data: roleData }, { data: canEditData }, { data: canAddData }] = await Promise.all([
+      supabase.rpc('app_current_role'),
+      supabase.rpc('app_can_edit_direct'),
+      supabase.rpc('app_can_add_activity')
+    ]);
+    context.role = typeof roleData === 'string' ? roleData : '';
+    context.can_edit_direct = typeof canEditData === 'boolean' ? canEditData : null;
+    context.can_add_activity = typeof canAddData === 'boolean' ? canAddData : null;
+  } catch {
+    /* ignore */
+  }
+  try {
+    const { data: userRow } = await supabase
+      .from('users')
+      .select('user_id')
+      .eq('auth_user_id', context.auth_uid)
+      .maybeSingle();
+    context.user_id = String(userRow?.user_id || '').trim();
+  } catch {
+    /* ignore */
+  }
+  return context;
+}
+
 function logActivityMutationDebug(stage, operation, payload, extra = {}) {
   // eslint-disable-next-line no-console
   console.info(`[activity-save:${stage}]`, {
@@ -1475,8 +1516,22 @@ async function updateActivityInSupabase(payload = {}) {
     .select('row_id')
     .maybeSingle();
   if (error) {
+    const authContext = await buildActivityMutationAuthContext();
     // eslint-disable-next-line no-console
-    console.error('[activity-save-error]', { operation: 'saveActivity', table: 'activities', payload: debugPayload, error });
+    console.error('[activity-save-error]', {
+      action: 'saveActivity',
+      table: 'activities',
+      row_id: rowId,
+      auth_uid: authContext.auth_uid,
+      user_id: authContext.user_id,
+      role: authContext.role,
+      can_edit_direct: authContext.can_edit_direct,
+      can_add_activity: authContext.can_add_activity,
+      supabase_error_code: error?.code || error?.status || '',
+      supabase_error_message: String(error?.message || 'save_failed'),
+      payload: debugPayload,
+      error
+    });
     throw buildSupabaseMutationError('saveActivity', error, 'save_failed');
   }
   if (!data) {

--- a/supabase/migrations/20260511_activities_rls_operation_manager_fix.sql
+++ b/supabase/migrations/20260511_activities_rls_operation_manager_fix.sql
@@ -1,0 +1,123 @@
+-- Align activities RLS with role-aware helper functions so operation_manager
+-- is evaluated by auth.uid() -> public.users.auth_user_id mapping.
+
+alter table public.users add column if not exists auth_user_id uuid unique;
+create index if not exists users_auth_user_id_idx on public.users(auth_user_id);
+
+create or replace function public.app_current_user_id()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select u.user_id
+  from public.users u
+  where u.auth_user_id = auth.uid()
+    and u.is_active = true
+  limit 1
+$$;
+
+create or replace function public.app_current_role()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select u.role
+  from public.users u
+  where u.auth_user_id = auth.uid()
+    and u.is_active = true
+  limit 1
+$$;
+
+create or replace function public.app_has_permission(flag text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(
+    lower(coalesce(u.permissions ->> flag, '')) in ('yes', 'true', '1'),
+    false
+  )
+  from public.users u
+  where u.auth_user_id = auth.uid()
+    and u.is_active = true
+  limit 1
+$$;
+
+create or replace function public.app_is_admin_or_operation_manager()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_current_role() in ('admin', 'operation_manager'), false)
+$$;
+
+create or replace function public.app_can_edit_direct()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_is_admin_or_operation_manager() or public.app_has_permission('can_edit_direct'), false)
+$$;
+
+create or replace function public.app_can_add_activity()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_is_admin_or_operation_manager() or public.app_has_permission('can_add_activity'), false)
+$$;
+
+revoke all on function public.app_current_user_id() from public;
+revoke all on function public.app_current_role() from public;
+revoke all on function public.app_has_permission(text) from public;
+revoke all on function public.app_is_admin_or_operation_manager() from public;
+revoke all on function public.app_can_edit_direct() from public;
+revoke all on function public.app_can_add_activity() from public;
+grant execute on function public.app_current_user_id() to authenticated;
+grant execute on function public.app_current_role() to authenticated;
+grant execute on function public.app_has_permission(text) to authenticated;
+grant execute on function public.app_is_admin_or_operation_manager() to authenticated;
+grant execute on function public.app_can_edit_direct() to authenticated;
+grant execute on function public.app_can_add_activity() to authenticated;
+
+alter table public.activities enable row level security;
+
+drop policy if exists activities_write_authenticated on public.activities;
+drop policy if exists activities_select_authenticated on public.activities;
+drop policy if exists activities_insert_can_add on public.activities;
+drop policy if exists activities_update_direct_editors on public.activities;
+
+create policy activities_select_authenticated
+on public.activities
+for select
+to authenticated
+using (auth.uid() is not null);
+
+create policy activities_insert_can_add
+on public.activities
+for insert
+to authenticated
+with check (public.app_can_add_activity());
+
+create policy activities_update_direct_editors
+on public.activities
+for update
+to authenticated
+using (public.app_can_edit_direct())
+with check (public.app_can_edit_direct());
+
+revoke insert, update, delete on public.activities from anon;
+grant select, insert, update on public.activities to authenticated;
+revoke delete on public.activities from authenticated;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new migration that formalizes role helper functions (`app_current_role`, `app_is_admin_or_operation_manager`, `app_can_edit_direct`, `app_can_add_activity`) based on `auth.uid() -> users.auth_user_id`
- replace broad `activities_write_authenticated` policy with explicit `select/insert/update` policies, including `activities_update_direct_editors` using `public.app_can_edit_direct()` in both `USING` and `WITH CHECK`
- enforce grants so `authenticated` has `select, insert, update` on `public.activities` while delete remains revoked
- enhance mutation diagnostics (`saveActivity`, `submitEditRequest`, `reviewEditRequest`, `addActivity`) with structured logs: action, table, row_id, auth uid, mapped user_id, role, can_edit_direct, can_add_activity, Supabase error code/message/details, and payload
- add centralized payload sanitizer `sanitizeActivityPayloadForSupabase(payload)` for every write path to `public.activities` (direct save, add, and apply approved edit-request payload)
- map drawer `meeting_date_*` fields to `date_*` before writes so PostgREST receives valid column names
- enforce edit-request vs direct-save routing for `activities_manager` with API-level reroute guard
- **edit requests screen:** fetch each activity by `source_row_id` when loading the approvals list; merge DB `original_values` with live row for accurate “before” values; show full context card (name, id, type, authority, school, manager, instructors, dates, requester, time); “מה השתנה?” table with Hebrew labels (including מפגש N for `date_*` and סטטוס פעילות); date formatting DD/MM/YYYY; empty old/new copy; hide approve when activity row cannot be loaded; store `original_values` + snapshot columns on new `submitEditRequest` inserts

## Why
- reviewers need enough context to approve safely without guessing from a single technical field
- old values were empty because `original_values` was never populated and the UI never re-fetched the live activity row
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb4827b-d8ec-46d8-8764-85cc461d1ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb4827b-d8ec-46d8-8764-85cc461d1ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

