### PR TITLE
Force service worker cache upgrade

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 354;
+const CACHE_VERSION = 355;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DArOhZXY.js",
+  "./assets/index-C6PDWofB.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -77,10 +77,24 @@ function shouldStoreResponse(response) {
 
 async function deleteOutdatedCaches() {
   const keys = await caches.keys();
+  const outdatedKeys = keys.filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME);
+  await Promise.all(outdatedKeys.map((key) => caches.delete(key)));
+  return outdatedKeys;
+}
+
+async function reloadClientsAfterCacheUpgrade(deletedKeys) {
+  if (!deletedKeys || deletedKeys.length === 0) return;
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   await Promise.all(
-    keys
-      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
-      .map((key) => caches.delete(key))
+    clients.map((client) => {
+      try {
+        const clientUrl = new URL(client.url);
+        if (!sameOrigin(clientUrl) || typeof client.navigate !== 'function') return Promise.resolve();
+        return client.navigate(client.url);
+      } catch (e) {
+        return Promise.resolve();
+      }
+    })
   );
 }
 
@@ -148,7 +162,12 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(deleteOutdatedCaches().then(() => self.clients.claim()));
+  event.waitUntil(
+    deleteOutdatedCaches().then(async (deletedKeys) => {
+      await self.clients.claim();
+      await reloadClientsAfterCacheUpgrade(deletedKeys);
+    })
+  );
 });
 
 self.addEventListener('fetch', (event) => {

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DArOhZXY.js"></script>
+  <script type="module" crossorigin src="./assets/index-C6PDWofB.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-CM6Hboyi.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 354;
+const CACHE_VERSION = 355;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DArOhZXY.js",
+  "./assets/index-C6PDWofB.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -77,10 +77,24 @@ function shouldStoreResponse(response) {
 
 async function deleteOutdatedCaches() {
   const keys = await caches.keys();
+  const outdatedKeys = keys.filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME);
+  await Promise.all(outdatedKeys.map((key) => caches.delete(key)));
+  return outdatedKeys;
+}
+
+async function reloadClientsAfterCacheUpgrade(deletedKeys) {
+  if (!deletedKeys || deletedKeys.length === 0) return;
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   await Promise.all(
-    keys
-      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
-      .map((key) => caches.delete(key))
+    clients.map((client) => {
+      try {
+        const clientUrl = new URL(client.url);
+        if (!sameOrigin(clientUrl) || typeof client.navigate !== 'function') return Promise.resolve();
+        return client.navigate(client.url);
+      } catch (e) {
+        return Promise.resolve();
+      }
+    })
   );
 }
 
@@ -148,7 +162,12 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(deleteOutdatedCaches().then(() => self.clients.claim()));
+  event.waitUntil(
+    deleteOutdatedCaches().then(async (deletedKeys) => {
+      await self.clients.claim();
+      await reloadClientsAfterCacheUpgrade(deletedKeys);
+    })
+  );
 });
 
 self.addEventListener('fetch', (event) => {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 354;
+const CACHE_VERSION = 355;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -54,10 +54,24 @@ function shouldStoreResponse(response) {
 
 async function deleteOutdatedCaches() {
   const keys = await caches.keys();
+  const outdatedKeys = keys.filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME);
+  await Promise.all(outdatedKeys.map((key) => caches.delete(key)));
+  return outdatedKeys;
+}
+
+async function reloadClientsAfterCacheUpgrade(deletedKeys) {
+  if (!deletedKeys || deletedKeys.length === 0) return;
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
   await Promise.all(
-    keys
-      .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
-      .map((key) => caches.delete(key))
+    clients.map((client) => {
+      try {
+        const clientUrl = new URL(client.url);
+        if (!sameOrigin(clientUrl) || typeof client.navigate !== 'function') return Promise.resolve();
+        return client.navigate(client.url);
+      } catch (e) {
+        return Promise.resolve();
+      }
+    })
   );
 }
 
@@ -125,7 +139,12 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(deleteOutdatedCaches().then(() => self.clients.claim()));
+  event.waitUntil(
+    deleteOutdatedCaches().then(async (deletedKeys) => {
+      await self.clients.claim();
+      await reloadClientsAfterCacheUpgrade(deletedKeys);
+    })
+  );
 });
 
 self.addEventListener('fetch', (event) => {

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 354;
+const SW_ENTRY_VERSION = 355;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/service-worker-pwa-cache.test.mjs
+++ b/tests/service-worker-pwa-cache.test.mjs
@@ -24,7 +24,7 @@ test('service worker entry and implementation use the same bumped cache version'
   assert.ok(entryVersion, 'root service worker should expose an entry version');
   assert.ok(cacheVersion, 'frontend service worker should expose a cache version');
   assert.equal(entryVersion[1], cacheVersion[1], 'entry import query should bust to the same SW version as the cache');
-  assert.ok(Number(cacheVersion[1]) >= 349, 'cache version should be bumped past the previous v348 cache');
+  assert.ok(Number(cacheVersion[1]) >= 355, 'cache version should be bumped past the previous v354 cache');
   assert.match(rootSw, /frontend\/sw\.js\?v=\$\{SW_ENTRY_VERSION\}/, 'root SW import should include a version query');
 });
 
@@ -34,7 +34,16 @@ test('service worker removes old dashboard caches during install and activate', 
   assert.match(frontendSw, /const CACHE_PREFIX = 'dashboard-static-v';/);
   assert.match(frontendSw, /key\.startsWith\(CACHE_PREFIX\) && key !== CACHE_NAME/, 'cleanup should target old dashboard cache versions');
   assert.match(frontendSw, /await deleteOutdatedCaches\(\);[\s\S]*self\.skipWaiting\(\);/, 'install should clean old caches before taking control');
-  assert.match(frontendSw, /event\.waitUntil\(deleteOutdatedCaches\(\)\.then\(\(\) => self\.clients\.claim\(\)\)\)/, 'activate should also clean old caches and claim clients');
+  assert.match(frontendSw, /deleteOutdatedCaches\(\)\.then\(async \(deletedKeys\) => \{[\s\S]*await self\.clients\.claim\(\);[\s\S]*await reloadClientsAfterCacheUpgrade\(deletedKeys\);/, 'activate should clean old caches, claim clients, and reload windows after a cache upgrade');
+});
+
+test('service worker reloads open dashboard windows after deleting old cache versions', async () => {
+  const frontendSw = await read(FRONTEND_SW_FILE);
+
+  assert.match(frontendSw, /return outdatedKeys;/, 'cache cleanup should report deleted old cache names');
+  assert.match(frontendSw, /async function reloadClientsAfterCacheUpgrade\(deletedKeys\)/, 'service worker should define forced client reload after cache upgrade');
+  assert.match(frontendSw, /self\.clients\.matchAll\(\{ type: 'window', includeUncontrolled: true \}\)/, 'reload should include currently open dashboard windows');
+  assert.match(frontendSw, /client\.navigate\(client\.url\)/, 'open clients should be navigated to fetch the fresh app shell and assets');
 });
 
 test('service worker fetches app shell and manifest fresh after deploy', async () => {


### PR DESCRIPTION
### Motivation
- למנוע מצב שבו דפדפנים ממשיכים לשרת JS/CSS ישן עקב cache של ה‑Service Worker אחרי תיקון פרודקשן. 
- להבטיח שכל הלקוחות הפתוחים יעדכנו את ה‑app shell והמשאבים מיד לאחר שדרוג ה‑cache.

### Description
- הבנתי את גרסת ה‑SW וה־cache מ־`354` ל־`355` בקובץ הכניסה `sw.js` ובמימוש `frontend/sw.js` באמצעות `SW_ENTRY_VERSION`/`CACHE_VERSION` ו־`CACHE_NAME` ב־`frontend/sw.js` ו־`sw.js`.
- חידשתי את `deleteOutdatedCaches()` כדי להחזיר את השמות שנמחקו (`outdatedKeys`) ולגרום למחיקה ברורה של כל cache שמתחיל ב־`dashboard-static-v` שאינו הגרסה הנוכחית.
- הוספתי `reloadClientsAfterCacheUpgrade(deletedKeys)` שמאתר חלונות (`self.clients.matchAll`) ומנווט מחדש את הלקוחות הפתוחים לאחר שמחיקה אמיתית התרחשה, וקראתי את זה ב־`activate` לאחר `self.clients.claim()`.
- עדכנתי את הבדיקה `tests/service-worker-pwa-cache.test.mjs` כדי לוודא את הקפיצה בגרסה, החזרת שמות הקאש שנמחקו, התנהגות ה־activate החדשה וטעינת נכסים טריים; ובניתי מחדש את `dist` כך שה‑artifacts משקפים את `CACHE_VERSION = 355` וה־precache המעודכן.

### Testing
- הרצת `node --test tests/service-worker-pwa-cache.test.mjs` והבדיקה עברה בהצלחה (5 tests passed, 0 failed). 
- הרצת `npm run build` והבנייה הצליחה (`vite build` + `scripts/postbuild-dist.mjs`) והתוצרים ב־`dist` עודכנו בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083d3b2f50832bb590748b00661c47)