### PR TITLE
Improve dashboard prefetch, fix end-dates filtering, and make tables compact

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -191,14 +191,14 @@ function schedulePostLoginPrefetch() {
   // dashboard painted immediately from localStorage — there is no hydration
   // competition to worry about, so we can start much sooner.  The 4 s floor is
   // preserved only when the caches are fully cold (very first load / hard clear).
-  const _PREFETCH_WARM_SCREENS = ['activities', 'week', 'month'];
+  const _PREFETCH_WARM_SCREENS = ['activities', 'week', 'month', 'end-dates', 'archive'];
   const _prefetchAnyWarm = _PREFETCH_WARM_SCREENS.some((r) => {
     if (!isAllowedRoute(r)) return false;
     const hit = state.screenDataCache[buildScreenDataCacheKey(r, state)];
     const ttl = SCREEN_CACHE_TTL_MS[r] ?? DEFAULT_CACHE_TTL_MS;
     return !!(hit && Date.now() - hit.t < ttl);
   });
-  const _prefetchDelay = _prefetchAnyWarm ? 2000 : 8000;
+  const _prefetchDelay = _prefetchAnyWarm ? 1200 : 3500;
 
   prefetchTimer = setTimeout(() => {
     prefetchTimer = null;
@@ -1043,7 +1043,7 @@ async function prefetchFromDashboardIfNeeded() {
   if (!state.token) return;
   if (state.route !== 'dashboard') return;
 
-  const PREFETCH_SCREENS = ['activities', 'week', 'month'];
+  const PREFETCH_SCREENS = ['activities', 'week', 'month', 'end-dates', 'archive'];
   const toFetch = PREFETCH_SCREENS.filter((r) => isAllowedRoute(r));
   if (!toFetch.length) return;
 

--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -174,7 +174,7 @@ function archiveTableRowsHtml(rows) {
         <td class="ds-activities-col ds-activities-col--instructor">
           <span class="ds-activities-cell-ellipsis">${instructor}</span>
         </td>
-        <td>${escapeHtml(manager)}</td>
+        <td class="ds-activities-col ds-activities-col--manager">${escapeHtml(manager)}</td>
         <td class="ds-archive-date-col"><time class="ds-activities-date">${escapeHtml(startHe)}</time></td>
         <td class="ds-archive-date-col"><time class="ds-activities-date ds-archive-end-date">${escapeHtml(endHe)}</time></td>
       </tr>`;
@@ -193,7 +193,13 @@ function renderArchiveTableSection(rows, state, allRowsCount = rows.length) {
   return dsTableWrap(`
       <table class="ds-table ds-table--interactive ds-table--activities-list ds-table--archive" dir="rtl">
         <colgroup>
-          <col><col><col><col><col><col><col>
+          <col class="ds-activities-col--program">
+          <col class="ds-activities-col--authority">
+          <col class="ds-activities-col--school">
+          <col class="ds-activities-col--instructor">
+          <col class="ds-activities-col--manager">
+          <col class="ds-activities-col--date">
+          <col class="ds-activities-col--date">
         </colgroup>
         <thead>
           <tr>

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -27,25 +27,18 @@ function resolveDates(row) {
   return { dates: [], source: 'none' };
 }
 
-function currentMonthStart() {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
-}
-function currentMonthYm() {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+function isClosedStatus(value) {
+  const status = String(value || '').trim().toLowerCase();
+  return status === 'סגור' || status === 'closed' || status === 'inactive';
 }
 
 function normalizeRows(rows, managerFilter = '') {
-  const monthStart = currentMonthStart();
   const selectedManager = String(managerFilter || '').trim();
   return rows
     .map((row) => {
       const endDate = asIso(row?.end_date) || asIso(row?.date_end);
       if (!endDate) return null;
-      const status = String(row?.status || '').trim();
-      if (status !== 'פעיל') return null;
-      if (endDate < monthStart) return null;
+      if (isClosedStatus(row?.status)) return null;
       if (selectedManager && String(row?.activity_manager || '').trim() !== selectedManager) return null;
       const { dates, source } = resolveDates(row);
       return { ...row, end_date: endDate, _dates: dates, _dateSource: source };
@@ -103,6 +96,13 @@ function renderMonthTable(month, monthIdx) {
       <span class="ds-end-dates__month-count">${month.rows.length}</span>
     </h3>
     <table class="ds-end-table ds-end-table--compact" dir="rtl">
+      <colgroup>
+        <col class="ds-end-col--name">
+        <col class="ds-end-col--school">
+        <col class="ds-end-col--authority">
+        <col class="ds-end-col--date">
+        <col class="ds-end-col--actions">
+      </colgroup>
       <thead><tr>
         <th class="ds-end-th ds-end-th--name">שם פעילות</th>
         <th class="ds-end-th ds-end-th--school">בית ספר</th>
@@ -144,9 +144,9 @@ function buildExcelBlob(rows) {
 export const endDatesScreen = {
   load: ({ api }) => api.endDates(),
 
-  render(data) {
+  render(data, { state }) {
     const rawRows = Array.isArray(data?.rows) ? data.rows : [];
-    const managerFilter = String(data?.selectedManager || '');
+    const managerFilter = String(state?.endDatesManager || data?.selectedManager || '');
     const rows    = normalizeRows(rawRows, managerFilter);
     const managerOptions = Array.from(new Set(rawRows.map((r) => String(r?.activity_manager || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'he'));
     const months  = groupByMonth(rows);
@@ -172,8 +172,9 @@ export const endDatesScreen = {
       </section>`);
   },
 
-  bind({ root, data, state, refresh }) {
-    const allRows = normalizeRows(Array.isArray(data?.rows) ? data.rows : [], data?.selectedManager || '');
+  bind({ root, data, state, rerender }) {
+    const managerFilter = String(state?.endDatesManager || data?.selectedManager || '');
+    const allRows = normalizeRows(Array.isArray(data?.rows) ? data.rows : [], managerFilter);
     const months  = groupByMonth(allRows);
 
     const rowMap = new Map();
@@ -213,7 +214,7 @@ export const endDatesScreen = {
     root.querySelector('[data-end-manager]')?.addEventListener('change', (e) => {
       data.selectedManager = e.target.value || '';
       state.endDatesManager = data.selectedManager;
-      refresh();
+      rerender();
     });
   }
 };

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8432,11 +8432,10 @@ select.ds-activity-add-field .ds-input,
 .ds-table--activities-list col.ds-activities-col--authority  { width: 9%; }
 .ds-table--activities-list col.ds-activities-col--school     { width: 11%; }
 .ds-table--activities-list col.ds-activities-col--instructor { width: 10%; }
+.ds-table--activities-list col.ds-activities-col--manager    { width: 10%; }
 .ds-table--activities-list col.ds-activities-col--date       { width: 8%; }
 .ds-table--activities-list col.ds-activities-col--meetings   { width: 8%; }
 .ds-table--activities-list col.ds-activities-col--notes      { width: 11%; }
-
-.ds-table--archive col { width: calc(100% / 8); }
 
 .ds-table--activities-list th,
 .ds-table--activities-list td {
@@ -8918,6 +8917,27 @@ select.ds-activity-add-field .ds-input,
 .ds-interactive-card.is-cal-today { box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--ds-accent) 45%, transparent); }
 .ds-end-table--compact { margin-inline: auto; width: min(100%, 1100px); }
 .ds-end-table--compact th, .ds-end-table--compact td { padding: 6px 8px; }
+.ds-end-table--compact {
+  width: 100%;
+  table-layout: fixed;
+}
+.ds-end-table--compact col.ds-end-col--name { width: 28%; }
+.ds-end-table--compact col.ds-end-col--school { width: 24%; }
+.ds-end-table--compact col.ds-end-col--authority { width: 24%; }
+.ds-end-table--compact col.ds-end-col--date { width: 18%; }
+.ds-end-table--compact col.ds-end-col--actions { width: 6%; }
+.ds-end-table--compact th,
+.ds-end-table--compact td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ds-end-table--compact th.ds-end-th--date,
+.ds-end-table--compact td.ds-end-td--date,
+.ds-end-table--compact th.ds-end-th--actions,
+.ds-end-table--compact td.ds-end-td--actions {
+  text-align: center;
+}
 
 /* ======================================================
    Dashboard design polish – 2026-05
@@ -9200,10 +9220,17 @@ select.ds-activity-add-field .ds-input,
   border-color: var(--ds-accent);
 }
 
+.ds-table--archive {
+  width: 100%;
+  table-layout: fixed;
+}
 .ds-table--archive th,
 .ds-table--archive td {
   text-align: right;
   padding: 4px 7px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .ds-table--archive th:nth-last-child(2),
 .ds-table--archive th:nth-last-child(1),
@@ -9212,13 +9239,12 @@ select.ds-activity-add-field .ds-input,
 .ds-table--archive .ds-archive-date-col {
   text-align: center;
 }
-.ds-table--archive col:nth-child(1) { width: 200px; }
-.ds-table--archive col:nth-child(2) { width: 155px; }
-.ds-table--archive col:nth-child(3) { width: 155px; }
-.ds-table--archive col:nth-child(4) { width: 155px; }
-.ds-table--archive col:nth-child(5) { width: 155px; }
-.ds-table--archive col:nth-child(6) { width: 105px; }
-.ds-table--archive col:nth-child(7) { width: 105px; }
+.ds-table--archive col.ds-activities-col--program { width: 22%; }
+.ds-table--archive col.ds-activities-col--authority,
+.ds-table--archive col.ds-activities-col--school,
+.ds-table--archive col.ds-activities-col--instructor,
+.ds-table--archive col.ds-activities-col--manager { width: 14%; }
+.ds-table--archive col.ds-activities-col--date { width: 11%; }
 
 /* Targeted fixes: instructors density + drawer actions */
 @media (min-width: 1281px) {


### PR DESCRIPTION
### Motivation
- להאיץ טעינת מסכים כבדים מבחינת חוויית המשתמש על-ידי חימום מוקדם של המסכים `end-dates` ו-`archive` מהדשבורד בלי לשנות את לוגיקת ה-cache/inflight/stale-while-revalidate.
- לתקן בעיה בתצוגת `end-dates` שגרמה להסתירות לא מכוונות של שורות ולקריאות לפונקציה לא קיימת ב-bind.
- לשפר קריאות ועימוד בטבלאות הרלוונטיות (activities, archive, end-dates) באמצעות אורך עמודות מפורש ו-ellipsis במקום שבר layout.

### Description
- הרחבתי את רשימת היעדים ש-prefetch מהדשבורד ב-`frontend/src/main.js` כך שתכלול גם `end-dates` ו-`archive`, ושיניתי את `prefetch` delay ל-`_prefetchDelay = _prefetchAnyWarm ? 1200 : 3500` כדי לחמם מסכים כבדים מוקדם יותר בלי לשבור `inflightRequests` או cache. (שינויים ב-`frontend/src/main.js`).
- ב-`frontend/src/screens/end-dates.js` הוצאתי את סינון ה-`status === 'פעיל'` והחלפתי בנירמול סטטוס סגור באמצעות פונקציה `isClosedStatus` שתזהה `סגור`/`closed`/`inactive`, והסרתי את הסינון לפי תחילת החודש כך שכל פעילויות עם `end_date` יוצגו אלא אם הן סגורות; בנוסף הוספתי קריאה ל-`state.endDatesManager` ב-`render` ו-`bind` ושיניתי את קריאת החידוש ל-`rerender()` במקום `refresh()` שלא הועבר. (שינויים ב-`frontend/src/screens/end-dates.js`).
- בטבלת `end-dates` הוספתי `colgroup` עם מחלקות עמודה מתאימות, וב-`archive` החלפתי את ה-`colgroup` הריק ב-`colgroup` עם מחלקות עמודה התואמות לטבלת `activities` ולהוספת מחלקת `manager` בתא הנתונים. (שינויים ב-`frontend/src/screens/end-dates.js` ו-`frontend/src/screens/archive.js`).
- עדכנתי CSS ב-`frontend/src/styles/main.css` כדי לאכוף `table-layout: fixed; width: 100%;` ולהוסיף `overflow:hidden; text-overflow: ellipsis; white-space: nowrap;` לטבלאות ועמודות היעד, להכריז רוחבי עמודות מפורשים ל-`activities`, `archive` ו-`end-dates`, ולרכז את עמודות התאריכים כפי שנדרש. (שינויים ב-`frontend/src/styles/main.css`).

### Testing
- הרצת `npm run -s lint` בוצעה אוטומטית בסביבה והסתיימה עם exit code `1` (לא הוצג פלט בסביבה זו), ולכן יש להריץ את ה-linter/CI בסביבת dev מלאה לפני פריסה; תוצאה: `failed`.
- לא בוצעו בדיקות אוטומטיות נוספות במסגרת הרולאוט הזה, ויש לבדוק התנהגות `prefetch` והגדרה של `state.endDatesManager` בדפדפן בפיתוח כדי לאמת רינדור וסינון שורות.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd216a2a0832bb500be7bc8a263cd)