### PR TITLE
שחזור תאריכים בפעילות: שמירת null ל־date, עדכון end_date, הסרת frequency והרפיית ולידציה

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1846,14 +1846,14 @@ function mapMeetingDateFieldNamesToSupabase(changes = {}) {
 
 function normalizeDateFieldForSupabase(value) {
   const clean = String(value ?? '').trim();
-  if (!clean) return '';
+  if (!clean) return null;
   const normalized = normalizeSupabaseDate(clean);
-  return normalized || '';
+  return normalized || null;
 }
 
 /**
  * Given a sanitized payload that may contain date_1..date_35,
- * returns the latest non-empty YYYY-MM-DD value, or '' if none found.
+ * returns the latest non-empty YYYY-MM-DD value, or null if none found.
  */
 function deriveEndDateFromDates(sanitized = {}) {
   let last = '';
@@ -1861,7 +1861,7 @@ function deriveEndDateFromDates(sanitized = {}) {
     const v = String(sanitized[`date_${i}`] || '').trim().slice(0, 10);
     if (/^\d{4}-\d{2}-\d{2}$/.test(v) && v > last) last = v;
   }
-  return last;
+  return last || null;
 }
 
 function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true } = {}) {
@@ -1874,7 +1874,7 @@ function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true 
     if (key === 'start_date' || key === 'end_date' || /^date_\d+$/.test(key)) {
       nextValue = normalizeDateFieldForSupabase(rawValue);
     }
-    sanitized[key] = nextValue === undefined || nextValue === null ? '' : nextValue;
+    sanitized[key] = nextValue === undefined ? '' : nextValue;
   }
   return sanitized;
 }
@@ -1883,9 +1883,9 @@ async function upsertActivityToSupabase(payload = {}) {
   const act = payload?.activity || payload || {};
   const row = sanitizeActivityPayloadForSupabase(sanitizeActivityPayload(act), { includeRowId: true });
   const derivedEnd = deriveEndDateFromDates(row);
-  if (derivedEnd) row.end_date = derivedEnd;
+  row.end_date = derivedEnd || null;
   logActivityMutationDebug('request', 'addActivity', { source_sheet: 'activities', source_row_id: row.row_id, changes: row });
-  const { data, error } = await supabase.from('activities').upsert(row, { onConflict: 'row_id' }).select().single();
+  const { data, error } = await supabase.from('activities').insert(row).select().single();
   if (error) {
     const authContext = await buildActivityMutationAuthContext();
     // eslint-disable-next-line no-console
@@ -1921,7 +1921,7 @@ async function updateActivityInSupabase(payload = {}) {
   const hasMeetingDateChange = Object.keys(changes).some((k) => /^date_\d+$/.test(k));
   if (hasMeetingDateChange) {
     const derivedEnd = deriveEndDateFromDates(changes);
-    changes.end_date = derivedEnd || '';
+    changes.end_date = derivedEnd || null;
   }
   if (!rowId) throw new Error('missing_row_id');
   if (!Object.keys(changes).length) throw new Error('No changes to submit');

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -348,7 +348,6 @@ function addActivityModalHtml(settings) {
         <input type="hidden" name="emp_id_2" value="">
         <label class="ds-activity-add-field"><span>תאריך התחלה</span><input class="ds-input" name="start_date" type="date"></label>
         <label class="ds-activity-add-field"><span>תאריך סיום</span><input class="ds-input" name="end_date" type="date"></label>
-        <label class="ds-activity-add-field"><span>תדירות</span><select class="ds-input" name="frequency" data-add-frequency>${optionsHtml(['weekly', 'biweekly'], 'weekly', 'בחרו תדירות')}</select></label>
         <div class="ds-activity-add-field ds-activity-add-field--span2" data-add-date-rows-wrap>
           <span>תאריכי מפגשים</span>
           <div class="ds-activity-add-date-rows" data-add-date-rows></div>
@@ -1112,11 +1111,10 @@ export const activitiesScreen = {
       syncSessionDateRows(form);
     }
 
-    function computeNextSessionDate(baseIso, index, frequency) {
+    function computeNextSessionDate(baseIso, index) {
       if (!/^\d{4}-\d{2}-\d{2}$/.test(String(baseIso || ''))) return '';
       const base = new Date(`${baseIso}T00:00:00`);
-      const stepDays = frequency === 'biweekly' ? 14 : 7;
-      base.setDate(base.getDate() + (index * stepDays));
+      base.setDate(base.getDate() + (index * 7));
       return `${base.getFullYear()}-${String(base.getMonth() + 1).padStart(2, '0')}-${String(base.getDate()).padStart(2, '0')}`;
     }
 
@@ -1125,10 +1123,9 @@ export const activitiesScreen = {
       const container = form.querySelector('[data-add-date-rows]');
       if (!container) return;
       const startDate = String(form.querySelector('[name="start_date"]')?.value || '').trim();
-      const frequency = String(form.querySelector('[data-add-frequency]')?.value || 'weekly').trim();
       const prev = Array.from(container.querySelectorAll('input[data-add-session-date]')).map((input) => String(input.value || '').trim());
       container.innerHTML = Array.from({ length: sessions }, (_, idx) => {
-        const value = prev[idx] || computeNextSessionDate(startDate, idx, frequency);
+        const value = prev[idx] || computeNextSessionDate(startDate, idx);
         return `<label class="ds-add-date-row"><span>מפגש ${idx + 1}</span><input class="ds-input ds-input--sm" type="date" data-add-session-date="${idx + 1}" value="${escapeHtml(value)}"></label>`;
       }).join('');
     }
@@ -1158,7 +1155,6 @@ export const activitiesScreen = {
       }, addActivitySig);
       form.querySelector('[data-add-sessions]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
       form.querySelector('[name="start_date"]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
-      form.querySelector('[data-add-frequency]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
     }
 
     async function submitAddActivityForm(form, submitBtn) {
@@ -1200,8 +1196,7 @@ export const activitiesScreen = {
         instructor_name_2: isShort ? '' : get('instructor_name_2'),
         emp_id_2: isShort ? '' : pickEmp(get('instructor_name_2')),
         start_date: get('start_date'),
-        end_date: get('end_date') || '',
-        frequency: get('frequency'),
+        end_date: get('end_date') || null,
         status: 'פעיל',
         notes: get('notes')
       };
@@ -1211,26 +1206,14 @@ export const activitiesScreen = {
       });
       if (!payload.end_date) {
         const lastDate = [...dateInputs].map((input) => String(input.value || '').trim()).filter(Boolean).pop();
-        payload.end_date = lastDate || payload.start_date || '';
+        payload.end_date = lastDate || payload.start_date || null;
       }
 
       const required = [
-        ['source', 'מקור'],
         ['activity_type', 'סוג פעילות'],
         ['activity_name', 'שם פעילות'],
-        ['activity_manager', 'מנהל פעילות'],
         ['authority', 'רשות'],
-        ['school', 'בית ספר'],
-        ['start_date', 'תאריך התחלה'],
-        ['end_date', 'תאריך סיום'],
-        ['sessions', 'מספר מפגשים'],
-        ['price', 'מחיר'],
-        ['funding', 'מימון'],
-        ['start_time', 'שעת התחלה'],
-        ['end_time', 'שעת סיום'],
-        ['instructor_name', 'מדריך/ה'],
-        ['emp_id', 'מספר עובד'],
-        ['notes', 'הערות']
+        ['school', 'בית ספר']
       ];
       const missing = required.filter(([key]) => !String(payload[key] || '').trim()).map(([, label]) => label);
       if (missing.length) {


### PR DESCRIPTION
### Motivation
- לתקן בעיה שבה מחיקת תאריכי מפגשים לא נשמרת כי שדות שנמחקו לא נשלחים כ־null ל־Supabase.
- להבטיח ששדות תאריך ריקים/לא תקינים ישמרו כ־`null` ולא כ־`''` כדי שבסיס הנתונים יעדכן אותם כראוי.
- למנוע שגיאת `42P10` בהוספת פעילות ולהסיר שדה מיותר (`frequency`) וטיפול בחובה מופרזת בטופס הוספה.

### Description
- `normalizeDateFieldForSupabase` שונתה להחזיר `null` כאשר הערך ריק או לא תקין במקום `''` כך ששדות תאריך ריקים ישמרו כ־`null` (`frontend/src/api.js`).
- `deriveEndDateFromDates` מעדכן את התוצאה ל־`null` כאשר אין תאריך תקין, ו־`updateActivityInSupabase` ו־`upsertActivityToSupabase` משתמשים ב־`null` כערך ברירת מחדל ל־`end_date` כאשר אין תאריכים תקינים (`frontend/src/api.js`).
- `sanitizeActivityPayloadForSupabase` לא ממיר עוד `null` חזרה ל־`''` עבור שדות תאריך כדי לאבטח שמירה של ערכי `null` למסדי נתונים (`frontend/src/api.js`).
- בהוספת פעילות החלפתי את קריאת הכתיבה מ־`upsert(..., { onConflict: 'row_id' })` ל־`insert(...).select().single()` כדי להימנע מ־`42P10` בלי לשנות סכמת טבלאות (`frontend/src/api.js`).
- הוסרה השימושיות בשדה `frequency` בטופס הוספת פעילות וכן הוסרו המאזינים והחישובים התלויים בו, והחישוב האוטומטי ליצירת תאריכים משתמש כברירת מחדל בצעד שבועי של 7 ימים (`frontend/src/screens/activities.js`).
- צומצמה ולידציית שדות החובה בטופס הוספת פעילות למינימום הנדרש: `activity_type`, `activity_name`, `authority`, `school`, וכל שאר השדות (מדריך, מספר עובד, תאריכים, הערות, מחיר, מימון, שעות וכו') אינם חוסמים שמירה יותר (`frontend/src/screens/activities.js`).

### Testing
- הרצת `npm --prefix frontend run lint` נכשלה בסביבה עם שגיאת `ENOENT` עקב היעדר `frontend/package.json`, לכן הלינט לא הצליח להרגיש שגיאות קוד אוטומטיות; זו תוצאה של סביבת הריצה ולא של השינויים עצמם.
- לא רוצו בדיקות אוטומטיות נוספות בסביבה זו בזמן השינוי; התיקון מצפה לאימות אינטגרציה מול Supabase בסביבת פיתוח/QA ולהרצת lint/CI ב־repository המלא.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4da37d20832ba13d7f9fdee10861)