### PR TITLE
Add admin-only Activities summary and compact Excel export

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 349;
+const CACHE_VERSION = 350;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DqD--Ecx.js",
+  "./assets/index-BrMp3EPI.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-B7PL3snU.css",
+  "./assets/style-CM6Hboyi.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DqD--Ecx.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-B7PL3snU.css">
+  <script type="module" crossorigin src="./assets/index-BrMp3EPI.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-CM6Hboyi.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 349;
+const CACHE_VERSION = 350;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DqD--Ecx.js",
+  "./assets/index-BrMp3EPI.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-B7PL3snU.css",
+  "./assets/style-CM6Hboyi.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -36,6 +36,133 @@ import {
 } from './shared/activity-options.js';
 
 const inflightActivityDetailRequests = new Map();
+
+const ADMIN_SUMMARY_TYPES = [
+  { key: 'course', label: 'קורסים' },
+  { key: 'workshop', label: 'סדנאות' },
+  { key: 'tour', label: 'סיורים' },
+  { key: 'after_school', label: 'אפטרסקול' }
+];
+const ADMIN_SUMMARY_TYPE_LABEL_BY_KEY = Object.fromEntries(ADMIN_SUMMARY_TYPES.map((item) => [item.key, item.label]));
+const ADMIN_SUMMARY_DISTRICTS = ['מחוז צפון', 'מחוז דרום'];
+const ADMIN_SUMMARY_DISTRICT_FIELDS = ['district', 'region', 'area', 'authority_district'];
+
+function isAdminUser(state) {
+  return state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
+}
+
+function normalizeAdminSummaryText(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function normalizeAdminSummarySearchText(value) {
+  return normalizeAdminSummaryText(value).toLowerCase().replace(/[\s_\-]+/g, '');
+}
+
+function normalizeAdminActivityType(value) {
+  const raw = normalizeAdminSummaryText(value);
+  const compact = normalizeAdminSummarySearchText(raw);
+  if (['course', 'courses', 'קורס', 'קורסים'].includes(compact)) return { key: 'course', label: 'קורסים' };
+  if (['workshop', 'workshops', 'סדנה', 'סדנאות'].includes(compact)) return { key: 'workshop', label: 'סדנאות' };
+  if (['tour', 'tours', 'סיור', 'סיורים', 'טיול', 'טיולים'].includes(compact)) return { key: 'tour', label: 'סיורים' };
+  if (['afterschool', 'after_school', 'חוגאפטרסקול', 'אפטרסקול'].map(normalizeAdminSummarySearchText).includes(compact)) {
+    return { key: 'after_school', label: 'אפטרסקול' };
+  }
+  return { key: 'other', label: raw || 'אחר' };
+}
+
+function normalizeAdminDistrict(row = {}) {
+  const raw = ADMIN_SUMMARY_DISTRICT_FIELDS.map((field) => normalizeAdminSummaryText(row?.[field])).find(Boolean) || '';
+  const compact = normalizeAdminSummarySearchText(raw);
+  if (!compact) return 'ללא מחוז';
+  if (compact.includes('צפון') || compact.includes('north')) return 'מחוז צפון';
+  if (compact.includes('דרום') || compact.includes('south')) return 'מחוז דרום';
+  return raw;
+}
+
+function createAdminSummaryBucket(label) {
+  return {
+    label,
+    counts: { course: 0, workshop: 0, tour: 0, after_school: 0, other: 0, total: 0 },
+    byName: new Map()
+  };
+}
+
+function addRowToAdminSummaryBucket(bucket, row = {}) {
+  const type = normalizeAdminActivityType(row.activity_type || row.activity_family || row.type);
+  const name = normalizeAdminSummaryText(row.activity_name || row.name || row.program_name) || 'ללא שם פעילות';
+  bucket.counts.total += 1;
+  bucket.counts[type.key] = (bucket.counts[type.key] || 0) + 1;
+  const detailKey = `${name}|${type.key}|${type.label}`;
+  const existing = bucket.byName.get(detailKey) || { name, typeKey: type.key, typeLabel: type.label, count: 0 };
+  existing.count += 1;
+  bucket.byName.set(detailKey, existing);
+}
+
+function buildAdminActivitiesSummary(rows) {
+  const buckets = new Map();
+  ADMIN_SUMMARY_DISTRICTS.forEach((label) => buckets.set(label, createAdminSummaryBucket(label)));
+  const total = createAdminSummaryBucket('סה״כ כללי');
+  (Array.isArray(rows) ? rows : []).forEach((row) => {
+    const district = normalizeAdminDistrict(row);
+    if (!buckets.has(district)) buckets.set(district, createAdminSummaryBucket(district));
+    addRowToAdminSummaryBucket(buckets.get(district), row);
+    addRowToAdminSummaryBucket(total, row);
+  });
+  const districtBuckets = Array.from(buckets.values()).filter((bucket) => ADMIN_SUMMARY_DISTRICTS.includes(bucket.label) || bucket.counts.total > 0);
+  return { districts: districtBuckets, total };
+}
+
+function adminSummaryCountsHtml(bucket) {
+  const other = Number(bucket?.counts?.other || 0);
+  return `<div class="ds-admin-summary__kpis">
+    ${ADMIN_SUMMARY_TYPES.map(({ key, label }) => `<div class="ds-admin-summary__kpi"><span>${escapeHtml(label)}</span><strong>${escapeHtml(String(bucket?.counts?.[key] || 0))}</strong></div>`).join('')}
+    ${other > 0 ? `<div class="ds-admin-summary__kpi"><span>אחר</span><strong>${escapeHtml(String(other))}</strong></div>` : ''}
+    <div class="ds-admin-summary__kpi ds-admin-summary__kpi--total"><span>סה״כ כל הפעילויות</span><strong>${escapeHtml(String(bucket?.counts?.total || 0))}</strong></div>
+  </div>`;
+}
+
+function adminSummaryDetailsHtml(bucket) {
+  const rows = Array.from(bucket?.byName?.values?.() || [])
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, 'he'));
+  if (!rows.length) return '<p class="ds-admin-summary__empty">אין פעילויות להצגה.</p>';
+  return `<ul class="ds-admin-summary__details">
+    ${rows.map((item) => {
+      const typeLabel = ADMIN_SUMMARY_TYPE_LABEL_BY_KEY[item.typeKey] || item.typeLabel || 'אחר';
+      return `<li><span>${escapeHtml(item.name)}</span><strong>${escapeHtml(String(item.count))} ${escapeHtml(typeLabel)}</strong></li>`;
+    }).join('')}
+  </ul>`;
+}
+
+function adminSummarySectionHtml(bucket, { total = false } = {}) {
+  return `<section class="ds-admin-summary__section${total ? ' ds-admin-summary__section--total' : ''}" dir="rtl">
+    <h3>${escapeHtml(bucket.label)}</h3>
+    ${adminSummaryCountsHtml(bucket)}
+    <h4>פירוט לפי שם פעילות</h4>
+    ${adminSummaryDetailsHtml(bucket)}
+  </section>`;
+}
+
+function adminSummaryLoadingHtml() {
+  return '<div class="ds-admin-summary" dir="rtl"><p class="ds-admin-summary__loading">טוען סיכום…</p></div>';
+}
+
+function adminSummaryErrorHtml() {
+  return '<div class="ds-admin-summary" dir="rtl"><p class="ds-admin-summary__error">לא ניתן לטעון את סיכום האדמין כרגע</p></div>';
+}
+
+function renderAdminActivitiesSummary(rows) {
+  const summary = buildAdminActivitiesSummary(rows);
+  return `<div class="ds-admin-summary" dir="rtl">
+    <header class="ds-admin-summary__intro">
+      <h2>סיכום אדמין – כלל הפעילויות</h2>
+      <p>הסיכום מבוסס על כלל הפעילויות שהוחזרו מהמערכת, ללא סינון חודש או סטטוס.</p>
+    </header>
+    ${summary.districts.map((bucket) => adminSummarySectionHtml(bucket)).join('')}
+    ${adminSummarySectionHtml(summary.total, { total: true })}
+  </div>`;
+}
+
 const ACTIVITIES_SCOPE = 'activities';
 const ACTIVITY_FILTER_FIELDS = [
   { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
@@ -459,7 +586,7 @@ export const activitiesScreen = {
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canAddActivity = !!state?.user?.can_add_activity;
-    const isAdmin = state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
+    const isAdmin = isAdminUser(state);
 
     const rosterUsers = getRosterUsers(state?.clientSettings || {});
     const instructorByEmpId = rosterUsers.reduce((acc, user) => {
@@ -559,7 +686,7 @@ export const activitiesScreen = {
       ${bareFilters}
       <div class="ds-activities-main-toolbar__actions">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
-        ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activities-export-all title="ייצוא כל הפעילויות לאקסל">ייצוא כל הפעילויות לאקסל</button>` : ''}
+        ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-export-all title="ייצוא כל הפעילויות לאקסל">ייצוא לאקסל</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-admin-summary title="סיכום אדמין לכלל הפעילויות">סיכום אדמין</button>` : ''}
         ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">+</button>` : ''}
       </div>
     </div>`;
@@ -588,7 +715,7 @@ export const activitiesScreen = {
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
     const canAddActivity = !!state?.user?.can_add_activity;
-    const isAdmin = state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
+    const isAdmin = isAdminUser(state);
 
     const rerenderLocal = () => {
       if (typeof rerenderActivitiesView === 'function') rerenderActivitiesView();
@@ -770,6 +897,10 @@ export const activitiesScreen = {
       }, Math.max(0, minMs - (Date.now() - startedAt)));
     };
 
+    async function loadAllActivitiesForAdmin() {
+      return typeof api.allActivities === 'function' ? api.allActivities() : api.activities({ activity_type: 'all' });
+    }
+
     root.querySelector('[data-activities-export-all]')?.addEventListener('click', async (ev) => {
       if (!isAdmin) return;
       const btn = ev.currentTarget;
@@ -777,13 +908,31 @@ export const activitiesScreen = {
       const originalText = btn.textContent;
       btn.textContent = 'מייצא…';
       try {
-        const res = await (typeof api.allActivities === 'function' ? api.allActivities() : api.activities({ activity_type: 'all' }));
+        const res = await loadAllActivitiesForAdmin();
         exportActivitiesToExcel(Array.isArray(res?.rows) ? res.rows : [], 'כל_הפעילויות');
       } catch (err) {
         console.error('Failed to export all activities to Excel', err);
       } finally {
         btn.disabled = false;
         btn.textContent = originalText;
+      }
+    });
+
+    root.querySelector('[data-activities-admin-summary]')?.addEventListener('click', async (ev) => {
+      if (!isAdmin || !ui) return;
+      const btn = ev.currentTarget;
+      btn.disabled = true;
+      ui.openDrawer({ title: 'סיכום אדמין – כלל הפעילויות', content: adminSummaryLoadingHtml() });
+      try {
+        const res = await loadAllActivitiesForAdmin();
+        const drawerContent = document.querySelector('.ds-drawer__content');
+        if (drawerContent) drawerContent.innerHTML = renderAdminActivitiesSummary(Array.isArray(res?.rows) ? res.rows : []);
+      } catch (err) {
+        console.error('[admin-summary:failed]', err);
+        const drawerContent = document.querySelector('.ds-drawer__content');
+        if (drawerContent) drawerContent.innerHTML = adminSummaryErrorHtml();
+      } finally {
+        btn.disabled = false;
       }
     });
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9263,3 +9263,129 @@ select.ds-activity-add-field .ds-input,
 .instr-page .instr-stat__lbl {
   display: none;
 }
+
+/* Admin-only compact actions and summary drawer for the activities toolbar. */
+.ds-activities-main-toolbar__actions .ds-activities-toolbar-btn {
+  width: auto;
+  min-width: 0;
+  max-width: 8.5rem;
+  padding-inline: 0.75rem;
+  white-space: nowrap;
+}
+
+.ds-admin-summary {
+  display: grid;
+  gap: 1rem;
+  direction: rtl;
+}
+
+.ds-admin-summary__intro h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.2rem;
+}
+
+.ds-admin-summary__intro p,
+.ds-admin-summary__loading,
+.ds-admin-summary__empty {
+  margin: 0;
+  color: var(--muted, #64748b);
+}
+
+.ds-admin-summary__error {
+  margin: 0;
+  color: var(--danger, #b91c1c);
+  font-weight: 700;
+}
+
+.ds-admin-summary__section {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 14px;
+  background: var(--surface, #fff);
+}
+
+.ds-admin-summary__section--total {
+  border-color: rgba(37, 99, 235, 0.3);
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.ds-admin-summary__section h3,
+.ds-admin-summary__section h4 {
+  margin: 0;
+}
+
+.ds-admin-summary__section h3 {
+  font-size: 1.05rem;
+}
+
+.ds-admin-summary__section h4 {
+  font-size: 0.95rem;
+  color: var(--muted, #64748b);
+}
+
+.ds-admin-summary__kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7.25rem, 1fr));
+  gap: 0.55rem;
+}
+
+.ds-admin-summary__kpi {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem;
+  border-radius: 12px;
+  background: var(--surface-muted, #f8fafc);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.ds-admin-summary__kpi span {
+  font-size: 0.82rem;
+  color: var(--muted, #64748b);
+}
+
+.ds-admin-summary__kpi strong {
+  font-size: 1.2rem;
+}
+
+.ds-admin-summary__kpi--total {
+  background: rgba(16, 185, 129, 0.08);
+}
+
+.ds-admin-summary__details {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ds-admin-summary__details li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.ds-admin-summary__details li:last-child {
+  border-bottom: 0;
+}
+
+.ds-admin-summary__details strong {
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .ds-activities-main-toolbar__actions .ds-activities-toolbar-btn {
+    flex: 0 0 auto;
+    max-width: 8rem;
+  }
+
+  .ds-admin-summary__details li {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 349;
+const CACHE_VERSION = 350;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -98,6 +98,37 @@ test('activities table keeps expected columns structure', () => {
 });
 
 
+test('activities render: admin sees compact Excel export and admin summary buttons', () => {
+  const html = activitiesScreen.render({ rows: [] }, { state: baseState() });
+  assert.match(html, /data-activities-export-all/);
+  assert.match(html, />ייצוא לאקסל<\/button>/);
+  assert.match(html, /data-activities-admin-summary/);
+  assert.match(html, />סיכום אדמין<\/button>/);
+  assert.doesNotMatch(html, /ייצוא כל הפעילויות לאקסל<\/button>/);
+});
+
+test('activities render: non-admin does not see admin toolbar buttons', () => {
+  const state = baseState();
+  state.user = { display_role: 'authorized_user', role: 'authorized_user', can_add_activity: false };
+  const html = activitiesScreen.render({ rows: [] }, { state });
+  assert.doesNotMatch(html, /data-activities-export-all/);
+  assert.doesNotMatch(html, /data-activities-admin-summary/);
+  assert.doesNotMatch(html, /ייצוא לאקסל/);
+  assert.doesNotMatch(html, /סיכום אדמין/);
+});
+
+test('activities source includes admin summary all-activities loading and district/type safeguards', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
+  assert.match(source, /function buildAdminActivitiesSummary\(rows\)/);
+  assert.match(source, /api\.allActivities/);
+  assert.match(source, /טוען סיכום…/);
+  assert.match(source, /\[admin-summary:failed\]/);
+  assert.match(source, /ADMIN_SUMMARY_DISTRICT_FIELDS = \['district', 'region', 'area', 'authority_district'\]/);
+  assert.match(source, /course[\s\S]*workshop[\s\S]*tour[\s\S]*after_school/);
+});
+
+
 
 
 


### PR DESCRIPTION
### Motivation
- Provide an admin-only summary view that aggregates all activities (active + archived) across districts and activity types without changing existing list/month UI behavior.
- Make the existing "export all activities" toolbar action compact and labeled `"ייצוא לאקסל"` while preserving its export logic.
- Ensure updates are picked up by clients by bumping the Service Worker cache version so updated JS/CSS are loaded after deploy.

### Description
- Added an admin-detection helper and admin-only UI in `frontend/src/screens/activities.js`, exposing two compact toolbar buttons for admins: `data-activities-export-all` (text changed to `"ייצוא לאקסל"`) and a new `data-activities-admin-summary` button that opens a drawer with the admin summary. (Uses `isAdminUser(state)`.)
- Implemented summary-build logic in `frontend/src/screens/activities.js` that loads all activities on demand via `api.allActivities()` (falls back to `api.activities({ activity_type: 'all' })`), groups activities by district (checks `district`, `region`, `area`, `authority_district` fields with a sensible fallback to `"ללא מחוז"`), counts types (mapped to `course`, `workshop`, `tour`, `after_school` + `other`) and produces per-name breakdowns; UI rendering helpers include loading and error states and console error logging (`[admin-summary:failed]`).
- Kept existing export logic unchanged: the export still fetches the full activities payload and calls `exportActivitiesToExcel(...)` in `frontend/src/screens/shared/excel-export.js`.
- Added compact toolbar/button styles and admin-summary drawer styles to `frontend/src/styles/main.css` and mobile-friendly adjustments to avoid breaking the toolbar layout.
- Bumped Service Worker `CACHE_VERSION` in `frontend/sw.js` (and rebuilt `dist` files), updating precache references to the new build assets so clients/PWA will fetch the new files.
- Added unit tests in `tests/activities-screen.test.mjs` to assert admin/non-admin visibility of toolbar buttons and to verify the presence of admin summary code and safeguards.

### Testing
- Ran the focused activities screen tests with `node --test tests/activities-screen.test.mjs`, which passed (new admin-related tests included) — 10 tests passed for the activities screen.
- Built production assets with `npm run build`, which succeeded and updated `dist` files and asset references used by the Service Worker.
- Ran the full test suite (`npm test` / `timeout 25 npm test`) while observing unrelated failures/timeouts in other snapshot/API mutation tests (these failures are pre-existing and not related to the activities screen changes); the activities-screen tests and the new tests passed before the timeout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078f6858a4832bad51805ebecb9f4f)