### PR TITLE
Fix persistence of meeting-date deletions in activity edit flow

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1921,7 +1921,7 @@ async function updateActivityInSupabase(payload = {}) {
   const hasMeetingDateChange = Object.keys(changes).some((k) => /^date_\d+$/.test(k));
   if (hasMeetingDateChange) {
     const derivedEnd = deriveEndDateFromDates(changes);
-    if (derivedEnd) changes.end_date = derivedEnd;
+    changes.end_date = derivedEnd || '';
   }
   if (!rowId) throw new Error('missing_row_id');
   if (!Object.keys(changes).length) throw new Error('No changes to submit');

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -148,6 +148,31 @@ function updateMoreDatesToggle(form) {
   syncMeetingRemoveButtons(form);
 }
 
+function buildMeetingDatesSnapshot(form) {
+  const pickers = Array.from(form.querySelectorAll('[data-meeting-dates-edit] input[data-meeting-idx]')).sort(
+    (a, b) => Number(a.dataset.meetingIdx) - Number(b.dataset.meetingIdx)
+  );
+  const dates = pickers
+    .map((picker) => String(picker?.value || '').trim())
+    .filter((value) => value);
+  const normalized = Array.from({ length: 35 }, (_, idx) => String(dates[idx] || '').trim());
+  let endDate = '';
+  normalized.forEach((value) => {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) endDate = value;
+  });
+  return { dates: normalized, endDate };
+}
+
+function hasMeetingDatesChanged(form, initialValues = {}) {
+  const { dates } = buildMeetingDatesSnapshot(form);
+  for (let i = 0; i < 35; i++) {
+    const current = String(dates[i] || '').trim();
+    const prev = String(initialValues[`meeting_date_${i}`] ?? initialValues[`date_${i + 1}`] ?? '').trim();
+    if (current !== prev) return true;
+  }
+  return false;
+}
+
 export function bindActivityEditForm(contentRoot, {
   api,
   clearScreenDataCache,
@@ -187,6 +212,14 @@ export function bindActivityEditForm(contentRoot, {
       if (nextValue === prevValue) return;
       changes[name] = nextValue;
     });
+
+    if (hasMeetingDatesChanged(form, initialValues)) {
+      const snapshot = buildMeetingDatesSnapshot(form);
+      for (let i = 0; i < 35; i++) {
+        changes[`meeting_date_${i}`] = snapshot.dates[i];
+      }
+      changes.end_date = snapshot.endDate;
+    }
 
     try {
       if (!Object.keys(changes).length) {


### PR DESCRIPTION
### Motivation
- Bug: removing a meeting/date in the activity-edit drawer removed the card from the DOM but the deletion was not persisted to the DB because the save collected only remaining input fields. 
- The change aims to send a full, ordered picture of all meeting slots so deletions/insertions/edits always rewrite `date_1..date_35` and `end_date` accordingly.

### Description
- When meeting dates change the form now builds a full 35-slot snapshot from on-screen order and injects `meeting_date_0..meeting_date_34` plus `end_date` into the `changes` payload before save, implemented in `frontend/src/screens/shared/bind-activity-edit-form.js` via `buildMeetingDatesSnapshot` and `hasMeetingDatesChanged` and usage in `saveActivityForm`.
- Snapshot compacts later dates up when a middle date is removed and fills trailing slots with empty strings so Supabase receives explicit clears for unused `date_*` columns.
- On the API side `frontend/src/api.js` was adjusted so that when any `date_*` fields are included in an update the `end_date` is always rewritten to the derived latest date or to an empty string (rather than leaving old `end_date` intact).
- Fix is targeted: no UI/design/schema/permission/refactor changes were made and only meeting-date persistence behavior was modified.

### Testing
- Ran the repository test suite with `npm test --silent`, which executed many unit tests and reported multiple passing tests as well as some preexisting unrelated failures in snapshot-related and edit-request API tests from the baseline; the test run completed.
- No new test failures attributable to the meeting-date changes were observed in the test output context, and the change is focused to the save payload behavior only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c46b68bdc832bb0eb5ec0baeb6afa)