### PR TITLE
Improve activity_names multi-select UX in Proposals & Agreements

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 405;
+const CACHE_VERSION = 407;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CL9L318L.js",
+  "./assets/index-DbJ_X7vL.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-ClEF0Kaa.css",
+  "./assets/style-Bauq48BP.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CL9L318L.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-ClEF0Kaa.css">
+  <script type="module" crossorigin src="./assets/index-DbJ_X7vL.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-Bauq48BP.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 405;
+const CACHE_VERSION = 407;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CL9L318L.js",
+  "./assets/index-DbJ_X7vL.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-ClEF0Kaa.css",
+  "./assets/style-Bauq48BP.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -220,7 +220,6 @@ function formFieldHtml(key, value = '', activityNameOptions = []) {
     return selectField(key, label, ACTIVITY_TYPE_GROUP_OPTIONS, value, required);
   }
   if (key === 'activity_names') {
-    const attrs = required ? ' required aria-required="true"' : '';
     const selectedValues = Array.isArray(value) ? value.map(text).filter(Boolean) : text(value).split(',').map(text).filter(Boolean);
     const allOptions = Array.from(new Set([...activityNameOptions, ...selectedValues])).filter(Boolean).sort((a, b) => a.localeCompare(b, 'he'));
     if (!allOptions.length) {
@@ -228,10 +227,20 @@ function formFieldHtml(key, value = '', activityNameOptions = []) {
     }
     const optionsHtml = allOptions.map((v) => {
       const safe = escapeHtml(v);
-      const sel = selectedValues.includes(v) ? ' selected' : '';
-      return `<option value="${safe}"${sel}>${safe}</option>`;
+      const checked = selectedValues.includes(v) ? ' checked' : '';
+      return `<label class="ds-pa-activity-option"><input type="checkbox" value="${safe}"${checked}><span>${safe}</span></label>`;
     }).join('');
-    return `<label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(label)}${required ? ' *' : ''}</span><select class="ds-input ds-input--sm" name="${key}" multiple size="${Math.min(allOptions.length, 7)}"${attrs}>${optionsHtml}</select></label>`;
+    return `<label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(label)}${required ? ' *' : ''}</span>
+      <div class="ds-pa-activity-picker" data-pa-activity-picker data-required="${required ? 'yes' : 'no'}">
+        <button type="button" class="ds-input ds-input--sm ds-pa-activity-trigger" data-pa-activity-toggle aria-expanded="false">בחרו שמות פעילויות</button>
+        <div class="ds-pa-activity-chips" data-pa-activity-chips></div>
+        <div class="ds-pa-activity-dropdown" data-pa-activity-dropdown hidden>
+          <input class="ds-input ds-input--sm ds-pa-activity-search" data-pa-activity-search placeholder="חיפוש פעילות..." autocomplete="off">
+          <div class="ds-pa-activity-options" data-pa-activity-options>${optionsHtml}</div>
+        </div>
+        <div data-pa-activity-hidden-inputs></div>
+      </div>
+    </label>`;
   }
   if (key === 'proposal_date') {
     return `<label class="ds-pa-form-field"><span>${escapeHtml(label)}</span><input class="ds-input ds-input--sm" type="date" name="${key}" value="${escapeHtml(value || '')}"></label>`;
@@ -382,10 +391,47 @@ export const proposalsAgreementsScreen = {
     root.querySelectorAll('[data-pa-filter]').forEach((el) => el.addEventListener('change', refreshTable, { signal }));
 
     const formHost = root.querySelector('[data-pa-form-host]');
+    const closeAllActivityDropdowns = () => {
+      root.querySelectorAll('[data-pa-activity-picker]').forEach((picker) => {
+        const dropdown = picker.querySelector('[data-pa-activity-dropdown]');
+        const trigger = picker.querySelector('[data-pa-activity-toggle]');
+        if (dropdown) dropdown.hidden = true;
+        if (trigger) trigger.setAttribute('aria-expanded', 'false');
+      });
+    };
+    const setupActivityPickers = (container) => {
+      container?.querySelectorAll?.('[data-pa-activity-picker]')?.forEach((picker) => {
+        const trigger = picker.querySelector('[data-pa-activity-toggle]');
+        const chipsHost = picker.querySelector('[data-pa-activity-chips]');
+        const dropdown = picker.querySelector('[data-pa-activity-dropdown]');
+        const search = picker.querySelector('[data-pa-activity-search]');
+        const optionsHost = picker.querySelector('[data-pa-activity-options]');
+        const hiddenInputsHost = picker.querySelector('[data-pa-activity-hidden-inputs]');
+        const checkboxes = Array.from(picker.querySelectorAll('.ds-pa-activity-option input[type="checkbox"]'));
+        const sync = () => {
+          const selected = checkboxes.filter((cb) => cb.checked).map((cb) => text(cb.value)).filter(Boolean);
+          chipsHost.innerHTML = selected.length
+            ? selected.map((item) => `<button type="button" class="ds-pa-chip" data-pa-chip-remove="${escapeHtml(item)}">${escapeHtml(item)} <span aria-hidden="true">×</span></button>`).join('')
+            : '<span class="ds-muted">לא נבחרו פעילויות</span>';
+          trigger.textContent = selected.length ? `נבחרו ${selected.length} פעילויות` : 'בחרו שמות פעילויות';
+          hiddenInputsHost.innerHTML = selected.map((item) => `<input type="hidden" name="activity_names" value="${escapeHtml(item)}">`).join('');
+        };
+        sync();
+        checkboxes.forEach((cb) => cb.addEventListener('change', sync, { signal }));
+        search?.addEventListener('input', () => {
+          const q = normalizeSearch(search.value);
+          optionsHost.querySelectorAll('.ds-pa-activity-option').forEach((option) => {
+            const label = normalizeSearch(option.textContent);
+            option.hidden = q ? !label.includes(q) : false;
+          });
+        }, { signal });
+      });
+    };
     const openForm = (mode, row = {}) => {
       if (!formHost) return;
       formHost.hidden = false;
       formHost.innerHTML = formHtml(mode, row, activityNameOptions);
+      setupActivityPickers(formHost);
       formHost.querySelector('input,textarea,select')?.focus?.();
     };
     const closeForm = () => {
@@ -398,6 +444,7 @@ export const proposalsAgreementsScreen = {
     root.addEventListener('click', async (event) => {
       const rowEl = event.target.closest?.('[data-pa-row-id]');
       if (rowEl) {
+        closeAllActivityDropdowns();
         const row = data.rows.find((item) => text(item.id) === text(rowEl.dataset.paRowId));
         const drawer = root.querySelector('[data-pa-drawer]');
         if (drawer && row) drawer.outerHTML = drawerHtml(row, activityNameOptions);
@@ -413,7 +460,36 @@ export const proposalsAgreementsScreen = {
         const row = data.rows.find((item) => text(item.id) === text(editBtn.dataset.paEditRow));
         const host = root.querySelector('[data-pa-inline-form]');
         if (host && row) host.innerHTML = formHtml('edit', row, activityNameOptions);
+        setupActivityPickers(host);
         return;
+      }
+      const toggleBtn = event.target.closest?.('[data-pa-activity-toggle]');
+      if (toggleBtn) {
+        const picker = toggleBtn.closest('[data-pa-activity-picker]');
+        const dropdown = picker?.querySelector('[data-pa-activity-dropdown]');
+        const isOpen = dropdown && !dropdown.hidden;
+        closeAllActivityDropdowns();
+        if (dropdown && !isOpen) {
+          dropdown.hidden = false;
+          toggleBtn.setAttribute('aria-expanded', 'true');
+          picker.querySelector('[data-pa-activity-search]')?.focus();
+        }
+        return;
+      }
+      const chipRemoveBtn = event.target.closest?.('[data-pa-chip-remove]');
+      if (chipRemoveBtn) {
+        const picker = chipRemoveBtn.closest('[data-pa-activity-picker]');
+        const targetValue = text(chipRemoveBtn.dataset.paChipRemove);
+        const checkbox = Array.from(picker?.querySelectorAll('.ds-pa-activity-option input[type="checkbox"]') || [])
+          .find((cb) => text(cb.value) === targetValue);
+        if (checkbox) {
+          checkbox.checked = false;
+          checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        return;
+      }
+      if (!event.target.closest?.('[data-pa-activity-picker]')) {
+        closeAllActivityDropdowns();
       }
       const deleteBtn = event.target.closest?.('[data-pa-delete-row]');
       if (deleteBtn) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9980,6 +9980,66 @@ select.ds-input {
   grid-column: 1 / -1;
 }
 
+.ds-pa-activity-picker {
+  position: relative;
+}
+
+.ds-pa-activity-trigger {
+  text-align: right;
+  min-height: 32px;
+}
+
+.ds-pa-activity-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.ds-pa-chip {
+  border: 1px solid var(--ds-color-border, #e2e8f0);
+  background: var(--ds-color-surface, #fff);
+  border-radius: 999px;
+  font-size: 0.76rem;
+  padding: 1px 8px;
+  cursor: pointer;
+}
+
+.ds-pa-activity-dropdown {
+  position: absolute;
+  z-index: 6;
+  inset-inline: 0;
+  margin-top: 6px;
+  border: 1px solid var(--ds-color-border, #e2e8f0);
+  border-radius: 10px;
+  background: #fff;
+  padding: 8px;
+  box-shadow: var(--ds-shadow-sm);
+}
+
+.ds-pa-activity-search {
+  margin-bottom: 6px;
+}
+
+.ds-pa-activity-options {
+  max-height: 210px;
+  overflow: auto;
+  display: grid;
+  gap: 4px;
+}
+
+.ds-pa-activity-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 4px;
+  border-radius: 8px;
+}
+
+.ds-pa-activity-option:hover {
+  background: var(--ds-color-surface-soft, #f8fafc);
+}
+
 .ds-pa-form-error {
   min-height: 1.2em;
   margin: 0 0 6px;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 406;
+const CACHE_VERSION = 407;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 359;
+const SW_ENTRY_VERSION = 360;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The native `<select multiple>` used for `activity_names` requires Ctrl/Command for multi-selection and is not user-friendly for the target users. 
- Replace it with a compact, touch-friendly multi-select UI that preserves the existing data model and works across add/edit flows.

### Description
- Replaced the `activity_names` native multi-select with a checkbox-based dropdown picker that opens on a normal click and shows selected items as removable chips. 
- Added an internal search field and scrollable dropdown to keep the list compact and filterable, and synchronized checkbox state with chips and hidden inputs so the form still submits `activity_names` as an array. 
- Implemented `setupActivityPickers` + event handling to initialize pickers for both add and inline-edit forms and to support removing selections via chip X or unchecking checkboxes. 
- Added compact CSS for the picker/chips/dropdown and bumped service worker cache/version constants to force clients to pick up the updated JS/CSS after deploy.

### Testing
- `npm run build` completed successfully for the repo build. 
- `npm --prefix frontend run build` failed because there is no separate `frontend/package.json` in this repository layout, which is expected for this project structure and thus not a blocker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef192cb30832ba628b26684bc49fc)