### PR TITLE
Import and safeguard admin "Export all activities" Excel export

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1,4 +1,5 @@
 import { escapeHtml } from './shared/html.js';
+import { exportActivitiesToExcel } from './shared/excel-export.js';
 import { formatDateHe, formatActivityDateColumnsHe } from './shared/format-date.js';
 import {
   hebrewColumn,
@@ -778,6 +779,8 @@ export const activitiesScreen = {
       try {
         const res = await (typeof api.allActivities === 'function' ? api.allActivities() : api.activities({ activity_type: 'all' }));
         exportActivitiesToExcel(Array.isArray(res?.rows) ? res.rows : [], 'כל_הפעילויות');
+      } catch (err) {
+        console.error('Failed to export all activities to Excel', err);
       } finally {
         btn.disabled = false;
         btn.textContent = originalText;

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -1,6 +1,27 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { activitiesScreen } from '../frontend/src/screens/activities.js';
+
+if (!globalThis.sessionStorage) {
+  const sessionStore = new Map();
+  globalThis.sessionStorage = {
+    getItem: (key) => sessionStore.has(key) ? sessionStore.get(key) : null,
+    setItem: (key, value) => sessionStore.set(key, String(value)),
+    removeItem: (key) => sessionStore.delete(key),
+    clear: () => sessionStore.clear()
+  };
+}
+
+if (!globalThis.localStorage) {
+  const localStore = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => localStore.has(key) ? localStore.get(key) : null,
+    setItem: (key, value) => localStore.set(key, String(value)),
+    removeItem: (key) => localStore.delete(key),
+    clear: () => localStore.clear()
+  };
+}
+
+const { activitiesScreen } = await import('../frontend/src/screens/activities.js');
 
 function baseState() {
   return {
@@ -94,4 +115,60 @@ test('activity drawer uses instructor emp_id fallback for display consistency', 
   const source = await fs.readFile(new URL('../frontend/src/screens/shared/activity-detail-html.js', import.meta.url), 'utf8');
   assert.match(source, /function resolveInstructorDisplayName\(name, empId, lookup\)/);
   assert.match(source, /resolveInstructorDisplayName\(row\.instructor_name,\s*row\.emp_id,\s*instructorLookup\)/);
+});
+
+
+test('admin all-activities Excel export is imported and logs failures', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
+  assert.match(source, /import \{ exportActivitiesToExcel \} from '\.\/shared\/excel-export\.js';/);
+  assert.match(source, /data-activities-export-all/);
+  assert.match(source, /exportActivitiesToExcel\(Array\.isArray\(res\?\.rows\) \? res\.rows : \[\], 'כל_הפעילויות'\)/);
+  assert.match(source, /catch \(err\) \{[\s\S]*console\.error\('Failed to export all activities to Excel', err\);/);
+});
+
+test('all-activities Excel filename keeps Hebrew base and date stamp', async () => {
+  const { exportActivitiesToExcel } = await import('../frontend/src/screens/shared/excel-export.js');
+  const originalDocument = globalThis.document;
+  const originalUrl = globalThis.URL;
+  const originalBlob = globalThis.Blob;
+  const appended = [];
+  let downloaded = '';
+
+  class TestBlob {
+    constructor(parts, options) {
+      this.parts = parts;
+      this.options = options;
+    }
+  }
+
+  const anchor = {
+    set href(value) { this._href = value; },
+    set download(value) { downloaded = value; },
+    click() {},
+    remove() {}
+  };
+
+  globalThis.Blob = TestBlob;
+  globalThis.URL = {
+    createObjectURL() { return 'blob:test'; },
+    revokeObjectURL() {}
+  };
+  globalThis.document = {
+    createElement(tag) {
+      assert.equal(tag, 'a');
+      return anchor;
+    },
+    body: { appendChild(node) { appended.push(node); } }
+  };
+
+  try {
+    exportActivitiesToExcel([{ RowID: 'A1', activity_name: 'בדיקה' }], 'כל_הפעילויות');
+    assert.equal(appended.length, 1);
+    assert.match(downloaded, /^כל_הפעילויות_\d{4}-\d{2}-\d{2}\.xls$/);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.URL = originalUrl;
+    globalThis.Blob = originalBlob;
+  }
 });


### PR DESCRIPTION
### Motivation
- The admin toolbar button `data-activities-export-all` called `exportActivitiesToExcel` but the function was not imported, so the export action did nothing for admins.
- Failures during export could be swallowed silently, making troubleshooting difficult.
- Ensure the exported filename still uses the Hebrew base `כל_הפעילויות` with a date stamp so downloads remain predictable.

### Description
- Added `import { exportActivitiesToExcel } from './shared/excel-export.js';` to `frontend/src/screens/activities.js` so the export button can call the shared exporter. 
- Wrapped the export call in a `try/catch` and added `console.error('Failed to export all activities to Excel', err);` to surface errors instead of failing silently. 
- Added regression tests in `tests/activities-screen.test.mjs` to verify the import, the click-target `data-activities-export-all` wiring, the `catch` logging, and that the produced filename matches `כל_הפעילויות_YYYY-MM-DD.xls`. 
- Added small test setup shims for `sessionStorage`/`localStorage` in the test file so the module can be imported in Node test runs.

### Testing
- Ran the targeted test file with `node --test tests/activities-screen.test.mjs`, and the updated suite passed locally (7 tests, all passing). 
- Built the production bundle with `npm run build`, which completed successfully. 
- Running the full test suite via `npm test` expands to many unrelated tests and hit existing environment/API failures unrelated to this change, so the full-suite run was not used as validation for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0787288294832bb7578cf46182dc48)