### PR TITLE
Refine dashboard & instructors UI and fix end-dates monthly counting

### DIFF
--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -422,7 +422,7 @@ export const dashboardScreen = {
         ${staleBanner}
         <div data-dash-data-area>
           <div class="ds-dashboard-summary-row">
-            <button type="button" class="ds-summary-btn" data-summary-target="national" aria-label="סיכום">סיכום</button>
+            <h2 class="ds-dashboard-summary-title">סיכום</h2>
           </div>
           <div class="ds-summary-panel" data-summary-panel="national" hidden>
             <div class="ds-summary-panel__content"></div>
@@ -551,12 +551,7 @@ export const dashboardScreen = {
       applyYm(shiftYm(state.dashboardMonthYm || currentMonthYm(), 1));
     });
 
-    root.querySelectorAll('.ds-summary-btn[data-summary-target]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const target = btn.dataset.summaryTarget || '';
-        handleSummaryClick(target);
-      });
-    });
+    handleSummaryClick('national');
 
     root.querySelectorAll('[data-kpi-info-toggle]').forEach((btn) => {
       btn.addEventListener('click', (e) => {

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -40,7 +40,6 @@ function normalizeRows(rows, managerFilter = '') {
   const currentYm = currentMonthYm();
   const selectedManager = String(managerFilter || '').trim();
   return rows
-    .filter((row) => String(row?.activity_family || '').trim() === 'program')
     .map((row) => {
       const endDate = asIso(row?.end_date) || asIso(row?.date_end);
       if (!endDate) return null;

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -35,10 +35,14 @@ function toYm(dateStr) {
 }
 
 function nextYm(ym) {
-  const m = /^(\d{4})-(\d{2})$/.exec(ym);
-  if (!m) return ym;
-  const [y, mo] = [Number(m[1]), Number(m[2])];
-  return mo === 12 ? `${y + 1}-01` : `${y}-${String(mo + 1).padStart(2, '0')}`;
+  return shiftMonth(ym, 1);
+}
+
+function shiftMonth(ym, delta) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || ''));
+  if (!m) return currentYm();
+  const date = new Date(Number(m[1]), Number(m[2]) - 1 + delta, 1);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
 }
 
 function buildMonthOptions(minYm, maxYm) {
@@ -295,17 +299,11 @@ function updatePopupBody(items, name, onActivityOpen) {
 
 function monthFilterBarHtml(fromYm, minYm, maxYm) {
   if (!minYm || !maxYm) return '';
-  const opts = buildMonthOptions(minYm, maxYm);
-  const blankOpt = '<option value="">— כל התקופה —</option>';
-  const fromOpts = opts.map((o) =>
-    `<option value="${escapeHtml(o.value)}"${o.value === fromYm ? ' selected' : ''}>${escapeHtml(o.label)}</option>`
-  ).join('');
-  const clearBtn = fromYm
-    ? `<button type="button" class="ds-btn ds-btn--ghost ds-btn--sm" data-instr-date-clear title="נקה סינון חודש">✕</button>`
-    : '';
-  return `<div class="instr-date-filter" dir="rtl">
-    <select class="ds-input ds-input--sm" data-instr-month-from>${blankOpt}${fromOpts}</select>
-    ${clearBtn}
+  const monthText = ymLabel(fromYm);
+  return `<div class="instr-date-filter instr-date-filter--nav" dir="rtl" aria-label="בחירת חודש">
+    <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-instr-month-prev title="חודש קודם" aria-label="חודש קודם">▶</button>
+    <span class="instr-date-filter__label">${escapeHtml(monthText)}</span>
+    <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-instr-month-next title="חודש הבא" aria-label="חודש הבא">◀</button>
   </div>`;
 }
 
@@ -332,7 +330,8 @@ export const instructorsScreen = {
     const locallyFiltered = applyLocalFilters(activeRows, filters, { filterFields: INSTRUCTOR_FILTER_FIELDS });
 
     const instrState = state._instrDateFilter = state._instrDateFilter || {};
-    const dateFrom = instrState.from || '';
+    if (!instrState.from) instrState.from = currentYm();
+    const dateFrom = instrState.from || currentYm();
 
     const { min: globalMin, max: globalMax } = globalDateRange(activeRows);
 
@@ -368,7 +367,7 @@ export const instructorsScreen = {
   },
 
   bind({ root, data, state, rerender, api, ui }) {
-    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 150 });
+    bindLocalFilters(root, state, INSTRUCTORS_SCOPE, rerender, { debounceMs: 300 });
     root.querySelector(`[data-list-show-more="${INSTRUCTORS_SCOPE}"]`)?.addEventListener('click', (ev) => {
       ensureActivityListFilters(state, INSTRUCTORS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
       rerender();
@@ -376,21 +375,16 @@ export const instructorsScreen = {
 
     const instrState = state._instrDateFilter = state._instrDateFilter || {};
 
-    const fromSel  = root.querySelector('[data-instr-month-from]');
-    const clearBtn = root.querySelector('[data-instr-date-clear]');
-
-    if (fromSel) {
-      fromSel.addEventListener('change', () => {
-        instrState.from = fromSel.value || '';
-        rerender();
-      });
-    }
-    if (clearBtn) {
-      clearBtn.addEventListener('click', () => {
-        instrState.from = '';
-        rerender();
-      });
-    }
+    root.querySelector('[data-instr-month-prev]')?.addEventListener('click', () => {
+      instrState.from = shiftMonth(instrState.from || currentYm(), -1);
+      rerender();
+    });
+    root.querySelector('[data-instr-month-next]')?.addEventListener('click', () => {
+      const next = nextYm(instrState.from || currentYm());
+      const cap = currentYm();
+      instrState.from = next > cap ? cap : next;
+      rerender();
+    });
 
     state.instructorsActivityDetailsCache = state.instructorsActivityDetailsCache || {};
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8956,6 +8956,42 @@ select.ds-activity-add-field .ds-input,
   color: var(--ds-accent);
 }
 
+.ds-dashboard-summary-row {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 var(--ds-space-2);
+}
+
+.ds-dashboard-summary-title {
+  margin: 0;
+  color: var(--ds-accent);
+  font-size: 1.02rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.ds-dashboard-kpi-rows {
+  margin-top: 0;
+}
+
+.ds-manager-card--district .ds-manager-card__name {
+  font-weight: 800;
+  color: var(--ds-text);
+}
+
+.instr-date-filter--nav {
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.instr-date-filter__label {
+  min-width: 132px;
+  text-align: center;
+  font-weight: 700;
+  color: var(--ds-text);
+}
+
 /* ── Section card titles – a bit stronger ── */
 .ds-dashboard-wrap .ds-card__title {
   font-weight: 700;


### PR DESCRIPTION
### Motivation
- Fix incorrect monthly counting on the "End Dates" screen so the counter includes every activity that has a valid `end_date` in the current month/year (manager filter should still apply).
- Improve the dashboard summary area to be visually centered and more prominent, and surface the summary content by default to make the information clearer to users.
- Make the instructors screen use explicit month-arrow navigation (default to current month) and reduce noisy client-side re-renders by increasing the local search debounce.

### Description
- End-dates logic: removed the `activity_family === 'program'` gating so `normalizeRows` now counts any activity with a valid `end_date` in the current month/year while still applying an optional manager filter; file updated: `frontend/src/screens/end-dates.js`.
- Dashboard UI/behavior: replaced the small summary button with a centered summary title above KPI cards and automatically opened the summary content on bind by invoking the existing summary renderer; file updated: `frontend/src/screens/dashboard.js`.
- Instructors UX: replaced the select-based "all period" control with arrow-based month navigation (defaulting to the current month and capped not to advance past the current month), added a small `shiftMonth` helper, and increased local search debounce to `300ms`; file updated: `frontend/src/screens/instructors.js`.
- Styles: tightened spacing and centered the summary title, reduced vertical gaps, and emphasized district card names using theme variables (no hard-coded title color); file updated: `frontend/src/styles/main.css`.

### Testing
- Ran a quick module import check with `node -e "import('./frontend/src/screens/instructors.js')..."` which succeeded.
- Ran targeted test patterns with the project test runner, e.g. `npm test -- --test-name-pattern="bindLocalFilters debounces one-character searches locally without calling external loaders|activities table keeps expected columns structure"`, which showed the UI/search-related tests passing but `activities table keeps expected columns structure` still failing in the suite.
- Observed multiple failing tests unrelated to these UI changes (backend snapshot / Apps Script helper tests and some API mutation tests), indicating existing baseline failures in server-side/snapshot logic that were not modified by this PR.
- No SQL changes were made as part of this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7b216d00832b97521237af161a6f)