### PR TITLE
מדריך שני אופציונלי ב־טופס הוספת פעילות (חד־יומיות)

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -356,9 +356,9 @@ function addActivityModalHtml(settings) {
 
         <p class="ds-activity-add-section">צוות וניהול</p>
         <label class="ds-activity-add-field"><span>מנהל פעילות</span><select class="ds-input" name="activity_manager">${optionsHtml(managerOptions, '', NO_ACTIVITY_MANAGER_LABEL)}</select></label>
-        <label class="ds-activity-add-field"><span>מדריך/ה</span><select class="ds-input" name="instructor_name" data-add-instructor>${optionsHtml(instructorOptions)}</select></label>
+        <label class="ds-activity-add-field"><span>מדריך/ה ראשי/ת</span><select class="ds-input" name="instructor_name" data-add-instructor>${optionsHtml(instructorOptions)}</select></label>
         <input type="hidden" name="emp_id" value="">
-        <label class="ds-activity-add-field" data-field-instructor2 style="display:none"><span>מדריך/ה 2</span><select class="ds-input" name="instructor_name_2" data-add-instructor-2>${optionsHtml(instructorOptions)}</select></label>
+        <label class="ds-activity-add-field" data-field-instructor2><span>מדריך/ה נוסף/ת (אופציונלי)</span><select class="ds-input" name="instructor_name_2" data-add-instructor-2>${optionsHtml(instructorOptions)}</select></label>
         <input type="hidden" name="emp_id_2" value="">
 
         <p class="ds-activity-add-section">הערות</p>
@@ -1122,9 +1122,6 @@ export const activitiesScreen = {
       const sessionsSel = form.querySelector('[data-add-sessions]');
       if (sessionsSel) sessionsSel.value = String(sessionsSel.value || '1') || '1';
 
-      const secondInstructorField = form.querySelector('[data-field-instructor2]');
-      if (secondInstructorField) secondInstructorField.style.display = 'none';
-
       const typeSel = form.querySelector('[data-add-activity-type]');
       if (typeSel) {
         let allTypes = [];
@@ -1238,8 +1235,8 @@ export const activitiesScreen = {
         end_time: get('end_time'),
         instructor_name: get('instructor_name'),
         emp_id: pickEmp(get('instructor_name')),
-        instructor_name_2: '',
-        emp_id_2: '',
+        instructor_name_2: get('instructor_name_2'),
+        emp_id_2: pickEmp(get('instructor_name_2')),
         start_date: isOneDay ? oneDayDate : get('start_date'),
         end_date: isOneDay ? oneDayDate || null : get('end_date') || null,
         status: 'פעיל',


### PR DESCRIPTION
### Motivation
- בלשונית "חד־יומיות" התאפשר לבחור רק מדריך אחד בפועל, והערך השני לא הוצג ולא נשמר, מה שמנטרל אפשרות לשמור שתי אחריות על פעילות.
- יש לאפשר שדה מדריך נוסף כאופציונלי בלי לשבור את העיצוב הקומפקטי או לגעת בלוגיקה של תוכניות/קורסים/after_school.

### Description
- שודרג ה־UI של טופס הוספת פעילות ב־`frontend/src/screens/activities.js` כדי להציג שני שדות: `מדריך/ה ראשי/ת` ו־`מדריך/ה נוסף/ת (אופציונלי)` במקום שדה יחיד בלבד. 
- הוסרה ההסתרה הבלתי־נחוצה של שדה המדריך השני בעת אתחול הטופס כדי להבטיח שהוא נראה תמיד בשלב הבחירה (ויש אפשרות לא להשלים אותו). 
- תיקנתי את בניית ה־payload בשמירה כך ש־`instructor_name_2` ו־`emp_id_2` נשלחים בהתאם לבחירה בטופס במקום להישאר ריקים, כך שבמקרים של שני מדריכים שניהם ישמרו.

### Testing
- הרצתי את יחידות הבדיקה עם `npm test -- tests/ui-fixes-regression.test.mjs tests/activity-list-filters-cache.test.mjs` והבקשה רצה אך הכלי הציג מספר כישלונות קיימים במערכת שאינם קשורים לשינוי זה. 
- הרצתי גם `node --test tests/ui-fixes-regression.test.mjs` והבחנתי בכשלים רגרסיביים קיימים שאינם תוצאה של התיקון; הבדיקות היחידות הספציפיות לקוד ששונה לא הראו כשל אחרי השינוי. 
- בדיקות Service Worker / hard refresh והאימות בדפדפן הן בדיקות ידניות לפי הדרישה ולא בוצעו כאן אוטומטית.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eeb53dbb8832b9aa0b57623db7707)