### PR TITLE
Count unique activities in Exceptions summary and bump Service Worker cache version

### DIFF
--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -55,36 +55,67 @@ function numericCount(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
+function optionalNumericCount(value) {
+  if (value === undefined || value === null || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function exceptionActivityKey(row) {
+  const explicitId = [row?.RowID, row?.row_id, row?.source_row_id]
+    .map((value) => String(value ?? '').trim())
+    .find(Boolean);
+  if (explicitId) return `id:${explicitId}`;
+  return [
+    row?.activity_name,
+    row?.activity_type,
+    row?.school,
+    row?.authority,
+    row?.start_date,
+    row?.end_date
+  ].map((value) => String(value ?? '').trim()).join('|');
+}
+
+function uniqueExceptionActivityCount(rows, predicate) {
+  const seen = new Set();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const types = normalizedExceptionTypes(row);
+    if (!types.length || (predicate && !predicate(types, row))) continue;
+    seen.add(exceptionActivityKey(row));
+  }
+  return seen.size;
+}
+
 function exceptionCountFromRows(rows, type) {
-  return (Array.isArray(rows) ? rows : []).reduce(
-    (sum, row) => sum + (normalizedExceptionTypes(row).includes(type) ? 1 : 0),
-    0
-  );
+  return uniqueExceptionActivityCount(rows, (types) => types.includes(type));
 }
 
 function exceptionsOperationalSummaryHtml(data, rows) {
   const counts = data?.counts && typeof data.counts === 'object' ? data.counts : {};
-  const missingInstructor = counts.missing_instructor !== undefined
-    ? numericCount(counts.missing_instructor)
-    : exceptionCountFromRows(rows, 'missing_instructor');
-  const missingStartDate = counts.missing_start_date !== undefined
-    ? numericCount(counts.missing_start_date)
-    : exceptionCountFromRows(rows, 'missing_start_date');
-  const lateEndDate = counts.late_end_date !== undefined
-    ? numericCount(counts.late_end_date)
-    : exceptionCountFromRows(rows, 'late_end_date');
-  const operationalTotal = missingInstructor + missingStartDate;
-  const endDateTotal = lateEndDate;
-  const allExceptionsTotal = operationalTotal + endDateTotal;
+  const hasRows = Array.isArray(rows) && rows.length > 0;
+  const missingInstructor = hasRows
+    ? exceptionCountFromRows(rows, 'missing_instructor')
+    : numericCount(counts.missing_instructor);
+  const missingStartDate = hasRows
+    ? exceptionCountFromRows(rows, 'missing_start_date')
+    : numericCount(counts.missing_start_date);
+  const lateEndDate = hasRows
+    ? exceptionCountFromRows(rows, 'late_end_date')
+    : numericCount(counts.late_end_date);
+  const operationalTotal = hasRows
+    ? uniqueExceptionActivityCount(rows, (types) => types.includes('missing_instructor') || types.includes('missing_start_date'))
+    : numericCount(data?.operationalTotal ?? data?.operational_gaps_unique_count);
+  const totalExceptionRows = optionalNumericCount(data?.totalExceptionRows);
+  const allExceptionsTotal = totalExceptionRows ?? uniqueExceptionActivityCount(rows);
 
   return dsCard({
-    title: `סה״כ חריגות: ${escapeHtml(String(allExceptionsTotal))}`,
+    title: `סה״כ פעילויות חריגות: ${escapeHtml(String(allExceptionsTotal))}`,
     body: `<div class="ds-summary-panel__structured" dir="rtl">
       <p class="ds-summary-panel__text">חריגות תפעוליות: <strong>${escapeHtml(String(operationalTotal))}</strong></p>
       <p class="ds-summary-panel__text">חסר מדריך: <strong>${escapeHtml(String(missingInstructor))}</strong></p>
       <p class="ds-summary-panel__text">חסר תאריך התחלה: <strong>${escapeHtml(String(missingStartDate))}</strong></p>
-      <p class="ds-summary-panel__text">חריגות תאריך סיום: <strong>${escapeHtml(String(endDateTotal))}</strong></p>
       <p class="ds-summary-panel__text">תאריך סיום מאוחר: <strong>${escapeHtml(String(lateEndDate))}</strong></p>
+      <p class="ds-summary-panel__text"><small>פעילות עם כמה סוגי חריגה נספרת פעם אחת בסה״כ.</small></p>
     </div>`
   });
 }
@@ -192,7 +223,7 @@ export const exceptionsScreen = {
       ${toolbarHtml}
       <section class="ds-screen-compact-90">${exceptionsOperationalSummaryHtml(data, allRows)}</section>
       <section class="ds-screen-compact-90">${dsCard({
-        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''} · סה״כ חריגות: ${escapeHtml(String(data?.totalExceptionRows ?? total))}`,
+        title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''} · סה״כ פעילויות חריגות: ${escapeHtml(String(data?.totalExceptionRows ?? total))}`,
         body: compact,
         padded: visibleRows.length === 0
       })}</section>

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 353;
+const CACHE_VERSION = 354;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 353;
+const SW_ENTRY_VERSION = 354;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -342,30 +342,42 @@ test('frontend exceptions title uses totalExceptionRows', async () => {
   );
 });
 
-test('frontend exceptions screen renders top summary with operational and end-date groups', async () => {
+test('frontend exceptions screen renders unique-activity top summary', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
   assert.match(src, /function exceptionsOperationalSummaryHtml\(data, rows\)/,
     'exceptions screen must render an exceptions summary block');
-  assert.match(src, /counts\.late_end_date/,
-    'summary must use late_end_date from data.counts when available');
+  assert.match(src, /function exceptionActivityKey\(row\)/,
+    'summary must key exception activities for dedupe');
+  assert.match(src, /row\?\.RowID, row\?\.row_id, row\?\.source_row_id/,
+    'summary must dedupe with the supported row id fields first');
+  assert.match(src, /row\?\.activity_name,[\s\S]*row\?\.activity_type,[\s\S]*row\?\.school,[\s\S]*row\?\.authority,[\s\S]*row\?\.start_date,[\s\S]*row\?\.end_date/,
+    'summary must fall back to the business activity fields when no id exists');
+  assert.match(src, /function uniqueExceptionActivityCount\(rows, predicate\)/,
+    'summary must count unique activities, not exception-type instances');
   assert.match(src, /exceptionCountFromRows\(rows, 'late_end_date'\)/,
-    'summary must fall back to rows.exception_types for late_end_date');
-  assert.match(src, /const operationalTotal = missingInstructor \+ missingStartDate/,
-    'operational parent count must be the sum of missing instructor and missing start date instances');
-  assert.match(src, /const allExceptionsTotal = operationalTotal \+ endDateTotal/,
-    'top summary total must include both operational and end-date exception groups');
-  assert.match(src, /סה״כ חריגות: \$\{escapeHtml\(String\(allExceptionsTotal\)\)\}/,
-    'summary title must display all exception instances');
+    'summary must count unique late_end_date activities from rows');
+  assert.match(src, /uniqueExceptionActivityCount\(rows, \(types\) => types\.includes\('missing_instructor'\) \|\| types\.includes\('missing_start_date'\)\)/,
+    'operational parent count must dedupe activities with either operational exception');
+  assert.doesNotMatch(src, /const operationalTotal = missingInstructor \+ missingStartDate/,
+    'operational parent count must not be the sum of child exception counts when rows are available');
+  assert.match(src, /const totalExceptionRows = optionalNumericCount\(data\?\.totalExceptionRows\)/,
+    'top summary must prefer totalExceptionRows when supplied');
+  assert.match(src, /const allExceptionsTotal = totalExceptionRows \?\? uniqueExceptionActivityCount\(rows\)/,
+    'top summary must fall back to unique rows when totalExceptionRows is not supplied');
+  assert.match(src, /סה״כ פעילויות חריגות: \$\{escapeHtml\(String\(allExceptionsTotal\)\)\}/,
+    'summary title must display unique exceptional activities');
   assert.match(src, /חריגות תפעוליות: <strong>\$\{escapeHtml\(String\(operationalTotal\)\)\}<\/strong>/,
     'summary must display the operational parent category count');
   assert.match(src, /חסר מדריך: <strong>\$\{escapeHtml\(String\(missingInstructor\)\)\}<\/strong>/,
-    'operational summary must display missing instructor as a separate exception count');
+    'operational summary must display missing instructor as a separate unique activity count');
   assert.match(src, /חסר תאריך התחלה: <strong>\$\{escapeHtml\(String\(missingStartDate\)\)\}<\/strong>/,
-    'operational summary must display missing start date as a separate exception count');
-  assert.match(src, /חריגות תאריך סיום: <strong>\$\{escapeHtml\(String\(endDateTotal\)\)\}<\/strong>/,
-    'summary must display the end-date exception group count');
+    'operational summary must display missing start date as a separate unique activity count');
+  assert.doesNotMatch(src, /חריגות תאריך סיום/,
+    'summary must not duplicate the late end date row with an end-date group label');
   assert.match(src, /תאריך סיום מאוחר: <strong>\$\{escapeHtml\(String\(lateEndDate\)\)\}<\/strong>/,
-    'summary must display late end date as a separate exception count');
+    'summary must display late end date as a separate unique activity count');
+  assert.match(src, /פעילות עם כמה סוגי חריגה נספרת פעם אחת בסה״כ/,
+    'summary should explain that multi-exception activities are counted once in the total');
 });
 
 test('frontend exception Hebrew labels describe the exception details clearly', async () => {


### PR DESCRIPTION
### Motivation
- Fix business rule: the Exceptions screen must count unique activities (one per activity) rather than summing exception-type instances.
- Ensure the top summary and operational subgroup counts deduplicate activities by supported row IDs or by a business-field fallback.
- Keep existing exception detection and data sources unchanged and only adjust the summary calculation and wording.

### Description
- Implemented unique-activity counting in `frontend/src/screens/exceptions.js` by adding `exceptionActivityKey`, `uniqueExceptionActivityCount`, and `optionalNumericCount`, and updating `exceptionCountFromRows` and `exceptionsOperationalSummaryHtml` to use them and prefer `data.totalExceptionRows` when provided.
- Changed the top summary wording to `סה״כ פעילויות חריגות` and adjusted the lower card title to match the new phrasing, removed the duplicate end-date group label, and added a short explanatory note that multi-exception activities are counted once.
- Preserved existing fallback behavior when `data.rows` is absent by reading numeric counts from `data.counts` and a fallback `data` field for operational totals.
- Bumped service worker cache versions in `frontend/sw.js` and `sw.js` from `353` to `354` to force cache invalidation after the frontend change.
- Updated tests in `tests/exceptions-all-types.test.mjs` to assert the unique-activity dedupe behavior and the new summary wording.

### Testing
- Ran `node --test tests/exceptions-all-types.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (20 passed, 0 failed).
- Ran `node --test tests/exceptions-all-types.test.mjs` and `node --test tests/service-worker-pwa-cache.test.mjs` individually and both succeeded.
- Ran `npm run build` to produce the production bundle and it completed successfully.
- `npm test` (full suite) was attempted earlier but did not complete due to unrelated existing fixture/environment failures; the focused exception and service-worker tests used to validate this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ab7b589c832baceb64de94be7aa7)