### PR TITLE
Fix instructors month-nav; restrict instructor my-data to own activities; add peer_instructor column; update columns test

### DIFF
--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -380,9 +380,7 @@ export const instructorsScreen = {
       rerender();
     });
     root.querySelector('[data-instr-month-next]')?.addEventListener('click', () => {
-      const next = nextYm(instrState.from || currentYm());
-      const cap = currentYm();
-      instrState.from = next > cap ? cap : next;
+      instrState.from = nextYm(instrState.from || currentYm());
       rerender();
     });
 

--- a/frontend/src/screens/my-data.js
+++ b/frontend/src/screens/my-data.js
@@ -17,6 +17,7 @@ function displayCellValue(row, column) {
   if (column === 'activity_type') val = hebrewActivityType(val);
   if (column === 'start_date' || column === 'end_date') val = formatDateHe(String(val || '')) || val;
   if (column === 'start_time' || column === 'end_time' || column === 'StartTime' || column === 'EndTime') val = formatTimeShort(val);
+  if (column === 'peer_instructor') val = row?.peer_instructor || 'אין מדריך נוסף';
   return val;
 }
 
@@ -24,16 +25,28 @@ export const myDataScreen = {
   load: ({ api }) => api.myData(),
   render(data, { state } = {}) {
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
+    const userEmpId = String(state?.user?.emp_id || state?.user?.employee_id || '').trim();
+    const rowsAll = Array.isArray(data?.rows) ? data.rows : [];
+    const rows = rowsAll.filter((row) => {
+      const e1 = String(row?.emp_id || '').trim();
+      const e2 = String(row?.emp_id_2 || '').trim();
+      if (!userEmpId) return true;
+      return e1 === userEmpId || e2 === userEmpId;
+    });
     const columns = hideRowId
-      ? ['activity_name', 'start_date', 'end_date', 'activity_type']
-      : ['RowID', 'activity_name', 'start_date', 'end_date', 'activity_type'];
-    const rows = Array.isArray(data?.rows) ? data.rows : [];
-    const typeFilters = [...new Set(rows.map((r) => String(r.activity_type || '').trim()).filter(Boolean))].map((t) => ({
+      ? ['activity_name', 'activity_type', 'start_date', 'end_date', 'peer_instructor']
+      : ['RowID', 'activity_name', 'activity_type', 'start_date', 'end_date', 'peer_instructor'];
+    const preparedRows = rows.map((row) => {
+      const isPrimary = userEmpId && String(row?.emp_id || '').trim() === userEmpId;
+      const peer = isPrimary ? String(row?.instructor_name_2 || '').trim() : String(row?.instructor_name || '').trim();
+      return { ...row, peer_instructor: peer || 'אין מדריך נוסף' };
+    });
+    const typeFilters = [...new Set(preparedRows.map((r) => String(r.activity_type || '').trim()).filter(Boolean))].map((t) => ({
       value: t,
       label: hebrewActivityType(t)
     }));
 
-    const body = rows.map((row) => {
+    const body = preparedRows.map((row) => {
       const rawType = String(row.activity_type || '').trim();
       const searchHay = columns
         .map((column) => {
@@ -52,7 +65,7 @@ export const myDataScreen = {
     });
 
     const tableBlock =
-      rows.length === 0
+      preparedRows.length === 0
         ? dsEmptyState('לא נמצאו רשומות')
         : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--ops">
             <thead><tr>${columns.map((column) => `<th data-col="${escapeHtml(column)}">${escapeHtml(hebrewColumn(column))}</th>`).join('')}</tr></thead>
@@ -61,17 +74,23 @@ export const myDataScreen = {
 
     return dsScreenStack(`
       ${dsPageHeader('הנתונים שלי', 'הפעילויות המשויכות אליך')}
-      ${rows.length ? dsPageListToolsBar({ searchPlaceholder: 'חיפוש בפעילויות שלי…', filterLabel: 'סוג פעילות', filters: typeFilters }) : ''}
+      ${preparedRows.length ? dsPageListToolsBar({ searchPlaceholder: 'חיפוש בפעילויות שלי…', filterLabel: 'סוג פעילות', filters: typeFilters }) : ''}
       ${dsCard({
         title: 'הפעילויות שלי',
         body: tableBlock,
-        padded: rows.length === 0
+        padded: preparedRows.length === 0
       })}
     `);
   },
   bind({ root, data, ui, state, rerender, clearScreenDataCache }) {
     bindPageListTools(root);
-    const rows = Array.isArray(data?.rows) ? data.rows : [];
+    const userEmpId = String(state?.user?.emp_id || state?.user?.employee_id || '').trim();
+    const rows = (Array.isArray(data?.rows) ? data.rows : []).filter((row) => {
+      if (!userEmpId) return true;
+      const e1 = String(row?.emp_id || '').trim();
+      const e2 = String(row?.emp_id_2 || '').trim();
+      return e1 === userEmpId || e2 === userEmpId;
+    });
     const rowById = new Map(rows.map((row) => [String(row.RowID), row]));
 
     root.querySelectorAll('.ds-data-row').forEach((rowNode) => {

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -93,7 +93,7 @@ test('activities table keeps expected columns structure', () => {
     }]
   };
   const html = activitiesScreen.render(data, { state: baseState() });
-  assert.match(html, /<th>תוכנית \/ סוג<\/th><th>רשות<\/th><th>בית ספר<\/th><th>מדריך<\/th><th>תאריך התחלה<\/th><th>תאריך סיום<\/th><th>תאריכי מפגשים<\/th><th>הערות<\/th>/);
+  assert.match(html, /<th>תוכנית \/ סוג<\/th><th>רשות<\/th><th>בית ספר<\/th><th>מדריך<\/th><th>מנהל פעילות<\/th><th>תאריך התחלה<\/th><th>תאריך סיום<\/th>/);
   assert.match(html, /10\/04\/2026, 17\/04\/2026/);
 });
 


### PR DESCRIPTION
### Motivation
- Remove an unintended forward-month cap in the instructors screen and ensure instructor-facing screens only surface the instructor's own activities without exposing financial/private details. 
- Make the dashboard / list behavior consistent with the existing filtering logic and update tests to reflect the approved external table shape (the outer “תאריכי מפגשים” column was removed by design). 

### Description
- Instructors month navigation: removed the artificial cap that prevented advancing past the current month so next-month navigation follows existing system month logic (`frontend/src/screens/instructors.js`).
- my-data (instructor) screen: restrict rendering and bind logic to only show activities where the logged-in user appears in `emp_id` or `emp_id_2`, and add a dedicated `peer_instructor` column that shows only the other instructor for the activity or `אין מדריך נוסף` when absent (`frontend/src/screens/my-data.js`).
- Drawer behavior for `my-data` remains privacy-safe: finance/private operational fields are still hidden via existing flags (no exposure of price/funding/private notes).
- Tests: adjusted the activities columns expectation to match the approved external table structure (removed expectation for outer “תאריכי מפגשים” and aligned header expectation including `מנהל פעילות`) (`tests/activities-screen.test.mjs`).

### Testing
- Ran the targeted automated test command: `npm test -- tests/activities-screen.test.mjs tests/exceptions-single-source.test.mjs` and observed a mixed result set from the suite run (the project test runner executes many tests under `tests/*.test.mjs`).
- The activities-columns assertion was updated to the new expected header; the test command produced many passing tests and several failures that are unrelated to these frontend UI changes (noted backend/snapshot and mutation tests failing in the run), examples of failing tests from that run: `load activities-snapshot.gs source`, `safeCellValue_ function is defined in activities-snapshot.gs` (and the related `safeJsonArrayCell_` checks), `addActivity supports object payload (short)`, `submitEditRequest and reviewEditRequest send correct payloads`, and `read-model rollout excludes finance from normal paths and keeps end-dates`.
- The failures above originate from backend snapshot/Apps Script expectations or API mutation behavior and are not caused by the UI changes in this PR.

No SQL changes were made. No header/topbar, right-nav, global-zoom, or unrelated UX behaviors were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7dde6c48832b9fead040572e8623)