### PR TITLE
תיקון: פתיחה מחדש בארכיון עם בחירת תאריך + חיפוש רוחבי ממותב (450ms, מינ' 4 תווים)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1188,10 +1188,10 @@ async function syncContactToSupabase(kind, row, origIdentity) {
 
 function invalidateScreenDataByAction(action) {
   const targetedMutations = {
-    saveActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
+    saveActivity: ['activities:', 'activityDetail:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     addActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     submitEditRequest: ['activities:', 'edit-requests', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'end-dates'],
-    reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:', 'exceptions:', 'activityDates:', 'week:', 'month:'],
+    reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:', 'exceptions:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:'],
     addUser: ['permissions', 'dashboard:'],
     deactivateUser: ['permissions', 'dashboard:'],
     reactivateUser: ['permissions', 'dashboard:'],

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -46,16 +46,18 @@ const ACTIVITY_FILTER_FIELDS = [
   { key: 'activity_type', label: 'סוג הפעילות', getOptionLabel: (value) => visibleActivityCategoryLabel(value) }
 ];
 const ACTIVITY_SEARCH_FIELDS = [
-  'RowID',
-  'activity_name',
-  'activity_manager',
-  'instructor_name',
-  'instructor_name_2',
-  'authority',
-  'school',
-  'funding',
-  'status',
-  'activity_type'
+  'RowID', 'row_id', 'source_row_id',
+  'activity_no', 'activity_number', 'activity_name', 'activity_type', 'activity_family',
+  'activity_manager', 'manager_name',
+  'instructor_name', 'instructor_name_2', 'Instructor', 'Instructor2',
+  'emp_id', 'emp_id_2', 'EmployeeID', 'EmployeeID2',
+  'authority', 'school', 'grade', 'class_group', 'group', 'class',
+  'funding', 'status',
+  'start_date', 'end_date', 'date_1', 'meeting_dates', 'date_cols',
+  'notes', 'description',
+  (row) => Array.from({ length: 30 }, (_, i) => row?.[`date_${i + 1}`]).filter(Boolean).join(' '),
+  (row) => Array.isArray(row?.meeting_dates) ? row.meeting_dates.join(' ') : '',
+  (row) => Array.isArray(row?.date_cols) ? row.date_cols.join(' ') : ''
 ];
 
 /** שם תצוגה למדריך/ים — כולל כינויים מה־API ומ־normalizeData (Employee וכו'). */
@@ -747,7 +749,7 @@ export const activitiesScreen = {
         .catch(() => {});
     }
 
-    bindLocalFilters(root, state, ACTIVITIES_SCOPE, rerenderLocal, { debounceMs: 420, onClear: () => {
+    bindLocalFilters(root, state, ACTIVITIES_SCOPE, rerenderLocal, { debounceMs: 450, onClear: () => {
       state.activityQuickFamily = '';
       state.activityQuickManager = '';
       state.activityEndingCurrentMonth = false;

--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -44,16 +44,19 @@ const ARCHIVE_FILTER_FIELDS = [
 ];
 
 const ARCHIVE_SEARCH_FIELDS = [
-  'RowID',
-  'activity_name',
-  'activity_manager',
-  'instructor_name',
-  'instructor_name_2',
-  'authority',
-  'school',
-  'activity_type',
-  'meeting_dates',
-  'date_cols'
+  'RowID', 'row_id', 'source_row_id',
+  'activity_no', 'activity_number', 'activity_name', 'activity_type', 'activity_family',
+  'activity_manager', 'manager_name',
+  'instructor_name', 'instructor_name_2', 'Instructor', 'Instructor2',
+  'emp_id', 'emp_id_2', 'EmployeeID', 'EmployeeID2',
+  'authority', 'school', 'grade', 'class_group', 'group', 'class',
+  'funding', 'status',
+  'start_date', 'end_date', 'date_1', 'meeting_dates', 'date_cols',
+  'notes', 'description',
+  (row) => activityManagerDisplayName(row?.activity_manager),
+  (row) => Array.from({ length: 30 }, (_, i) => row?.[`date_${i + 1}`]).filter(Boolean).join(' '),
+  (row) => Array.isArray(row?.meeting_dates) ? row.meeting_dates.join(' ') : '',
+  (row) => Array.isArray(row?.date_cols) ? row.date_cols.join(' ') : ''
 ];
 
 const inflightDetailRequests = new Map();
@@ -83,6 +86,38 @@ function yearOptions(rows) {
     if (y !== '—') years.add(y);
   });
   return Array.from(years).sort((a, b) => b.localeCompare(a));
+}
+
+function todayIso() {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function reopenModalHtml(today) {
+  return `<div class="ds-perm-edit-form" dir="rtl" data-archive-reopen-form>
+    <p class="ds-muted">כדי להחזיר את הפעילות לפעילה, יש לבחור תאריך התחלה חדש.<br>ניתן לבחור רק תאריך מהיום והלאה.</p>
+    <label class="ds-perm-field">
+      <span class="ds-muted">תאריך התחלה חדש</span>
+      <input class="ds-input ds-input--sm" type="date" name="start_date" min="${escapeHtml(today)}" required data-reopen-start>
+    </label>
+    <label class="ds-perm-field">
+      <span class="ds-muted">תאריך סיום חדש</span>
+      <input class="ds-input ds-input--sm" type="date" name="end_date" min="${escapeHtml(today)}" data-reopen-end>
+    </label>
+    <p class="ds-muted" role="alert" data-reopen-error></p>
+  </div>`;
+}
+
+function clearArchiveReopenCaches(state) {
+  const prefixes = ['archive', 'archiveDetail:', 'archiveDates:', 'activities:', 'month:', 'week:', 'dashboard:'];
+  Object.keys(state?.screenDataCache || {}).forEach((key) => {
+    if (prefixes.some((prefix) => key === prefix || key.startsWith(prefix))) {
+      delete state.screenDataCache[key];
+    }
+  });
 }
 
 function applyArchiveFilters(rows, state) {
@@ -237,7 +272,7 @@ export const archiveScreen = {
     const rerenderLocal = () => rerender();
 
     bindLocalFilters(root, state, ARCHIVE_SCOPE, rerenderLocal, {
-      debounceMs: 300,
+      debounceMs: 450,
       onClear: () => { state.archiveYear = ''; }
     });
 
@@ -345,22 +380,76 @@ export const archiveScreen = {
       if (!canReopen) return;
       const btn = contentRoot.querySelector('[data-archive-reopen]');
       if (!btn) return;
-      btn.addEventListener('click', async () => {
-        btn.disabled = true;
-        btn.textContent = 'שומר…';
-        try {
-          await api.saveActivity({
-            source_sheet: row.source_sheet || 'activities',
-            source_row_id: row.RowID || row.row_id,
-            changes: { status: 'פעיל' }
-          });
-          btn.textContent = '✓ נפתח';
-          ui.closeDrawer?.();
-          rerender();
-        } catch (_e) {
-          btn.disabled = false;
-          btn.textContent = '🔓 פתח מחדש';
-        }
+      btn.addEventListener('click', () => {
+        const today = todayIso();
+        ui.openModal({
+          title: 'פתיחה מחדש של פעילות',
+          content: reopenModalHtml(today),
+          actions: `
+            <button type="button" class="ds-btn ds-btn--ghost" data-ui-close-modal>ביטול</button>
+            <button type="button" class="ds-btn ds-btn--primary" data-archive-reopen-confirm>אישור פתיחה מחדש</button>
+          `
+        });
+
+        const modal = document.querySelector('.ds-modal');
+        const startInput = modal?.querySelector('[data-reopen-start]');
+        const endInput = modal?.querySelector('[data-reopen-end]');
+        const errorEl = modal?.querySelector('[data-reopen-error]');
+        const confirmBtn = modal?.querySelector('[data-archive-reopen-confirm]');
+        const setError = (msg) => { if (errorEl) errorEl.textContent = msg || ''; };
+
+        startInput?.addEventListener('input', () => {
+          const start = String(startInput.value || '').trim();
+          if (endInput) endInput.min = start || today;
+          setError('');
+        });
+        endInput?.addEventListener('input', () => setError(''));
+
+        confirmBtn?.addEventListener('click', async () => {
+          const selectedStartDate = String(startInput?.value || '').trim();
+          const selectedEndDate = String(endInput?.value || '').trim();
+          if (!selectedStartDate) {
+            setError('יש לבחור תאריך התחלה חדש.');
+            startInput?.focus();
+            return;
+          }
+          if (selectedStartDate < today) {
+            setError('תאריך ההתחלה חייב להיות מהיום והלאה.');
+            startInput?.focus();
+            return;
+          }
+          if (selectedEndDate && selectedEndDate < selectedStartDate) {
+            setError('תאריך הסיום לא יכול להיות לפני תאריך ההתחלה.');
+            endInput?.focus();
+            return;
+          }
+
+          const finalEndDate = selectedEndDate || selectedStartDate;
+          confirmBtn.disabled = true;
+          confirmBtn.textContent = 'שומר…';
+          try {
+            await api.saveActivity({
+              source_sheet: row.source_sheet || 'activities',
+              source_row_id: row.RowID || row.row_id,
+              changes: {
+                status: 'פעיל',
+                start_date: selectedStartDate,
+                end_date: finalEndDate,
+                date_1: selectedStartDate
+              }
+            });
+            ui.closeModal?.();
+            ui.closeDrawer?.();
+            clearArchiveReopenCaches(state);
+            state.activitiesMonthYm = selectedStartDate.slice(0, 7);
+            state.route = 'activities';
+            rerender();
+          } catch (_e) {
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'אישור פתיחה מחדש';
+            setError('שמירת הפתיחה מחדש נכשלה. נסו שוב.');
+          }
+        });
       });
     }
 

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -98,8 +98,8 @@ function renderInstrCard(row) {
     </button>`;
 }
 
-function instrTabHtml(rows, searchQ) {
-  const filtered = searchQ ? applyLocalFilters(rows, { q: searchQ }, { filterFields: [] }) : rows;
+function instrTabHtml(rows, filters) {
+  const filtered = applyLocalFilters(rows, filters, { filterFields: [] });
   const body = filtered.length === 0
     ? dsEmptyState('לא נמצאו אנשי קשר')
     : `<div class="ci-person-grid">${filtered.map((r) => renderInstrCard(r)).join('')}</div>`;
@@ -264,8 +264,8 @@ function renderLetterSection(letter, authoritiesMap) {
   </div>`;
 }
 
-function schoolTabHtml(rows, searchQ) {
-  const filtered = searchQ ? applyLocalFilters(rows, { q: searchQ }, { filterFields: [] }) : rows;
+function schoolTabHtml(rows, filters) {
+  const filtered = applyLocalFilters(rows, filters, { filterFields: [] });
   if (filtered.length === 0) return { filtered, body: dsEmptyState('לא נמצאו אנשי קשר') };
   const authorityGroups = groupByAuthorityThenSchool(filtered);
   const byLetter = groupByLetter(authorityGroups);
@@ -289,14 +289,22 @@ export const contactsScreen = {
   render(data, { state } = {}) {
     const instrRows  = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows)     ? data.school_rows     : [];
-    prepareRowsForSearch(instrRows, ['full_name', 'contact_name', 'mobile', 'phone', 'email', 'authority', 'school', 'role', 'contact_role']);
-    prepareRowsForSearch(schoolRows, ['full_name', 'contact_name', 'mobile', 'phone', 'email', 'authority', 'school', 'role', 'contact_role']);
+    prepareRowsForSearch(instrRows, [
+      'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
+      'mobile', 'phone', 'email', 'authority', 'school',
+      'role', 'contact_role', 'employment_type', 'direct_manager', 'active',
+      'notes', 'address', 'activity_name', 'activity_type'
+    ]);
+    prepareRowsForSearch(schoolRows, [
+      'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
+      'mobile', 'phone', 'email', 'authority', 'school',
+      'role', 'contact_role', 'position', 'active', 'notes', 'address',
+      'instructor_name', 'activity_name', 'activity_type'
+    ]);
     const filters = ensureActivityListFilters(state, CONTACTS_SCOPE);
     const canViewInstr  = data?.can_view_instructors !== false;
     const canViewSchool = data?.can_view_schools     !== false;
     const tab     = state?.contactsTab || (canViewInstr ? 'instr' : 'school');
-    const searchQ = filters.q || '';
-
     const tabBtns = [
       canViewInstr  && { key: 'instr',  label: `אנשי קשר מדריכים (${instrRows.length})`  },
       canViewSchool && { key: 'school', label: `אנשי קשר בתי ספר (${schoolRows.length})` }
@@ -308,10 +316,10 @@ export const contactsScreen = {
     let listHtml    = '';
 
     if (tab === 'instr' && canViewInstr) {
-      const { body } = instrTabHtml(instrRows, searchQ);
+      const { body } = instrTabHtml(instrRows, filters);
       listHtml = body;
     } else if (tab === 'school' && canViewSchool) {
-      const { body } = schoolTabHtml(schoolRows, searchQ);
+      const { body } = schoolTabHtml(schoolRows, filters);
       listHtml = body;
     }
     searchInput = filtersToolbarHtml(CONTACTS_SCOPE, tab === 'instr' ? instrRows : schoolRows, state, {
@@ -342,7 +350,7 @@ export const contactsScreen = {
         rerender();
       });
     });
-    bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, { debounceMs: 420 });
+    bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, { debounceMs: 450 });
 
     const bindCopyBtns = (container) => {
       container.querySelectorAll('[data-copy-email]').forEach((btn) => {

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -192,7 +192,7 @@ export const exceptionsScreen = {
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
     const allRows   = (Array.isArray(data?.rows) ? data.rows : []);
-    bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 300 });
+    bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 450 });
     root.querySelector(`[data-list-show-more="${EXCEPTIONS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, EXCEPTIONS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
       rerender();

--- a/frontend/src/screens/instructor-contacts.js
+++ b/frontend/src/screens/instructor-contacts.js
@@ -7,6 +7,9 @@ import {
   dsEmptyState,
   dsStatusChip
 } from './shared/layout.js';
+const MIN_SEARCH_CHARS = 4;
+const SEARCH_DEBOUNCE_MS = 450;
+
 const AVATAR_PALETTE = [
   '#ef4444','#f97316','#eab308','#22c55e',
   '#3b82f6','#8b5cf6','#ec4899','#14b8a6',
@@ -42,16 +45,19 @@ function drawerHtml(row, hideEmpIds) {
   return `<div class="ds-details-grid" dir="rtl">${lines}</div>`;
 }
 
+function normalizeSearch(value) {
+  return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
 function applySearch(rows, q) {
-  if (!q) return rows;
-  const lq = q.toLowerCase();
-  return rows.filter((r) =>
-    String(r.full_name || '').toLowerCase().includes(lq) ||
-    String(r.emp_id || '').toLowerCase().includes(lq) ||
-    String(r.email || '').toLowerCase().includes(lq) ||
-    String(r.mobile || '').toLowerCase().includes(lq) ||
-    hebrewEmploymentType(r.employment_type).toLowerCase().includes(lq)
-  );
+  const lq = normalizeSearch(q);
+  if (!lq) return rows;
+  return rows.filter((r) => [
+    r.full_name, r.name, r.emp_id, r.employee_id,
+    r.email, r.mobile, r.phone, r.address,
+    r.employment_type, hebrewEmploymentType(r.employment_type),
+    r.direct_manager, r.active, r.authority, r.school, r.role, r.notes
+  ].some((value) => normalizeSearch(value).includes(lq)));
 }
 
 function renderContactCard(row) {
@@ -79,13 +85,17 @@ export const instructorContactsScreen = {
   render(data, { state } = {}) {
     const allRows = Array.isArray(data?.rows) ? data.rows : [];
     const searchQ = state?.instrContactsSearch || '';
+    if (!Object.prototype.hasOwnProperty.call(state, 'instrContactsAppliedSearch')) {
+      state.instrContactsAppliedSearch = normalizeSearch(searchQ).length >= MIN_SEARCH_CHARS ? searchQ : '';
+    }
+    const appliedSearchQ = state?.instrContactsAppliedSearch || '';
     const activeFilter = state?.instrContactsActiveFilter || '';
 
     const contactsSource = state?.clientSettings?.instructor_contacts_source;
     const contactsLabel = hebrewSheetLabel(contactsSource || 'contacts_instructors');
     const sourceSheetName = escapeHtml(contactsSource || 'contacts_instructors');
 
-    let rows = applySearch(allRows, searchQ);
+    let rows = applySearch(allRows, appliedSearchQ);
     if (activeFilter) {
       rows = rows.filter((r) => String(r.active || '').toLowerCase() === activeFilter);
     }
@@ -140,15 +150,25 @@ export const instructorContactsScreen = {
       const next = ev.target.value || '';
       const cursorPos = ev.target?.selectionStart ?? next.length;
       clearTimeout(searchTimer);
-      searchTimer = setTimeout(() => {
-        state.instrContactsSearch = next;
+      state.instrContactsSearch = next;
+
+      const apply = () => {
+        state.instrContactsAppliedSearch = next;
         rerender();
         const newInput = root.querySelector('#instr-contacts-search');
         if (newInput) {
           newInput.focus();
           try { newInput.setSelectionRange(cursorPos, cursorPos); } catch (_) {}
         }
-      }, 280);
+      };
+
+      const len = normalizeSearch(next).length;
+      if (len === 0) {
+        apply();
+        return;
+      }
+      if (len < MIN_SEARCH_CHARS) return;
+      searchTimer = setTimeout(apply, SEARCH_DEBOUNCE_MS);
     });
 
     root.querySelectorAll('[data-active-filter]').forEach((btn) => {

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -203,12 +203,16 @@ export const instructorsScreen = {
   render(data, { state } = {}) {
     const allRows  = Array.isArray(data?.rows) ? data.rows : [];
     prepareRowsForSearch(allRows, [
-      'full_name', 'emp_id',
+      'full_name', 'name', 'instructor_name', 'emp_id', 'employee_id', 'EmployeeID',
+      'activity_name', 'activity_type', 'activity_manager', 'authority', 'school',
+      'status', 'start_date', 'end_date', 'earliest_start_date', 'latest_end_date',
+      'mobile', 'phone', 'email', 'employment_type', 'direct_manager',
       (row) => (Array.isArray(row.activity_managers) ? row.activity_managers : []).join(' '),
       (row) => (Array.isArray(row.authorities) ? row.authorities : []).join(' '),
       (row) => (Array.isArray(row.schools) ? row.schools : []).join(' '),
       (row) => (Array.isArray(row.activity_names) ? row.activity_names : []).join(' '),
-      'authority', 'school', 'activity_name'
+      (row) => (Array.isArray(row.activity_types) ? row.activity_types : []).join(' '),
+      (row) => row.activity_type_counts ? Object.keys(row.activity_type_counts).join(' ') : ''
     ]);
     const filters = ensureActivityListFilters(state, INSTRUCTORS_SCOPE);
 
@@ -252,7 +256,7 @@ export const instructorsScreen = {
   },
 
   bind({ root, data, state, rerender, api }) {
-    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 300 });
+    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 450 });
     root.querySelector(`[data-list-show-more="${INSTRUCTORS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, INSTRUCTORS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
       rerender();

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -318,7 +318,7 @@ export const monthScreen = {
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const showPrivateNote = state?.user?.display_role === 'operation_manager';
-    bindLocalFilters(root, state, MONTH_SCOPE, rerender, { debounceMs: 420 });
+    bindLocalFilters(root, state, MONTH_SCOPE, rerender, { debounceMs: 450 });
     const cells = Array.isArray(data?.cells) ? data.cells : [];
     const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
     const allItemsByRowId = new Map();

--- a/frontend/src/screens/shared/activity-list-filters.js
+++ b/frontend/src/screens/shared/activity-list-filters.js
@@ -1,6 +1,8 @@
 import { escapeHtml } from './html.js';
 
-const DEFAULT_SEARCH_DEBOUNCE_MS = 300;
+export const MIN_SEARCH_CHARS = 4;
+export const SEARCH_DEBOUNCE_MS = 450;
+const DEFAULT_SEARCH_DEBOUNCE_MS = SEARCH_DEBOUNCE_MS;
 const DEFAULT_VISIBLE_LIMIT = 200;
 const FILTER_OPTIONS_CACHE = new WeakMap();
 
@@ -28,14 +30,18 @@ export function prepareRowsForSearch(rows, fields) {
   const list = Array.isArray(rows) ? rows : [];
   list.forEach((row) => {
     if (!row || typeof row !== 'object') return;
-    if (!row.__searchText) row.__searchText = buildSearchText(row, fields);
+    row.__searchText = buildSearchText(row, fields);
   });
   return list;
 }
 
 export function ensureActivityListFilters(state, scope) {
   state.listFilters = state.listFilters || {};
-  state.listFilters[scope] = state.listFilters[scope] || { q: '', visibleCount: DEFAULT_VISIBLE_LIMIT };
+  state.listFilters[scope] = state.listFilters[scope] || { q: '', appliedQ: '', visibleCount: DEFAULT_VISIBLE_LIMIT };
+  if (!Object.prototype.hasOwnProperty.call(state.listFilters[scope], 'appliedQ')) {
+    const q = normalizeText(state.listFilters[scope].q || '');
+    state.listFilters[scope].appliedQ = q.length >= MIN_SEARCH_CHARS ? state.listFilters[scope].q : '';
+  }
   if (typeof state.listFilters[scope].visibleCount !== 'number') {
     state.listFilters[scope].visibleCount = DEFAULT_VISIBLE_LIMIT;
   }
@@ -74,7 +80,9 @@ export function collectFilterOptions(rows, fields) {
 export function applyLocalFilters(rows, filters, config = {}) {
   const list = Array.isArray(rows) ? rows : [];
   const scoped = filters || {};
-  const search = normalizeText(scoped.q || '');
+  const rawSearch = Object.prototype.hasOwnProperty.call(scoped, 'appliedQ') ? scoped.appliedQ : scoped.q;
+  const normalizedSearch = normalizeText(rawSearch || '');
+  const search = normalizedSearch.length >= MIN_SEARCH_CHARS ? normalizedSearch : '';
   const filterFields = Array.isArray(config.filterFields) ? config.filterFields : [];
 
   return list.filter((row) => {
@@ -166,11 +174,15 @@ export function bindLocalFilters(root, state, scope, rerender, options = {}) {
   let searchTimer;
   searchInput?.addEventListener('input', (ev) => {
     const nextValue = ev.target?.value || '';
-    if (nextValue === String(filters.q || '')) return;
     const cursorPos = ev.target?.selectionStart ?? nextValue.length;
     clearTimeout(searchTimer);
+
+    // Keep the typed value in state immediately, but only apply expensive
+    // filtering/rerendering when the query is empty or long enough.
+    filters.q = nextValue;
+
     const apply = () => {
-      filters.q = nextValue;
+      filters.appliedQ = nextValue;
       filters.visibleCount = DEFAULT_VISIBLE_LIMIT;
       rerender();
       const newInput = root.querySelector(`[data-filter-search="${scope}"]`);
@@ -179,6 +191,13 @@ export function bindLocalFilters(root, state, scope, rerender, options = {}) {
         try { newInput.setSelectionRange(cursorPos, cursorPos); } catch (_) {}
       }
     };
+
+    const trimmedLength = normalizeText(nextValue).length;
+    if (trimmedLength === 0) {
+      apply();
+      return;
+    }
+    if (trimmedLength < MIN_SEARCH_CHARS) return;
     if (debounceMs <= 0) apply();
     else searchTimer = setTimeout(apply, debounceMs);
   });
@@ -195,7 +214,7 @@ export function bindLocalFilters(root, state, scope, rerender, options = {}) {
 
   clearBtn?.addEventListener('click', () => {
     const prevVisibleCount = state.listFilters?.[scope]?.visibleCount;
-    state.listFilters[scope] = { q: '', visibleCount: typeof prevVisibleCount === 'number' ? prevVisibleCount : DEFAULT_VISIBLE_LIMIT };
+    state.listFilters[scope] = { q: '', appliedQ: '', visibleCount: typeof prevVisibleCount === 'number' ? prevVisibleCount : DEFAULT_VISIBLE_LIMIT };
     if (typeof options.onClear === 'function') options.onClear();
     rerender();
   });

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -304,7 +304,7 @@ export const weekScreen = {
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const showPrivateNote = state?.user?.display_role === 'operation_manager';
-    bindLocalFilters(root, state, WEEK_SCOPE, rerender, { debounceMs: 420 });
+    bindLocalFilters(root, state, WEEK_SCOPE, rerender, { debounceMs: 450 });
 
     const bindActivityEditForm = (contentRoot) =>
       bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender, onRowSaved: (p) => patchCachedActivityDetail(p, state) });


### PR DESCRIPTION
### Motivation
- כשפותחים פעילות מהארכיון יש לוודא שהמשתמש יבחר תאריך התחלה עדכני (מהיום והלאה) כדי שהפעילות תופיע כראוי במסך הפעילויות לפי חודש. 
- שורת החיפוש גורמת לרינדור אחרי כל הקלדה; יש להפחית קריאות ורינדרים מיותרות ולהרחיב את החיפוש לכל השדות הרלוונטיים בכל מסך.

### Description
- ארכיון: החלפת פעולת "פתח מחדש" בפתיחת מודאל אישור עם שדה תאריך התחלה (type=date, `min` = היום) ושדה תאריך סיום אופציונלי; הוספת ולידציות (אין אישור ללא תאריך התחלה, אין בחירת תחילה לפני היום, סיום לא קטן מהתחלה), ושמירת `api.saveActivity` עם `status:'פעיל'`, `start_date`, `end_date`, `date_1`, ואז סגירת המודאל/drawer, ניקוי מטמון מסכים רלוונטיים, עדכון `state.activitiesMonthYm` והמעבר ל־`state.route='activities'`. (שינויים ב־`frontend/src/screens/archive.js`).
- קאש/Invalidation: עדכון `invalidateScreenDataByAction` ב־`frontend/src/api.js` כדי ש־`saveActivity` ו־`reviewEditRequest` יניקו גם את קבצי הארכיון (`archive`, `archiveDetail:`, `archiveDates:`) בנוסף למסכי פעילויות/חודש/שבוע/דאשבורד.
- חיפוש/דיבאונס משותף: הרחבה של `frontend/src/screens/shared/activity-list-filters.js` עם `MIN_SEARCH_CHARS = 4` ו־`SEARCH_DEBOUNCE_MS = 450`, שמירת הטקסט המוקלד ב־`filters.q` אך הפעלת מיון/רינדור רק ל־`filters.appliedQ` אחרי debounce ו/או כשהשדה ריק; שינוי התנהגות כפתור הניקוי לאפס גם את `appliedQ`.
- שדות חיפוש מורחבים: העשרת רשימות שדות החיפוש ב־`activities.js`, `archive.js`, `instructors.js`, `contacts.js`, `instructor-contacts.js` כדי לכלול מזהים, מספר פעילות, שדות זיהוי מדריכים/מנויים/emp_id, תאריכים, תאריכי מפגשים, הערות ועוד, וכן שימוש ב־`prepareRowsForSearch` על מערכי שדות אלה.
- איחוד debounce במסכים: עדכון קריאות `bindLocalFilters(..., { debounceMs: ... })` ל־450ms ברוב המסכים (activities, archive, instructors, contacts, month, week, exceptions ועוד) כדי לשמור התנהגות אחידה ומניעת רינדורים תכופים.

### Testing
- סינטקס/בדיקות מהירות: בדיקות תחביר של קבצים (`node --check` על הקבצים שעודכנו) עברו בהצלחה.
- בנייה: `npm run build` עבר בהצלחה והפיק חבילה תקינה (Vite build OK).
- בדיקות יחידה: `npm test` ירץ בסביבת Node המקומית ונתקל בכשלים סביבתיים; הבדל הבולט הראשון הוא שגיאה בסביבת ה־test: `sessionStorage is not defined` ב־`frontend/src/state.js`, ולאחריה הופיעו כשלים נוספים שנובעים ממOCK/API בסביבה הזו — אלה בעיות קיימות בסביבת הבדיקות ולא קשורות לשינויים הפונקציונליים שבוצעו פה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077e258538832ba962137747b60559)