### PR TITLE
Add proposals and agreements screen

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -34,7 +34,9 @@ const MUTATING_ACTIONS = {
   deleteUser: true,
   savePrivateNote: true,
   saveSheetMapping: true,
-  saveClientSetting: true
+  saveClientSetting: true,
+  addProposalAgreement: true,
+  updateProposalAgreement: true
 };
 
 const READ_ACTIONS = {
@@ -57,6 +59,7 @@ const READ_ACTIONS = {
   operationsDetail: true,
   editRequests: true,
   permissions: true,
+  proposalsAgreements: true,
   adminSettings: true,
   adminLists: true,
   listSheets: true,
@@ -1249,7 +1252,9 @@ function invalidateScreenDataByAction(action) {
     addContact: ['contacts', 'instructor-contacts'],
     saveContact: ['contacts', 'instructor-contacts'],
     saveSheetMapping: ['adminSettings', 'listSheets', 'dashboard:', 'activities:', 'week:', 'month:'],
-    saveClientSetting: ['adminSettings', 'dashboard:', 'activities:', 'week:', 'month:']
+    saveClientSetting: ['adminSettings', 'dashboard:', 'activities:', 'week:', 'month:'],
+    addProposalAgreement: ['proposals-agreements'],
+    updateProposalAgreement: ['proposals-agreements']
   };
   const prefixes = targetedMutations[action];
   if (!prefixes || !prefixes.length) return;
@@ -1332,17 +1337,98 @@ function normalizeData(data) {
   return normalized;
 }
 
+
+const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
+const PROPOSALS_AGREEMENTS_COLUMNS = 'id,client_authority,school_framework,document_type,activity_type,contact_name,contact_role,contact_phone,contact_email,notes,created_at,updated_at';
+
+function canUseProposalsAgreementsApi() {
+  const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+  return PROPOSALS_AGREEMENTS_ALLOWED_ROLES.has(role);
+}
+
+function assertCanUseProposalsAgreementsApi() {
+  if (!canUseProposalsAgreementsApi()) throw new Error('proposals_agreements_forbidden');
+}
+
+function cleanProposalAgreementText(value) {
+  return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+function buildProposalAgreementSearchText(row = {}) {
+  return [
+    row.id,
+    row.client_authority,
+    row.school_framework,
+    row.document_type,
+    row.activity_type,
+    row.notes,
+    row.contact_name,
+    row.contact_role,
+    row.contact_phone,
+    row.contact_email
+  ].map(cleanProposalAgreementText).filter(Boolean).join(' ').toLowerCase();
+}
+
+function normalizeProposalAgreementRow(row = {}) {
+  const normalized = {
+    id: cleanProposalAgreementText(row.id),
+    client_authority: cleanProposalAgreementText(row.client_authority),
+    school_framework: cleanProposalAgreementText(row.school_framework),
+    document_type: cleanProposalAgreementText(row.document_type),
+    activity_type: cleanProposalAgreementText(row.activity_type),
+    contact_name: cleanProposalAgreementText(row.contact_name),
+    contact_role: cleanProposalAgreementText(row.contact_role),
+    contact_phone: cleanProposalAgreementText(row.contact_phone),
+    contact_email: cleanProposalAgreementText(row.contact_email),
+    notes: cleanProposalAgreementText(row.notes),
+    created_at: cleanProposalAgreementText(row.created_at),
+    updated_at: cleanProposalAgreementText(row.updated_at)
+  };
+  normalized._searchText = buildProposalAgreementSearchText(normalized);
+  return normalized;
+}
+
+function sanitizeProposalAgreementPayload(payload = {}) {
+  const row = {
+    client_authority: cleanProposalAgreementText(payload.client_authority),
+    school_framework: cleanProposalAgreementText(payload.school_framework),
+    document_type: cleanProposalAgreementText(payload.document_type),
+    activity_type: cleanProposalAgreementText(payload.activity_type),
+    contact_name: cleanProposalAgreementText(payload.contact_name),
+    contact_role: cleanProposalAgreementText(payload.contact_role),
+    contact_phone: cleanProposalAgreementText(payload.contact_phone),
+    contact_email: cleanProposalAgreementText(payload.contact_email),
+    notes: cleanProposalAgreementText(payload.notes)
+  };
+  const missing = ['client_authority', 'school_framework', 'document_type', 'activity_type'].filter((key) => !row[key]);
+  if (missing.length) throw new Error(`missing_required_fields:${missing.join(',')}`);
+  return row;
+}
+
+async function readProposalsAgreementsFromSupabase() {
+  assertCanUseProposalsAgreementsApi();
+  const { data, error } = await supabase
+    .from('proposals_agreements')
+    .select(PROPOSALS_AGREEMENTS_COLUMNS)
+    .order('client_authority', { ascending: true })
+    .order('school_framework', { ascending: true })
+    .order('document_type', { ascending: true })
+    .order('activity_type', { ascending: true });
+  if (error) throw new Error(error.message || 'proposals_agreements_read_failed');
+  return { rows: (Array.isArray(data) ? data : []).map(normalizeProposalAgreementRow), _source: 'supabase' };
+}
+
 const USER_PUBLIC_COLUMNS = 'user_id,email,name,role,display_role,is_active,permissions,auth_user_id';
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager']);
 const ROLES_WITH_DIRECT_EDIT = new Set(['admin', 'operation_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
-  admin: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
-  operation_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  admin: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
+  operation_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  domain_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  domain_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   instructor: ['dashboard', 'activities', 'archive', 'week', 'month', 'instructor-contacts', 'my-data']
 };
@@ -2042,6 +2128,7 @@ export const api = {
     }));
     return buildEditRequestGroups(rows, canReview, activityByRowId);
   },
+  proposalsAgreements: async () => readProposalsAgreementsFromSupabase(),
   permissions: async () => {
     if (!supabase) throw new Error('no_supabase_client');
     const { data, error } = await supabase.from('users').select(USER_PUBLIC_COLUMNS).order('created_at', { ascending: false });
@@ -2096,6 +2183,31 @@ export const api = {
     const supabaseData = await readListsFromSupabase();
     if (supabaseData) return supabaseData;
     return buildSupabaseErrorPayload({ categories: [] }, 'admin_lists_supabase_failed');
+  },
+  addProposalAgreement: async (payload) => {
+    assertCanUseProposalsAgreementsApi();
+    const insert = sanitizeProposalAgreementPayload(payload);
+    const { data, error } = await supabase
+      .from('proposals_agreements')
+      .insert(insert)
+      .select(PROPOSALS_AGREEMENTS_COLUMNS)
+      .single();
+    if (error) throw new Error(error.message || 'proposals_agreement_add_failed');
+    return { ok: true, row: normalizeProposalAgreementRow(data) };
+  },
+  updateProposalAgreement: async (id, payload) => {
+    assertCanUseProposalsAgreementsApi();
+    const rowId = cleanProposalAgreementText(id);
+    if (!rowId) throw new Error('missing_proposal_agreement_id');
+    const patch = sanitizeProposalAgreementPayload(payload);
+    const { data, error } = await supabase
+      .from('proposals_agreements')
+      .update(patch)
+      .eq('id', rowId)
+      .select(PROPOSALS_AGREEMENTS_COLUMNS)
+      .single();
+    if (error) throw new Error(error.message || 'proposals_agreement_update_failed');
+    return { ok: true, row: normalizeProposalAgreementRow(data) };
   },
   addContact: async (payload) => {
     const kind = String(payload?.kind || '').trim();

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -509,7 +509,8 @@ const screenLabels = {
   'admin-home': 'בית — ניהול',
   'admin-settings': 'הגדרות מערכת',
   'admin-lists': 'ניהול רשימות',
-  archive: 'ארכיון'
+  archive: 'ארכיון',
+  'proposals-agreements': 'הצעות והסכמים'
 };
 
 const screenLoaders = {
@@ -528,7 +529,8 @@ const screenLoaders = {
   'admin-home': () => import('./screens/admin-home.js').then((m) => m.adminHomeScreen),
   'admin-settings': () => import('./screens/admin-settings.js').then((m) => m.adminSettingsScreen),
   'admin-lists': () => import('./screens/admin-lists.js').then((m) => m.adminListsScreen),
-  archive: () => import('./screens/archive.js').then((m) => m.archiveScreen)
+  archive: () => import('./screens/archive.js').then((m) => m.archiveScreen),
+  'proposals-agreements': () => import('./screens/proposals-agreements.js').then((m) => m.proposalsAgreementsScreen)
 };
 const loadedScreens = new Map();
 const loadingScreens = new Map();
@@ -726,7 +728,7 @@ function shell(content) {
 
   const systemName = escapeHtml(systemNameDisplay());
 
-  const HEADER_ALWAYS_EXCLUDE = new Set(['edit-requests', 'contacts', 'instructor-contacts']);
+  const HEADER_ALWAYS_EXCLUDE = new Set(['edit-requests', 'contacts', 'instructor-contacts', 'proposals-agreements']);
   const adminHeaderExclude = isAdminUser ? new Set(['operations', 'my-data', 'permissions']) : new Set();
   const headerNavHtml = headerNavGridHtml({
     route: state.route,

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1,0 +1,361 @@
+import { escapeHtml } from './shared/html.js';
+import { dsCard, dsEmptyState, dsPageHeader, dsScreenStack, dsTableWrap } from './shared/layout.js';
+import { getActivityCatalog } from './shared/activity-options.js';
+
+export const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
+const SEARCH_DEBOUNCE_MS = 280;
+
+const FIELD_LABELS = {
+  client_authority: 'לקוח / רשות',
+  school_framework: 'בית ספר / מסגרת',
+  document_type: 'סוג מסמך',
+  activity_type: 'סוג פעילות',
+  notes: 'הערות',
+  contact_name: 'שם איש קשר',
+  contact_role: 'תפקיד איש קשר',
+  contact_phone: 'טלפון',
+  contact_email: 'דוא״ל'
+};
+
+const REQUIRED_FIELDS = ['client_authority', 'school_framework', 'document_type', 'activity_type'];
+const FORM_FIELDS = [
+  'client_authority',
+  'school_framework',
+  'document_type',
+  'activity_type',
+  'contact_name',
+  'contact_role',
+  'contact_phone',
+  'contact_email',
+  'notes'
+];
+
+function userRole(state) {
+  return String(state?.user?.display_role || state?.user?.role || '').trim();
+}
+
+export function canAccessProposalsAgreements(state) {
+  return PROPOSALS_AGREEMENTS_ALLOWED_ROLES.has(userRole(state));
+}
+
+function text(value) {
+  return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeSearch(value) {
+  return text(value).toLowerCase();
+}
+
+export function buildProposalsAgreementsSearchText(row = {}) {
+  return [
+    row.id,
+    row.client_authority,
+    row.school_framework,
+    row.document_type,
+    row.activity_type,
+    row.notes,
+    row.contact_name,
+    row.contact_role,
+    row.contact_phone,
+    row.contact_email
+  ].map(normalizeSearch).filter(Boolean).join(' ');
+}
+
+export function normalizeProposalAgreementRow(row = {}) {
+  const normalized = {
+    id: text(row.id),
+    client_authority: text(row.client_authority),
+    school_framework: text(row.school_framework),
+    document_type: text(row.document_type),
+    activity_type: text(row.activity_type),
+    contact_name: text(row.contact_name),
+    contact_role: text(row.contact_role),
+    contact_phone: text(row.contact_phone),
+    contact_email: text(row.contact_email),
+    notes: text(row.notes),
+    created_at: text(row.created_at),
+    updated_at: text(row.updated_at)
+  };
+  normalized._searchText = buildProposalsAgreementsSearchText(normalized);
+  return normalized;
+}
+
+function sortRows(rows) {
+  return [...(Array.isArray(rows) ? rows : [])].sort((a, b) => (
+    text(a.client_authority).localeCompare(text(b.client_authority), 'he') ||
+    text(a.school_framework).localeCompare(text(b.school_framework), 'he') ||
+    text(a.document_type).localeCompare(text(b.document_type), 'he') ||
+    text(a.activity_type).localeCompare(text(b.activity_type), 'he')
+  ));
+}
+
+function rowMatches(row, filters) {
+  const q = normalizeSearch(filters.q);
+  if (q && !normalizeSearch(row._searchText).includes(q)) return false;
+  if (filters.document_type && text(row.document_type) !== filters.document_type) return false;
+  if (filters.activity_type && text(row.activity_type) !== filters.activity_type) return false;
+  return true;
+}
+
+function uniqueValues(rows, key) {
+  return Array.from(new Set((Array.isArray(rows) ? rows : []).map((row) => text(row[key])).filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b, 'he'));
+}
+
+function optionHtml(value, selected = '') {
+  const safe = escapeHtml(value);
+  return `<option value="${safe}"${value === selected ? ' selected' : ''}>${safe}</option>`;
+}
+
+function filterSelectHtml(key, label, values) {
+  const options = ['<option value="">הכול</option>', ...values.map((value) => optionHtml(value))].join('');
+  return `<label class="ds-pa-filter"><span>${escapeHtml(label)}</span><select class="ds-input ds-input--sm" data-pa-filter="${escapeHtml(key)}">${options}</select></label>`;
+}
+
+function contactSummary(row) {
+  const parts = [row.contact_name, row.contact_role, row.contact_phone, row.contact_email].map(text).filter(Boolean);
+  return parts.length ? parts.join(' · ') : '—';
+}
+
+function detailRowsHtml(row) {
+  return FORM_FIELDS.map((key) => `
+    <div class="ds-pa-detail-row">
+      <span class="ds-pa-detail-label">${escapeHtml(FIELD_LABELS[key])}</span>
+      <span class="ds-pa-detail-value">${escapeHtml(key.startsWith('contact_') ? (row[key] || '—') : (row[key] || '—'))}</span>
+    </div>`).join('');
+}
+
+export function proposalsAgreementsTableRowsHtml(rows) {
+  if (!rows.length) {
+    return `<tr class="ds-pa-empty-row"><td colspan="5">אין רשומות להצגה</td></tr>`;
+  }
+  return rows.map((row) => `
+    <tr data-pa-row-id="${escapeHtml(row.id)}" tabindex="0">
+      <td>${escapeHtml(row.client_authority || '—')}</td>
+      <td>${escapeHtml(row.school_framework || '—')}</td>
+      <td>${escapeHtml(row.document_type || '—')}</td>
+      <td>${escapeHtml(row.activity_type || '—')}</td>
+      <td class="ds-pa-notes" title="${escapeHtml(row.notes || '')}">${escapeHtml(row.notes || '—')}</td>
+    </tr>`).join('');
+}
+
+function tableHtml(rows) {
+  return dsTableWrap(`
+    <table class="ds-table ds-pa-table" data-pa-table>
+      <thead><tr><th>לקוח / רשות</th><th>בית ספר / מסגרת</th><th>סוג מסמך</th><th>סוג פעילות</th><th>הערות</th></tr></thead>
+      <tbody data-pa-table-body>${proposalsAgreementsTableRowsHtml(rows)}</tbody>
+    </table>
+  `);
+}
+
+function formFieldHtml(key, value = '', activityOptions = []) {
+  const label = FIELD_LABELS[key] || key;
+  const required = REQUIRED_FIELDS.includes(key);
+  const attrs = required ? ' required aria-required="true"' : '';
+  const val = escapeHtml(value || '');
+  if (key === 'notes') {
+    return `<label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(label)}${required ? ' *' : ''}</span><textarea class="ds-input" name="${key}" rows="3"${attrs}>${val}</textarea></label>`;
+  }
+  const listAttr = key === 'activity_type' ? ' list="proposalsAgreementsActivityOptions"' : '';
+  const datalist = key === 'activity_type'
+    ? `<datalist id="proposalsAgreementsActivityOptions">${activityOptions.map((item) => `<option value="${escapeHtml(item)}"></option>`).join('')}</datalist>`
+    : '';
+  return `<label class="ds-pa-form-field"><span>${escapeHtml(label)}${required ? ' *' : ''}</span><input class="ds-input ds-input--sm" name="${key}" value="${val}"${listAttr}${attrs}></label>${datalist}`;
+}
+
+function formHtml(mode, row = {}, activityOptions = []) {
+  const title = mode === 'edit' ? 'עריכת רשומה' : 'הוספת הצעה / הסכם';
+  return `<form class="ds-pa-form" data-pa-form data-pa-mode="${escapeHtml(mode)}" data-pa-id="${escapeHtml(row.id || '')}" dir="rtl">
+    <h3>${escapeHtml(title)}</h3>
+    <div class="ds-pa-form-grid">${FORM_FIELDS.map((key) => formFieldHtml(key, row[key] || '', activityOptions)).join('')}</div>
+    <p class="ds-pa-form-error" data-pa-form-error role="alert"></p>
+    <div class="ds-pa-form-actions">
+      <button type="submit" class="ds-btn ds-btn--primary ds-btn--sm">שמירה</button>
+      <button type="button" class="ds-btn ds-btn--sm" data-pa-cancel-form>ביטול</button>
+    </div>
+  </form>`;
+}
+
+function drawerHtml(row, activityOptions) {
+  if (!row) return `<aside class="ds-pa-drawer" data-pa-drawer hidden></aside>`;
+  return `<aside class="ds-pa-drawer" data-pa-drawer data-pa-drawer-id="${escapeHtml(row.id)}" aria-live="polite" dir="rtl">
+    <div class="ds-pa-drawer-panel">
+      <header class="ds-pa-drawer-head">
+        <div><p class="ds-muted">פרטי רשומה</p><h3>${escapeHtml(row.client_authority || '—')}</h3></div>
+        <button type="button" class="ds-btn ds-btn--sm" data-pa-close-drawer aria-label="סגירת פרטי רשומה">✕</button>
+      </header>
+      <div class="ds-pa-detail-grid">${detailRowsHtml(row)}</div>
+      <p class="ds-pa-contact-line"><span class="ds-muted">פרטי קשר:</span> ${escapeHtml(contactSummary(row))}</p>
+      <div class="ds-pa-drawer-actions"><button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button></div>
+      <div data-pa-inline-form></div>
+    </div>
+  </aside>`;
+}
+
+function activityOptionsFromState(state) {
+  const catalog = typeof getActivityCatalog === 'function' ? getActivityCatalog(state?.clientSettings || {}) : [];
+  return Array.from(new Set(catalog.map((item) => text(item.label || item.activity_type)).filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b, 'he'));
+}
+
+function displayRows(data, filters = {}) {
+  return sortRows((Array.isArray(data?.rows) ? data.rows : []).map(normalizeProposalAgreementRow)).filter((row) => rowMatches(row, filters));
+}
+
+function currentFilters(root) {
+  return {
+    q: root.querySelector('[data-pa-search]')?.value || '',
+    document_type: root.querySelector('[data-pa-filter="document_type"]')?.value || '',
+    activity_type: root.querySelector('[data-pa-filter="activity_type"]')?.value || ''
+  };
+}
+
+export function updateProposalsAgreementsTableOnly(root, rows) {
+  const body = root?.querySelector('[data-pa-table-body]');
+  const counter = root?.querySelector('[data-pa-results-count]');
+  if (body) body.innerHTML = proposalsAgreementsTableRowsHtml(rows);
+  if (counter) counter.textContent = String(rows.length);
+}
+
+function payloadFromForm(form) {
+  const formData = new FormData(form);
+  const payload = {};
+  FORM_FIELDS.forEach((key) => { payload[key] = text(formData.get(key)); });
+  return payload;
+}
+
+function validatePayload(payload) {
+  const missing = REQUIRED_FIELDS.filter((key) => !text(payload[key]));
+  return missing.length ? `חובה למלא: ${missing.map((key) => FIELD_LABELS[key]).join(', ')}` : '';
+}
+
+function replaceLocalRow(data, savedRow) {
+  const normalized = normalizeProposalAgreementRow(savedRow);
+  const rows = Array.isArray(data.rows) ? data.rows : [];
+  const idx = rows.findIndex((row) => text(row.id) === normalized.id);
+  if (idx >= 0) rows[idx] = normalized;
+  else rows.unshift(normalized);
+  data.rows = sortRows(rows.map(normalizeProposalAgreementRow));
+}
+
+export const proposalsAgreementsScreen = {
+  load: ({ api, state }) => {
+    if (!canAccessProposalsAgreements(state)) return { rows: [], unauthorized: true };
+    return api.proposalsAgreements();
+  },
+  render(data = {}, { state } = {}) {
+    if (data?.unauthorized || !canAccessProposalsAgreements(state)) {
+      return dsScreenStack(`${dsPageHeader('הצעות והסכמים', 'גישה מוגבלת למורשים בלבד')}${dsEmptyState('אין לך הרשאה לצפות במסך זה')}`);
+    }
+    const rows = displayRows(data, {});
+    const rawRows = Array.isArray(data?.rows) ? data.rows.map(normalizeProposalAgreementRow) : [];
+    const activityOptions = activityOptionsFromState(state);
+    return dsScreenStack(`
+      ${dsPageHeader('הצעות והסכמים', 'ניהול הצעות, הסכמים ופרטי קשר לרשומה')}
+      <section class="ds-pa-screen" data-pa-screen dir="rtl">
+        <div class="ds-pa-toolbar">
+          <label class="ds-pa-search"><span>חיפוש</span><input class="ds-input ds-input--sm" data-pa-search placeholder="חיפוש מקומי" autocomplete="off"></label>
+          ${filterSelectHtml('document_type', 'סוג מסמך', uniqueValues(rawRows, 'document_type'))}
+          ${filterSelectHtml('activity_type', 'סוג פעילות', uniqueValues(rawRows, 'activity_type'))}
+          <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-add>הוספה</button>
+        </div>
+        <div class="ds-pa-local-status" aria-live="polite">מציג <strong data-pa-results-count>${rows.length}</strong> רשומות</div>
+        <div data-pa-form-host hidden></div>
+        ${dsCard({ title: 'רשומות', padded: false, body: `<div data-pa-table-region>${tableHtml(rows)}</div>` })}
+        ${drawerHtml(null, activityOptions)}
+      </section>
+    `);
+  },
+  bind({ root, data, state, api }) {
+    if (!root || data?.unauthorized || !canAccessProposalsAgreements(state)) return;
+    data.rows = sortRows((Array.isArray(data.rows) ? data.rows : []).map(normalizeProposalAgreementRow));
+    const activityOptions = activityOptionsFromState(state);
+    let debounceTimer = null;
+
+    const refreshTable = () => updateProposalsAgreementsTableOnly(root, displayRows(data, currentFilters(root)));
+    const debouncedRefresh = () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(refreshTable, SEARCH_DEBOUNCE_MS);
+    };
+
+    root.querySelector('[data-pa-search]')?.addEventListener('input', debouncedRefresh);
+    root.querySelectorAll('[data-pa-filter]').forEach((el) => el.addEventListener('change', refreshTable));
+
+    const formHost = root.querySelector('[data-pa-form-host]');
+    const openForm = (mode, row = {}) => {
+      if (!formHost) return;
+      formHost.hidden = false;
+      formHost.innerHTML = formHtml(mode, row, activityOptions);
+      formHost.querySelector('input,textarea,select')?.focus?.();
+    };
+    const closeForm = () => {
+      if (!formHost) return;
+      formHost.hidden = true;
+      formHost.innerHTML = '';
+    };
+
+    root.querySelector('[data-pa-add]')?.addEventListener('click', () => openForm('add'));
+    root.addEventListener('click', async (event) => {
+      const rowEl = event.target.closest?.('[data-pa-row-id]');
+      if (rowEl) {
+        const row = data.rows.find((item) => text(item.id) === text(rowEl.dataset.paRowId));
+        const drawer = root.querySelector('[data-pa-drawer]');
+        if (drawer && row) drawer.outerHTML = drawerHtml(row, activityOptions);
+        return;
+      }
+      if (event.target.closest?.('[data-pa-close-drawer]')) {
+        const drawer = root.querySelector('[data-pa-drawer]');
+        if (drawer) drawer.outerHTML = drawerHtml(null, activityOptions);
+        return;
+      }
+      const editBtn = event.target.closest?.('[data-pa-edit-row]');
+      if (editBtn) {
+        const row = data.rows.find((item) => text(item.id) === text(editBtn.dataset.paEditRow));
+        const host = root.querySelector('[data-pa-inline-form]');
+        if (host && row) host.innerHTML = formHtml('edit', row, activityOptions);
+        return;
+      }
+      if (event.target.closest?.('[data-pa-cancel-form]')) {
+        const inlineForm = event.target.closest('[data-pa-inline-form]');
+        if (inlineForm) inlineForm.innerHTML = '';
+        closeForm();
+      }
+    });
+
+    root.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter') return;
+      const rowEl = event.target.closest?.('[data-pa-row-id]');
+      if (rowEl) rowEl.click();
+    });
+
+    root.addEventListener('submit', async (event) => {
+      const form = event.target.closest?.('[data-pa-form]');
+      if (!form) return;
+      event.preventDefault();
+      const errorEl = form.querySelector('[data-pa-form-error]');
+      const payload = payloadFromForm(form);
+      const validationError = validatePayload(payload);
+      if (validationError) {
+        if (errorEl) errorEl.textContent = validationError;
+        return;
+      }
+      const mode = form.dataset.paMode;
+      const id = text(form.dataset.paId);
+      try {
+        const result = mode === 'edit'
+          ? await api.updateProposalAgreement(id, payload)
+          : await api.addProposalAgreement(payload);
+        replaceLocalRow(data, result?.row || { ...payload, id });
+        refreshTable();
+        closeForm();
+        const drawer = root.querySelector('[data-pa-drawer]');
+        if (drawer && mode === 'edit') {
+          const updated = data.rows.find((item) => text(item.id) === id);
+          drawer.outerHTML = drawerHtml(updated, activityOptions);
+        }
+      } catch (err) {
+        if (errorEl) errorEl.textContent = `שגיאה בשמירה: ${err?.message || err}`;
+      }
+    });
+  }
+};

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9449,3 +9449,174 @@ select.ds-activity-add-field .ds-input,
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ——— Proposals & agreements screen ——— */
+.ds-pa-screen {
+  direction: rtl;
+}
+
+.ds-pa-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: end;
+  margin-bottom: 10px;
+}
+
+.ds-pa-search,
+.ds-pa-filter,
+.ds-pa-form-field {
+  display: grid;
+  gap: 4px;
+  color: var(--ds-color-text-muted, #64748b);
+  font-size: 0.82rem;
+}
+
+.ds-pa-search {
+  min-width: 220px;
+  flex: 1 1 260px;
+}
+
+.ds-pa-filter {
+  min-width: 150px;
+}
+
+.ds-pa-local-status {
+  margin: 0 0 8px;
+  color: var(--ds-color-text-muted, #64748b);
+  font-size: 0.86rem;
+}
+
+.ds-pa-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.ds-pa-table th,
+.ds-pa-table td {
+  padding: 8px 10px;
+  vertical-align: middle;
+}
+
+.ds-pa-table tbody tr {
+  cursor: pointer;
+}
+
+.ds-pa-table tbody tr:hover,
+.ds-pa-table tbody tr:focus {
+  background: var(--ds-color-surface-hover, rgba(37, 99, 235, 0.06));
+  outline: none;
+}
+
+.ds-pa-notes {
+  max-width: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ds-pa-empty-row td {
+  text-align: center;
+  color: var(--ds-color-text-muted, #64748b);
+}
+
+.ds-pa-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  justify-content: flex-start;
+  background: rgba(15, 23, 42, 0.18);
+}
+
+.ds-pa-drawer[hidden] {
+  display: none;
+}
+
+.ds-pa-drawer-panel {
+  width: min(430px, 92vw);
+  height: 100%;
+  overflow: auto;
+  background: var(--ds-color-surface, #fff);
+  border-inline-start: 1px solid var(--ds-color-border, #e2e8f0);
+  box-shadow: var(--ds-shadow-lg, 0 18px 45px rgba(15, 23, 42, 0.16));
+  padding: 16px;
+}
+
+.ds-pa-drawer-head,
+.ds-pa-form-actions,
+.ds-pa-drawer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ds-pa-drawer-head h3,
+.ds-pa-form h3 {
+  margin: 0;
+  color: var(--ds-color-text, #0f172a);
+}
+
+.ds-pa-detail-grid {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.ds-pa-detail-row {
+  display: grid;
+  grid-template-columns: minmax(100px, 34%) 1fr;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--ds-color-border-subtle, #eef2f7);
+}
+
+.ds-pa-detail-label {
+  color: var(--ds-color-text-muted, #64748b);
+  font-size: 0.8rem;
+}
+
+.ds-pa-detail-value,
+.ds-pa-contact-line {
+  color: var(--ds-color-text, #0f172a);
+  font-size: 0.9rem;
+}
+
+.ds-pa-form {
+  margin: 10px 0 14px;
+  padding: 12px;
+  border: 1px solid var(--ds-color-border, #e2e8f0);
+  border-radius: var(--ds-radius-lg, 14px);
+  background: var(--ds-color-surface-soft, #f8fafc);
+}
+
+.ds-pa-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.ds-pa-form-field--wide {
+  grid-column: 1 / -1;
+}
+
+.ds-pa-form-error {
+  min-height: 1.2em;
+  margin: 0 0 8px;
+  color: var(--ds-color-danger, #b91c1c);
+  font-size: 0.84rem;
+}
+
+@media (max-width: 720px) {
+  .ds-pa-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ds-pa-table th,
+  .ds-pa-table td {
+    padding: 7px 8px;
+    font-size: 0.82rem;
+  }
+}

--- a/supabase/migrations/20260518_create_proposals_agreements.sql
+++ b/supabase/migrations/20260518_create_proposals_agreements.sql
@@ -1,0 +1,87 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.proposals_agreements (
+  id uuid primary key default gen_random_uuid(),
+  client_authority text not null,
+  school_framework text not null,
+  document_type text not null,
+  activity_type text not null,
+  contact_name text not null default '',
+  contact_role text not null default '',
+  contact_phone text not null default '',
+  contact_email text not null default '',
+  notes text not null default '',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint proposals_agreements_client_authority_not_blank check (btrim(client_authority) <> ''),
+  constraint proposals_agreements_school_framework_not_blank check (btrim(school_framework) <> ''),
+  constraint proposals_agreements_document_type_not_blank check (btrim(document_type) <> ''),
+  constraint proposals_agreements_activity_type_not_blank check (btrim(activity_type) <> '')
+);
+
+create index if not exists proposals_agreements_default_sort_idx
+  on public.proposals_agreements (client_authority, school_framework, document_type, activity_type);
+
+create index if not exists proposals_agreements_document_type_idx
+  on public.proposals_agreements (document_type);
+
+create index if not exists proposals_agreements_activity_type_idx
+  on public.proposals_agreements (activity_type);
+
+create or replace function public.touch_proposals_agreements_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_touch_proposals_agreements_updated_at on public.proposals_agreements;
+create trigger trg_touch_proposals_agreements_updated_at
+before update on public.proposals_agreements
+for each row
+execute function public.touch_proposals_agreements_updated_at();
+
+create or replace function public.app_can_use_proposals_agreements()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_current_role() in ('domain_manager', 'operation_manager', 'admin'), false)
+$$;
+
+revoke all on function public.app_can_use_proposals_agreements() from public;
+grant execute on function public.app_can_use_proposals_agreements() to authenticated;
+
+alter table public.proposals_agreements enable row level security;
+
+drop policy if exists proposals_agreements_select_allowed_roles on public.proposals_agreements;
+drop policy if exists proposals_agreements_insert_allowed_roles on public.proposals_agreements;
+drop policy if exists proposals_agreements_update_allowed_roles on public.proposals_agreements;
+
+create policy proposals_agreements_select_allowed_roles
+on public.proposals_agreements
+for select
+to authenticated
+using (public.app_can_use_proposals_agreements());
+
+create policy proposals_agreements_insert_allowed_roles
+on public.proposals_agreements
+for insert
+to authenticated
+with check (public.app_can_use_proposals_agreements());
+
+create policy proposals_agreements_update_allowed_roles
+on public.proposals_agreements
+for update
+to authenticated
+using (public.app_can_use_proposals_agreements())
+with check (public.app_can_use_proposals_agreements());
+
+revoke all on public.proposals_agreements from anon;
+grant select, insert, update on public.proposals_agreements to authenticated;
+revoke delete on public.proposals_agreements from authenticated;

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1,0 +1,185 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+import { JSDOM } from 'jsdom';
+
+if (!globalThis.sessionStorage) {
+  const sessionStore = new Map();
+  globalThis.sessionStorage = {
+    getItem: (key) => sessionStore.has(key) ? sessionStore.get(key) : null,
+    setItem: (key, value) => sessionStore.set(key, String(value)),
+    removeItem: (key) => sessionStore.delete(key),
+    clear: () => sessionStore.clear()
+  };
+}
+
+if (!globalThis.localStorage) {
+  const localStore = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => localStore.has(key) ? localStore.get(key) : null,
+    setItem: (key, value) => localStore.set(key, String(value)),
+    removeItem: (key) => localStore.delete(key),
+    clear: () => localStore.clear()
+  };
+}
+
+const MAIN_FILE = new URL('../frontend/src/main.js', import.meta.url);
+const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
+const ACT_NAV_FILE = new URL('../frontend/src/screens/shared/act-nav-grid.js', import.meta.url);
+const SCREEN_FILE = new URL('../frontend/src/screens/proposals-agreements.js', import.meta.url);
+const MIGRATION_FILE = new URL('../supabase/migrations/20260518_create_proposals_agreements.sql', import.meta.url);
+
+const { proposalsAgreementsScreen, canAccessProposalsAgreements } = await import('../frontend/src/screens/proposals-agreements.js');
+
+function stateFor(role) {
+  return {
+    user: { display_role: role, role },
+    clientSettings: {
+      dropdown_options: {
+        activity_names: [
+          { label: 'רובוטיקה', activity_type: 'סדנה' },
+          { label: 'יזמות', activity_type: 'קורס' }
+        ]
+      }
+    }
+  };
+}
+
+const sampleRows = [
+  {
+    id: '11111111-1111-1111-1111-111111111111',
+    client_authority: 'רשות א',
+    school_framework: 'בית ספר א',
+    document_type: 'הצעה',
+    activity_type: 'רובוטיקה',
+    contact_name: 'דנה קשר',
+    contact_role: 'מנהלת',
+    contact_phone: '050-1111111',
+    contact_email: 'dana@example.com',
+    notes: 'הערה קצרה'
+  },
+  {
+    id: '22222222-2222-2222-2222-222222222222',
+    client_authority: 'רשות ב',
+    school_framework: 'מסגרת ב',
+    document_type: 'הסכם',
+    activity_type: 'יזמות',
+    contact_name: 'יוסי קשר',
+    contact_phone: '050-2222222',
+    notes: 'רשומה שנייה'
+  }
+];
+
+test('screen authorization allows only domain_manager, operation_manager and admin', () => {
+  for (const role of ['domain_manager', 'operation_manager', 'admin']) {
+    assert.equal(canAccessProposalsAgreements(stateFor(role)), true, `${role} should be allowed`);
+    const html = proposalsAgreementsScreen.render({ rows: [] }, { state: stateFor(role) });
+    assert.match(html, /הצעות והסכמים/);
+    assert.doesNotMatch(html, /אין לך הרשאה/);
+  }
+
+  for (const role of ['authorized_user', 'finance', 'activities_manager', 'instructor_manager', 'instructor']) {
+    assert.equal(canAccessProposalsAgreements(stateFor(role)), false, `${role} should be denied`);
+    const html = proposalsAgreementsScreen.render({ rows: [] }, { state: stateFor(role) });
+    assert.match(html, /אין לך הרשאה לצפות במסך זה/);
+  }
+});
+
+test('proposals-agreements route is registered and role-gated in route definitions', async () => {
+  const mainSource = await readFile(MAIN_FILE, 'utf8');
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(mainSource, /'proposals-agreements': 'הצעות והסכמים'/);
+  assert.match(mainSource, /'proposals-agreements': \(\) => import\('\.\/screens\/proposals-agreements\.js'\)/);
+  assert.match(apiSource, /admin: \[[^\]]*'proposals-agreements'/);
+  assert.match(apiSource, /operation_manager: \[[^\]]*'proposals-agreements'/);
+  assert.match(apiSource, /domain_manager: \[[^\]]*'proposals-agreements'/);
+  assert.doesNotMatch(apiSource, /authorized_user: \[[^\]]*'proposals-agreements'/);
+  assert.doesNotMatch(apiSource, /instructor: \[[^\]]*'proposals-agreements'/);
+});
+
+test('table structure includes required outer columns', () => {
+  const html = proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') });
+  assert.match(html, /<th>לקוח \/ רשות<\/th><th>בית ספר \/ מסגרת<\/th><th>סוג מסמך<\/th><th>סוג פעילות<\/th><th>הערות<\/th>/);
+  assert.match(html, /data-pa-table-region/);
+  assert.match(html, /table-layout: fixed|ds-pa-table/);
+});
+
+test('contact details are hidden from the outer table and available only in drawer markup', () => {
+  const html = proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') });
+  const tableRegion = html.match(/<div data-pa-table-region>[\s\S]*?<aside class="ds-pa-drawer"/)?.[0] || '';
+  assert.doesNotMatch(tableRegion, /דנה קשר/);
+  assert.doesNotMatch(tableRegion, /050-1111111/);
+  assert.doesNotMatch(tableRegion, /dana@example\.com/);
+
+  const drawerSource = html.match(/<aside class="ds-pa-drawer"[\s\S]*?<\/aside>/)?.[0] || '';
+  assert.doesNotMatch(drawerSource, /דנה קשר/);
+});
+
+test('page is excluded from header nav and ACT_SUBNAV_ITEMS', async () => {
+  const mainSource = await readFile(MAIN_FILE, 'utf8');
+  const actNavSource = await readFile(ACT_NAV_FILE, 'utf8');
+  const headerExcludeBlock = mainSource.match(/const HEADER_ALWAYS_EXCLUDE = new Set\(\[[\s\S]*?\]\);/)?.[0] || '';
+  assert.match(headerExcludeBlock, /'proposals-agreements'/);
+
+  const subnavBlock = actNavSource.match(/export const ACT_SUBNAV_ITEMS = \[[\s\S]*?\];/)?.[0] || '';
+  assert.doesNotMatch(subnavBlock, /proposals-agreements/);
+});
+
+test('local search debounces 280ms and updates only table region and counter', async () => {
+  const dom = new JSDOM(`<main id="root">${proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') })}</main>`);
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  const previousFormData = globalThis.FormData;
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.FormData = dom.window.FormData;
+
+  try {
+    const root = dom.window.document.getElementById('root');
+    proposalsAgreementsScreen.bind({ root, data: { rows: [...sampleRows] }, state: stateFor('admin'), api: {} });
+    const headerNode = root.querySelector('.ds-page-header');
+    const toolbarNode = root.querySelector('.ds-pa-toolbar');
+    const tableRegion = root.querySelector('[data-pa-table-region]');
+    const beforeTableHtml = tableRegion.innerHTML;
+    const input = root.querySelector('[data-pa-search]');
+
+    input.value = 'רשות ב';
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    await delay(120);
+    assert.equal(tableRegion.innerHTML, beforeTableHtml, 'table should not update before debounce delay');
+
+    await delay(210);
+    assert.equal(root.querySelector('.ds-page-header'), headerNode, 'page header node should not be replaced');
+    assert.equal(root.querySelector('.ds-pa-toolbar'), toolbarNode, 'toolbar node should not be replaced');
+    assert.match(root.querySelector('[data-pa-results-count]').textContent, /^1$/);
+    assert.match(tableRegion.textContent, /רשות ב/);
+    assert.doesNotMatch(tableRegion.textContent, /רשות א/);
+  } finally {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+    globalThis.FormData = previousFormData;
+  }
+});
+
+test('screen and API source enforce authorization before API/Supabase calls', async () => {
+  const screenSource = await readFile(SCREEN_FILE, 'utf8');
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(screenSource, /if \(!canAccessProposalsAgreements\(state\)\) return \{ rows: \[\], unauthorized: true \};/);
+  assert.match(apiSource, /function assertCanUseProposalsAgreementsApi\(\)/);
+  assert.match(apiSource, /assertCanUseProposalsAgreementsApi\(\);[\s\S]*\.from\('proposals_agreements'\)/);
+});
+
+test('migration creates proposals_agreements with indexes, updated_at trigger and role RLS', async () => {
+  const migration = await readFile(MIGRATION_FILE, 'utf8');
+  assert.match(migration, /create table if not exists public\.proposals_agreements/);
+  for (const column of ['id uuid primary key', 'client_authority text not null', 'school_framework text not null', 'document_type text not null', 'activity_type text not null', 'contact_name text', 'contact_phone text', 'contact_email text', 'notes text', 'created_at timestamptz', 'updated_at timestamptz']) {
+    assert.match(migration, new RegExp(column.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(migration, /proposals_agreements_default_sort_idx/);
+  assert.match(migration, /trg_touch_proposals_agreements_updated_at/);
+  assert.match(migration, /app_current_role\(\) in \('domain_manager', 'operation_manager', 'admin'\)/);
+  assert.match(migration, /for select[\s\S]*to authenticated[\s\S]*app_can_use_proposals_agreements\(\)/);
+  assert.match(migration, /for insert[\s\S]*with check \(public\.app_can_use_proposals_agreements\(\)\)/);
+  assert.match(migration, /for update[\s\S]*using \(public\.app_can_use_proposals_agreements\(\)\)/);
+});


### PR DESCRIPTION
### Motivation
- להוסיף מסך חדש לניהול "הצעות והסכמים" המיועד רק לתפקידים מורשים ולשמור על הופעה בסרגל הצד בלבד בלי לשנות לוגיקה לא קשורה.
- לאפשר קריאות Supabase מאובטחות לקריאה/הוספה/עדכון של הטבלה החדשה עם נרמול, ולידציה וסדר ברירת מחדל מתאים.
- לספק חיפוש וסינון מקומיים עם debounce ועדכון רק של אזור הטבלה והמונה, ולספק Drawer, טפסי הוספה/עריכה ולידציה ועדכון מקומי (no full refresh).

### Description
- נוספו קבצים ראשיים: `frontend/src/screens/proposals-agreements.js` (מסך חדש, Drawer, טפסים, debounce 280ms, `updateProposalsAgreementsTableOnly`), `tests/proposals-agreements-screen.test.mjs` (בדיקות ייעודיות) ו־`supabase/migrations/20260518_create_proposals_agreements.sql` (migration ל־`public.proposals_agreements`).
- שונו קבצים קיימים: `frontend/src/api.js` (הוספת `proposalsAgreements`, `addProposalAgreement`, `updateProposalAgreement`, נרמול/ולידציה/אכיפת הרשאות ברמת ה־API, הוספת פעולות למטמון), `frontend/src/main.js` (רישום route `proposals-agreements` וחריגתו מה־header/nav) ו־`frontend/src/styles/main.css` (CSS קומפקטי ו־RTL למסך).
- הרשאות: הגבלת הגישה ל־`domain_manager`, `operation_manager`, `admin` באכיפה בשלוש רמות — הגדרת route, בדיקה בתוך המסך ו־`assertCanUseProposalsAgreementsApi` לפני קריאות Supabase.
- API/DB: קריאות Supabase חדשות לקריאה/הוספה/עדכון עם בדיקות קלט, נרמול שדות ובחירת סדר ברירת מחדל; migration יוצר אינדקסים, trigger לעדכון `updated_at` ו־RLS המגביל `select/insert/update` לתפקידים המורשים.

### Testing
- הרץ: `node --test tests/proposals-agreements-screen.test.mjs` — כל הבדיקות בפרויקט זה עברו בהצלחה (8 passed).
- בנייה: `npm run build` — build עבר בהצלחה (Vite produced bundles; שגיאות אזהרה לא חוסמות).
- בדיקות סטטיות: `git diff --check` לא הראה בעיות נוספות.
- הערות בדיקה: לא שיניתי או הרצתי את הבדיקות הלא קשורות (למשל `tests/activities-screen.test.mjs` או `npm test`), ולכן כשל קיים שמוזכר במפרט לגבי הכותרת "תאריכי מפגשים" vs "המפגש הבא" לא טופל במסגרת זו.

הערה פריסה: יש להריץ את ה־migration `supabase/migrations/20260518_create_proposals_agreements.sql` בסביבת Supabase לפני שימוש מלא במסך החדש.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4976ddc8832b993b7970e03694c7)