### PR TITLE
Refine permissions page compact layout and restore employee number binding

### DIFF
--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -116,6 +116,32 @@ function buildPermFlagGrid(row, keys) {
   return `<div class="ds-perm-flag-grid">${chips}</div>`;
 }
 
+
+function resolveEmployeeNumber(row) {
+  const source = row && typeof row === 'object' ? row : {};
+  const preferredKeys = [
+    'entry_code',
+    'employee_number',
+    'employeeNumber',
+    'employee_id',
+    'employeeId',
+    'worker_number',
+    'payroll_number',
+    'payrollNumber',
+    'ms',
+    'id'
+  ];
+
+  for (const key of preferredKeys) {
+    if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+    const value = source[key];
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text) return text;
+  }
+  return '—';
+}
+
 function buildAddUserDrawerHtml(roleDefaults) {
   return `<div class="ds-perm-edit-form" dir="rtl">
     <div class="ds-perm-edit-section">
@@ -243,7 +269,7 @@ function renderUserRow(row, canEdit, isAdmin, currentUserId, adminCount) {
 
   return `<tr class="ds-perm-row" data-perm-user="${uid}" data-list-item data-search="${escapeHtml(searchHay)}" data-filter="${escapeHtml(roleKey)}" data-status-filter="${isActive ? 'yes' : 'no'}">
     <td style="font-weight:600;">${escapeHtml(row.full_name || uid)}</td>
-    <td class="ds-muted" style="font-size:0.75rem;">${escapeHtml(row.entry_code || '—')}</td>
+    <td class="ds-muted" style="font-size:0.75rem;">${escapeHtml(resolveEmployeeNumber(row))}</td>
     <td>${dsStatusChip(label, roleChipKind(code))}</td>
     <td>${dsStatusChip(activeLabel, activeKind)}</td>
     <td><div style="display:flex;gap:4px;flex-wrap:wrap;justify-content:flex-end;">${actionBtns}</div></td>
@@ -351,15 +377,17 @@ export const permissionsScreen = {
       : '';
 
     return dsScreenStack(`
-      ${dsPageHeader('הרשאות', 'ניהול גישה ודגלי הרשאה — תואם לגיליון permissions')}
-      ${safeRows.length ? dsKpiGrid(kpis) : ''}
-      ${toolsBar}
-      ${dsCard({
+      <section class="ds-perm-screen">
+        ${dsPageHeader('הרשאות', 'ניהול גישה ודגלי הרשאה — תואם לגיליון permissions')}
+        ${safeRows.length ? dsKpiGrid(kpis) : ''}
+        ${toolsBar}
+        ${dsCard({
         title: 'משתמשים והרשאות',
         badge: `${safeRows.length} משתמשים`,
         body,
         padded: safeRows.length === 0
       })}
+      </section>
     `);
   },
   bind({ root, data, api, ui, rerender, clearScreenDataCache }) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9758,3 +9758,97 @@ select.ds-activity-add-field .ds-input,
     max-width: 100%;
   }
 }
+
+/* Permissions page compact alignment (content area only) */
+.ds-perm-screen .ds-page-header {
+  margin-bottom: var(--ds-space-2);
+}
+
+.ds-perm-screen .ds-kpi-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: var(--ds-space-2);
+}
+
+.ds-perm-screen .ds-kpi {
+  min-height: 86px;
+  height: 100%;
+}
+
+.ds-perm-screen .ds-perm-tools {
+  margin-bottom: var(--ds-space-2);
+  gap: 8px;
+  flex-wrap: nowrap;
+}
+
+.ds-perm-screen .ds-perm-tools__q,
+.ds-perm-screen .ds-perm-tools__select,
+.ds-perm-screen .ds-perm-tools .ds-btn {
+  min-height: 34px;
+  height: 34px;
+}
+
+.ds-perm-screen .ds-perm-tools__q {
+  flex: 1 1 260px;
+  min-width: 220px;
+  order: 1;
+}
+
+.ds-perm-screen .ds-perm-tools__select {
+  flex: 0 0 152px;
+  min-width: 152px;
+}
+
+.ds-perm-screen .ds-perm-tools__select[data-page-role-filter] { order: 2; }
+.ds-perm-screen .ds-perm-tools__select[data-page-status-filter] { order: 3; }
+.ds-perm-screen .ds-perm-tools .ds-btn[data-add-user] { order: 4; }
+
+.ds-perm-screen .ds-card {
+  margin-top: 0;
+}
+
+.ds-perm-screen .ds-card__head {
+  padding-block: 10px;
+}
+
+.ds-perm-screen .ds-perm-table th,
+.ds-perm-screen .ds-perm-table td {
+  padding: 3px 8px;
+  line-height: 1.2;
+  vertical-align: middle;
+}
+
+.ds-perm-screen .ds-perm-table td {
+  height: 34px;
+}
+
+.ds-perm-screen .ds-perm-table td .ds-btn {
+  min-height: 24px;
+  padding: 1px 8px;
+}
+
+@media (max-width: 1200px) {
+  .ds-perm-screen .ds-kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .ds-perm-screen .ds-perm-tools {
+    flex-wrap: wrap;
+  }
+
+  .ds-perm-screen .ds-perm-tools__q,
+  .ds-perm-screen .ds-perm-tools__select,
+  .ds-perm-screen .ds-perm-tools .ds-btn {
+    flex: 1 1 100%;
+    min-width: 100%;
+    max-width: 100%;
+    height: auto;
+    min-height: 34px;
+  }
+
+  .ds-perm-screen .ds-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the Permissions screen look more compact, professional and consistent while touching only the content area and leaving header/sidebar/navigation intact. 
- Restore the visible employee number values in the table without changing data schema, API, permissions or business logic.

### Description
- Added a `resolveEmployeeNumber(row)` helper that selects an existing employee identifier from a deterministic fallback list (starting with the legacy `entry_code`) and returns `—` only if no value exists. 
- Rebound the table `מספר עובד` column to use `resolveEmployeeNumber(row)` instead of the previous direct reference. 
- Scoped the permissions content into a dedicated wrapper (`<section class="ds-perm-screen">`) and added compact CSS rules in `frontend/src/styles/main.css` to tighten vertical spacing, enforce equal-height KPI cards, keep KPI cards on a single row on wide screens, align toolbar controls in one row with consistent heights and RTL ordering, and reduce table row and button heights for a denser layout. 
- Preserved functionality and UX constraints: the table columns remain `שם | מספר עובד | תפקיד | סטטוס | פעולות`, permission details still open in a Drawer/Modal via the `הרשאות` action, and no API/DB/schema/permission logic was changed.

### Testing
- Ran the project linter with `npm --prefix frontend run -s lint`, which exited with code 254 and produced no output in this environment (lint did not complete successfully). 
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b680a357c832ba8aa43648e958754)