### PR TITLE
Compact activity-names multi-select in Proposals & Agreements; bump SW cache

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9982,11 +9982,16 @@ select.ds-input {
 
 .ds-pa-activity-picker {
   position: relative;
+  max-width: 100%;
 }
 
 .ds-pa-activity-trigger {
   text-align: right;
   min-height: 32px;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .ds-pa-activity-chips {
@@ -9994,6 +9999,9 @@ select.ds-input {
   gap: 6px;
   flex-wrap: wrap;
   margin-top: 6px;
+  max-height: 62px;
+  overflow: auto;
+  padding-inline-end: 2px;
 }
 
 .ds-pa-chip {
@@ -10008,32 +10016,44 @@ select.ds-input {
 .ds-pa-activity-dropdown {
   position: absolute;
   z-index: 6;
-  inset-inline: 0;
+  inset-inline-start: 0;
+  inline-size: min(380px, 100%);
   margin-top: 6px;
   border: 1px solid var(--ds-color-border, #e2e8f0);
   border-radius: 10px;
   background: #fff;
-  padding: 8px;
+  padding: 7px;
   box-shadow: var(--ds-shadow-sm);
 }
 
 .ds-pa-activity-search {
   margin-bottom: 6px;
+  min-height: 30px;
+  padding-block: 3px;
 }
 
 .ds-pa-activity-options {
-  max-height: 210px;
+  max-height: 240px;
   overflow: auto;
   display: grid;
-  gap: 4px;
+  gap: 2px;
 }
 
 .ds-pa-activity-option {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 2px 4px;
+  gap: 7px;
+  padding: 2px 5px;
   border-radius: 8px;
+  font-size: 0.82rem;
+  line-height: 1.25;
+}
+
+.ds-pa-activity-option input[type="checkbox"] {
+  inline-size: 14px;
+  block-size: 14px;
+  margin: 0;
+  flex: 0 0 auto;
 }
 
 .ds-pa-activity-option:hover {
@@ -10056,6 +10076,10 @@ select.ds-input {
   .ds-pa-table td {
     padding: 7px 8px;
     font-size: 0.82rem;
+  }
+
+  .ds-pa-activity-dropdown {
+    inline-size: 100%;
   }
 }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 407;
+const CACHE_VERSION = 408;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- The `activity_names` picker in the Proposals & Agreements form opened as an oversized blank block that broke the form layout and produced excessive whitespace. 
- The UI must be compact, RTL-friendly and not push the entire form when opened, while keeping multi-select behaviour and stored `activity_names` data unchanged.

### Description
- Tightened the picker layout by updating `frontend/src/styles/main.css` to limit dropdown width (`inline-size: min(380px, 100%)`) and align it to the field (`inset-inline-start: 0`).
- Capped the dropdown height with internal scrolling (`max-height: 240px`) and reduced option gap/padding for compact rows, plus reduced checkbox size for a tidy compact look. 
- Made the selected-chips area scrollable with a max height (`max-height: 62px`) so many selections do not enlarge the form. 
- Kept responsive behaviour by allowing full-width dropdown on small screens and bumped the service worker `CACHE_VERSION` in `frontend/sw.js` to force clients to fetch updated JS/CSS.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully. 
- Ran the test suite via `npm test` and observed multiple pre-existing failing tests that are unrelated to this CSS/UI change. 
- No automated visual tests were added; this change is CSS-only and validated by the successful build and local inspection of the proposals form layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef35a2758832b9def46850c78a5f7)