### PR TITLE
הוספת מסך 'כספים / גבייה' עם הרשאת `finance_access`

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1564,7 +1564,11 @@ function flattenUserRow(userRow = {}) {
 function buildBootstrapFromUser(userRow) {
   const flat = flattenUserRow(userRow);
   const role = normalizeSupabaseRole(flat.role);
-  const allowedRoutes = SUPABASE_ROLE_ROUTES[role] || SUPABASE_ROLE_ROUTES.authorized_user;
+  const allowedRoutes = [...(SUPABASE_ROLE_ROUTES[role] || SUPABASE_ROLE_ROUTES.authorized_user)];
+  const hasFinanceAccess = permissionFlagYes((userRow?.permissions || {}).finance_access);
+  const financeIdx = allowedRoutes.indexOf('finance');
+  if (hasFinanceAccess && financeIdx === -1) allowedRoutes.push('finance');
+  if (!hasFinanceAccess && financeIdx >= 0) allowedRoutes.splice(financeIdx, 1);
   const canEditDirect = ROLES_WITH_DIRECT_EDIT.has(role) || permissionFlagYes(flat.can_edit_direct);
   const canRequestEdit = canEditDirect || permissionFlagYes(flat.can_request_edit) || role !== 'instructor';
   return {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -510,7 +510,8 @@ const screenLabels = {
   'admin-settings': 'הגדרות מערכת',
   'admin-lists': 'ניהול רשימות',
   archive: 'ארכיון',
-  'proposals-agreements': 'הצעות'
+  'proposals-agreements': 'הצעות',
+  finance: 'כספים / גבייה'
 };
 
 const screenLoaders = {
@@ -530,7 +531,8 @@ const screenLoaders = {
   'admin-settings': () => import('./screens/admin-settings.js').then((m) => m.adminSettingsScreen),
   'admin-lists': () => import('./screens/admin-lists.js').then((m) => m.adminListsScreen),
   archive: () => import('./screens/archive.js').then((m) => m.archiveScreen),
-  'proposals-agreements': () => import('./screens/proposals-agreements.js').then((m) => m.proposalsAgreementsScreen)
+  'proposals-agreements': () => import('./screens/proposals-agreements.js').then((m) => m.proposalsAgreementsScreen),
+  finance: () => import('./screens/finance.js').then((m) => m.financeScreen)
 };
 const loadedScreens = new Map();
 const loadingScreens = new Map();
@@ -601,7 +603,7 @@ function effectiveRoutes() {
  * Routes that are permanently disabled regardless of user permissions.
  * Any attempt to navigate to these is silently redirected to dashboard (or the first allowed route).
  */
-const PERMANENTLY_DISABLED_ROUTES = new Set(['finance']);
+const PERMANENTLY_DISABLED_ROUTES = new Set([]);
 
 function redirectIfDisabledRoute() {
   if (!PERMANENTLY_DISABLED_ROUTES.has(state.route)) return;

--- a/frontend/src/screens/finance.js
+++ b/frontend/src/screens/finance.js
@@ -1,0 +1,84 @@
+import { escapeHtml } from './shared/html.js';
+import { formatDateHe } from './shared/format-date.js';
+import { dsPageHeader, dsCard, dsScreenStack, dsTableWrap, dsEmptyState, dsStatusChip } from './shared/layout.js';
+import { hebrewActivityType, financeStatusVariant } from './shared/ui-hebrew.js';
+
+const FINANCE_CLOSED = 'סגור';
+
+function normalizeFinanceStatus(value) { return String(value || '').trim(); }
+function isFinanceClosed(value) { return normalizeFinanceStatus(value) === FINANCE_CLOSED; }
+function num(v) { const n = Number(v); return Number.isFinite(n) ? n : 0; }
+function money(v) { return `₪${num(v).toLocaleString('he-IL', { maximumFractionDigits: 2 })}`; }
+
+function buildGroupKey(row = {}) {
+  const funding = String(row.funding || '').trim() || 'ללא מימון';
+  const authority = String(row.authority || '').trim() || '—';
+  const school = String(row.school || '').trim() || '—';
+  const cluster = funding === 'גפ״ן' ? school : (funding === 'רשות' ? authority : funding);
+  return `${funding}__${authority}__${cluster}`;
+}
+
+function groupActivities(rows = []) {
+  const map = new Map();
+  for (const row of rows) {
+    const key = buildGroupKey(row);
+    const funding = String(row.funding || '').trim() || 'ללא מימון';
+    const authority = String(row.authority || '').trim() || '—';
+    const school = String(row.school || '').trim() || '—';
+    const cluster = funding === 'גפ״ן' ? school : (funding === 'רשות' ? authority : funding);
+    if (!map.has(key)) map.set(key, { key, funding, authority, cluster, activities: [], total: 0, notesCount: 0, openCount: 0 });
+    const g = map.get(key);
+    g.activities.push(row);
+    g.total += num(row.price);
+    if (String(row.finance_notes || '').trim()) g.notesCount += 1;
+    if (!isFinanceClosed(row.finance_status)) g.openCount += 1;
+  }
+  return [...map.values()].sort((a, b) => b.activities.length - a.activities.length);
+}
+
+function groupFinanceStatus(g) { return g.openCount === 0 ? FINANCE_CLOSED : 'פתוח'; }
+
+export const financeScreen = {
+  load: ({ api }) => api.allActivities(),
+  render(data, { state } = {}) {
+    const hasAccess = ['yes', 'true', '1'].includes(String(state?.user?.finance_access || '').toLowerCase());
+    if (!hasAccess) return dsScreenStack(`${dsPageHeader('כספים / גבייה', 'גישה מוגבלת')} ${dsEmptyState('אין הרשאה לעמוד כספים (finance_access).')}`);
+
+    const tab = String(state?.financeTab || 'active');
+    const allRows = Array.isArray(data?.rows) ? data.rows : [];
+    const rows = allRows.filter((r) => tab === 'archive' ? isFinanceClosed(r.finance_status) : !isFinanceClosed(r.finance_status));
+    const groups = groupActivities(rows);
+
+    const tabs = `<div class="ds-tabs" style="display:flex;gap:8px"><button class="ds-btn ds-btn--sm ${tab === 'active' ? 'ds-btn--primary' : ''}" data-finance-tab="active">גבייה פעילה</button><button class="ds-btn ds-btn--sm ${tab === 'archive' ? 'ds-btn--primary' : ''}" data-finance-tab="archive">ארכיון כספים</button></div>`;
+    const body = groups.map((g) => `<tr class="ds-data-row" data-finance-group="${escapeHtml(g.key)}" role="button" tabindex="0"><td>${escapeHtml(g.funding)}</td><td>${escapeHtml(g.authority)}</td><td>${g.activities.length}</td><td>${escapeHtml(money(g.total))}</td></tr>`).join('');
+    const table = groups.length ? dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--compact"><thead><tr><th>גורם מימון</th><th>רשות</th><th>כמות פעילויות</th><th>סה״כ לגבייה</th></tr></thead><tbody>${body}</tbody></table>`) : dsEmptyState('אין רשומות בלשונית זו');
+    return dsScreenStack(`${dsPageHeader('כספים / גבייה', `ריכוזי גבייה (${groups.length})`)} ${tabs} ${dsCard({ title:'ריכוז גבייה', body: table, padded: groups.length===0 })}`);
+  },
+  bind({ root, data, state, ui, api, rerender, clearScreenDataCache }) {
+    const hasAccess = ['yes', 'true', '1'].includes(String(state?.user?.finance_access || '').toLowerCase());
+    if (!hasAccess) return;
+    const allRows = Array.isArray(data?.rows) ? data.rows : [];
+    const tab = String(state?.financeTab || 'active');
+    const filtered = allRows.filter((r) => tab === 'archive' ? isFinanceClosed(r.finance_status) : !isFinanceClosed(r.finance_status));
+    const groups = groupActivities(filtered);
+    const byKey = new Map(groups.map((g) => [g.key, g]));
+
+    root.querySelectorAll('[data-finance-tab]').forEach((b) => b.addEventListener('click', () => { state.financeTab = b.dataset.financeTab; rerender?.(); }));
+
+    const openGroup = (g) => {
+      const summary = `<div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px;font-size:13px"><div><strong>גורם מימון:</strong> ${escapeHtml(g.funding)}</div><div><strong>רשות:</strong> ${escapeHtml(g.authority)}</div><div><strong>גורם ריכוז:</strong> ${escapeHtml(g.cluster)}</div><div><strong>כמות פעילויות:</strong> ${g.activities.length}</div><div><strong>סה״כ לגבייה:</strong> ${escapeHtml(money(g.total))}</div><div><strong>סטטוס כספים:</strong> ${dsStatusChip(groupFinanceStatus(g), financeStatusVariant(groupFinanceStatus(g)))}</div><div><strong>הערות כספים:</strong> ${g.notesCount > 0 ? 'יש' : 'אין'}</div></div>`;
+      const activities = g.activities.map((row, idx) => `<details class="ds-acc" style="border:1px solid #e5e7eb;border-radius:8px;padding:6px"><summary style="cursor:pointer;display:flex;justify-content:space-between;gap:8px"><span>${escapeHtml(row.activity_name || 'ללא שם')}</span><span>${escapeHtml(hebrewActivityType(row.activity_type))}</span><span>${escapeHtml(formatDateHe(row.end_date || row.date_end || '') || '—')}</span><span>${escapeHtml(money(row.price))}</span></summary><div style="margin-top:8px;font-size:13px;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px"><div><strong>שם פעילות:</strong> ${escapeHtml(row.activity_name || '')}</div><div><strong>סוג פעילות:</strong> ${escapeHtml(hebrewActivityType(row.activity_type))}</div><div><strong>בית ספר:</strong> ${escapeHtml(row.school || '—')}</div><div><strong>רשות:</strong> ${escapeHtml(row.authority || '—')}</div><div><strong>מדריך:</strong> ${escapeHtml(row.instructor_name || '—')}</div><div><strong>מנהל / אחראי:</strong> ${escapeHtml(row.activity_manager || '—')}</div><div><strong>תאריך התחלה:</strong> ${escapeHtml(formatDateHe(row.start_date || row.date_start || '') || '—')}</div><div><strong>תאריך סיום:</strong> ${escapeHtml(formatDateHe(row.end_date || row.date_end || '') || '—')}</div><div><strong>מספר מפגשים:</strong> ${escapeHtml(String(row.sessions || '—'))}</div><div><strong>סכום פעילות:</strong> <input class="ds-input ds-input--sm" data-finance-field="price" data-row-id="${escapeHtml(row.RowID || row.row_id)}" value="${escapeHtml(String(row.price ?? ''))}" /></div><div><strong>סטטוס פעילות:</strong> ${escapeHtml(row.status || '—')}</div><div><strong>סטטוס כספים:</strong> <input class="ds-input ds-input--sm" data-finance-field="finance_status" data-row-id="${escapeHtml(row.RowID || row.row_id)}" value="${escapeHtml(String(row.finance_status || ''))}" /></div><div style="grid-column:1/-1"><strong>הערות כספים:</strong> <textarea class="ds-input" rows="2" data-finance-field="finance_notes" data-row-id="${escapeHtml(row.RowID || row.row_id)}">${escapeHtml(String(row.finance_notes || ''))}</textarea></div><div style="grid-column:1/-1;display:flex;gap:6px"><button class="ds-btn ds-btn--sm ds-btn--primary" data-finance-save="${escapeHtml(row.RowID || row.row_id)}">שמירה</button></div></div></details>`).join('');
+      ui.openDrawer({ title: 'פירוט גבייה', content: `<div style="display:grid;gap:10px">${summary}<div style="display:grid;gap:6px">${activities}</div></div>` });
+      document.querySelectorAll('[data-finance-save]').forEach((btn) => btn.addEventListener('click', async () => {
+        const rowId = btn.dataset.financeSave;
+        const changes = {};
+        document.querySelectorAll(`[data-row-id="${rowId}"]`).forEach((el) => { changes[el.dataset.financeField] = el.value; });
+        await api.saveActivity({ source_row_id: rowId, source_sheet: 'activities', changes });
+        clearScreenDataCache?.();
+        rerender?.();
+      }));
+    };
+
+    root.querySelectorAll('[data-finance-group]').forEach((rowEl) => rowEl.addEventListener('click', () => { const g = byKey.get(rowEl.dataset.financeGroup); if (g) openGroup(g); }));
+  }
+};

--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -10,7 +10,8 @@ const KEY_PERM_FLAGS = [
   'can_request_edit',
   'can_review_requests',
   'view_admin',
-  'view_permissions'
+  'view_permissions',
+  'finance_access'
 ];
 
 const PERMISSION_ROLE_OPTIONS = [
@@ -79,7 +80,8 @@ function sortedPermissionEditorKeys(row) {
       k === 'display_role2' ||
       k === 'default_view' ||
       k.startsWith('view_') ||
-      k.startsWith('can_')
+      k.startsWith('can_') ||
+      k === 'finance_access'
     );
   });
   const rank = (k) => {

--- a/frontend/src/screens/shared/act-nav-grid.js
+++ b/frontend/src/screens/shared/act-nav-grid.js
@@ -11,7 +11,8 @@ export const ACT_SUBNAV_ITEMS = [
   { route: 'contacts',            label: 'אנשי קשר',             icon: '📇' },
   { route: 'permissions',         label: 'הרשאות',               icon: '🔑' },
   { route: 'edit-requests',       label: 'אישורים',              icon: '✅' },
-  { route: 'my-data',             label: 'הנתונים שלי',          icon: '👤' }
+  { route: 'my-data',             label: 'הנתונים שלי',          icon: '👤' },
+  { route: 'finance',             label: 'כספים / גבייה',         icon: '💰' }
 ];
 
 /**

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -156,6 +156,7 @@ const PERMISSION_FIELD_LABELS = {
   view_exceptions: 'צפייה — חריגות',
   view_my_data: 'צפייה — הנתונים שלי',
   view_operations_data: 'צפייה — נתוני תפעול',
+  finance_access: 'גישה — כספים / גבייה',
   view_contacts_instructors: 'צפייה — אנשי קשר מדריכים',
   'view_contacts_instructors 2': 'צפייה — אנשי קשר מדריכים (2)',
   view_permissions: 'צפייה — הרשאות',


### PR DESCRIPTION
### Motivation

- להוסיף מסך נפרד לניהול מעקב גבייה שיתמקד בסטטוס כספים, סכומים והערות ללא הפיכתו למערכת הנהלת חשבונות מלאה.
- לאפשר גישה מבוקרת לפי הרשאת `finance_access` בלבד ולמנוע שימוש בבדיקה קשיחה של מספר עובד או מתן גישה לפי תפקידים כלליים.

### Description

- נוסף מסך חדש `finance` ב-`frontend/src/screens/finance.js` שמציג שתי לשוניות: `גבייה פעילה` ו-`ארכיון כספים`, כאשר המעבר נקבע אך ורק לפי השדה `finance_status` (`'סגור'` נכנס לארכיון).
- מסך הריכוז טוען את כלל הפעילויות דרך `api.allActivities()` ומרכז לפי כלל ה-`funding` (כללים: `גפ״ן` => בית ספר, `רשות` => רשות, אחרת לפי ערך המימון), ומציג בטבלה החיצונית רק את 4 העמודות המבוקשות.
- לחיצה על שורת ריכוז פותחת `Drawer` עם אקורדיון של הפעילויות; בפירוט כל פעילות מוצגים שדות קריאה ועריכה קומפקטיים כולל עריכת `finance_status`, `finance_notes` ו-`price` ושמירה דרך `api.saveActivity`.
- הוספו שינויים בניווט ובהרשאות: הוספת `finance` ל-`screenLabels` ו-`screenLoaders`, ביטול החסימה הקשיחה של `finance` ב-`main.js`, הוספת שדה הרשאה `finance_access` ל-`permissions` UI ולמילון התוויות עברי, ובלימת הוספת ה-route ב-`bootstrap` עד ש-`permissions.finance_access` הוא `yes/true/1` (לוגיקה ב-`frontend/src/api.js`).
- קבצים מרכזיים ששונו: `frontend/src/screens/finance.js` (חדש), `frontend/src/main.js`, `frontend/src/api.js`, `frontend/src/screens/permissions.js`, `frontend/src/screens/shared/ui-hebrew.js`, `frontend/src/screens/shared/act-nav-grid.js`.

### Testing

- הרצת פקודת בדיקה: `npm test -- tests/auth-permissions-routes.test.mjs` (הסקריפט הריץ את ה-suite של `tests/*.test.mjs`).
- תוצאות אוטומטיות: הקונסול הדפיס הרבה בדיקות שעברו בהצלחה אך הופיעו גם מספר כשלי בדיקה; מבחן רלוונטי ל-routing שהתקיים כשל: `read-model rollout excludes finance from normal paths and keeps end-dates` והיו כשלות נוספות בסביבת ה-tests (כולל מודולים של snapshot ו-mutations) שלא קשורות ישירות לשינוי ה-UI.
- מסקנה מבחני CI: השינוי הוכנס לקוד ונבדק מקומית, אך יש להריץ את ה-suite המלא בסביבת CI ולהתייחס לכשלים הקיימים בספריית הבדיקות לפני merge סופי.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0befc9701c832bbda851f07833a14c)