### PR TITLE
Fix missing_start_date exception loading and bump SW cache version

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 350;
+const CACHE_VERSION = 352;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 350;
+const CACHE_VERSION = 352;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1103,7 +1103,7 @@ async function readExceptionsFromSupabase(params = {}) {
     );
 
     // Query 2 + 3 + 4 (parallel):
-    // 2 — open courses with missing start_date AND missing date_1
+    // 2 — broad open-course candidates for missing_start_date
     // 3 — open courses where all instructor fields are empty
     // 4 — open courses where emp_id is set but NOT in the known instructors list
     const queryBase = () =>
@@ -1112,12 +1112,14 @@ async function readExceptionsFromSupabase(params = {}) {
     const knownIdsList = [...knownInstructorIds];
 
     const [missingStartResult, missingInstructorResult, invalidInstructorResult] = await Promise.all([
-      // 2: missing start_date AND missing date_1. This query is intentionally
+      // 2: broad missing-start candidates. This query is intentionally
       // not constrained by month: undated courses must stay visible as
       // missing_start_date exceptions even while a month filter is active.
-      queryBase()
-        .or('start_date.is.null,start_date.eq.')
-        .or('date_1.is.null,date_1.eq.'),
+      // Keep this broad instead of relying on Supabase .or() null/blank
+      // filters so textual markers like "NULL", "null", "undefined" and
+      // whitespace-only values are normalized and classified in code by
+      // rowExceptionTypesFromActivity/buildExceptionsModelFromRows.
+      queryBase(),
       // 3: all instructor fields are empty
       queryBase()
         .or('emp_id.is.null,emp_id.eq.')

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 351;
+const CACHE_VERSION = 352;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/tests/api-undated-activities.test.mjs
+++ b/tests/api-undated-activities.test.mjs
@@ -85,6 +85,37 @@ test('entering a valid start_date or date_1 removes missing_start_date automatic
   assert.equal(rowExceptionTypesFromActivity(activeCourse({ start_date: '', date_1: '2026-05-10' })).includes('missing_start_date'), false);
 });
 
+
+test('textual null markers in start_date/date_1 are treated as missing_start_date', () => {
+  const bothTextual = activeCourse({ RowID: 'A-5', start_date: 'NULL', date_1: '' });
+  const date1Textual = activeCourse({ RowID: 'A-6', start_date: '', date_1: 'NULL' });
+  const undefinedWhitespace = activeCourse({ RowID: 'A-7', start_date: ' undefined ', date_1: ' ' });
+
+  assert.equal(rowExceptionTypesFromActivity(bothTextual).includes('missing_start_date'), true);
+  assert.equal(rowExceptionTypesFromActivity(date1Textual).includes('missing_start_date'), true);
+  assert.equal(rowExceptionTypesFromActivity(undefinedWhitespace).includes('missing_start_date'), true);
+});
+
+test('closed and non-course rows are excluded from course exceptions', () => {
+  const workshop = activeCourse({ RowID: 'A-8', activity_type: 'workshop', start_date: '', date_1: '' });
+  const closed = activeCourse({ RowID: 'A-9', status: 'סגור', start_date: '', date_1: '' });
+
+  const model = buildExceptionsModelFromRows([workshop, closed], '2026-05', { include_rows: true });
+
+  assert.equal(model.totalExceptionRows, 0);
+  assert.equal(model.rows.length, 0);
+  assert.equal(model.counts.missing_start_date, 0);
+});
+
+test('Supabase missing-start candidates are loaded broadly and filtered in code', async () => {
+  const source = await readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+
+  const block = source.match(/const \[missingStartResult[\s\S]*?\] = await Promise\.all\(\[([\s\S]*?)\n    \]\);/);
+  assert.ok(block, 'readExceptionsFromSupabase should fetch parallel exception candidate queries');
+  assert.match(block[1], /queryBase\(\),/);
+  assert.doesNotMatch(block[1], /start_date\.is\.null,start_date\.eq\.[\s\S]*date_1\.is\.null,date_1\.eq\./);
+});
+
 test('allActivities export path reads all activities without applying month/date filters', async () => {
   const source = await readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
 


### PR DESCRIPTION
### Motivation
- The Supabase candidate query for missing-start exceptions was too narrow and could miss active courses with non-standard empty values, causing them to disappear from the exceptions screen when a month filter was applied.
- The intent is to fetch a broader set of active-course candidates and keep final classification of exceptions in existing code paths (`rowExceptionTypesFromActivity` / `buildExceptionsModelFromRows`) without changing screens, admin summary, or exports.

### Description
- Replaced the narrow `.or('start_date.is.null,start_date.eq.').or('date_1.is.null,date_1.eq.')` candidate query with a broad `queryBase()` fetch so all active courses are considered as candidates for `missing_start_date` and the final filtering happens in code. (file: `frontend/src/api.js`)
- Preserved current behaviour where undated courses remain visible under a month filter because classification and `activityOverlapsMonthForExceptions` still handle missing start dates in code. (file: `frontend/src/api.js`)
- Ensured textual markers and whitespace-only values are normalized/treated as empty by existing helpers (`isEmptyValue`, `nullStr`, `normalizeSupabaseDate`) and validated via tests. (files: `frontend/src/api.js`, `frontend/src/utils/empty-value.js`)
- Bumped Service Worker cache version from `351` to `352` so clients/PWA pick up the updated `api.js`. Updated tracked built SW files accordingly. (files: `frontend/sw.js`, `dist/sw.js`, `dist/frontend/sw.js`)
- Added unit tests covering textual null markers, closed/non-course exclusion, and asserting the missing-start candidate query is now broad. (file: `tests/api-undated-activities.test.mjs`)

### Testing
- Ran targeted tests: `node --test tests/api-undated-activities.test.mjs` — all added and related tests passed (9/9).
- Built production bundle: `npm run build` — build completed successfully and generated updated `dist` artifacts.
- Ran full test suite with `npm test` — the broader suite showed pre-existing unrelated failures (network/Supabase/backed checks); the focused exception tests used to validate this change passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a29694b0832ba4ffdfffbab1f78a)