### PR TITLE
Fix admin activities summary grouping

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -429,7 +429,7 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
     return getItems(...keys).map((i) => i.value).filter(Boolean);
   }
 
-  const managerItems    = getItems('activity_manager', 'activity_managers', 'manager', 'managers');
+  const managerItems    = getItems('activity_manager', 'activity_managers', 'activities_manager_users', 'activity_manager_users', 'manager', 'managers');
   const instructorItems = getItems('instructor_users', 'instructor_name', 'instructor', 'instructors', 'instructor_names');
   const activityNameItems = getItems('activity_names', 'activity_name', 'activities', 'activity');
   const fundingValues   = getValues('funding', 'fundings');
@@ -467,11 +467,27 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
     .filter(managerIsActive)
     .map((i) => cleanActivityManagerName(i.value || i.label))
     .filter(Boolean);
-  const managerUsers = managerItems.map((i) => ({
-    name: cleanActivityManagerName(i.value || i.label),
-    is_active: managerIsActive(i),
-    active: i.active,
-  })).filter((user) => user.name);
+  const managerUsers = managerItems.map((i) => {
+    const row = i?._row && typeof i._row === 'object' ? i._row : {};
+    return {
+      name: cleanActivityManagerName(i.value || i.label),
+      value: i.value,
+      label: i.label,
+      is_active: managerIsActive(i),
+      active: i.active,
+      district: row.district,
+      region: row.region,
+      area: row.area,
+      group: row.group,
+      parent_value: row.parent_value,
+      metadata: row.metadata,
+      zone: row.zone,
+      manager_district: row.manager_district,
+      activity_manager_district: row.activity_manager_district,
+      manager_region: row.manager_region,
+      activity_manager_region: row.activity_manager_region,
+    };
+  }).filter((user) => user.name);
 
   return {
     dropdown_options: {

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -25,6 +25,7 @@ import {
 } from './shared/activity-list-filters.js';
 import {
   activityManagerDisplayName,
+  cleanActivityManagerName,
   getActivityCatalog,
   getActivityTypesByFamily,
   getActivityNamesForType,
@@ -45,7 +46,17 @@ const ADMIN_SUMMARY_TYPES = [
 ];
 const ADMIN_SUMMARY_TYPE_LABEL_BY_KEY = Object.fromEntries(ADMIN_SUMMARY_TYPES.map((item) => [item.key, item.label]));
 const ADMIN_SUMMARY_DISTRICTS = ['מחוז צפון', 'מחוז דרום'];
-const ADMIN_SUMMARY_DISTRICT_FIELDS = ['district', 'region', 'area', 'authority_district'];
+const ADMIN_SUMMARY_UNASSIGNED_DISTRICT = 'ללא מחוז';
+const ADMIN_SUMMARY_MANAGER_LIST_FIELDS = [
+  'district', 'region', 'area', 'group', 'parent_value', 'metadata', 'zone',
+  'manager_district', 'activity_manager_district', 'manager_region', 'activity_manager_region'
+];
+const ADMIN_SUMMARY_MANAGER_NAME_FIELDS = ['name', 'value', 'label', 'activity_manager', 'manager', 'full_name'];
+const ADMIN_SUMMARY_DEDUPE_ID_FIELDS = ['RowID', 'row_id', 'source_row_id'];
+const ADMIN_SUMMARY_DEDUPE_FALLBACK_FIELDS = ['activity_name', 'activity_type', 'school', 'authority', 'start_date', 'end_date'];
+const ADMIN_SUMMARY_MANAGER_OPTION_KEYS = [
+  'activities_manager_users', 'activity_manager_users', 'activity_manager', 'activity_managers', 'manager', 'managers'
+];
 
 function isAdminUser(state) {
   return state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
@@ -71,13 +82,105 @@ function normalizeAdminActivityType(value) {
   return { key: 'other', label: raw || 'אחר' };
 }
 
-function normalizeAdminDistrict(row = {}) {
-  const raw = ADMIN_SUMMARY_DISTRICT_FIELDS.map((field) => normalizeAdminSummaryText(row?.[field])).find(Boolean) || '';
+function normalizeAdminDistrictValue(value) {
+  const raw = normalizeAdminSummaryText(value);
   const compact = normalizeAdminSummarySearchText(raw);
-  if (!compact) return 'ללא מחוז';
+  if (!compact) return '';
   if (compact.includes('צפון') || compact.includes('north')) return 'מחוז צפון';
   if (compact.includes('דרום') || compact.includes('south')) return 'מחוז דרום';
-  return raw;
+  return '';
+}
+
+function adminSummaryCandidateValues(value) {
+  if (value == null) return [];
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return [value];
+  if (Array.isArray(value)) return value.flatMap((item) => adminSummaryCandidateValues(item));
+  if (typeof value === 'object') {
+    const direct = [];
+    ADMIN_SUMMARY_MANAGER_LIST_FIELDS.forEach((field) => {
+      if (field in value) direct.push(...adminSummaryCandidateValues(value[field]));
+    });
+    return direct;
+  }
+  return [];
+}
+
+function resolveAdminSummaryManagerDistrict(managerItem = {}) {
+  const row = managerItem?._row && typeof managerItem._row === 'object' ? managerItem._row : null;
+  const sources = [managerItem, row].filter(Boolean);
+  for (const source of sources) {
+    for (const field of ADMIN_SUMMARY_MANAGER_LIST_FIELDS) {
+      const values = adminSummaryCandidateValues(source?.[field]);
+      for (const value of values) {
+        const district = normalizeAdminDistrictValue(value);
+        if (district) return district;
+      }
+    }
+  }
+  return '';
+}
+
+function managerNamesFromSettingsItem(item) {
+  const row = item?._row && typeof item._row === 'object' ? item._row : null;
+  const sources = [item, row].filter(Boolean);
+  const names = [];
+  sources.forEach((source) => {
+    ADMIN_SUMMARY_MANAGER_NAME_FIELDS.forEach((field) => {
+      const clean = cleanActivityManagerName(source?.[field]);
+      if (clean) names.push(clean);
+    });
+  });
+  if (typeof item === 'string') {
+    const clean = cleanActivityManagerName(item);
+    if (clean) names.push(clean);
+  }
+  return names;
+}
+
+function buildAdminSummaryManagerDistrictLookup(settings = {}) {
+  const lookup = new Map();
+  const options = settings?.dropdown_options || {};
+  ADMIN_SUMMARY_MANAGER_OPTION_KEYS.forEach((key) => {
+    const list = Array.isArray(options?.[key]) ? options[key] : [];
+    list.forEach((item) => {
+      const district = resolveAdminSummaryManagerDistrict(item);
+      if (!district) return;
+      managerNamesFromSettingsItem(item).forEach((name) => {
+        lookup.set(normalizeAdminSummarySearchText(name), district);
+      });
+    });
+  });
+  return lookup;
+}
+
+function adminSummaryRowManagerName(row = {}) {
+  return cleanActivityManagerName(row.activity_manager || row.manager_name || row.manager || row.activityManager);
+}
+
+function normalizeAdminDistrict(row = {}, managerDistrictLookup = new Map()) {
+  const managerName = adminSummaryRowManagerName(row);
+  if (!managerName) return ADMIN_SUMMARY_UNASSIGNED_DISTRICT;
+  return managerDistrictLookup.get(normalizeAdminSummarySearchText(managerName)) || ADMIN_SUMMARY_UNASSIGNED_DISTRICT;
+}
+
+function adminSummaryDedupeKey(row = {}) {
+  for (const field of ADMIN_SUMMARY_DEDUPE_ID_FIELDS) {
+    const value = normalizeAdminSummaryText(row?.[field]);
+    if (value) return `id:${field}:${value}`;
+  }
+  return `fallback:${ADMIN_SUMMARY_DEDUPE_FALLBACK_FIELDS.map((field) => normalizeAdminSummarySearchText(row?.[field])).join('|')}`;
+}
+
+function uniqueAdminSummaryRows(rows) {
+  const seen = new Set();
+  const unique = [];
+  (Array.isArray(rows) ? rows : []).forEach((row) => {
+    const key = adminSummaryDedupeKey(row);
+    if (seen.has(key)) return;
+    seen.add(key);
+    unique.push(row);
+  });
+  return unique;
 }
 
 function createAdminSummaryBucket(label) {
@@ -93,23 +196,28 @@ function addRowToAdminSummaryBucket(bucket, row = {}) {
   const name = normalizeAdminSummaryText(row.activity_name || row.name || row.program_name) || 'ללא שם פעילות';
   bucket.counts.total += 1;
   bucket.counts[type.key] = (bucket.counts[type.key] || 0) + 1;
-  const detailKey = `${name}|${type.key}|${type.label}`;
+  const detailKey = `${name}|${type.key}`;
   const existing = bucket.byName.get(detailKey) || { name, typeKey: type.key, typeLabel: type.label, count: 0 };
   existing.count += 1;
   bucket.byName.set(detailKey, existing);
 }
 
-function buildAdminActivitiesSummary(rows) {
+function buildAdminActivitiesSummary(rows, settings = {}) {
   const buckets = new Map();
   ADMIN_SUMMARY_DISTRICTS.forEach((label) => buckets.set(label, createAdminSummaryBucket(label)));
   const total = createAdminSummaryBucket('סה״כ כללי');
-  (Array.isArray(rows) ? rows : []).forEach((row) => {
-    const district = normalizeAdminDistrict(row);
+  const managerDistrictLookup = buildAdminSummaryManagerDistrictLookup(settings);
+  uniqueAdminSummaryRows(rows).forEach((row) => {
+    const district = normalizeAdminDistrict(row, managerDistrictLookup);
     if (!buckets.has(district)) buckets.set(district, createAdminSummaryBucket(district));
     addRowToAdminSummaryBucket(buckets.get(district), row);
     addRowToAdminSummaryBucket(total, row);
   });
-  const districtBuckets = Array.from(buckets.values()).filter((bucket) => ADMIN_SUMMARY_DISTRICTS.includes(bucket.label) || bucket.counts.total > 0);
+  const districtBuckets = ADMIN_SUMMARY_DISTRICTS
+    .map((label) => buckets.get(label))
+    .filter(Boolean);
+  const unassigned = buckets.get(ADMIN_SUMMARY_UNASSIGNED_DISTRICT);
+  if (unassigned?.counts?.total > 0) districtBuckets.push(unassigned);
   return { districts: districtBuckets, total };
 }
 
@@ -151,8 +259,8 @@ function adminSummaryErrorHtml() {
   return '<div class="ds-admin-summary" dir="rtl"><p class="ds-admin-summary__error">לא ניתן לטעון את סיכום האדמין כרגע</p></div>';
 }
 
-function renderAdminActivitiesSummary(rows) {
-  const summary = buildAdminActivitiesSummary(rows);
+function renderAdminActivitiesSummary(rows, settings = {}) {
+  const summary = buildAdminActivitiesSummary(rows, settings);
   return `<div class="ds-admin-summary" dir="rtl">
     <header class="ds-admin-summary__intro">
       <h2>סיכום אדמין – כלל הפעילויות</h2>
@@ -926,7 +1034,7 @@ export const activitiesScreen = {
       try {
         const res = await loadAllActivitiesForAdmin();
         const drawerContent = document.querySelector('.ds-drawer__content');
-        if (drawerContent) drawerContent.innerHTML = renderAdminActivitiesSummary(Array.isArray(res?.rows) ? res.rows : []);
+        if (drawerContent) drawerContent.innerHTML = renderAdminActivitiesSummary(Array.isArray(res?.rows) ? res.rows : [], state?.clientSettings || {});
       } catch (err) {
         console.error('[admin-summary:failed]', err);
         const drawerContent = document.querySelector('.ds-drawer__content');

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 350;
+const CACHE_VERSION = 351;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -120,12 +120,17 @@ test('activities render: non-admin does not see admin toolbar buttons', () => {
 test('activities source includes admin summary all-activities loading and district/type safeguards', async () => {
   const fs = await import('node:fs/promises');
   const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
-  assert.match(source, /function buildAdminActivitiesSummary\(rows\)/);
+  assert.match(source, /function buildAdminActivitiesSummary\(rows, settings = \{\}\)/);
   assert.match(source, /api\.allActivities/);
   assert.match(source, /טוען סיכום…/);
   assert.match(source, /\[admin-summary:failed\]/);
-  assert.match(source, /ADMIN_SUMMARY_DISTRICT_FIELDS = \['district', 'region', 'area', 'authority_district'\]/);
+  assert.match(source, /ADMIN_SUMMARY_MANAGER_LIST_FIELDS = \[[\s\S]*'district'[\s\S]*'region'[\s\S]*'area'[\s\S]*'group'[\s\S]*'parent_value'[\s\S]*'metadata'[\s\S]*'zone'/);
   assert.match(source, /course[\s\S]*workshop[\s\S]*tour[\s\S]*after_school/);
+
+  assert.match(source, /buildAdminSummaryManagerDistrictLookup\(settings\)/);
+  assert.match(source, /uniqueAdminSummaryRows\(rows\)/);
+  assert.match(source, /ADMIN_SUMMARY_DEDUPE_ID_FIELDS = \['RowID', 'row_id', 'source_row_id'\]/);
+  assert.match(source, /activity_name', 'activity_type', 'school', 'authority', 'start_date', 'end_date'/);
 });
 
 


### PR DESCRIPTION
### Motivation

- Ensure the Admin Summary button produces a correct, deduplicated summary of all activities using only `api.allActivities()` and existing client settings from Supabase lists. 
- Use the manager->district mapping only when that mapping already exists in the lists data, and avoid any hard-coded manager-to-district mapping or DB schema changes.
- Prevent duplicate counting of the same activity across sources and provide a clear “ללא מחוז” bucket for managers that cannot be assigned.

### Description

- Updated `frontend/src/screens/activities.js` to add deduplication (`ADMIN_SUMMARY_DEDUPE_*`), a manager-district lookup built from `state.clientSettings.dropdown_options`, and new logic to assign activities to `מחוז צפון` / `מחוז דרום` or `ללא מחוז` only when list metadata provides it; the admin summary rendering now accepts `settings` and uses `buildAdminActivitiesSummary(rows, settings)`.
- Added helper functions in `activities.js` to extract candidate district fields from manager list rows, normalize types, compute a stable dedupe key (id fields then fallback), and produce unique rows prior to counting and grouping by normalized activity type and name.
- Extended `frontend/src/api.js`'s `buildClientSettingsFromLists` to preserve manager list metadata fields (district/region/area/group/parent_value/metadata/zone and related manager-region fields) in `activities_manager_users` so the summary can use existing Supabase list fields without adding SQL or changing DB shape.
- Bumped the service worker cache version in `frontend/sw.js` to invalidate old caches (`CACHE_VERSION` -> `351`) so updated frontend assets load after deploy.
- Updated `tests/activities-screen.test.mjs` expectations to reflect the new admin-summary helpers and signature changes; no other app logic or data-loading flows were altered.

### Testing

- Ran static checks: `node --check frontend/src/screens/activities.js && node --check frontend/src/api.js && node --check frontend/sw.js` which succeeded.
- Ran the focused UI tests: `node --test tests/activities-screen.test.mjs` and the suite passed (10 passed, 0 failed).
- Built production assets with `npm run build` which completed successfully and produced updated `dist` output.
- Note: running the full `npm test` on the whole repository earlier surfaced unrelated existing failures in other test suites (snapshot/API mutation/read-model/perf areas); those failures are not related to this change and the focused tests for this PR passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079cbd57d8832b9ca9fb19828d88d0)