### PR TITLE
Exceptions summary: include late_end_date in top total, rename label, and bump SW cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 352;
+const CACHE_VERSION = 353;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 352;
+const CACHE_VERSION = 353;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -70,13 +70,21 @@ function exceptionsOperationalSummaryHtml(data, rows) {
   const missingStartDate = counts.missing_start_date !== undefined
     ? numericCount(counts.missing_start_date)
     : exceptionCountFromRows(rows, 'missing_start_date');
+  const lateEndDate = counts.late_end_date !== undefined
+    ? numericCount(counts.late_end_date)
+    : exceptionCountFromRows(rows, 'late_end_date');
   const operationalTotal = missingInstructor + missingStartDate;
+  const endDateTotal = lateEndDate;
+  const allExceptionsTotal = operationalTotal + endDateTotal;
 
   return dsCard({
-    title: `חריגות תפעוליות: ${escapeHtml(String(operationalTotal))}`,
+    title: `סה״כ חריגות: ${escapeHtml(String(allExceptionsTotal))}`,
     body: `<div class="ds-summary-panel__structured" dir="rtl">
+      <p class="ds-summary-panel__text">חריגות תפעוליות: <strong>${escapeHtml(String(operationalTotal))}</strong></p>
       <p class="ds-summary-panel__text">חסר מדריך: <strong>${escapeHtml(String(missingInstructor))}</strong></p>
       <p class="ds-summary-panel__text">חסר תאריך התחלה: <strong>${escapeHtml(String(missingStartDate))}</strong></p>
+      <p class="ds-summary-panel__text">חריגות תאריך סיום: <strong>${escapeHtml(String(endDateTotal))}</strong></p>
+      <p class="ds-summary-panel__text">תאריך סיום מאוחר: <strong>${escapeHtml(String(lateEndDate))}</strong></p>
     </div>`
   });
 }

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -80,7 +80,7 @@ export function exceptionTypeVariant(exceptionType) {
 export const HEBREW_EXCEPTION_TYPE = {
   missing_instructor:       'חסר מדריך',
   missing_start_date:       'חסר תאריך התחלה',
-  late_end_date:            'תאריך סיום',
+  late_end_date:            'תאריך סיום מאוחר',
   dangerous_end_date:       'תאריך סיום',
   missing_activity_manager: 'חסר מנהל פעילות',
   missing_school:           'חסרה בית ספר',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 352;
+const CACHE_VERSION = 353;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 349;
+const SW_ENTRY_VERSION = 353;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -342,24 +342,37 @@ test('frontend exceptions title uses totalExceptionRows', async () => {
   );
 });
 
-test('frontend exceptions screen renders operational summary as parent total with child counts', async () => {
+test('frontend exceptions screen renders top summary with operational and end-date groups', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
   assert.match(src, /function exceptionsOperationalSummaryHtml\(data, rows\)/,
-    'exceptions screen must render an operational summary block');
+    'exceptions screen must render an exceptions summary block');
+  assert.match(src, /counts\.late_end_date/,
+    'summary must use late_end_date from data.counts when available');
+  assert.match(src, /exceptionCountFromRows\(rows, 'late_end_date'\)/,
+    'summary must fall back to rows.exception_types for late_end_date');
   assert.match(src, /const operationalTotal = missingInstructor \+ missingStartDate/,
     'operational parent count must be the sum of missing instructor and missing start date instances');
-  assert.match(src, /חריגות תפעוליות: \$\{escapeHtml\(String\(operationalTotal\)\)\}/,
-    'operational summary must display the parent category count');
+  assert.match(src, /const allExceptionsTotal = operationalTotal \+ endDateTotal/,
+    'top summary total must include both operational and end-date exception groups');
+  assert.match(src, /סה״כ חריגות: \$\{escapeHtml\(String\(allExceptionsTotal\)\)\}/,
+    'summary title must display all exception instances');
+  assert.match(src, /חריגות תפעוליות: <strong>\$\{escapeHtml\(String\(operationalTotal\)\)\}<\/strong>/,
+    'summary must display the operational parent category count');
   assert.match(src, /חסר מדריך: <strong>\$\{escapeHtml\(String\(missingInstructor\)\)\}<\/strong>/,
     'operational summary must display missing instructor as a separate exception count');
   assert.match(src, /חסר תאריך התחלה: <strong>\$\{escapeHtml\(String\(missingStartDate\)\)\}<\/strong>/,
     'operational summary must display missing start date as a separate exception count');
+  assert.match(src, /חריגות תאריך סיום: <strong>\$\{escapeHtml\(String\(endDateTotal\)\)\}<\/strong>/,
+    'summary must display the end-date exception group count');
+  assert.match(src, /תאריך סיום מאוחר: <strong>\$\{escapeHtml\(String\(lateEndDate\)\)\}<\/strong>/,
+    'summary must display late end date as a separate exception count');
 });
 
-test('frontend exception Hebrew labels describe the missing operational details', async () => {
+test('frontend exception Hebrew labels describe the exception details clearly', async () => {
   const src = await read('frontend/src/screens/shared/ui-hebrew.js');
   assert.match(src, /missing_instructor:\s+'חסר מדריך'/);
   assert.match(src, /missing_start_date:\s+'חסר תאריך התחלה'/);
+  assert.match(src, /late_end_date:\s+'תאריך סיום מאוחר'/);
 });
 
 test('frontend drawer shows exception type chip when opening activity detail', async () => {


### PR DESCRIPTION
### Motivation
- Fix user-visible mismatch where `late_end_date` instances appeared in the list but were not shown in the top summary, causing the header total to differ from the operational subtotal.
- Do not change API, counts, data loading or Supabase logic; only fix the summary display and the Hebrew label to avoid misleading naming.

### Description
- Updated `frontend/src/screens/exceptions.js` to include `late_end_date` from `data.counts` (with a fallback to counting `rows`) and compute a top-level `סה״כ חריגות` total while keeping a separate operational subtotal and an end-date group.
- Adjusted the summary card markup to show: overall total, operational subtotal (with `missing_instructor` and `missing_start_date`), and end-date group (`late_end_date`) including the new group label `חריגות תאריך סיום` and the specific `תאריך סיום מאוחר` count.
- Renamed the Hebrew label for `late_end_date` in `frontend/src/screens/shared/ui-hebrew.js` from `תאריך סיום` to `תאריך סיום מאוחר` to clarify that the late end date is the exception.
- Bumped the Service Worker/cache version to `353` in `frontend/sw.js` and the root `sw.js` entry (and updated tracked `dist` copies) so clients will refresh the shell after deploy.
- Updated test expectations in `tests/exceptions-all-types.test.mjs` to assert the new summary structure and the Hebrew label change.

### Testing
- Ran targeted tests with `node --test tests/exceptions-all-types.test.mjs tests/service-worker-pwa-cache.test.mjs` and verified the updated assertions and SW cache-version checks passed (all targeted tests passed).
- Built production assets with `npm run build` to refresh `dist` artifacts and confirm SW dist copies were updated successfully.
- A full `npm test` run was attempted earlier and encountered unrelated existing failures in broader suites; targeted test runs and final verification of the two affected tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a7bfce54832ba66d4f75c4fde40a)