### PR TITLE
Fix meeting completion counting and add archive review indicator

### DIFF
--- a/frontend/src/screens/archive.js
+++ b/frontend/src/screens/archive.js
@@ -83,6 +83,17 @@ function endYear(row) {
   return d || '—';
 }
 
+function archiveReviewFlag(row) {
+  const status = String(row?.status || '').trim().toLowerCase();
+  const isArchived = status === 'סגור' || status === 'closed' || status === 'inactive';
+  if (!isArchived) return false;
+  const total = Number(row?.meetings_total);
+  const done = Number(row?.meetings_done);
+  if (!Number.isFinite(total) || total <= 0) return false;
+  if (!Number.isFinite(done) || done < 0) return false;
+  return done < total;
+}
+
 const ARCHIVE_FIXED_YEARS = ['2026', '2025'];
 
 function todayIso() {
@@ -147,6 +158,7 @@ function applyArchiveFilters(rows, state) {
 function archiveTableRowsHtml(rows) {
   return rows.map((row) => {
     const name = escapeHtml(row.activity_name || '—');
+    const needsReview = archiveReviewFlag(row);
     const typeLabel = escapeHtml(visibleActivityCategoryLabel(row.activity_type));
     const authority = escapeHtml(row.authority || '—');
     const school = escapeHtml(row.school || '—');
@@ -162,6 +174,7 @@ function archiveTableRowsHtml(rows) {
         <td class="ds-activities-col ds-activities-col--program">
           <div class="ds-activities-program-cell">
             <strong class="ds-activities-program-name" title="${name}">${name}</strong>
+            ${needsReview ? '<span class="ds-status-pill ds-status-pill--subtle" title="פעילות בארכיון עם מפגשים לא מלאים">דורש בדיקה</span>' : ''}
             <span class="ds-activities-program-type">${typeLabel}</span>
           </div>
         </td>

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -44,10 +44,14 @@ function todayStr() {
 }
 
 function countDoneMeetings(schedule) {
-  const today = todayStr();
   return Array.isArray(schedule)
-    ? schedule.filter((m) => m?.date && m.date <= today).length
+    ? schedule.filter((m) => String(m?.performed || '').trim().toLowerCase() === 'yes').length
     : 0;
+}
+
+function numericOrNull(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
 }
 
 function normStatus(v) {
@@ -472,8 +476,10 @@ function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
   const activityType = String(row.activity_type || '').trim();
   const isOnce = ONCE_TYPES.includes(activityType);
   const computedEnd = autoEndDate(row);
-  const done = countDoneMeetings(schedule) || Number(row?.meetings_done || 0);
-  const total = Number(row?.meetings_total || schedule.length || 0);
+  const doneFromSchedule = countDoneMeetings(schedule);
+  const doneFallback = numericOrNull(row?.meetings_done);
+  const done = doneFromSchedule > 0 ? doneFromSchedule : (doneFallback ?? 0);
+  const total = numericOrNull(row?.meetings_total) ?? schedule.length ?? 0;
   const progressPct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
   const viewChips = buildDateChipsHtml(schedule, isOnce);
   const editDates = isOnce ? schedule.slice(0, 1) : schedule;
@@ -592,8 +598,10 @@ export function patchDrawerDatesSection(sectionEl, datesData) {
   const schedule = Array.isArray(datesData?.meeting_schedule) ? datesData.meeting_schedule : [];
   const activityType = String(datesData?.activity_type || '').trim();
   const isOnce = ONCE_TYPES.includes(activityType);
-  const done = countDoneMeetings(schedule) || Number(datesData?.meetings_done || 0);
-  const total = Number(datesData?.meetings_total || schedule.length || 0);
+  const doneFromSchedule = countDoneMeetings(schedule);
+  const doneFallback = numericOrNull(datesData?.meetings_done);
+  const done = doneFromSchedule > 0 ? doneFromSchedule : (doneFallback ?? 0);
+  const total = numericOrNull(datesData?.meetings_total) ?? schedule.length ?? 0;
   const progressPct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
   const computedEnd = autoEndDate({ meeting_schedule: schedule }) || String(datesData?.end_date || '');
 


### PR DESCRIPTION
### Motivation
- Prevent incorrect completed/total meeting counts that were inferred from past dates rather than explicit performed markers. 
- Surface possible mismatches in archived activities without changing status or auto-classifying them as operational errors. 
- Keep backward compatibility for rows that still rely on legacy `meetings_done` / `meetings_total` fields.

### Description
- Change meeting completion logic to count only meetings with `performed === 'yes'` in the `meeting_schedule` instead of inferring completion from the meeting date. (`frontend/src/screens/shared/activity-detail-html.js`)
- When explicit performed markers are not available, fall back to numeric `meetings_done` / `meetings_total` values with safe parsing. (`frontend/src/screens/shared/activity-detail-html.js`)
- Add a non-blocking archive review flag and UI pill (`דורש בדיקה`) for closed activities where numeric `meetings_done < meetings_total` to indicate a potential mismatch. (`frontend/src/screens/archive.js`)
- Do not change archive inclusion logic (still status-based); the marker is informational only.

### Testing
- Ran the test suite with `npm test -- --test-reporter=spec`; many frontend unit tests passed, including activity rendering and progress-related assertions. 
- The test run surfaced existing unrelated failures in snapshot and some mutation tests (e.g. `activities-snapshot.gs` and certain API mutation flows), which preexisted this change and do not appear caused by these edits. 
- Code was linted/compiled in the normal build flow and commits were created for the two modified files (`archive.js`, `activity-detail-html.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dbbe1e70c832bbd3033ed0df4ff43)