### PR TITLE
שדרוג חלונית הוספת פעילות: קומפקטיות, RTL, ורשות/בית ספר חדשים

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 403;
+const CACHE_VERSION = 405;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BIZ-Kx9s.js",
+  "./assets/index-CL9L318L.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BcftOQQK.css",
+  "./assets/style-ClEF0Kaa.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BIZ-Kx9s.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BcftOQQK.css">
+  <script type="module" crossorigin src="./assets/index-CL9L318L.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-ClEF0Kaa.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 403;
+const CACHE_VERSION = 405;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BIZ-Kx9s.js",
+  "./assets/index-CL9L318L.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BcftOQQK.css",
+  "./assets/style-ClEF0Kaa.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -308,13 +308,27 @@ function addActivityModalHtml(settings) {
   const initialActivityNames = getActivityNamesForType(settings, initialType);
   const sessionsList = Array.from({ length: 35 }, (_, i) => String(i + 1));
 
-  const authorityField = authorityOptions.length
-    ? `<label class="ds-activity-add-field"><span>רשות</span><input class="ds-input" name="authority" type="text" list="add-authority-list" autocomplete="off">${datalistHtml('add-authority-list', authorityOptions)}</label>`
-    : `<label class="ds-activity-add-field"><span>רשות</span><input class="ds-input" name="authority" type="text"></label>`;
+  const authorityField = `
+    <div class="ds-activity-add-field ds-activity-add-field--entity" data-entity-field="authority">
+      <div class="ds-activity-add-label-row">
+        <span>רשות</span>
+        <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-entity-toggle="authority">+ רשות חדשה</button>
+      </div>
+      <input class="ds-input" name="authority" type="text" list="add-authority-list" autocomplete="off" data-entity-select="authority">
+      ${datalistHtml('add-authority-list', authorityOptions)}
+      <input class="ds-input" name="authority_custom" type="text" placeholder="הזנת רשות חדשה" style="display:none" data-entity-custom="authority">
+    </div>`;
 
-  const schoolField = schoolOptions.length
-    ? `<label class="ds-activity-add-field"><span>בית ספר</span><input class="ds-input" name="school" type="text" list="add-school-list" autocomplete="off">${datalistHtml('add-school-list', schoolOptions)}</label>`
-    : `<label class="ds-activity-add-field"><span>בית ספר</span><input class="ds-input" name="school" type="text"></label>`;
+  const schoolField = `
+    <div class="ds-activity-add-field ds-activity-add-field--entity" data-entity-field="school">
+      <div class="ds-activity-add-label-row">
+        <span>בית ספר</span>
+        <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-entity-toggle="school">+ בית ספר חדש</button>
+      </div>
+      <input class="ds-input" name="school" type="text" list="add-school-list" autocomplete="off" data-entity-select="school">
+      ${datalistHtml('add-school-list', schoolOptions)}
+      <input class="ds-input" name="school_custom" type="text" placeholder="הזנת בית ספר חדש" style="display:none" data-entity-custom="school">
+    </div>`;
 
   return `
     <form class="ds-activity-add-form" dir="rtl" data-add-activity-form
@@ -1196,6 +1210,37 @@ export const activitiesScreen = {
       form.querySelector('[data-add-sessions]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
       form.querySelector('[name="start_date"]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
       form.querySelector('[name="one_day_date"]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
+      bindEntityFieldToggle(form, 'authority');
+      bindEntityFieldToggle(form, 'school');
+    }
+
+    function bindEntityFieldToggle(form, entityKey) {
+      const toggleBtn = form.querySelector(`[data-entity-toggle="${entityKey}"]`);
+      const selectInput = form.querySelector(`[data-entity-select="${entityKey}"]`);
+      const customInput = form.querySelector(`[data-entity-custom="${entityKey}"]`);
+      if (!toggleBtn || !selectInput || !customInput) return;
+      let useCustom = false;
+      const render = () => {
+        selectInput.style.display = useCustom ? 'none' : '';
+        customInput.style.display = useCustom ? '' : 'none';
+        customInput.disabled = !useCustom;
+        selectInput.disabled = useCustom;
+        toggleBtn.textContent = useCustom
+          ? (entityKey === 'authority' ? 'בחירה מהרשימה' : 'בחירה מהרשימה')
+          : (entityKey === 'authority' ? '+ רשות חדשה' : '+ בית ספר חדש');
+        if (useCustom) {
+          selectInput.value = '';
+          customInput.focus();
+        } else {
+          customInput.value = '';
+          selectInput.focus();
+        }
+      };
+      toggleBtn.addEventListener('click', () => {
+        useCustom = !useCustom;
+        render();
+      }, addActivitySig);
+      render();
     }
 
     async function submitAddActivityForm(form, submitBtn) {
@@ -1205,6 +1250,10 @@ export const activitiesScreen = {
       const fd = new (window?.FormData || FormData)(form);
       const get = (k) => String(fd.get(k) || '').trim();
       const familySource = get('source') || 'catalog';
+      const authorityCustom = get('authority_custom');
+      const schoolCustom = get('school_custom');
+      const authorityValue = authorityCustom || get('authority');
+      const schoolValue = schoolCustom || get('school');
       const selectedName = get('activity_name');
       const hit = activityMap.find((x) => {
         const label = String(x?.label || '').trim();
@@ -1221,8 +1270,8 @@ export const activitiesScreen = {
       const payload = {
         source: familySource,
         activity_manager: get('activity_manager'),
-        authority: get('authority'),
-        school: get('school'),
+        authority: authorityValue,
+        school: schoolValue,
         grade: get('grade'),
         class_group: get('class_group'),
         activity_type: get('activity_type'),

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7970,14 +7970,14 @@ select.ds-input {
 .ds-activity-add-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 6px 8px;
-  margin-top: 4px;
+  gap: 5px 8px;
+  margin-top: 2px;
 }
 
 .ds-activity-add-section {
   grid-column: 1 / -1;
-  margin: 4px 0 0;
-  padding-top: 4px;
+  margin: 3px 0 0;
+  padding-top: 3px;
   border-top: 1px solid rgba(15, 23, 42, 0.08);
   font-size: 0.74rem;
   font-weight: 700;
@@ -8003,12 +8003,12 @@ select.ds-input {
 .ds-activity-add-field {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
   min-width: 0;
 }
 
 .ds-activity-add-field > span {
-  font-size: 0.71rem;
+  font-size: 0.7rem;
   font-weight: 700;
   color: #334155;
   line-height: 1.2;
@@ -8017,10 +8017,24 @@ select.ds-input {
 .ds-activity-add-field .ds-input {
   width: 100%;
   max-width: 100%;
-  min-height: 30px;
-  font-size: 0.8rem;
+  min-height: 31px;
+  font-size: 0.79rem;
   line-height: 1.2;
   padding: 3px 7px;
+}
+
+.ds-activity-add-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.ds-activity-add-field--entity .ds-btn--xs {
+  padding: 2px 6px;
+  min-height: 24px;
+  font-size: 0.7rem;
+  line-height: 1.1;
 }
 
 .ds-activity-add-field.ds-activity-add-field--compact {
@@ -8033,7 +8047,7 @@ select.ds-input {
 
 .ds-activity-add-field textarea.ds-input {
   resize: vertical;
-  min-height: 52px;
+  min-height: 48px;
 }
 
 @media (min-width: 760px) {
@@ -8048,7 +8062,7 @@ select.ds-input {
   .ds-activity-add-grid,
   .ds-activity-add-date-rows {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 6px 10px;
+    gap: 5px 9px;
   }
 }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 404;
+const CACHE_VERSION = 405;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 358;
+const SW_ENTRY_VERSION = 359;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להקטין את החלונית של "הוספת פעילות" ולהפוך אותה לקומפקטית, מסודרת וסימטרית מבלי לשבור פונקציונליות קיימת.
- להוסיף דרך גלויה ונגישה להזנת ערכים חדשים עבור `רשות` ו־`בית ספר` מבלי להסתמך על אפשרות נסתרת ברשימה.
- להבטיח שהשינוי לא ישפיע על תמיכת מדריך שני בשדות חד־יומיות ולמנוע בעיות PWA / cache ישן.

### Description
- שודרגת ה־UI של הטופס עם מבנה גריד רספונסיבי ומדודים מצומצמים יותר ב־`frontend/src/styles/main.css` להקטנת ריווחים, גודל שדות וטיפוגרפיה.
- נוספו כפתורי `+ רשות חדשה` ו־`+ בית ספר חדש` ואלמנטים לקפיצה בין בחירה מרשימה להזנת ערך חופשי ב־`frontend/src/screens/activities.js` (שדות `authority_custom` / `school_custom` ו־`bindEntityFieldToggle`).
- שינוי לוגי מינורי בשמירת הטופס שמעדיף ערך custom אם הוזן (`authority` / `school`) מבלי לשנות סכימות או שמות שדות קיימים, והותירה תמיכת `instructor_name_2` כפי שהייתה.
- בוצע bump של גרסאות ה־Service Worker ב־`sw.js` ו־`frontend/sw.js` (`SW_ENTRY_VERSION`, `CACHE_VERSION`) כדי להבטיח שה־cache יתעדכן ויהיה סיכוי נמוך למימוש גרסה ישנה.

### Testing
- הרצת `npm run build` בוצעה בהצלחה ויצרה את קבצי ה־`dist` (ה빌ד הניב אזהרת chunk-size של Vite אך לא כשל בבילד).
- נבדקו שהשינויים בקבצי `frontend/src/screens/activities.js` ו־`frontend/src/styles/main.css` מתבצעים בקוד הייצור דרך תהליך ה־build. 
- לא בוצעו בדיקות אוטומטיות נוספות; השינויים הם בעיקר UI/UX וצומצמו לשינויים לוגיים נקודתיים בלבד כדי לשמור על היסודות הקיימים של המערכת.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eecee0658832bb3068dbe8b89140d)