### PR TITLE
Refresh dashboard service worker cache version

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,8 +3,9 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 347;
-const CACHE_NAME = `dashboard-static-v${CACHE_VERSION}`;
+const CACHE_VERSION = 348;
+const CACHE_PREFIX = 'dashboard-static-v';
+const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 /** Relative paths from sw.js location — works on any origin/proxy (Replit, deploy, etc). */
 const PRECACHE_URLS = [
@@ -57,9 +58,13 @@ function isStaticAssetUrl(url) {
   if (p.endsWith('/index.html') || p === '/' || p.endsWith('.html')) return true;
   if (p.endsWith('.js') || p.endsWith('.css')) return true;
   if (p.endsWith('.png') || p.endsWith('.ico') || p.endsWith('.svg') || p.endsWith('.webp')) return true;
-  if (p.endsWith('.json') && p.includes('manifest')) return true;
+  if (isManifestUrl(url)) return true;
   if (p.endsWith('.woff2') || p.endsWith('.woff')) return true;
   return false;
+}
+
+function isManifestUrl(url) {
+  return url.pathname.endsWith('/manifest.json') || (url.pathname.endsWith('.json') && url.pathname.includes('manifest'));
 }
 
 function isNavigationRequest(request) {
@@ -70,9 +75,27 @@ function shouldStoreResponse(response) {
   return response && response.ok && response.type === 'basic' && sameOrigin(new URL(response.url));
 }
 
+async function deleteOutdatedCaches() {
+  const keys = await caches.keys();
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+      .map((key) => caches.delete(key))
+  );
+}
+
 function withNoStore(request) {
   if (request.cache === 'no-store') return request;
   return new Request(request, { cache: 'no-store' });
+}
+
+async function precacheFresh(cache, path) {
+  const url = resolveUrl(path);
+  const response = await fetch(new Request(url, { cache: 'reload' }));
+  if (!shouldStoreResponse(response)) {
+    throw new Error(`Unexpected precache response for ${path}: ${response.status}`);
+  }
+  await cache.put(url, response.clone());
 }
 
 async function cacheFirst(request, cache) {
@@ -113,25 +136,19 @@ self.addEventListener('install', (event) => {
     caches.open(CACHE_NAME).then(async (cache) => {
       for (const path of PRECACHE_URLS) {
         try {
-          await cache.add(resolveUrl(path));
+          await precacheFresh(cache, path);
         } catch (e) {
           console.warn('[SW] precache skip', path, e);
         }
       }
+      await deleteOutdatedCaches();
       self.skipWaiting();
     })
   );
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
-      )
-      .then(() => self.clients.claim())
-  );
+  event.waitUntil(deleteOutdatedCaches().then(() => self.clients.claim()));
 });
 
 self.addEventListener('fetch', (event) => {
@@ -148,6 +165,6 @@ self.addEventListener('fetch', (event) => {
 
   if (!(isNavigationRequest(request) || isStaticAssetUrl(url))) return;
 
-  const networkFresh = isNavigationRequest(request) || url.pathname.endsWith('.html') || url.pathname.endsWith('.js') || url.pathname.endsWith('.css');
+  const networkFresh = isNavigationRequest(request) || url.pathname.endsWith('.html') || url.pathname.endsWith('.js') || url.pathname.endsWith('.css') || isManifestUrl(url);
   event.respondWith(caches.open(CACHE_NAME).then((cache) => networkFresh ? networkFirst(request, cache) : cacheFirst(request, cache)));
 });

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,8 +3,9 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 347;
-const CACHE_NAME = `dashboard-static-v${CACHE_VERSION}`;
+const CACHE_VERSION = 348;
+const CACHE_PREFIX = 'dashboard-static-v';
+const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 /** Relative paths from sw.js location — works on any origin/proxy (Replit, deploy, etc). */
 const PRECACHE_URLS = [
@@ -57,9 +58,13 @@ function isStaticAssetUrl(url) {
   if (p.endsWith('/index.html') || p === '/' || p.endsWith('.html')) return true;
   if (p.endsWith('.js') || p.endsWith('.css')) return true;
   if (p.endsWith('.png') || p.endsWith('.ico') || p.endsWith('.svg') || p.endsWith('.webp')) return true;
-  if (p.endsWith('.json') && p.includes('manifest')) return true;
+  if (isManifestUrl(url)) return true;
   if (p.endsWith('.woff2') || p.endsWith('.woff')) return true;
   return false;
+}
+
+function isManifestUrl(url) {
+  return url.pathname.endsWith('/manifest.json') || (url.pathname.endsWith('.json') && url.pathname.includes('manifest'));
 }
 
 function isNavigationRequest(request) {
@@ -70,9 +75,27 @@ function shouldStoreResponse(response) {
   return response && response.ok && response.type === 'basic' && sameOrigin(new URL(response.url));
 }
 
+async function deleteOutdatedCaches() {
+  const keys = await caches.keys();
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+      .map((key) => caches.delete(key))
+  );
+}
+
 function withNoStore(request) {
   if (request.cache === 'no-store') return request;
   return new Request(request, { cache: 'no-store' });
+}
+
+async function precacheFresh(cache, path) {
+  const url = resolveUrl(path);
+  const response = await fetch(new Request(url, { cache: 'reload' }));
+  if (!shouldStoreResponse(response)) {
+    throw new Error(`Unexpected precache response for ${path}: ${response.status}`);
+  }
+  await cache.put(url, response.clone());
 }
 
 async function cacheFirst(request, cache) {
@@ -113,25 +136,19 @@ self.addEventListener('install', (event) => {
     caches.open(CACHE_NAME).then(async (cache) => {
       for (const path of PRECACHE_URLS) {
         try {
-          await cache.add(resolveUrl(path));
+          await precacheFresh(cache, path);
         } catch (e) {
           console.warn('[SW] precache skip', path, e);
         }
       }
+      await deleteOutdatedCaches();
       self.skipWaiting();
     })
   );
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
-      )
-      .then(() => self.clients.claim())
-  );
+  event.waitUntil(deleteOutdatedCaches().then(() => self.clients.claim()));
 });
 
 self.addEventListener('fetch', (event) => {
@@ -148,6 +165,6 @@ self.addEventListener('fetch', (event) => {
 
   if (!(isNavigationRequest(request) || isStaticAssetUrl(url))) return;
 
-  const networkFresh = isNavigationRequest(request) || url.pathname.endsWith('.html') || url.pathname.endsWith('.js') || url.pathname.endsWith('.css');
+  const networkFresh = isNavigationRequest(request) || url.pathname.endsWith('.html') || url.pathname.endsWith('.js') || url.pathname.endsWith('.css') || isManifestUrl(url);
   event.respondWith(caches.open(CACHE_NAME).then((cache) => networkFresh ? networkFirst(request, cache) : cacheFirst(request, cache)));
 });

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,8 +3,9 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 347;
-const CACHE_NAME = `dashboard-static-v${CACHE_VERSION}`;
+const CACHE_VERSION = 348;
+const CACHE_PREFIX = 'dashboard-static-v';
+const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
 /** Relative paths from sw.js location — works on any origin/proxy (Replit, deploy, etc). */
 const PRECACHE_URLS = [
@@ -34,9 +35,13 @@ function isStaticAssetUrl(url) {
   if (p.endsWith('/index.html') || p === '/' || p.endsWith('.html')) return true;
   if (p.endsWith('.js') || p.endsWith('.css')) return true;
   if (p.endsWith('.png') || p.endsWith('.ico') || p.endsWith('.svg') || p.endsWith('.webp')) return true;
-  if (p.endsWith('.json') && p.includes('manifest')) return true;
+  if (isManifestUrl(url)) return true;
   if (p.endsWith('.woff2') || p.endsWith('.woff')) return true;
   return false;
+}
+
+function isManifestUrl(url) {
+  return url.pathname.endsWith('/manifest.json') || (url.pathname.endsWith('.json') && url.pathname.includes('manifest'));
 }
 
 function isNavigationRequest(request) {
@@ -47,9 +52,27 @@ function shouldStoreResponse(response) {
   return response && response.ok && response.type === 'basic' && sameOrigin(new URL(response.url));
 }
 
+async function deleteOutdatedCaches() {
+  const keys = await caches.keys();
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+      .map((key) => caches.delete(key))
+  );
+}
+
 function withNoStore(request) {
   if (request.cache === 'no-store') return request;
   return new Request(request, { cache: 'no-store' });
+}
+
+async function precacheFresh(cache, path) {
+  const url = resolveUrl(path);
+  const response = await fetch(new Request(url, { cache: 'reload' }));
+  if (!shouldStoreResponse(response)) {
+    throw new Error(`Unexpected precache response for ${path}: ${response.status}`);
+  }
+  await cache.put(url, response.clone());
 }
 
 async function cacheFirst(request, cache) {
@@ -90,25 +113,19 @@ self.addEventListener('install', (event) => {
     caches.open(CACHE_NAME).then(async (cache) => {
       for (const path of PRECACHE_URLS) {
         try {
-          await cache.add(resolveUrl(path));
+          await precacheFresh(cache, path);
         } catch (e) {
           console.warn('[SW] precache skip', path, e);
         }
       }
+      await deleteOutdatedCaches();
       self.skipWaiting();
     })
   );
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
-      )
-      .then(() => self.clients.claim())
-  );
+  event.waitUntil(deleteOutdatedCaches().then(() => self.clients.claim()));
 });
 
 self.addEventListener('fetch', (event) => {
@@ -125,6 +142,6 @@ self.addEventListener('fetch', (event) => {
 
   if (!(isNavigationRequest(request) || isStaticAssetUrl(url))) return;
 
-  const networkFresh = isNavigationRequest(request) || url.pathname.endsWith('.html') || url.pathname.endsWith('.js') || url.pathname.endsWith('.css');
+  const networkFresh = isNavigationRequest(request) || url.pathname.endsWith('.html') || url.pathname.endsWith('.js') || url.pathname.endsWith('.css') || isManifestUrl(url);
   event.respondWith(caches.open(CACHE_NAME).then((cache) => networkFresh ? networkFirst(request, cache) : cacheFirst(request, cache)));
 });

--- a/sw.js
+++ b/sw.js
@@ -1,2 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-importScripts(new URL('frontend/sw.js', self.location).href);
+const SW_ENTRY_VERSION = 348;
+importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/service-worker-pwa-cache.test.mjs
+++ b/tests/service-worker-pwa-cache.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const ROOT_SW_FILE = join(ROOT, 'sw.js');
+const FRONTEND_SW_FILE = join(ROOT, 'frontend', 'sw.js');
+const MANIFEST_FILE = join(ROOT, 'frontend', 'public', 'manifest.json');
+
+async function read(path) {
+  return readFile(path, 'utf8');
+}
+
+test('service worker entry and implementation use the same bumped cache version', async () => {
+  const rootSw = await read(ROOT_SW_FILE);
+  const frontendSw = await read(FRONTEND_SW_FILE);
+  const entryVersion = rootSw.match(/const SW_ENTRY_VERSION = (\d+);/);
+  const cacheVersion = frontendSw.match(/const CACHE_VERSION = (\d+);/);
+
+  assert.ok(entryVersion, 'root service worker should expose an entry version');
+  assert.ok(cacheVersion, 'frontend service worker should expose a cache version');
+  assert.equal(entryVersion[1], cacheVersion[1], 'entry import query should bust to the same SW version as the cache');
+  assert.ok(Number(cacheVersion[1]) >= 348, 'cache version should be bumped past the previous v347 cache');
+  assert.match(rootSw, /frontend\/sw\.js\?v=\$\{SW_ENTRY_VERSION\}/, 'root SW import should include a version query');
+});
+
+test('service worker removes old dashboard caches during install and activate', async () => {
+  const frontendSw = await read(FRONTEND_SW_FILE);
+
+  assert.match(frontendSw, /const CACHE_PREFIX = 'dashboard-static-v';/);
+  assert.match(frontendSw, /key\.startsWith\(CACHE_PREFIX\) && key !== CACHE_NAME/, 'cleanup should target old dashboard cache versions');
+  assert.match(frontendSw, /await deleteOutdatedCaches\(\);[\s\S]*self\.skipWaiting\(\);/, 'install should clean old caches before taking control');
+  assert.match(frontendSw, /event\.waitUntil\(deleteOutdatedCaches\(\)\.then\(\(\) => self\.clients\.claim\(\)\)\)/, 'activate should also clean old caches and claim clients');
+});
+
+test('service worker fetches app shell and manifest fresh after deploy', async () => {
+  const frontendSw = await read(FRONTEND_SW_FILE);
+
+  assert.match(frontendSw, /new Request\(url, \{ cache: 'reload' \}\)/, 'precache should bypass the browser HTTP cache');
+  assert.match(frontendSw, /new Request\(request, \{ cache: 'no-store' \}\)/, 'network-first requests should bypass stale browser cache');
+  assert.match(frontendSw, /\|\| isManifestUrl\(url\)/, 'manifest should use the network-first path');
+  assert.match(frontendSw, /if \(isApiLikeUrl\(url\)\) \{[\s\S]*event\.respondWith\(fetch\(request\)\)/, 'API-like requests should remain network-only');
+});
+
+test('PWA manifest and icon files still point to existing dashboard assets', async () => {
+  const manifest = JSON.parse(await read(MANIFEST_FILE));
+
+  assert.equal(manifest.name, 'Dashboard-Taasiyeda');
+  assert.equal(manifest.display, 'standalone');
+  assert.ok(Array.isArray(manifest.icons) && manifest.icons.length >= 4, 'manifest should include dashboard PWA icons');
+
+  for (const icon of manifest.icons) {
+    assert.ok(icon.src, 'manifest icon should have a src');
+    const rel = icon.src.replace(/^\/dashboard_system\//, 'frontend/');
+    assert.ok(existsSync(join(ROOT, rel)), `missing PWA icon asset: ${icon.src}`);
+  }
+});


### PR DESCRIPTION
### Motivation

- Ensure users load the latest dashboard assets after deploy by forcing a service worker update and removing stale caches. 
- Prevent the dashboard from getting stuck serving an older cached app shell, manifest or PWA assets after a deploy.

### Description

- Bumped the service worker cache version to `348` and added a root entry version `SW_ENTRY_VERSION` so the root `sw.js` imports `frontend/sw.js` with a version query (`?v=${SW_ENTRY_VERSION}`) to force updates on deploy. 
- Added `CACHE_PREFIX`, `deleteOutdatedCaches()` and `precacheFresh()` helpers so install/activate remove old `dashboard-static-v*` caches and precache uses `new Request(..., { cache: 'reload' })`. 
- Treated the PWA `manifest` as network-first (included manifest in the network-fresh path) and kept API-like requests network-only, while using `cache: 'no-store'` for network-first fetches to bypass stale browser cache. 
- Propagated the same changes into the built `dist` SW artifacts and added a test file `tests/service-worker-pwa-cache.test.mjs` that verifies version alignment, cache cleanup, fresh precache behavior, and manifest/icon assets.

### Testing

- Ran `node --test tests/service-worker-pwa-cache.test.mjs` and all tests passed (4/4). 
- Ran `VITE_BASE=/dashboard_system/ npm run build` and the build + postbuild completed successfully (precache entries updated). 
- Ran `VITE_BASE=/dashboard_system/ npx vite preview --host 127.0.0.1 --port 4173` and verified via `curl` that desktop index, mobile index, `manifest.json`, `sw.js` and PWA icons returned `200`. 
- Ran the full test suite with `npm test` (and `timeout 60s npm test`); the run was interrupted / timed out and surfaced existing unrelated failures (e.g. `sessionStorage is not defined` in `tests/activities-screen.test.mjs`) which are not caused by this SW change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078225d0fc832b98b9f3de7f4d6ae5)