### PR TITLE
חיווי 'אישורים' בסרגל, כפתור מידע בלוח הבקרה, עדכון 'הצעות והסכמים' ועדכון SW

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2270,6 +2270,15 @@ export const api = {
     }));
     return buildEditRequestGroups(rows, canReview, activityByRowId);
   },
+  editRequestsOpenCount: async () => {
+    const openStatuses = ['pending', 'open', 'awaiting approval', 'awaiting_approval'];
+    const { count, error } = await supabase
+      .from('edit_requests')
+      .select('request_id', { count: 'exact', head: true })
+      .in('status', openStatuses);
+    if (error) throw new Error(error.message || 'edit_requests_open_count_failed');
+    return Number.isFinite(count) ? Number(count) : 0;
+  },
   proposalsAgreements: async () => readProposalsAgreementsFromSupabase(),
   permissions: async () => {
     if (!supabase) throw new Error('no_supabase_client');

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -510,9 +510,31 @@ const screenLabels = {
   'admin-settings': 'הגדרות מערכת',
   'admin-lists': 'ניהול רשימות',
   archive: 'ארכיון',
-  'proposals-agreements': 'הצעות',
+  'proposals-agreements': 'הצעות והסכמים',
   finance: 'כספים / גבייה'
 };
+
+function navLabelForRoute(route) {
+  const base = screenLabels[route] || 'מסך';
+  if (route !== 'edit-requests') return base;
+  const count = Number(state.openEditRequestsCount);
+  if (!Number.isFinite(count) || count <= 0) return base;
+  return `${base} (${count})`;
+}
+
+async function refreshOpenEditRequestsCount() {
+  if (!isAllowedRoute('edit-requests')) return;
+  try {
+    const count = await api.editRequestsOpenCount();
+    const normalized = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+    if (state.openEditRequestsCount !== normalized) {
+      state.openEditRequestsCount = normalized;
+      if (state.token) scheduleRender();
+    }
+  } catch {
+    // Keep existing count on transient failures.
+  }
+}
 
 const screenLoaders = {
   dashboard: () => import('./screens/dashboard.js').then((m) => m.dashboardScreen),
@@ -718,7 +740,7 @@ function shell(content) {
     )
     .map(
       (route) =>
-        `<button type="button" class="shell-nav__btn ${route === state.route ? 'is-active' : ''}" data-route="${route}">${screenLabels[route] || 'מסך'}</button>`
+        `<button type="button" class="shell-nav__btn ${route === state.route ? 'is-active' : ''}" data-route="${route}">${navLabelForRoute(route)}</button>`
     )
     .join('');
 
@@ -1349,6 +1371,7 @@ function backgroundSyncBootstrap() {
     } else {
       updateNavActiveClasses();
     }
+    refreshOpenEditRequestsCount().catch(() => {});
   }).catch(() => {});
 }
 
@@ -1381,6 +1404,7 @@ async function restoreSession() {
     state.user.finance_access = !!bootstrap.has_finance_access;
     localStorage.setItem('dashboard_user', JSON.stringify(state.user));
   }
+  refreshOpenEditRequestsCount().catch(() => {});
 }
 
 async function mountScreen() {
@@ -1727,6 +1751,7 @@ async function render() {
             beginPerfTimer('login:applyBootstrap');
             const bootstrapApplyStartMs = performance.now();
             applyBootstrapFromLoginData(data);
+            refreshOpenEditRequestsCount().catch(() => {});
             loginBootstrapDurationMs = performance.now() - bootstrapApplyStartMs;
             applyGlobalAccent(accentNameFromStorage(state.clientSettings));
             renderShellLoadingImmediately();

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -252,6 +252,7 @@ function dashboardErrorHtml(data, ym) {
 
 const DASHBOARD_LOAD_GUARD_MS = 22000;
 const DASHBOARD_LOAD_ERROR_HE = 'לא ניתן לטעון את לוח הבקרה כרגע. נסו לרענן או בדקו את חיבור השרת.';
+const DASHBOARD_INFO_TEXT = 'לוח הבקרה מציג את פעילויות החודש הנוכחי. החלוקה לפי מחוזות מתייחסת רק לפעילויות שעדיין לא הסתיימו, כדי להציג תמונת מצב תפעולית עדכנית.';
 
 /** Snapshot / read-model status line above dashboard body (controlled copy). */
 function buildDashboardStaleBanner(data) {
@@ -430,8 +431,12 @@ export const dashboardScreen = {
 
     const navLoading = !!state?.dashboardNavLoading;
     const staleBanner = buildDashboardStaleBanner(data);
+    const infoIcon = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="11" x2="12" y2="16"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>';
     const dashHeader = `<header class="ds-dash-header" dir="rtl">
-      <h1 class="ds-dash-header__title">לוח בקרה</h1>
+      <div class="ds-dash-header__title-row">
+        <h1 class="ds-dash-header__title">לוח בקרה</h1>
+        <button type="button" class="ds-dash-info-btn" aria-label="מה מוצג כאן?">${infoIcon}<span class="ds-dash-info-tooltip" role="tooltip">${escapeHtml(DASHBOARD_INFO_TEXT)}</span></button>
+      </div>
       <div class="ds-dash-month-nav${navLoading ? ' is-nav-loading' : ''}" dir="rtl" aria-label="בחירת חודש לתצוגה">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-dash-month-prev aria-label="חודש קודם" title="חודש קודם" ${navLoading ? 'disabled' : ''}>▶</button>
         <span class="ds-dash-month-nav__label">${escapeHtml(hebrewMonthTitle(ym))}${navLoading ? ' <span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -80,7 +80,9 @@ export const state = {
   /** הגדרות UI ממקור הנתונים (bootstrap / login) */
   clientSettings: defaultClientSettings(),
   /** @type {Record<string, { data: unknown, t: number }>} */
-  screenDataCache: {}
+  screenDataCache: {},
+  /** Sidebar badge for open approval requests (null = not loaded yet). */
+  openEditRequestsCount: null
 };
 
 function parseTokenPayloadClaims(token) {
@@ -140,6 +142,7 @@ export function setSession(session) {
     state.monthYm = '';
     state.clientSettings = defaultClientSettings();
     state.screenDataCache = {};
+    state.openEditRequestsCount = null;
     localStorage.removeItem('dashboard_token');
     localStorage.removeItem('dashboard_user');
     try { localStorage.removeItem('dashboard_calendar_month_ym'); } catch { /* ignore */ }
@@ -166,6 +169,7 @@ export function setSession(session) {
   state.monthYm = (newCalKey && localStorage.getItem(newCalKey)) || '';
   try { localStorage.removeItem('dashboard_calendar_month_ym'); } catch { /* ignore */ }
   state.screenDataCache = {};
+  state.openEditRequestsCount = null;
   localStorage.setItem('dashboard_token', session.token);
   localStorage.setItem('dashboard_user', JSON.stringify(state.user));
   sessionStorage.setItem('ds_session_alive', '1');

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -8966,6 +8966,54 @@ select.ds-activity-add-field .ds-input,
   letter-spacing: -0.02em;
 }
 
+.ds-dash-header__title-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ds-dash-info-btn {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--ds-border);
+  background: #fff;
+  color: var(--ds-text-muted);
+  border-radius: 999px;
+  cursor: help;
+}
+.ds-dash-info-btn:hover,
+.ds-dash-info-btn:focus-visible {
+  color: var(--ds-accent);
+  border-color: var(--ds-accent);
+  outline: none;
+}
+.ds-dash-info-tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  inset-inline-end: 0;
+  width: min(340px, 84vw);
+  text-align: right;
+  background: #fff;
+  border: 1px solid var(--ds-border);
+  border-radius: var(--ds-radius-md);
+  box-shadow: var(--ds-shadow-md);
+  padding: 8px 10px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--ds-text);
+  z-index: 150;
+}
+.ds-dash-info-btn:hover .ds-dash-info-tooltip,
+.ds-dash-info-btn:focus .ds-dash-info-tooltip,
+.ds-dash-info-btn:focus-visible .ds-dash-info-tooltip {
+  display: block;
+}
+
 /* Month nav sits flush inside the header, no extra padding */
 .ds-dash-header .ds-dash-month-nav {
   padding: 0;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 399;
+const CACHE_VERSION = 400;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 357;
+const SW_ENTRY_VERSION = 358;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להראות למשתמשים חיווי מספרי דינמי ליד פריט הניווט "אישורים" לפי כמות בקשות פתוחות במערכת בלי לשנות את מבנה הניווט או להכניס ערכים hardcoded. 
- להציג עמוד הניהול החדש בשם מלא "הצעות והסכמים" בסרגל עבור משתמשים עם הרשאה מתאימה. 
- למנוע בלבול על מה מסכם לוח הבקרה באמצעות כפתור מידע ברור לצד הכותרת. 
- לוודא שגרסת ה‑Service Worker/קאש מתעדכנת לאחר פריסה כדי שאפליקציה תיטען עם השינויים החדשים.

### Description
- הוספת שדה state `openEditRequestsCount` ב־`frontend/src/state.js` לניהול המונה של בקשות אישור פתוחות.  
- הוספת פונקציה חדשה ב־API `editRequestsOpenCount` ב־`frontend/src/api.js` שמבצעת שאילתה על טבלת `edit_requests` לספירת סטטוסים פתוחים (`pending`, `open`, `awaiting approval`, `awaiting_approval`).  
- בשורה של ניווט בסרגל (`frontend/src/main.js`) הוחלפה התצוגה של תוויות הניווט לקריאה ל־`navLabelForRoute` שמציגה `אישורים`, `אישורים (N)` בהתאם למונה; הוספו פונקציות `navLabelForRoute` ו־`refreshOpenEditRequestsCount` והן נקראות במהלך bootstrap / login / background sync.  
- שם התצוגה של מסך `proposals-agreements` שונה ל־`הצעות והסכמים` כדי להופיע במלואו בסרגל לניהול.  
- הוספת כפתור מידע קטן עם tooltip בלוח הבקרה ב־`frontend/src/screens/dashboard.js` והגדרות סגנון תואמות ב־`frontend/src/styles/main.css` שמסביר: "לוח הבקרה מציג את פעילויות החודש הנוכחי... החלוקה לפי מחוזות מתייחסת רק לפעילויות שעדיין לא הסתיימו".  
- בוצע bump לגרסאות ה‑Service Worker כדי לבצע cache-busting: `SW_ENTRY_VERSION` ב־`sw.js` ו־`CACHE_VERSION` ב־`frontend/sw.js` הוגדלו כדי לדחוף עדכון קאש ללקוחות.

### Testing
- הרצת הבדיקה האוטומטית עם הפקודה `npm test -- tests/edit-requests-screen.test.mjs tests/proposals-agreements-screen.test.mjs tests/dashboard-stability.test.mjs tests/service-worker-pwa-cache.test.mjs` ובוצע ריצה מלאה של המבחנים.  
- במהלך הריצה נרשמו מספר בדיקות frontend ואינטגרציה שעברו בהצלחה, והשינויים לניווט/UI ולטקסט ה־dashboard לא גרמו לכשל ישיר בבדיקות הUI שהותאמו; ראו תוצאות ריצה מלאה בקונסול.  
- הופיעו מספר כשלונות בבדיקות קיימות שאינן קשורות ישירות לשינויים אלה (דוגמה: בדיקות סקריפטים של snapshot/gs ופיצ'רים של write-flow), לכן מומלץ להריץ את ה‑CI המלא ולבדוק את הכשלים הקיימים בסביבה שמפעילה את backend/ה־supabase לפני פריסה ב‑production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc6f9fccc832b9ecae06cfe5d487c)