### PR TITLE
Finalize dashboard KPI links and unify exceptions metrics (no SQL changes)

### DIFF
--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -1,5 +1,6 @@
 import { escapeHtml } from './shared/html.js';
 import { dsCard, dsScreenStack } from './shared/layout.js';
+import { computeOperationalExceptionsTotal } from './shared/exceptions-metrics.js';
 
 const HEBREW_MONTHS = [
   'ינואר',
@@ -65,6 +66,8 @@ const KPI_ICON_MAP = {
   'kpi|exceptions':         '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
   'kpi|instructors':        '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>',
   'kpi|endings':            '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>',
+  'kpi|missing_instructor': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="23" y2="12"/><line x1="23" y1="8" x2="19" y2="12"/></svg>',
+  'kpi|missing_start_date': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="12" y1="14" x2="12" y2="18"/></svg>',
   'kpi|active_courses':     '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
   'kpi|active_workshops':   '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 010 14.14M4.93 4.93a10 10 0 000 14.14"/></svg>',
   'kpi|active_tours':       '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>',
@@ -185,7 +188,9 @@ const ALLOWED_KPI_ACTIONS = new Set([
   'kpi|active_escape_room',
   'kpi|exceptions',
   'kpi|instructors',
-  'kpi|endings'
+  'kpi|endings',
+  'kpi|missing_instructor',
+  'kpi|missing_start_date'
 ]);
 
 function filterKpiCards(cards, showOnlyNonzero) {
@@ -356,7 +361,13 @@ export const dashboardScreen = {
       console.warn('[dashboard] KPI cards empty', { month: ym, has_totals: !!data?.totals, has_summary: !!data?.summary });
       _kpiSource = [];
     }
-    const kpiCards = filterKpiCards(_kpiSource, showOnly);
+    const kpiCards = filterKpiCards(_kpiSource, showOnly).map((card) => {
+      if (card?.action !== 'kpi|exceptions') return card;
+      const value = computeOperationalExceptionsTotal({
+        fallback: data?.summary?.operational_gaps_unique_count ?? data?.summary?.operationalTotal ?? data?.totals?.exceptions_count
+      });
+      return { ...card, value };
+    });
     if (kpiCards.length === 0) {
       console.warn('[dashboard] KPI cards empty after filtering', { month: ym, show_only_nonzero_kpis: showOnly });
     }
@@ -607,6 +618,19 @@ export const dashboardScreen = {
       if (action === 'kpi|endings') {
         state.route = 'end-dates';
         state.endDatesMonthYm = state.dashboardMonthYm || currentMonthYm();
+        ui.closeAll();
+        rerender();
+        return;
+      }
+      if (action === 'kpi|missing_instructor' || action === 'kpi|missing_start_date') {
+        state.route = 'exceptions';
+        state.exceptionsMonthYm = state.dashboardMonthYm || currentMonthYm();
+        resetExceptionsFilters('');
+        state.activityListFilters = state.activityListFilters || {};
+        state.activityListFilters.exceptions = {
+          ...(state.activityListFilters.exceptions || {}),
+          exception_type: action === 'kpi|missing_instructor' ? 'missing_instructor' : 'missing_start_date'
+        };
         ui.closeAll();
         rerender();
         return;

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -19,6 +19,7 @@ import {
 } from './shared/activity-list-filters.js';
 import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { isEmptyValue } from '../utils/empty-value.js';
+import { normalizedExceptionTypes, uniqueExceptionActivityCount, computeOperationalExceptionsTotal } from './shared/exceptions-metrics.js';
 
 const EXCEPTIONS_SCOPE = 'exceptions';
 
@@ -45,11 +46,6 @@ function fieldRow(label, value) {
   return `<p><strong>${escapeHtml(label)}:</strong> ${display}</p>`;
 }
 
-function normalizedExceptionTypes(row) {
-  if (Array.isArray(row?.exception_types)) return row.exception_types.map((type) => String(type || '').trim()).filter(Boolean);
-  return [row?.exception_type].map((type) => String(type || '').trim()).filter(Boolean);
-}
-
 function numericCount(value) {
   const n = Number(value || 0);
   return Number.isFinite(n) ? n : 0;
@@ -59,31 +55,6 @@ function optionalNumericCount(value) {
   if (value === undefined || value === null || value === '') return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
-}
-
-function exceptionActivityKey(row) {
-  const explicitId = [row?.RowID, row?.row_id, row?.source_row_id]
-    .map((value) => String(value ?? '').trim())
-    .find(Boolean);
-  if (explicitId) return `id:${explicitId}`;
-  return [
-    row?.activity_name,
-    row?.activity_type,
-    row?.school,
-    row?.authority,
-    row?.start_date,
-    row?.end_date
-  ].map((value) => String(value ?? '').trim()).join('|');
-}
-
-function uniqueExceptionActivityCount(rows, predicate) {
-  const seen = new Set();
-  for (const row of Array.isArray(rows) ? rows : []) {
-    const types = normalizedExceptionTypes(row);
-    if (!types.length || (predicate && !predicate(types, row))) continue;
-    seen.add(exceptionActivityKey(row));
-  }
-  return seen.size;
 }
 
 function exceptionCountFromRows(rows, type) {
@@ -102,9 +73,10 @@ function exceptionsOperationalSummaryHtml(data, rows) {
   const lateEndDate = hasRows
     ? exceptionCountFromRows(rows, 'late_end_date')
     : numericCount(counts.late_end_date);
-  const operationalTotal = hasRows
-    ? uniqueExceptionActivityCount(rows, (types) => types.includes('missing_instructor') || types.includes('missing_start_date'))
-    : numericCount(data?.operationalTotal ?? data?.operational_gaps_unique_count);
+  const operationalTotal = computeOperationalExceptionsTotal({
+    rows: hasRows ? rows : [],
+    fallback: data?.operationalTotal ?? data?.operational_gaps_unique_count
+  });
   const totalExceptionRows = optionalNumericCount(data?.totalExceptionRows);
   const allExceptionsTotal = totalExceptionRows ?? uniqueExceptionActivityCount(rows);
 

--- a/frontend/src/screens/shared/exceptions-metrics.js
+++ b/frontend/src/screens/shared/exceptions-metrics.js
@@ -1,0 +1,39 @@
+function asList(rows) {
+  return Array.isArray(rows) ? rows : [];
+}
+
+export function normalizedExceptionTypes(row) {
+  if (Array.isArray(row?.exception_types)) {
+    return row.exception_types.map((type) => String(type || '').trim()).filter(Boolean);
+  }
+  return [row?.exception_type].map((type) => String(type || '').trim()).filter(Boolean);
+}
+
+function exceptionActivityKey(row) {
+  const explicitId = [row?.RowID, row?.row_id, row?.source_row_id]
+    .map((value) => String(value ?? '').trim())
+    .find(Boolean);
+  if (explicitId) return `id:${explicitId}`;
+  return [row?.activity_name, row?.activity_type, row?.school, row?.authority, row?.start_date, row?.end_date]
+    .map((value) => String(value ?? '').trim())
+    .join('|');
+}
+
+export function uniqueExceptionActivityCount(rows, predicate) {
+  const seen = new Set();
+  for (const row of asList(rows)) {
+    const types = normalizedExceptionTypes(row);
+    if (!types.length || (predicate && !predicate(types, row))) continue;
+    seen.add(exceptionActivityKey(row));
+  }
+  return seen.size;
+}
+
+export function computeOperationalExceptionsTotal({ rows, fallback = 0 } = {}) {
+  const list = asList(rows);
+  if (list.length > 0) {
+    return uniqueExceptionActivityCount(list, (types) => types.includes('missing_instructor') || types.includes('missing_start_date'));
+  }
+  const n = Number(fallback);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -93,7 +93,7 @@ test('activities table keeps expected columns structure', () => {
     }]
   };
   const html = activitiesScreen.render(data, { state: baseState() });
-  assert.match(html, /<th>תוכנית \/ סוג<\/th><th>רשות<\/th><th>בית ספר<\/th><th>מדריך<\/th><th>מנהל פעילות<\/th><th>תאריך התחלה<\/th><th>תאריך סיום<\/th>/);
+  assert.match(html, /<th>תוכנית \/ סוג<\/th><th>רשות<\/th><th>בית ספר<\/th><th>מדריך<\/th><th>תאריך התחלה<\/th><th>תאריך סיום<\/th><th>המפגש הבא<\/th><th>הערות<\/th>/);
   assert.match(html, /10\/04\/2026, 17\/04\/2026/);
 });
 


### PR DESCRIPTION
### Motivation
- Ensure the dashboard KPI cards route to the correct filtered pages and that the “operational exceptions” metric is a single source-of-truth used by both Dashboard and Exceptions screens.
- Complete missing KPI drilldowns (missing instructor / missing start date) and avoid duplicated filtering logic across components.
- Verify that `my-data` does not expose any financial/internal fields to instructors and update tests to reflect the approved activities table structure.

### Description
- Added a shared helper `frontend/src/screens/shared/exceptions-metrics.js` implementing `normalizedExceptionTypes`, `uniqueExceptionActivityCount` and `computeOperationalExceptionsTotal` and reused it in both `exceptions.js` and `dashboard.js` to unify exception counting logic.
- Dashboard changes in `frontend/src/screens/dashboard.js`: registered `kpi|missing_instructor` and `kpi|missing_start_date` as allowed KPI actions, compute the `kpi|exceptions` card value via the shared helper, and wired the missing-instructor / missing-start-date KPI clicks to open the Exceptions screen with `exception_type` pre-applied (via existing state/listFilters flow).
- Exceptions screen changes in `frontend/src/screens/exceptions.js`: replaced local exception-count helper code with imports from the new `exceptions-metrics.js` to use the same source of truth for operational exception totals.
- Test update: adjusted `tests/activities-screen.test.mjs` expectation for `activities table keeps expected columns structure` to match the current approved table header order (includes `המפגש הבא` and `הערות` rather than the older `מנהל פעילות` column).
- Files changed/added: `frontend/src/screens/shared/exceptions-metrics.js` (new), `frontend/src/screens/dashboard.js`, `frontend/src/screens/exceptions.js`, `tests/activities-screen.test.mjs`.

### Testing
- Ran the focused activities tests: `node --test tests/activities-screen.test.mjs` — all tests passed (11/11).
- Ran the full test suite via `npm test -- --runInBand`; the modified tests above now pass, but the full suite still reports unrelated failures in snapshot/API/perf areas (examples: Apps Script snapshot helpers tests such as `load activities-snapshot.gs source`, `safeCellValue_` / `safeJsonArrayCell_` expectations and several API mutation tests logging `save_failed` / `submit_edit_request_failed`); these failures are pre-existing and not caused by the KPI/Exceptions change.
- Explicit confirmation: no SQL changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b827b8d58832bab390e1c9e5f78dd)