### PR TITLE
Refine Add Activity modal: compact responsive 3-column grid & SW cache bump

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7960,7 +7960,7 @@ select.ds-input {
   box-shadow: 0 4px 12px rgba(26, 51, 88, 0.1), 0 1px 4px rgba(0, 0, 0, 0.06);
 }
 
-/* ——— Add-activity form: compact 2-col layout ——— */
+/* ——— Add-activity form: compact responsive grid layout ——— */
 .ds-activity-add-form {
   display: flex;
   flex-direction: column;
@@ -7969,8 +7969,8 @@ select.ds-input {
 
 .ds-activity-add-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px 10px;
+  grid-template-columns: 1fr;
+  gap: 6px 8px;
   margin-top: 4px;
 }
 
@@ -7996,7 +7996,7 @@ select.ds-input {
 
 .ds-activity-add-date-rows {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 5px 8px;
 }
 
@@ -8024,7 +8024,7 @@ select.ds-input {
 }
 
 .ds-activity-add-field.ds-activity-add-field--compact {
-  max-width: 190px;
+  max-width: 100%;
 }
 
 .ds-activity-add-field.ds-activity-add-field--wide {
@@ -8036,7 +8036,23 @@ select.ds-input {
   min-height: 52px;
 }
 
-@media (max-width: 760px) {
+@media (min-width: 760px) {
+  .ds-activity-add-grid,
+  .ds-activity-add-date-rows {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 8px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .ds-activity-add-grid,
+  .ds-activity-add-date-rows {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px 10px;
+  }
+}
+
+@media (max-width: 759px) {
   .ds-activity-add-grid,
   .ds-activity-add-date-rows {
     grid-template-columns: 1fr;
@@ -8047,7 +8063,7 @@ select.ds-input {
     max-width: 100%;
   }
 }
-/* wider modal for add-activity form */
+/* keep modal compact for add-activity form */
 @media (min-width: 960px) {
   .ds-ui-layer.is-modal-open .ds-modal {
     width: min(94vw, 640px);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 403;
+const CACHE_VERSION = 404;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- Make the “הוספת פעילות” form compact, symmetric and easier to scan on desktop by avoiding overly wide fields and large empty center area.
- Use a 3×2-like grid on desktop (3 columns, up to 2 rows per logical section) while keeping 2 columns for medium screens and 1 column on mobile to satisfy responsive requirements.
- Ensure this is a purely layout change that does not modify save logic, field names, data structures, or existing behavior (including support for one-day activities with two instructors).

### Description
- Adjusted the add-activity form CSS in `frontend/src/styles/main.css` to use a responsive grid with `1fr` default and media queries adding `repeat(2, ...)` at `min-width: 760px` and `repeat(3, ...)` at `min-width: 1024px`, and tightened uniform gaps for compactness.
- Removed the hard `max-width: 190px` constraint on `.ds-activity-add-field--compact` and unified compact field sizing to `max-width: 100%` so all inputs align symmetrically and do not stretch excessively across the modal.
- Kept the modal width compact (no enlargement) and updated date-rows layout to follow the same responsive grid rules.
- Bumped the service worker cache version in `frontend/sw.js` from `403` to `404` to reduce the chance users see stale CSS from cache after deploy.

### Testing
- Attempted an automated build with `npm --prefix frontend run build`, which failed in this environment due to a missing `frontend/package.json` (so a local build could not be completed here).
- Verified the presence of the new CSS rules and media queries via automated CLI checks (`rg`/`sed`) against `frontend/src/styles/main.css`, and confirmed the `CACHE_VERSION` update in `frontend/sw.js`; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee9983a0c832b9b04bfb2813ba379)