### PR TITLE
Fix duplicate contact labels in Proposals & Agreements UI and bump SW cache

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -14,8 +14,8 @@ const FIELD_LABELS = {
   activity_type_group: 'סוג פעילות',
   proposal_date:       'תאריך הצעה',
   activity_names:      'שם הפעילויות',
-  contact_name:        'שם איש קשר',
-  contact_role:        'תפקיד איש קשר',
+  contact_name:        'איש קשר',
+  contact_role:        'תפקיד',
   phone:               'טלפון',
   email:               'דוא״ל',
   notes:               'הערות'
@@ -135,13 +135,9 @@ function filterSelectHtml(key, label, values) {
   return `<label class="ds-pa-filter"><span>${escapeHtml(label)}</span><select class="ds-input ds-input--sm" data-pa-filter="${escapeHtml(key)}">${options}</select></label>`;
 }
 
-function contactSummary(row) {
-  const parts = [row.contact_name, row.contact_role, row.phone, row.email].map(text).filter(Boolean);
-  return parts.length ? parts.join(' · ') : '—';
-}
-
 function detailRowsHtml(row) {
   return FORM_FIELDS.map((key) => {
+    if (['contact_name', 'contact_role', 'phone', 'email'].includes(key)) return '';
     let displayValue;
     if (key === 'activity_names') {
       displayValue = (Array.isArray(row[key]) ? row[key] : []).join(', ') || '';
@@ -157,6 +153,21 @@ function detailRowsHtml(row) {
       <span class="ds-pa-detail-value">${escapeHtml(displayValue)}</span>
     </div>`;
   }).join('');
+}
+
+function contactDetailRowsHtml(row = {}) {
+  const contactFields = ['contact_name', 'contact_role', 'phone', 'email'];
+  const rows = contactFields.map((key) => {
+    const value = text(row[key]);
+    if (!value) return '';
+    return `
+    <div class="ds-pa-detail-row">
+      <span class="ds-pa-detail-label">${escapeHtml(FIELD_LABELS[key] || key)}</span>
+      <span class="ds-pa-detail-value">${escapeHtml(value)}</span>
+    </div>`;
+  }).join('');
+  if (!rows) return '';
+  return `<section class="ds-pa-contact-section"><h4 class="ds-pa-contact-title">אנשי קשר</h4>${rows}</section>`;
 }
 
 export function proposalsAgreementsTableRowsHtml(rows) {
@@ -251,7 +262,7 @@ function drawerHtml(row, activityNameOptions = []) {
         <button type="button" class="ds-btn ds-btn--sm" data-pa-close-drawer aria-label="סגירת פרטי רשומה">✕</button>
       </header>
       <div class="ds-pa-detail-grid">${detailRowsHtml(row)}</div>
-      <p class="ds-pa-contact-line"><span class="ds-muted">פרטי קשר:</span> ${escapeHtml(contactSummary(row))}</p>
+      ${contactDetailRowsHtml(row)}
       <div class="ds-pa-drawer-actions">
         <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button>
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-delete-row="${escapeHtml(row.id)}">מחיקה</button>

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 402;
+const CACHE_VERSION = 403;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- Remove repeated/overlapping contact wording in the Proposals & Agreements details so the UI shows a clear hierarchy between section title and field labels. 
- Keep internal field keys and data structures unchanged while fixing only displayed text and rendering. 
- Ensure clients receive the updated JS by invalidating the service worker cache after deploy.

### Description
- Changed displayed labels in `frontend/src/screens/proposals-agreements.js` so `contact_name` is `"איש קשר"` and `contact_role` is `"תפקיד"`. 
- Prevented contact fields from being rendered twice by excluding `contact_name`, `contact_role`, `phone`, and `email` from the generic `detailRowsHtml`. 
- Added `contactDetailRowsHtml` to render a dedicated contact section with heading `"אנשי קשר"` and individual contact rows, and replaced the old inline contact summary in the drawer with this section. 
- Incremented `CACHE_VERSION` in `frontend/sw.js` (to `403`) so the service worker will drop old caches and clients will fetch the updated assets.

### Testing
- Performed static checks with `node --check frontend/src/screens/proposals-agreements.js`, which succeeded. 
- Performed static checks with `node --check frontend/sw.js`, which succeeded. 
- Confirmed no internal field/key names or payload shapes were modified; changes are UI-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee2fa22e0832b9e125a5378118d92)