### PR TITLE
Improve local search responsiveness

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -750,7 +750,7 @@ export const activitiesScreen = {
         .catch(() => {});
     }
 
-    bindLocalFilters(root, state, ACTIVITIES_SCOPE, rerenderLocal, { debounceMs: 450, onClear: () => {
+    bindLocalFilters(root, state, ACTIVITIES_SCOPE, rerenderLocal, { debounceMs: 150, onClear: () => {
       state.activityQuickFamily = '';
       state.activityQuickManager = '';
       state.activityEndingCurrentMonth = false;

--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -272,7 +272,7 @@ export const archiveScreen = {
     const rerenderLocal = () => rerender();
 
     bindLocalFilters(root, state, ARCHIVE_SCOPE, rerenderLocal, {
-      debounceMs: 450,
+      debounceMs: 150,
       onClear: () => { state.archiveYear = ''; }
     });
 

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -350,7 +350,7 @@ export const contactsScreen = {
         rerender();
       });
     });
-    bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, { debounceMs: 450 });
+    bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, { debounceMs: 150 });
 
     const bindCopyBtns = (container) => {
       container.querySelectorAll('[data-copy-email]').forEach((btn) => {

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -192,7 +192,7 @@ export const exceptionsScreen = {
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
     const allRows   = (Array.isArray(data?.rows) ? data.rows : []);
-    bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 450 });
+    bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 150 });
     root.querySelector(`[data-list-show-more="${EXCEPTIONS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, EXCEPTIONS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
       rerender();

--- a/frontend/src/screens/instructor-contacts.js
+++ b/frontend/src/screens/instructor-contacts.js
@@ -7,8 +7,8 @@ import {
   dsEmptyState,
   dsStatusChip
 } from './shared/layout.js';
-const MIN_SEARCH_CHARS = 4;
-const SEARCH_DEBOUNCE_MS = 450;
+const MIN_SEARCH_CHARS = 1;
+const SEARCH_DEBOUNCE_MS = 150;
 
 const AVATAR_PALETTE = [
   '#ef4444','#f97316','#eab308','#22c55e',
@@ -167,7 +167,6 @@ export const instructorContactsScreen = {
         apply();
         return;
       }
-      if (len < MIN_SEARCH_CHARS) return;
       searchTimer = setTimeout(apply, SEARCH_DEBOUNCE_MS);
     });
 

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -256,7 +256,7 @@ export const instructorsScreen = {
   },
 
   bind({ root, data, state, rerender, api }) {
-    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 450 });
+    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 150 });
     root.querySelector(`[data-list-show-more="${INSTRUCTORS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, INSTRUCTORS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
       rerender();

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -318,7 +318,7 @@ export const monthScreen = {
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const showPrivateNote = state?.user?.display_role === 'operation_manager';
-    bindLocalFilters(root, state, MONTH_SCOPE, rerender, { debounceMs: 450 });
+    bindLocalFilters(root, state, MONTH_SCOPE, rerender, { debounceMs: 150 });
     const cells = Array.isArray(data?.cells) ? data.cells : [];
     const itemsById = data?.items_by_id && typeof data.items_by_id === 'object' ? data.items_by_id : {};
     const allItemsByRowId = new Map();

--- a/frontend/src/screens/shared/activity-list-filters.js
+++ b/frontend/src/screens/shared/activity-list-filters.js
@@ -1,7 +1,7 @@
 import { escapeHtml } from './html.js';
 
-export const MIN_SEARCH_CHARS = 4;
-export const SEARCH_DEBOUNCE_MS = 450;
+export const MIN_SEARCH_CHARS = 1;
+export const SEARCH_DEBOUNCE_MS = 150;
 const DEFAULT_SEARCH_DEBOUNCE_MS = SEARCH_DEBOUNCE_MS;
 const DEFAULT_VISIBLE_LIMIT = 200;
 const FILTER_OPTIONS_CACHE = new WeakMap();
@@ -177,8 +177,8 @@ export function bindLocalFilters(root, state, scope, rerender, options = {}) {
     const cursorPos = ev.target?.selectionStart ?? nextValue.length;
     clearTimeout(searchTimer);
 
-    // Keep the typed value in state immediately, but only apply expensive
-    // filtering/rerendering when the query is empty or long enough.
+    // Keep the typed value in state immediately and debounce only the local
+    // filtering/rerendering work so one-character searches feel responsive.
     filters.q = nextValue;
 
     const apply = () => {
@@ -193,13 +193,11 @@ export function bindLocalFilters(root, state, scope, rerender, options = {}) {
     };
 
     const trimmedLength = normalizeText(nextValue).length;
-    if (trimmedLength === 0) {
+    if (trimmedLength === 0 || debounceMs <= 0) {
       apply();
       return;
     }
-    if (trimmedLength < MIN_SEARCH_CHARS) return;
-    if (debounceMs <= 0) apply();
-    else searchTimer = setTimeout(apply, debounceMs);
+    searchTimer = setTimeout(apply, debounceMs);
   });
 
   root.querySelectorAll(`[data-filter-scope="${scope}"][data-filter-field]`).forEach((node) => {

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -304,7 +304,7 @@ export const weekScreen = {
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const showPrivateNote = state?.user?.display_role === 'operation_manager';
-    bindLocalFilters(root, state, WEEK_SCOPE, rerender, { debounceMs: 450 });
+    bindLocalFilters(root, state, WEEK_SCOPE, rerender, { debounceMs: 150 });
 
     const bindActivityEditForm = (contentRoot) =>
       bindActivityEditFormShared(contentRoot, { api, ui, clearScreenDataCache, rerender, onRowSaved: (p) => patchCachedActivityDetail(p, state) });

--- a/tests/activity-list-filters-search.test.mjs
+++ b/tests/activity-list-filters-search.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import {
+  MIN_SEARCH_CHARS,
+  SEARCH_DEBOUNCE_MS,
+  applyLocalFilters,
+  bindLocalFilters,
+  ensureActivityListFilters,
+  prepareRowsForSearch
+} from '../frontend/src/screens/shared/activity-list-filters.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test('local activity filters search from the first Hebrew character on prepared rows', () => {
+  const rows = prepareRowsForSearch([
+    { RowID: 11, activity_name: 'כדורגל', authority: 'חיפה', school: 'אלון', instructor_name: 'דנה' },
+    { RowID: 12, activity_name: 'מחול', authority: 'נתניה', school: 'ברוש', instructor_name: 'נועה' }
+  ], ['RowID', 'activity_name', 'authority', 'school', 'instructor_name']);
+
+  assert.equal(MIN_SEARCH_CHARS, 1);
+  assert.deepEqual(
+    applyLocalFilters(rows, { appliedQ: 'כ' }).map((row) => row.RowID),
+    [11]
+  );
+  assert.deepEqual(
+    applyLocalFilters(rows, { appliedQ: 'ני' }).map((row) => row.RowID),
+    [12]
+  );
+});
+
+test('existing one-character query is preserved as applied search state', () => {
+  const state = { listFilters: { activities: { q: 'ד', visibleCount: 200 } } };
+  const filters = ensureActivityListFilters(state, 'activities');
+
+  assert.equal(filters.appliedQ, 'ד');
+});
+
+test('bindLocalFilters debounces one-character searches locally without calling external loaders', async () => {
+  const dom = new JSDOM('<div><input data-filter-search="activities" value=""><button data-filter-clear="activities"></button></div>');
+  const root = dom.window.document.querySelector('div');
+  const input = root.querySelector('[data-filter-search="activities"]');
+  const state = {};
+  let renderCount = 0;
+  let loaderCount = 0;
+
+  bindLocalFilters(root, state, 'activities', () => {
+    renderCount += 1;
+  }, { debounceMs: 150, onClear: () => { loaderCount += 1; } });
+
+  input.value = 'א';
+  input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+
+  assert.equal(state.listFilters.activities.q, 'א');
+  assert.equal(state.listFilters.activities.appliedQ, '');
+  assert.equal(renderCount, 0);
+  assert.equal(loaderCount, 0);
+
+  await sleep(SEARCH_DEBOUNCE_MS + 40);
+
+  assert.equal(state.listFilters.activities.appliedQ, 'א');
+  assert.equal(renderCount, 1);
+  assert.equal(loaderCount, 0);
+});


### PR DESCRIPTION
### Motivation
- Make local list search responsive from the first typed character while keeping filtering strictly client-side and avoiding extra API calls or dashboard reloads.

### Description
- Lower shared search thresholds to `MIN_SEARCH_CHARS = 1` and `SEARCH_DEBOUNCE_MS = 150` in `frontend/src/screens/shared/activity-list-filters.js` to allow single-character searches with a short debounce.
- Remove the minimum-length gating in `bindLocalFilters` so `filters.q` is updated immediately and the expensive apply/rerender step is debounced (local-only), preserving `filters.appliedQ` semantics.
- Update all callers to use the shorter debounce (`debounceMs: 150`) in screens that bind local filters (`activities`, `month`, `week`, `instructors`, `exceptions`, `archive`, `contacts`) and adjust `instructor-contacts` local search to the new `MIN_SEARCH_CHARS`/debounce behavior.
- Preserve client-side-only behavior by continuing to use `prepareRowsForSearch`, `applyLocalFilters` and `splitVisibleRows` so no API/fetch is triggered by typing and large renders are avoided via pagination/“show more”.

### Testing
- Ran the focused regression tests with `node --test tests/activity-list-filters-search.test.mjs` and all tests passed (3/3).
- Built the production bundle with `npm run build` and the build completed successfully.
- Verified no remaining stale search thresholds with a `rg` check for old constants (`MIN_SEARCH_CHARS = [2-9]` / `SEARCH_DEBOUNCE_MS = 450` / `debounceMs: 450`), which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078a611a2c832bb1cbffaefa43aa84)