### PR TITLE
Prevent duplicate proposal saves, add delete API & UI, and bump SW cache version

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -36,7 +36,8 @@ const MUTATING_ACTIONS = {
   saveSheetMapping: true,
   saveClientSetting: true,
   addProposalAgreement: true,
-  updateProposalAgreement: true
+  updateProposalAgreement: true,
+  deleteProposalAgreement: true
 };
 
 const READ_ACTIONS = {
@@ -1260,7 +1261,8 @@ function invalidateScreenDataByAction(action) {
     saveSheetMapping: ['adminSettings', 'listSheets', 'dashboard:', 'activities:', 'week:', 'month:'],
     saveClientSetting: ['adminSettings', 'dashboard:', 'activities:', 'week:', 'month:'],
     addProposalAgreement: ['proposals-agreements'],
-    updateProposalAgreement: ['proposals-agreements']
+    updateProposalAgreement: ['proposals-agreements'],
+    deleteProposalAgreement: ['proposals-agreements']
   };
   const prefixes = targetedMutations[action];
   if (!prefixes || !prefixes.length) return;
@@ -2348,6 +2350,18 @@ export const api = {
       .single();
     if (error) throw new Error(error.message || 'proposals_agreement_update_failed');
     return { ok: true, row: normalizeProposalAgreementRow(data) };
+  },
+
+  deleteProposalAgreement: async (id) => {
+    assertCanUseProposalsAgreementsApi();
+    const rowId = cleanProposalAgreementText(id);
+    if (!rowId) throw new Error('missing_proposal_agreement_id');
+    const { error } = await supabase
+      .from('proposals_agreements')
+      .delete()
+      .eq('id', rowId);
+    if (error) throw new Error(error.message || 'proposals_agreement_delete_failed');
+    return { ok: true, id: rowId };
   },
   addContact: async (payload) => {
     const kind = String(payload?.kind || '').trim();

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -252,7 +252,10 @@ function drawerHtml(row, activityNameOptions = []) {
       </header>
       <div class="ds-pa-detail-grid">${detailRowsHtml(row)}</div>
       <p class="ds-pa-contact-line"><span class="ds-muted">פרטי קשר:</span> ${escapeHtml(contactSummary(row))}</p>
-      <div class="ds-pa-drawer-actions"><button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button></div>
+      <div class="ds-pa-drawer-actions">
+        <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button>
+        <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-delete-row="${escapeHtml(row.id)}">מחיקה</button>
+      </div>
       <div data-pa-inline-form></div>
     </div>
   </aside>`;
@@ -313,7 +316,7 @@ function replaceLocalRow(data, savedRow) {
   const idx = rows.findIndex((row) => text(row.id) === normalized.id);
   if (idx >= 0) rows[idx] = normalized;
   else rows.unshift(normalized);
-  data.rows = sortRows(rows.map(normalizeProposalAgreementRow));
+  data.rows = dedupeById(sortRows(rows.map(normalizeProposalAgreementRow)));
 }
 
 export const proposalsAgreementsScreen = {
@@ -345,6 +348,10 @@ export const proposalsAgreementsScreen = {
   },
   bind({ root, data, state, api }) {
     if (!root || data?.unauthorized || !canAccessProposalsAgreements(state)) return;
+    if (root._paAbort) root._paAbort.abort();
+    const abortController = new AbortController();
+    root._paAbort = abortController;
+    const { signal } = abortController;
     const seenIds = new Set();
     data.rows = sortRows((Array.isArray(data.rows) ? data.rows : [])
       .map(normalizeProposalAgreementRow)
@@ -358,8 +365,8 @@ export const proposalsAgreementsScreen = {
       debounceTimer = setTimeout(refreshTable, SEARCH_DEBOUNCE_MS);
     };
 
-    root.querySelector('[data-pa-search]')?.addEventListener('input', debouncedRefresh);
-    root.querySelectorAll('[data-pa-filter]').forEach((el) => el.addEventListener('change', refreshTable));
+    root.querySelector('[data-pa-search]')?.addEventListener('input', debouncedRefresh, { signal });
+    root.querySelectorAll('[data-pa-filter]').forEach((el) => el.addEventListener('change', refreshTable, { signal }));
 
     const formHost = root.querySelector('[data-pa-form-host]');
     const openForm = (mode, row = {}) => {
@@ -374,7 +381,7 @@ export const proposalsAgreementsScreen = {
       formHost.innerHTML = '';
     };
 
-    root.querySelector('[data-pa-add]')?.addEventListener('click', () => openForm('add'));
+    root.querySelector('[data-pa-add]')?.addEventListener('click', () => openForm('add'), { signal });
     root.addEventListener('click', async (event) => {
       const rowEl = event.target.closest?.('[data-pa-row-id]');
       if (rowEl) {
@@ -395,28 +402,53 @@ export const proposalsAgreementsScreen = {
         if (host && row) host.innerHTML = formHtml('edit', row, activityNameOptions);
         return;
       }
+      const deleteBtn = event.target.closest?.('[data-pa-delete-row]');
+      if (deleteBtn) {
+        const id = text(deleteBtn.dataset.paDeleteRow);
+        const row = data.rows.find((item) => text(item.id) === id);
+        if (!row) return;
+        if (!window.confirm('למחוק את ההצעה/ההסכם?')) return;
+        deleteBtn.disabled = true;
+        try {
+          await api.deleteProposalAgreement(id);
+          data.rows = dedupeById((Array.isArray(data.rows) ? data.rows : []).filter((item) => text(item.id) !== id).map(normalizeProposalAgreementRow));
+          refreshTable();
+          const drawer = root.querySelector('[data-pa-drawer]');
+          if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions);
+        } catch (err) {
+          deleteBtn.disabled = false;
+          window.alert(`שגיאה במחיקה: ${err?.message || err}`);
+        }
+        return;
+      }
       if (event.target.closest?.('[data-pa-cancel-form]')) {
         const inlineForm = event.target.closest('[data-pa-inline-form]');
         if (inlineForm) inlineForm.innerHTML = '';
         closeForm();
       }
-    });
+    }, { signal });
 
     root.addEventListener('keydown', (event) => {
       if (event.key !== 'Enter') return;
       const rowEl = event.target.closest?.('[data-pa-row-id]');
       if (rowEl) rowEl.click();
-    });
+    }, { signal });
 
     root.addEventListener('submit', async (event) => {
       const form = event.target.closest?.('[data-pa-form]');
       if (!form) return;
       event.preventDefault();
       const errorEl = form.querySelector('[data-pa-form-error]');
+      const submitBtn = form.querySelector('button[type="submit"]');
+      if (form.dataset.saving === 'yes') return;
+      form.dataset.saving = 'yes';
+      if (submitBtn) submitBtn.disabled = true;
       const payload = payloadFromForm(form);
       const validationError = validatePayload(payload);
       if (validationError) {
         if (errorEl) errorEl.textContent = validationError;
+        form.dataset.saving = '';
+        if (submitBtn) submitBtn.disabled = false;
         return;
       }
       const mode = form.dataset.paMode;
@@ -435,7 +467,9 @@ export const proposalsAgreementsScreen = {
         }
       } catch (err) {
         if (errorEl) errorEl.textContent = `שגיאה בשמירה: ${err?.message || err}`;
+        form.dataset.saving = '';
+        if (submitBtn) submitBtn.disabled = false;
       }
-    });
+    }, { signal });
   }
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 398;
+const CACHE_VERSION = 399;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 356;
+const SW_ENTRY_VERSION = 357;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Prevent duplicate proposal/agreement records caused by repeated event bindings and concurrent submits. 
- Provide a safe, explicit way to delete a proposal/agreement from the UI and server. 
- Ensure the updated frontend code is loaded for clients by advancing Service Worker cache versions so old bundles are evicted. 

### Description
- Added a screen-scoped `AbortController` (`root._paAbort`) in `proposals-agreements` to abort previous bindings and attach all listeners with the controller `signal` to avoid duplicate listeners after rebinds. 
- Introduced submit re-entry protection on the form using `form.dataset.saving = 'yes'` and immediate submit-button disabling so duplicate `addProposalAgreement`/`updateProposalAgreement` calls are blocked. 
- Kept edit flow behavior and enforced local uniqueness by id after add/edit via `dedupeById` when updating `data.rows`. 
- Added a drawer-level delete button (`data-pa-delete-row`) and implemented delete handling in the screen: confirmation, temporary disable, call to `api.deleteProposalAgreement(id)`, local removal, table refresh, and drawer close with error handling. 
- Extended API: added `deleteProposalAgreement` to `MUTATING_ACTIONS`, mapped it to cache invalidation for `proposals-agreements`, and implemented `api.deleteProposalAgreement(id)` which validates id, calls Supabase `.delete().eq('id', rowId)`, and returns `{ ok: true, id }` or throws appropriate errors. 
- Bumped Service Worker versions (`SW_ENTRY_VERSION` and `CACHE_VERSION`) in `sw.js` and `frontend/sw.js` so the new SW will precache freshly and evict old caches, while preserving existing SW behavior (`skipWaiting`, `clients.claim`, outdated cache cleanup). 

### Testing
- Ran `node --check frontend/src/screens/proposals-agreements.js` and it succeeded. 
- Ran `node --check frontend/src/api.js` and it succeeded. 
- Verified modified files were staged and committed in the repo (4 files changed) as part of automated workflow validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc094fbe4832b8cd8df8febd13b69)