### PR TITLE
Proposals/Agreements: remove contact column, show activity_names as list, bump SW cache

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -140,7 +140,9 @@ function detailRowsHtml(row) {
     if (['contact_name', 'contact_role', 'phone', 'email'].includes(key)) return '';
     let displayValue;
     if (key === 'activity_names') {
-      displayValue = (Array.isArray(row[key]) ? row[key] : []).join(', ') || '';
+      const items = (Array.isArray(row[key]) ? row[key] : []).map(text).filter(Boolean);
+      if (!items.length) return '';
+      displayValue = `<ul class="ds-pa-activity-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
     } else if (key === 'proposal_date') {
       displayValue = formatDateDisplay(row[key]);
     } else {
@@ -150,7 +152,7 @@ function detailRowsHtml(row) {
     return `
     <div class="ds-pa-detail-row">
       <span class="ds-pa-detail-label">${escapeHtml(FIELD_LABELS[key] || key)}</span>
-      <span class="ds-pa-detail-value">${escapeHtml(displayValue)}</span>
+      <span class="ds-pa-detail-value">${key === 'activity_names' ? displayValue : escapeHtml(displayValue)}</span>
     </div>`;
   }).join('');
 }
@@ -178,17 +180,17 @@ export function proposalsAgreementsTableRowsHtml(rows) {
     <tr data-pa-row-id="${escapeHtml(row.id)}" tabindex="0">
       <td>${escapeHtml(row.client_authority || '—')}</td>
       <td>${escapeHtml(row.school_framework || '—')}</td>
-      <td>${escapeHtml(row.contact_name || '')}</td>
       <td>${escapeHtml(row.document_type || '—')}</td>
       <td>${escapeHtml(row.activity_type_group || '—')}</td>
       <td>${escapeHtml(formatDateDisplay(row.proposal_date) || '')}</td>
+      <td>${escapeHtml(row.notes || '')}</td>
     </tr>`).join('');
 }
 
 function tableHtml(rows) {
   return dsTableWrap(`
     <table class="ds-table ds-pa-table" data-pa-table>
-      <thead><tr><th>לקוח / רשות</th><th>בית ספר / מסגרת</th><th>איש קשר</th><th>סוג מסמך</th><th>סוג פעילות</th><th>תאריך הצעה</th></tr></thead>
+      <thead><tr><th>לקוח / רשות</th><th>בית ספר / מסגרת</th><th>סוג מסמך</th><th>סוג פעילות</th><th>תאריך הצעה</th><th>הערות</th></tr></thead>
       <tbody data-pa-table-body>${proposalsAgreementsTableRowsHtml(rows)}</tbody>
     </table>
   `);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 405;
+const CACHE_VERSION = 406;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- להקטין כפילויות בעמודת טבלה חיצונית על ידי הסרת שדה "איש קשר" ולהשאיר רק שדות לזיהוי מהיר של הרשומה.  
- לשפר את קריאות פרטי הרשומה על‑ידי הצגת `activity_names` בצורה ברורה ונגישה גם במצב צפייה (view).  
- למנוע טעינת JS ישן אחרי פריסה על‑ידי עדכון גרסת ה‑Service Worker (`CACHE_VERSION`).

### Description
- הסרתי את עמודת `contact_name` מהטבלה החיצונית ב`frontend/src/screens/proposals-agreements.js` (הכותרת והתא בשורה הוסרו) והוספתי תצוגת `notes` בעמודה שמחליפה אותה בטבלה לסיכום מהיר.  
- שיניתי את הפונקציה `detailRowsHtml` כך ש־`activity_names` יוצג כ`<ul class="ds-pa-activity-list">` עם פריטים `li` לכל ערך במערך במקום מחרוזת מופרדת בפסיקים.  
- שמרתי את התנהגות העריכה/שמירה של `activity_names` ללא שינוי — העריכה נשארת כ־multi-select וה‑payload ממשיך להשתמש במפתח `activity_names` כמערך.  
- עדכנתי את `frontend/sw.js` והגביתי את `CACHE_VERSION` (הגדלתי מ`405` ל`406`) כדי לגרום לביטול cache של הלקוחות לאחר הפריסה.

### Testing
- הווידוא הדיפ נעשה באמצעות `git diff` לראות את השינויים ב־`frontend/src/screens/proposals-agreements.js` וב־`frontend/sw.js`, והבדיקה אישרה את הסרת העמודה ושינוי התצוגה של `activity_names`.  
- נרשם ניסיון להריץ `npm --prefix frontend run -s lint`, אך הוא נכשל בגלל היעדר `frontend/package.json` בסביבה ולכן lint/tests לא הורצו כאן.  
- ביצעתי commit של השינויים ב־Git כדי לאשר שהקבצים הועודכנו בהצלחה.  
- יש לשים לב שבדיקה ידנית/אוטומטית בסביבת ה frontend מלאה תעבור לאחר פריסה וכוללת רענון ה‑Service Worker כדי למנוע bundle ישן.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef052ef08832ba4c396a75ed36645)