### PR TITLE
השתמש ב-clientSettings הקנוני בחלון הוספת פעילות עבור operation_manager

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1329,10 +1329,9 @@ export const activitiesScreen = {
       addBtn.addEventListener('click', () => {
         ui.openModal({
           title: 'הוספת פעילות',
-          content: addActivityModalHtml(mergeSettingsWithFallback(
-            state?.clientSettings || {},
-            buildFallbackOptionsFromRows(activitiesRows)
-          )),
+          // חשוב: חלון הוספת פעילות חייב להשתמש ב-client settings האחידים
+          // (כמו admin), ללא בניית רשימות fallback מתוך rows חלקיים של המסך.
+          content: addActivityModalHtml(state?.clientSettings || {}),
           actions: `
             <button type="button" class="ds-btn ds-btn--primary" data-add-activity-submit>שמור</button>
             <button type="button" class="ds-btn" data-ui-close-modal>ביטול</button>


### PR DESCRIPTION
### Motivation
- לתקן מצב שבו `operation_manager` רואה לשוניות/סוגי פעילות ושמות פעילות שונים מ־admin על ידי החזרת חלון ה"הוספת פעילות" לשימוש ב־client settings הקנוני במקום בבניית fallback מתוך שורות חלקיות של המסך.

### Description
- שונתה הקריאה ב־`frontend/src/screens/activities.js` כך ש־`ui.openModal` מעבירה `addActivityModalHtml(state?.clientSettings || {})` במקום `addActivityModalHtml(mergeSettingsWithFallback(state?.clientSettings || {}, buildFallbackOptionsFromRows(activitiesRows)))`, וכך המודאל משתמש תמיד ב־`client_settings` המרכזי.

### Testing
- הרצתי את המבחנים עם `npm test --silent`; המערכת מכילה כשלונות קיימים שאינם קשורים לשינוי זה ולא זוהו כשלונות חדשים שנוצרו על ידי התיקון.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db67c2204832b8484f2da2a2e50bd)