### PR TITLE
End-dates: filter from today and right-align archive manager column

### DIFF
--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -174,7 +174,7 @@ function archiveTableRowsHtml(rows) {
         <td class="ds-activities-col ds-activities-col--instructor">
           <span class="ds-activities-cell-ellipsis">${instructor}</span>
         </td>
-        <td class="ds-activities-col ds-activities-col--manager">${escapeHtml(manager)}</td>
+        <td class="ds-activities-col ds-activities-col--manager ds-archive-col-manager">${escapeHtml(manager)}</td>
         <td class="ds-archive-date-col"><time class="ds-activities-date">${escapeHtml(startHe)}</time></td>
         <td class="ds-archive-date-col"><time class="ds-activities-date ds-archive-end-date">${escapeHtml(endHe)}</time></td>
       </tr>`;
@@ -207,7 +207,7 @@ function renderArchiveTableSection(rows, state, allRowsCount = rows.length) {
             <th>רשות</th>
             <th>בית ספר</th>
             <th>מדריך</th>
-            <th>מנהל פעילות</th>
+            <th class="ds-archive-col-manager">מנהל פעילות</th>
             <th>תאריך התחלה</th>
             <th>תאריך סיום</th>
           </tr>

--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -32,13 +32,23 @@ function isClosedStatus(value) {
   return status === 'סגור' || status === 'closed' || status === 'inactive';
 }
 
+function localTodayIso() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 function normalizeRows(rows, managerFilter = '') {
   const selectedManager = String(managerFilter || '').trim();
+  const today = localTodayIso();
   return rows
     .map((row) => {
       const endDate = asIso(row?.end_date) || asIso(row?.date_end);
       if (!endDate) return null;
       if (isClosedStatus(row?.status)) return null;
+      if (endDate < today) return null;
       if (selectedManager && String(row?.activity_manager || '').trim() !== selectedManager) return null;
       const { dates, source } = resolveDates(row);
       return { ...row, end_date: endDate, _dates: dates, _dateSource: source };
@@ -183,7 +193,7 @@ export const endDatesScreen = {
     });
 
     root.querySelector('[data-end-dates-export]')?.addEventListener('click', () => {
-      const stamp = new Date().toISOString().slice(0, 10);
+      const stamp = localTodayIso();
       triggerExcelDownload(buildExcelBlob(allRows), `תאריכי_סיום_${stamp}.xls`);
     });
 
@@ -207,7 +217,7 @@ export const endDatesScreen = {
         if (!row) return;
         const name  = String(row.activity_name || 'פעילות')
           .replace(/[/\\?%*:|"<>]/g, '_').slice(0, 40);
-        const stamp = new Date().toISOString().slice(0, 10);
+        const stamp = localTodayIso();
         triggerExcelDownload(buildExcelBlob([row]), `${name}_${stamp}.xls`);
       });
     });

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9245,6 +9245,9 @@ select.ds-activity-add-field .ds-input,
 .ds-table--archive col.ds-activities-col--instructor,
 .ds-table--archive col.ds-activities-col--manager { width: 14%; }
 .ds-table--archive col.ds-activities-col--date { width: 11%; }
+.ds-table--archive .ds-archive-col-manager {
+  text-align: right;
+}
 
 /* Targeted fixes: instructors density + drawer actions */
 @media (min-width: 1281px) {


### PR DESCRIPTION
### Motivation
- Ensure the `end-dates` screen shows only non-closed activities with a valid `end_date` from the local current day onward (`end_date >= today`) and avoid any automatic archiving behavior. 
- Prevent timezone-based day shifts in export filenames by using a local `YYYY-MM-DD` date string. 
- Make the archive table's "מנהל פעילות" column visually aligned to the right without changing archive logic.

### Description
- Added `localTodayIso()` and applied it in `frontend/src/screens/end-dates.js` to generate local `YYYY-MM-DD` dates and to filter out rows with `end_date < today`, while preserving manager filtering, sorting and monthly grouping. 
- Replaced uses of `toISOString()` for export filename stamps in `end-dates` with `localTodayIso()` to avoid timezone day shifts. 
- Added the `ds-archive-col-manager` class to the manager column header and cells in `frontend/src/screens/archive.js`. 
- Added a focused CSS rule in `frontend/src/styles/main.css` (`.ds-table--archive .ds-archive-col-manager { text-align: right; }`) to right-align the manager column header and cell content without other styling or logic changes.

### Testing
- Ran `git -C /workspace/dashboard_system diff --check` with no reported issues. 
- Verified repository status with `git -C /workspace/dashboard_system status --short`. 
-Committed the changes successfully to the local branch (commit recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdfa86480832b96af5cd630574841)