### PR TITLE
פתיחה מחדש בארכיון: עדכון רק של תאריך מפגש אחרון וכיבוד `end_date` מפורש

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1919,7 +1919,8 @@ async function updateActivityInSupabase(payload = {}) {
     { includeRowId: false }
   );
   const hasMeetingDateChange = Object.keys(changes).some((k) => /^date_\d+$/.test(k));
-  if (hasMeetingDateChange) {
+  const hasExplicitEndDate = Object.prototype.hasOwnProperty.call(changes, 'end_date');
+  if (hasMeetingDateChange && !hasExplicitEndDate) {
     const derivedEnd = deriveEndDateFromDates(changes);
     changes.end_date = derivedEnd || null;
   }

--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -523,18 +523,28 @@ export const archiveScreen = {
           }
 
           const finalEndDate = selectedEndDate || selectedStartDate;
+          const dateKeys = Array.from({ length: 35 }, (_, idx) => `date_${idx + 1}`);
+          let lastExistingDateKey = '';
+          for (const key of dateKeys) {
+            const value = String(row?.[key] || '').trim();
+            if (value) lastExistingDateKey = key;
+          }
+          const changes = {
+            status: 'פעיל',
+            end_date: finalEndDate,
+            [lastExistingDateKey || 'date_1']: finalEndDate
+          };
+          if (!String(row?.start_date || '').trim()) {
+            changes.start_date = selectedStartDate;
+          }
+
           confirmBtn.disabled = true;
           confirmBtn.textContent = 'שומר…';
           try {
             await api.saveActivity({
               source_sheet: row.source_sheet || 'activities',
               source_row_id: row.RowID || row.row_id,
-              changes: {
-                status: 'פעיל',
-                start_date: selectedStartDate,
-                end_date: finalEndDate,
-                date_1: selectedStartDate
-              }
+              changes
             });
             ui.closeModal?.();
             ui.closeDrawer?.();


### PR DESCRIPTION
### Motivation
- למנוע שמירה שתדרוס או תשנה את לוח המפגשים הקיים בעת פתיחה מחדש של פעילות/קורס בארכיון. 
- להבטיח ש־`end_date` שנשלח במפורש לא יוחלף על ידי חישוב אוטומטי המבוסס על שדות `date_1..date_35`.
- לשמור על `start_date` קיים ולא לעדכן אותו אלא אם לא קיים כלל תאריך תחילה ברשומה.

### Description
- שונתה הלוגיקה במסך הארכיון (`frontend/src/screens/archive.js`) כך שבפעולת הפתיחה מחדש נבנה אובייקט `changes` דינמי שמכיל רק את `status: 'פעיל'`, את ה־`end_date` הנבחר, ואת שדה התאריך האחרון הקיים מתוך `date_1..date_35` (או `date_1` כגיבוי), כאשר `start_date` מתווסף רק אם חסר.
- שונתה הפונקציה `updateActivityInSupabase` ב־`frontend/src/api.js` כך שחישוב נגזרת ה־`end_date` מתוך שדות `date_*` מתבצע רק אם יש שינויים בתאריכי מפגשים וגם לא נשלח `end_date` מפורש ב־`changes` (מניעת דריסה של `end_date` מפורש).
- לא נמחקו שדות תאריכים קיימים ולא נעשה חישוב מחודש של כל לוח המפגשים; רק השדה האחרון מעודכן כדי לשמר את המערך הקיים.

### Testing
- הרץ את המבחנים הממוקדים עם `node --test tests/archive-local-search.test.mjs tests/api-undated-activities.test.mjs`, וכולם עברו בהצלחה.
- ניסיון להריץ דרך `npm test -- tests/archive-local-search.test.mjs tests/api-undated-activities.test.mjs` נכשל כי סקריפט ה־`npm` מריץ את כל הקבצים ב־`tests/*.test.mjs` וגרם לכשלונות שאינם קשורים לשינויים אלו.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4b89f958832bad9529cecf7816d5)