### PR TITLE
Fix PWA manifest paths for GitHub Pages

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-B7vNqOCM.js",
+  "./assets/index-DSYNDFrm.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -29,7 +29,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-RcHmWAKz.css",
+  "./assets/style-B7PL3snU.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -9,12 +9,12 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <meta name="apple-mobile-web-app-title" content="Dashboard-Taasiyeda" />
-  <link rel="manifest" href="./manifest.json" />
-  <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
-  <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
+  <link rel="manifest" href="/dashboard_system/manifest.json" />
+  <link rel="icon" href="/dashboard_system/assets/favicon-D0Y9bj5H.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="/dashboard_system/assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-B7vNqOCM.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-RcHmWAKz.css">
+  <script type="module" crossorigin src="/dashboard_system/assets/index-DSYNDFrm.js"></script>
+  <link rel="stylesheet" crossorigin href="/dashboard_system/assets/style-B7PL3snU.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "./index.html",
+  "id": "/dashboard_system/",
   "name": "Dashboard-Taasiyeda",
   "short_name": "Dashboard-Taasiyeda",
   "description": "מערכת ניהול פנימית לפעילויות, הרשאות ותפעול.",
-  "start_url": "./index.html",
-  "scope": "./",
+  "start_url": "/dashboard_system/",
+  "scope": "/dashboard_system/",
   "display": "standalone",
   "orientation": "portrait-primary",
   "background_color": "#111827",
@@ -17,25 +17,25 @@
   ],
   "icons": [
     {
-      "src": "./assets/pwa/icon-192.png",
+      "src": "/dashboard_system/assets/pwa/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "./assets/pwa/icon-512.png",
+      "src": "/dashboard_system/assets/pwa/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "./assets/pwa/icon-maskable-512.png",
+      "src": "/dashboard_system/assets/pwa/icon-maskable-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "./assets/apple-touch-icon.png",
+      "src": "/dashboard_system/assets/apple-touch-icon.png",
       "sizes": "180x180",
       "type": "image/png",
       "purpose": "any"

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -14,7 +14,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-B7vNqOCM.js",
+  "./assets/index-DSYNDFrm.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -29,7 +29,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-RcHmWAKz.css",
+  "./assets/style-B7PL3snU.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,38 +1,41 @@
 {
-  "id": "../../index.html",
+  "id": "/dashboard_system/",
   "name": "Dashboard-Taasiyeda",
   "short_name": "Dashboard-Taasiyeda",
   "description": "מערכת ניהול פנימית לפעילויות, הרשאות ותפעול.",
-  "start_url": "../../index.html",
-  "scope": "../../",
+  "start_url": "/dashboard_system/",
+  "scope": "/dashboard_system/",
   "display": "standalone",
   "orientation": "portrait-primary",
   "background_color": "#111827",
   "theme_color": "#111827",
   "lang": "he",
   "dir": "rtl",
-  "categories": ["business", "productivity"],
+  "categories": [
+    "business",
+    "productivity"
+  ],
   "icons": [
     {
-      "src": "../assets/pwa/icon-192.png",
+      "src": "/dashboard_system/assets/pwa/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "../assets/pwa/icon-512.png",
+      "src": "/dashboard_system/assets/pwa/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "../assets/pwa/icon-maskable-512.png",
+      "src": "/dashboard_system/assets/pwa/icon-maskable-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "../assets/apple-touch-icon.png",
+      "src": "/dashboard_system/assets/apple-touch-icon.png",
       "sizes": "180x180",
       "type": "image/png",
       "purpose": "any"

--- a/scripts/postbuild-dist.mjs
+++ b/scripts/postbuild-dist.mjs
@@ -58,21 +58,29 @@ mkdirSync(join(dist, 'assets'), { recursive: true });
 cpSync(join(root, 'frontend', 'assets'), join(dist, 'assets'), { recursive: true });
 
 const viteBaseRaw = process.env.VITE_BASE || './';
+const isAbsoluteBase = viteBaseRaw.startsWith('/') && viteBaseRaw !== '/';
+const basePrefix = isAbsoluteBase
+  ? viteBaseRaw.replace(/\/$/, '') + '/'
+  : './';
 const manPath = join(dist, 'manifest.json');
 if (existsSync(manPath)) {
   const m = JSON.parse(readFileSync(manPath, 'utf8'));
-  const isAbsoluteBase = viteBaseRaw.startsWith('/') && viteBaseRaw !== '/';
-  const basePrefix = isAbsoluteBase
-    ? viteBaseRaw.replace(/\/$/, '') + '/'
-    : './';
-  m.start_url = isAbsoluteBase ? basePrefix + 'index.html' : './index.html';
+  m.start_url = basePrefix;
   m.scope = basePrefix;
-  m.id = isAbsoluteBase ? basePrefix + 'index.html' : './index.html';
+  m.id = basePrefix;
   m.icons = (m.icons || []).map((icon) => {
     const src = String(icon.src || '');
-    const next = src
-      .replace(/^\.\.\/assets\//, './assets/')
-      .replace(/^\.\/frontend\/assets\//, './assets/');
+    const assetPath = src
+      .replace(/^\.\.\/assets\//, 'assets/')
+      .replace(/^\.\/frontend\/assets\//, 'assets/')
+      .replace(/^\.\/assets\//, 'assets/')
+      .replace(/^\/[^/]+\/assets\//, 'assets/')
+      .replace(/^\/assets\//, 'assets/');
+    const next = isAbsoluteBase && assetPath.startsWith('assets/')
+      ? basePrefix + assetPath
+      : assetPath.startsWith('assets/')
+        ? './' + assetPath
+        : src;
     return { ...icon, src: next };
   });
   writeFileSync(manPath, JSON.stringify(m, null, 2));
@@ -81,14 +89,13 @@ if (existsSync(manPath)) {
 mkdirSync(join(dist, 'frontend'), { recursive: true });
 
 let html = readFileSync(join(dist, 'index.html'), 'utf8');
-const hashedManifest = html.match(/href="(\.\/assets\/manifest-[^"]+)"/);
+const manifestHref = isAbsoluteBase ? basePrefix + 'manifest.json' : './manifest.json';
+const hashedManifest = html.match(/href="((?:\.|\/[^"]*)?\/assets\/manifest-[^"]+)"/);
 if (hashedManifest) {
-  const orphan = join(dist, hashedManifest[1].replace(/^\.\//, ''));
-  html = html.replace(
-    /<link rel="manifest" href="\.\/assets\/manifest-[^"]+"\s*\/?>/,
-    '<link rel="manifest" href="./manifest.json" />'
-  );
-  writeFileSync(join(dist, 'index.html'), html);
+  const orphanRel = hashedManifest[1]
+    .replace(/^\.\//, '')
+    .replace(new RegExp('^' + basePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), '');
+  const orphan = join(dist, orphanRel);
   if (existsSync(orphan)) {
     try {
       unlinkSync(orphan);
@@ -97,6 +104,11 @@ if (hashedManifest) {
     }
   }
 }
+html = html.replace(
+  /<link rel="manifest" href="[^"]+"\s*\/?>/,
+  `<link rel="manifest" href="${manifestHref}" />`
+);
+writeFileSync(join(dist, 'index.html'), html);
 
 const precache = new Set(['./index.html', './manifest.json']);
 for (const u of collectAssetRefs(html, viteBaseRaw)) {


### PR DESCRIPTION
### Motivation
- The PWA from `Add to Home Screen` opened a relative `./index.html` path and produced 404 on GitHub Pages; the manifest and built assets must use the repository base `/dashboard_system/` so home-screen launches open the site root.

### Description
- Update `frontend/public/manifest.json` to set `id`, `start_url`, and `scope` to `/dashboard_system/` and make `icons[*].src` point to `/dashboard_system/assets/...`.
- Change `scripts/postbuild-dist.mjs` to read `VITE_BASE`, compute a `basePrefix`, write `m.id`, `m.start_url`, and `m.scope` as the base (absolute when `VITE_BASE` starts with `/`), normalize icon paths accordingly, and patch `dist/index.html` manifest link to the correct `manifest.json` location.
- Keep `vite.config.js` using the `VITE_BASE` value for `base` and rebuild `dist` so `dist/index.html`, `dist/manifest.json`, `dist/sw.js` and `dist/frontend/sw.js` reference the correct hashed assets under `/dashboard_system/`.

### Testing
- Ran `VITE_BASE=/dashboard_system/ npm run build` and the build completed successfully (`vite build` + `scripts/postbuild-dist.mjs`) with updated `dist` artifacts.
- Executed a Node validation that read `dist/index.html` and `dist/manifest.json` and verified `id`, `start_url`, `scope`, `display` and that `icons` entries exist and corresponding files are present, which passed.
- Ran `npm test` (project test suite) which failed due to pre-existing, unrelated test issues (e.g. `sessionStorage is not defined` and other app-specific mocks); these failures are not related to the PWA manifest changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03081c5bdc832ba96511d2e68e1dce)