### PR TITLE
Add status workflow and client picker to proposals-agreements

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 407;
+const CACHE_VERSION = 410;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DbJ_X7vL.js",
+  "./assets/index-BhyoifUu.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-Bauq48BP.css",
+  "./assets/style-gmNpalxU.css",
   "./index.html",
   "./manifest.json"
 ];
@@ -82,15 +82,19 @@ async function deleteOutdatedCaches() {
   return outdatedKeys;
 }
 
-async function notifyClientsOfUpdate() {
+async function reloadClientsAfterCacheUpgrade(deletedKeys) {
+  if (!Array.isArray(deletedKeys) || !deletedKeys.length) return;
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-  clients.forEach((client) => {
-    try { client.postMessage({ type: 'SW_UPDATED', version: CACHE_VERSION }); } catch (e) { /* ignore */ }
-  });
+  await Promise.all(clients.map(async (client) => {
+    try {
+      await client.navigate(client.url);
+    } catch (e) {
+      try { client.postMessage({ type: 'SW_UPDATED', version: CACHE_VERSION }); } catch (_) { /* ignore */ }
+    }
+  }));
 }
 
 function withNoStore(request) {
-  if (request.cache === 'no-store') return request;
   return new Request(request, { cache: 'no-store' });
 }
 
@@ -156,11 +160,10 @@ self.addEventListener('install', (event) => {
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    deleteOutdatedCaches().then(async () => {
+    deleteOutdatedCaches().then(async (deletedKeys) => {
       // Claim all open tabs so this SW serves them right away.
       await self.clients.claim();
-      // Notify tabs that a new version is active (app can show a toast if desired).
-      await notifyClientsOfUpdate();
+      await reloadClientsAfterCacheUpgrade(deletedKeys);
     })
   );
 });
@@ -196,7 +199,7 @@ self.addEventListener('fetch', (event) => {
     url.pathname.endsWith('.html') ||
     url.pathname.endsWith('.js') ||
     url.pathname.endsWith('.css') ||
-    isManifestUrl(url)
+    url.pathname.endsWith('/manifest.json') || isManifestUrl(url)
   );
 
   event.respondWith(

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DbJ_X7vL.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-Bauq48BP.css">
+  <script type="module" crossorigin src="./assets/index-BhyoifUu.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-gmNpalxU.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 407;
+const CACHE_VERSION = 410;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DbJ_X7vL.js",
+  "./assets/index-BhyoifUu.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-Bauq48BP.css",
+  "./assets/style-gmNpalxU.css",
   "./index.html",
   "./manifest.json"
 ];
@@ -82,15 +82,19 @@ async function deleteOutdatedCaches() {
   return outdatedKeys;
 }
 
-async function notifyClientsOfUpdate() {
+async function reloadClientsAfterCacheUpgrade(deletedKeys) {
+  if (!Array.isArray(deletedKeys) || !deletedKeys.length) return;
   const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-  clients.forEach((client) => {
-    try { client.postMessage({ type: 'SW_UPDATED', version: CACHE_VERSION }); } catch (e) { /* ignore */ }
-  });
+  await Promise.all(clients.map(async (client) => {
+    try {
+      await client.navigate(client.url);
+    } catch (e) {
+      try { client.postMessage({ type: 'SW_UPDATED', version: CACHE_VERSION }); } catch (_) { /* ignore */ }
+    }
+  }));
 }
 
 function withNoStore(request) {
-  if (request.cache === 'no-store') return request;
   return new Request(request, { cache: 'no-store' });
 }
 
@@ -156,11 +160,10 @@ self.addEventListener('install', (event) => {
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    deleteOutdatedCaches().then(async () => {
+    deleteOutdatedCaches().then(async (deletedKeys) => {
       // Claim all open tabs so this SW serves them right away.
       await self.clients.claim();
-      // Notify tabs that a new version is active (app can show a toast if desired).
-      await notifyClientsOfUpdate();
+      await reloadClientsAfterCacheUpgrade(deletedKeys);
     })
   );
 });
@@ -196,7 +199,7 @@ self.addEventListener('fetch', (event) => {
     url.pathname.endsWith('.html') ||
     url.pathname.endsWith('.js') ||
     url.pathname.endsWith('.css') ||
-    isManifestUrl(url)
+    url.pathname.endsWith('/manifest.json') || isManifestUrl(url)
   );
 
   event.respondWith(

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -37,6 +37,7 @@ const MUTATING_ACTIONS = {
   saveClientSetting: true,
   addProposalAgreement: true,
   updateProposalAgreement: true,
+  updateProposalAgreementStatus: true,
   deleteProposalAgreement: true
 };
 
@@ -1269,6 +1270,7 @@ function invalidateScreenDataByAction(action) {
     saveClientSetting: ['adminSettings', 'dashboard:', 'activities:', 'week:', 'month:'],
     addProposalAgreement: ['proposals-agreements'],
     updateProposalAgreement: ['proposals-agreements'],
+    updateProposalAgreementStatus: ['proposals-agreements'],
     deleteProposalAgreement: ['proposals-agreements']
   };
   const prefixes = targetedMutations[action];
@@ -1354,7 +1356,7 @@ function normalizeData(data) {
 
 
 const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
-const PROPOSALS_AGREEMENTS_COLUMNS = 'id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_COLUMNS = 'id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,created_at,updated_at';
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
 function parseActivityNamesFromNotes(notes) {
@@ -1398,8 +1400,17 @@ function cleanProposalAgreementText(value) {
   return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
 }
 
+const PA_STATUS_LABELS = {
+  draft:                'טיוטה',
+  pending_approval:     'ממתין לאישור',
+  returned_for_changes: 'הוחזר לתיקון',
+  approved:             'מאושר',
+  cancelled:            'בוטל'
+};
+
 function buildProposalAgreementSearchText(row = {}) {
   const activityNames = Array.isArray(row.activity_names) ? row.activity_names.join(' ') : '';
+  const statusLabel = PA_STATUS_LABELS[cleanProposalAgreementText(row.status)] || cleanProposalAgreementText(row.status);
   return [
     row.id,
     row.client_authority,
@@ -1411,7 +1422,8 @@ function buildProposalAgreementSearchText(row = {}) {
     row.contact_name,
     row.contact_role,
     row.phone,
-    row.email
+    row.email,
+    statusLabel
   ].map(cleanProposalAgreementText).filter(Boolean).join(' ').toLowerCase();
 }
 
@@ -1422,6 +1434,8 @@ function normalizeProposalAgreementActivityNames(value) {
 
 function normalizeProposalAgreementRow(row = {}) {
   const parsedNotes = parseActivityNamesFromNotes(row.notes);
+  const PA_VALID_STATUSES = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
+  const rawStatus = cleanProposalAgreementText(row.status);
   const normalized = {
     id:                  cleanProposalAgreementText(row.id),
     client_authority:    cleanProposalAgreementText(row.client_authority),
@@ -1439,6 +1453,9 @@ function normalizeProposalAgreementRow(row = {}) {
     phone:               cleanProposalAgreementText(row.phone || row.contact_phone),
     email:               cleanProposalAgreementText(row.email || row.contact_email),
     notes:               parsedNotes.notes,
+    status:              PA_VALID_STATUSES.has(rawStatus) ? rawStatus : 'draft',
+    approval_note:       cleanProposalAgreementText(row.approval_note),
+    total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
     created_at:          cleanProposalAgreementText(row.created_at),
     updated_at:          cleanProposalAgreementText(row.updated_at)
   };
@@ -1446,8 +1463,11 @@ function normalizeProposalAgreementRow(row = {}) {
   return normalized;
 }
 
+const PA_VALID_STATUSES_SET = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
+
 function sanitizeProposalAgreementPayload(payload = {}) {
   const activity_names = normalizeProposalAgreementActivityNames(payload.activity_names);
+  const rawStatus = cleanProposalAgreementText(payload.status);
   const row = {
     client_authority:    cleanProposalAgreementText(payload.client_authority),
     school_framework:    cleanProposalAgreementText(payload.school_framework),
@@ -1459,7 +1479,9 @@ function sanitizeProposalAgreementPayload(payload = {}) {
     contact_role:        cleanProposalAgreementText(payload.contact_role),
     phone:               cleanProposalAgreementText(payload.phone),
     email:               cleanProposalAgreementText(payload.email),
-    notes:               parseActivityNamesFromNotes(payload.notes).notes
+    notes:               parseActivityNamesFromNotes(payload.notes).notes,
+    status:              PA_VALID_STATUSES_SET.has(rawStatus) ? rawStatus : 'draft',
+    approval_note:       cleanProposalAgreementText(payload.approval_note)
   };
   const missing = ['client_authority', 'school_framework', 'document_type', 'activity_type_group'].filter((key) => !row[key]);
   if (missing.length) throw new Error(`missing_required_fields:${missing.join(',')}`);
@@ -1482,9 +1504,29 @@ async function readProposalActivityNamesFromSupabase() {
   }
 }
 
+async function readContactsSchoolsForProposals() {
+  try {
+    const { data, error } = await supabase
+      .from('contacts_schools')
+      .select('authority,school,contact_name,contact_role,phone,email,mobile')
+      .order('authority', { ascending: true });
+    if (error) return [];
+    return (Array.isArray(data) ? data : []).map((c) => ({
+      authority:    cleanProposalAgreementText(c.authority),
+      school:       cleanProposalAgreementText(c.school),
+      contact_name: cleanProposalAgreementText(c.contact_name),
+      contact_role: cleanProposalAgreementText(c.contact_role),
+      phone:        cleanProposalAgreementText(c.phone || c.mobile || ''),
+      email:        cleanProposalAgreementText(c.email || '')
+    })).filter((c) => c.authority);
+  } catch {
+    return [];
+  }
+}
+
 async function readProposalsAgreementsFromSupabase() {
   assertCanUseProposalsAgreementsApi();
-  const [paResult, activityNameOptions] = await Promise.all([
+  const [paResult, activityNameOptions, contactOptions] = await Promise.all([
     supabase
       .from('proposals_agreements')
       .select(PROPOSALS_AGREEMENTS_COLUMNS)
@@ -1492,12 +1534,14 @@ async function readProposalsAgreementsFromSupabase() {
       .order('school_framework', { ascending: true })
       .order('document_type', { ascending: true })
       .order('activity_type_group', { ascending: true }),
-    readProposalActivityNamesFromSupabase()
+    readProposalActivityNamesFromSupabase(),
+    readContactsSchoolsForProposals()
   ]);
   if (paResult.error) throw new Error(paResult.error.message || 'proposals_agreements_read_failed');
   return {
     rows: (Array.isArray(paResult.data) ? paResult.data : []).map(normalizeProposalAgreementRow),
     activityNameOptions,
+    contactOptions,
     _source: 'supabase'
   };
 }
@@ -2378,6 +2422,22 @@ export const api = {
       .eq('id', rowId);
     if (error) throw new Error(error.message || 'proposals_agreement_delete_failed');
     return { ok: true, id: rowId };
+  },
+  updateProposalAgreementStatus: async (id, status, approvalNote = '') => {
+    assertCanUseProposalsAgreementsApi();
+    const rowId = cleanProposalAgreementText(id);
+    const cleanStatus = cleanProposalAgreementText(status);
+    if (!rowId) throw new Error('missing_proposal_agreement_id');
+    if (!PA_VALID_STATUSES_SET.has(cleanStatus)) throw new Error('invalid_proposal_agreement_status');
+    const patch = { status: cleanStatus, approval_note: cleanProposalAgreementText(approvalNote) };
+    const { data, error } = await supabase
+      .from('proposals_agreements')
+      .update(patch)
+      .eq('id', rowId)
+      .select(PROPOSALS_AGREEMENTS_COLUMNS)
+      .single();
+    if (error) throw new Error(error.message || 'proposals_agreement_status_update_failed');
+    return { ok: true, row: normalizeProposalAgreementRow(data) };
   },
   addContact: async (payload) => {
     const kind = String(payload?.kind || '').trim();

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -7,6 +7,15 @@ const SEARCH_DEBOUNCE_MS = 280;
 const DOCUMENT_TYPE_OPTIONS = ['הצעת מחיר', 'הסכם'];
 const ACTIVITY_TYPE_GROUP_OPTIONS = ['הצעה משולבת', 'פעילויות קיץ', 'שנה הבאה'];
 
+export const STATUS_OPTIONS = ['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'];
+export const STATUS_LABELS = {
+  draft:                'טיוטה',
+  pending_approval:     'ממתין לאישור',
+  returned_for_changes: 'הוחזר לתיקון',
+  approved:             'מאושר',
+  cancelled:            'בוטל'
+};
+
 const FIELD_LABELS = {
   client_authority:    'לקוח / רשות',
   school_framework:    'בית ספר / מסגרת',
@@ -18,7 +27,9 @@ const FIELD_LABELS = {
   contact_role:        'תפקיד',
   phone:               'טלפון',
   email:               'דוא״ל',
-  notes:               'הערות'
+  notes:               'הערות',
+  status:              'סטטוס',
+  approval_note:       'הערת אישור'
 };
 
 const REQUIRED_FIELDS = ['client_authority', 'school_framework', 'document_type', 'activity_type_group'];
@@ -64,7 +75,8 @@ export function buildProposalsAgreementsSearchText(row = {}) {
     row.contact_name,
     row.contact_role,
     row.phone,
-    row.email
+    row.email,
+    row.status ? (STATUS_LABELS[row.status] || row.status) : ''
   ].map(normalizeSearch).filter(Boolean).join(' ');
 }
 
@@ -86,6 +98,8 @@ export function normalizeProposalAgreementRow(row = {}) {
     phone:               text(row.phone || row.contact_phone),
     email:               text(row.email || row.contact_email),
     notes:               text(row.notes),
+    status:              STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft',
+    approval_note:       text(row.approval_note),
     created_at:          text(row.created_at),
     updated_at:          text(row.updated_at)
   };
@@ -117,6 +131,7 @@ function rowMatches(row, filters) {
   if (q && !normalizeSearch(row._searchText).includes(q)) return false;
   if (filters.document_type && text(row.document_type) !== filters.document_type) return false;
   if (filters.activity_type_group && text(row.activity_type_group) !== filters.activity_type_group) return false;
+  if (filters.status && text(row.status) !== filters.status) return false;
   return true;
 }
 
@@ -125,14 +140,35 @@ function uniqueValues(rows, key) {
     .sort((a, b) => a.localeCompare(b, 'he'));
 }
 
-function optionHtml(value, selected = '') {
+function optionHtml(value, selected = '', display = '') {
   const safe = escapeHtml(value);
-  return `<option value="${safe}"${value === selected ? ' selected' : ''}>${safe}</option>`;
+  const label = escapeHtml(display || value);
+  return `<option value="${safe}"${value === selected ? ' selected' : ''}>${label}</option>`;
 }
 
 function filterSelectHtml(key, label, values) {
   const options = ['<option value="">הכול</option>', ...values.map((value) => optionHtml(value))].join('');
   return `<label class="ds-pa-filter"><span>${escapeHtml(label)}</span><select class="ds-input ds-input--sm" data-pa-filter="${escapeHtml(key)}">${options}</select></label>`;
+}
+
+function statusFilterHtml() {
+  const options = ['<option value="">הכול</option>',
+    ...STATUS_OPTIONS.map((s) => `<option value="${escapeHtml(s)}">${escapeHtml(STATUS_LABELS[s] || s)}</option>`)
+  ].join('');
+  return `<label class="ds-pa-filter"><span>סטטוס</span><select class="ds-input ds-input--sm" data-pa-filter="status">${options}</select></label>`;
+}
+
+function statusBadgeHtml(status) {
+  const label = STATUS_LABELS[status] || status || '—';
+  const colorMap = {
+    draft:                '#888',
+    pending_approval:     '#d97706',
+    returned_for_changes: '#dc2626',
+    approved:             '#16a34a',
+    cancelled:            '#6b7280'
+  };
+  const color = colorMap[status] || '#888';
+  return `<span class="ds-pa-badge" style="display:inline-block;padding:1px 7px;border-radius:10px;font-size:0.78rem;background:${color};color:#fff;white-space:nowrap">${escapeHtml(label)}</span>`;
 }
 
 function detailRowsHtml(row) {
@@ -169,12 +205,12 @@ function contactDetailRowsHtml(row = {}) {
     </div>`;
   }).join('');
   if (!rows) return '';
-  return `<section class="ds-pa-contact-section"><h4 class="ds-pa-contact-title">אנשי קשר</h4>${rows}</section>`;
+  return `<section class="ds-pa-contact-section"><h4 class="ds-pa-contact-title">פרטי קשר</h4>${rows}</section>`;
 }
 
 export function proposalsAgreementsTableRowsHtml(rows) {
   if (!rows.length) {
-    return `<tr class="ds-pa-empty-row"><td colspan="6">אין רשומות להצגה</td></tr>`;
+    return `<tr class="ds-pa-empty-row"><td colspan="7">אין רשומות להצגה</td></tr>`;
   }
   return rows.map((row) => `
     <tr data-pa-row-id="${escapeHtml(row.id)}" tabindex="0">
@@ -183,6 +219,7 @@ export function proposalsAgreementsTableRowsHtml(rows) {
       <td>${escapeHtml(row.document_type || '—')}</td>
       <td>${escapeHtml(row.activity_type_group || '—')}</td>
       <td>${escapeHtml(formatDateDisplay(row.proposal_date) || '')}</td>
+      <td>${statusBadgeHtml(row.status)}</td>
       <td>${escapeHtml(row.notes || '')}</td>
     </tr>`).join('');
 }
@@ -190,7 +227,7 @@ export function proposalsAgreementsTableRowsHtml(rows) {
 function tableHtml(rows) {
   return dsTableWrap(`
     <table class="ds-table ds-pa-table" data-pa-table>
-      <thead><tr><th>לקוח / רשות</th><th>בית ספר / מסגרת</th><th>סוג מסמך</th><th>סוג פעילות</th><th>תאריך הצעה</th><th>הערות</th></tr></thead>
+      <thead><tr><th>לקוח / רשות</th><th>בית ספר / מסגרת</th><th>סוג מסמך</th><th>סוג פעילות</th><th>תאריך הצעה</th><th>סטטוס</th><th>הערות</th></tr></thead>
       <tbody data-pa-table-body>${proposalsAgreementsTableRowsHtml(rows)}</tbody>
     </table>
   `);
@@ -209,75 +246,168 @@ function textField(key, label, value, required) {
   return `<label class="ds-pa-form-field"><span>${escapeHtml(label)}${required ? ' *' : ''}</span><input class="ds-input ds-input--sm" name="${key}" value="${escapeHtml(value || '')}"${attrs}></label>`;
 }
 
-function formFieldHtml(key, value = '', activityNameOptions = []) {
-  const label = FIELD_LABELS[key] || key;
-  const required = REQUIRED_FIELDS.includes(key);
-
-  if (key === 'document_type') {
-    return selectField(key, label, DOCUMENT_TYPE_OPTIONS, value, required);
+function activityPickerHtml(value, activityNameOptions) {
+  const selectedValues = Array.isArray(value) ? value.map(text).filter(Boolean) : text(value).split(',').map(text).filter(Boolean);
+  const allOptions = Array.from(new Set([...activityNameOptions, ...selectedValues])).filter(Boolean).sort((a, b) => a.localeCompare(b, 'he'));
+  const label = FIELD_LABELS.activity_names;
+  if (!allOptions.length) {
+    return `<div class="ds-pa-form-field ds-pa-form-field--wide"><span class="ds-pa-field-label">${escapeHtml(label)}</span><p class="ds-muted" style="font-size:0.8rem;margin:2px 0">אין פעילויות זמינות ברשימה</p></div>`;
   }
-  if (key === 'activity_type_group') {
-    return selectField(key, label, ACTIVITY_TYPE_GROUP_OPTIONS, value, required);
-  }
-  if (key === 'activity_names') {
-    const selectedValues = Array.isArray(value) ? value.map(text).filter(Boolean) : text(value).split(',').map(text).filter(Boolean);
-    const allOptions = Array.from(new Set([...activityNameOptions, ...selectedValues])).filter(Boolean).sort((a, b) => a.localeCompare(b, 'he'));
-    if (!allOptions.length) {
-      return `<label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(label)}</span><p class="ds-muted" style="font-size:0.8rem;margin:2px 0">אין פעילויות זמינות ברשימה</p></label>`;
-    }
-    const optionsHtml = allOptions.map((v) => {
-      const safe = escapeHtml(v);
-      const checked = selectedValues.includes(v) ? ' checked' : '';
-      return `<label class="ds-pa-activity-option"><input type="checkbox" value="${safe}"${checked}><span>${safe}</span></label>`;
-    }).join('');
-    return `<label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(label)}${required ? ' *' : ''}</span>
-      <div class="ds-pa-activity-picker" data-pa-activity-picker data-required="${required ? 'yes' : 'no'}">
-        <button type="button" class="ds-input ds-input--sm ds-pa-activity-trigger" data-pa-activity-toggle aria-expanded="false">בחרו שמות פעילויות</button>
-        <div class="ds-pa-activity-chips" data-pa-activity-chips></div>
-        <div class="ds-pa-activity-dropdown" data-pa-activity-dropdown hidden>
-          <input class="ds-input ds-input--sm ds-pa-activity-search" data-pa-activity-search placeholder="חיפוש פעילות..." autocomplete="off">
-          <div class="ds-pa-activity-options" data-pa-activity-options>${optionsHtml}</div>
-        </div>
-        <div data-pa-activity-hidden-inputs></div>
+  const optionsHtml = allOptions.map((v) => {
+    const safe = escapeHtml(v);
+    const checked = selectedValues.includes(v) ? ' checked' : '';
+    return `<label class="ds-pa-activity-option"><input type="checkbox" value="${safe}"${checked}><span>${safe}</span></label>`;
+  }).join('');
+  return `<div class="ds-pa-form-field ds-pa-form-field--wide">
+    <span class="ds-pa-field-label">${escapeHtml(label)}</span>
+    <div class="ds-pa-activity-picker" data-pa-activity-picker data-required="no">
+      <button type="button" class="ds-input ds-input--sm ds-pa-activity-trigger" data-pa-activity-toggle aria-expanded="false">בחרו פעילויות</button>
+      <div class="ds-pa-activity-chips" data-pa-activity-chips></div>
+      <div class="ds-pa-activity-dropdown" data-pa-activity-dropdown hidden>
+        <input class="ds-input ds-input--sm ds-pa-activity-search" data-pa-activity-search placeholder="חיפוש פעילות..." autocomplete="off">
+        <div class="ds-pa-activity-options" data-pa-activity-options>${optionsHtml}</div>
       </div>
-    </label>`;
-  }
-  if (key === 'proposal_date') {
-    return `<label class="ds-pa-form-field"><span>${escapeHtml(label)}</span><input class="ds-input ds-input--sm" type="date" name="${key}" value="${escapeHtml(value || '')}"></label>`;
-  }
-  if (key === 'notes') {
-    return `<label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(label)}</span><textarea class="ds-input ds-input--sm" name="${key}" rows="2">${escapeHtml(value || '')}</textarea></label>`;
-  }
-  return textField(key, label, value, required);
+      <div data-pa-activity-hidden-inputs></div>
+    </div>
+  </div>`;
 }
 
-function formHtml(mode, row = {}, activityNameOptions = []) {
-  const title = mode === 'edit' ? 'עריכת רשומה' : 'הוספת הצעה / הסכם';
+function clientSelectHtml(contactOptions, row) {
+  const seen = new Set();
+  const pairs = [];
+  for (const c of (Array.isArray(contactOptions) ? contactOptions : [])) {
+    const key = `${text(c.authority)}||${text(c.school)}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      pairs.push({ authority: text(c.authority), school: text(c.school) });
+    }
+  }
+  pairs.sort((a, b) => a.authority.localeCompare(b.authority, 'he') || a.school.localeCompare(b.school, 'he'));
+
+  const rowAuth = text(row.client_authority);
+  const rowSchool = text(row.school_framework);
+  const selectedVal = rowAuth ? `${rowAuth}||${rowSchool}` : '';
+
+  const optionsHtml = ['<option value="">— בחרו לקוח קיים —</option>',
+    ...pairs.map((p) => {
+      const val = `${p.authority}||${p.school}`;
+      const label = p.school ? `${p.authority} — ${p.school}` : p.authority;
+      return `<option value="${escapeHtml(val)}"${val === selectedVal ? ' selected' : ''}>${escapeHtml(label)}</option>`;
+    })
+  ].join('');
+  return `<select class="ds-input ds-input--sm" data-pa-client-select style="flex:1;min-width:0">${optionsHtml}</select>`;
+}
+
+function contactPickerHtml(contactOptions, authority, school, selectedContactName) {
+  const contacts = (Array.isArray(contactOptions) ? contactOptions : []).filter(
+    (c) => text(c.authority) === authority && text(c.school) === school
+  );
+  if (contacts.length <= 1) return '';
+  const optionsHtml = ['<option value="">— בחרו איש קשר —</option>',
+    ...contacts.map((c) => {
+      const val = text(c.contact_name);
+      const label = c.contact_role ? `${val} (${text(c.contact_role)})` : val;
+      return `<option value="${escapeHtml(val)}"${val === selectedContactName ? ' selected' : ''}>${escapeHtml(label)}</option>`;
+    })
+  ].join('');
+  return `<label class="ds-pa-form-field"><span>בחרו איש קשר</span>
+    <select class="ds-input ds-input--sm" data-pa-contact-select>${optionsHtml}</select>
+  </label>`;
+}
+
+function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = []) {
+  const title = mode === 'edit' ? 'עריכת הצעה / הסכם' : 'יצירת הצעת מחיר / הסכם';
+  const rowActivity = Array.isArray(row.activity_names) ? row.activity_names : [];
+  const currentStatus = STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft';
+  const initAuth = text(row.client_authority);
+  const initSchool = text(row.school_framework);
+  const initContact = text(row.contact_name);
+  const initPickerHtml = initAuth ? contactPickerHtml(contactOptions, initAuth, initSchool, initContact) : '';
+
   return `<form class="ds-pa-form ds-pa-form--compact" data-pa-form data-pa-mode="${escapeHtml(mode)}" data-pa-id="${escapeHtml(row.id || '')}" dir="rtl">
     <h3 class="ds-pa-form-title">${escapeHtml(title)}</h3>
-    <div class="ds-pa-form-grid">${FORM_FIELDS.map((key) => formFieldHtml(key, key === 'activity_names' ? (Array.isArray(row[key]) ? row[key] : []) : (row[key] || ''), activityNameOptions)).join('')}</div>
+
+    <div class="ds-pa-form-section" style="margin-bottom:8px">
+      <div class="ds-pa-client-row" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:4px">
+        ${clientSelectHtml(contactOptions, row)}
+        <button type="button" class="ds-btn ds-btn--sm" data-pa-new-client-toggle>+ לקוח חדש</button>
+      </div>
+      <div data-pa-new-client-hint hidden style="margin-bottom:4px">
+        <span class="ds-muted" style="font-size:0.8rem">מלאו את שדות הלקוח / הקשר ישירות למטה</span>
+      </div>
+      <div data-pa-contact-picker-host>${initPickerHtml}</div>
+    </div>
+
+    <div class="ds-pa-form-grid">
+      ${textField('client_authority', FIELD_LABELS.client_authority, row.client_authority, true)}
+      ${textField('school_framework', FIELD_LABELS.school_framework, row.school_framework, true)}
+      ${selectField('document_type', FIELD_LABELS.document_type, DOCUMENT_TYPE_OPTIONS, text(row.document_type), true)}
+      ${selectField('activity_type_group', FIELD_LABELS.activity_type_group, ACTIVITY_TYPE_GROUP_OPTIONS, text(row.activity_type_group), true)}
+      <label class="ds-pa-form-field"><span>${escapeHtml(FIELD_LABELS.proposal_date)}</span><input class="ds-input ds-input--sm" type="date" name="proposal_date" value="${escapeHtml(text(row.proposal_date))}"></label>
+      ${textField('contact_name', FIELD_LABELS.contact_name, row.contact_name, false)}
+      ${textField('contact_role', FIELD_LABELS.contact_role, row.contact_role, false)}
+      ${textField('phone', FIELD_LABELS.phone, row.phone, false)}
+      ${textField('email', FIELD_LABELS.email, row.email, false)}
+    </div>
+
+    ${activityPickerHtml(rowActivity, activityNameOptions)}
+
+    <label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(FIELD_LABELS.notes)}</span><textarea class="ds-input ds-input--sm" name="notes" rows="2">${escapeHtml(text(row.notes))}</textarea></label>
+
+    <input type="hidden" name="status" data-pa-status-input value="${escapeHtml(currentStatus)}">
     <p class="ds-pa-form-error" data-pa-form-error role="alert"></p>
     <div class="ds-pa-form-actions">
-      <button type="submit" class="ds-btn ds-btn--primary ds-btn--sm">שמירה</button>
-      <button type="button" class="ds-btn ds-btn--sm" data-pa-cancel-form>ביטול</button>
+      <button type="button" class="ds-btn ds-btn--sm" data-pa-save-draft>שמירת טיוטה</button>
+      <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-save-pending>שליחה לאישור</button>
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-cancel-form>ביטול</button>
     </div>
   </form>`;
 }
 
-function drawerHtml(row, activityNameOptions = []) {
+function drawerActionButtons(row, state) {
+  const status = text(row?.status) || 'draft';
+  const role = state ? String(state?.user?.display_role || state?.user?.role || '').trim() : '';
+  const isAdminRole = role === 'admin';
+  const buttons = [];
+
+  if (['draft', 'returned_for_changes'].includes(status) || isAdminRole) {
+    buttons.push(`<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button>`);
+  }
+  if (['draft', 'returned_for_changes'].includes(status) && !isAdminRole) {
+    buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="pending_approval" data-pa-action-id="${escapeHtml(row.id)}">שליחה לאישור</button>`);
+  }
+  if (isAdminRole) {
+    if (status === 'pending_approval') {
+      buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="approved" data-pa-action-id="${escapeHtml(row.id)}">אישור</button>`);
+      buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="returned_for_changes" data-pa-action-id="${escapeHtml(row.id)}">החזרה לתיקון</button>`);
+    }
+    if (!['cancelled', 'approved'].includes(status)) {
+      buttons.push(`<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-status-action="cancelled" data-pa-action-id="${escapeHtml(row.id)}">ביטול</button>`);
+    }
+    buttons.push(`<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-delete-row="${escapeHtml(row.id)}">מחיקה</button>`);
+  }
+  return buttons.join('');
+}
+
+function drawerHtml(row, activityNameOptions = [], state = null) {
   if (!row) return `<aside class="ds-pa-drawer" data-pa-drawer hidden></aside>`;
+  const approvalNoteHtml = text(row.approval_note) ? `
+    <div class="ds-pa-detail-row">
+      <span class="ds-pa-detail-label">${escapeHtml(FIELD_LABELS.approval_note)}</span>
+      <span class="ds-pa-detail-value">${escapeHtml(text(row.approval_note))}</span>
+    </div>` : '';
+
   return `<aside class="ds-pa-drawer" data-pa-drawer data-pa-drawer-id="${escapeHtml(row.id)}" aria-live="polite" dir="rtl">
     <div class="ds-pa-drawer-panel">
       <header class="ds-pa-drawer-head">
         <div><p class="ds-muted">פרטי רשומה</p><h3>${escapeHtml(row.client_authority || '—')}</h3></div>
         <button type="button" class="ds-btn ds-btn--sm" data-pa-close-drawer aria-label="סגירת פרטי רשומה">✕</button>
       </header>
+      <div class="ds-pa-drawer-status" style="margin-bottom:8px">${statusBadgeHtml(row.status)}</div>
       <div class="ds-pa-detail-grid">${detailRowsHtml(row)}</div>
+      ${approvalNoteHtml}
       ${contactDetailRowsHtml(row)}
-      <div class="ds-pa-drawer-actions">
-        <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button>
-        <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-delete-row="${escapeHtml(row.id)}">מחיקה</button>
-      </div>
+      <div class="ds-pa-drawer-actions">${drawerActionButtons(row, state)}</div>
       <div data-pa-inline-form></div>
     </div>
   </aside>`;
@@ -302,7 +432,8 @@ function currentFilters(root) {
   return {
     q:                   root.querySelector('[data-pa-search]')?.value || '',
     document_type:       root.querySelector('[data-pa-filter="document_type"]')?.value || '',
-    activity_type_group: root.querySelector('[data-pa-filter="activity_type_group"]')?.value || ''
+    activity_type_group: root.querySelector('[data-pa-filter="activity_type_group"]')?.value || '',
+    status:              root.querySelector('[data-pa-filter="status"]')?.value || ''
   };
 }
 
@@ -324,6 +455,7 @@ function payloadFromForm(form) {
     }
     payload[key] = text(formData.get(key));
   });
+  payload.status = text(formData.get('status')) || 'draft';
   return payload;
 }
 
@@ -359,12 +491,13 @@ export const proposalsAgreementsScreen = {
           <label class="ds-pa-search"><span>חיפוש</span><input class="ds-input ds-input--sm" data-pa-search placeholder="חיפוש מקומי" autocomplete="off"></label>
           ${filterSelectHtml('document_type', 'סוג מסמך', uniqueValues(rawRows, 'document_type'))}
           ${filterSelectHtml('activity_type_group', 'סוג פעילות', uniqueValues(rawRows, 'activity_type_group'))}
+          ${statusFilterHtml()}
           <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-add>הוספה</button>
         </div>
         <div class="ds-pa-local-status" aria-live="polite">מציג <strong data-pa-results-count>${rows.length}</strong> רשומות</div>
         <div data-pa-form-host hidden></div>
         ${dsCard({ title: 'רשומות', padded: false, body: `<div class="ds-pa-records-shell" data-pa-table-region>${tableHtml(rows)}</div>` })}
-        ${drawerHtml(null)}
+        ${drawerHtml(null, [], state)}
       </section>
     `);
   },
@@ -379,6 +512,7 @@ export const proposalsAgreementsScreen = {
       .map(normalizeProposalAgreementRow)
       .filter((r) => { const k = text(r.id); if (!k || seenIds.has(k)) return false; seenIds.add(k); return true; }));
     const activityNameOptions = Array.from(new Set((Array.isArray(data?.activityNameOptions) ? data.activityNameOptions : []).map((v) => text(v)).filter(Boolean)));
+    const contactOptions = Array.isArray(data?.contactOptions) ? data.contactOptions : [];
     let debounceTimer = null;
 
     const refreshTable = () => updateProposalsAgreementsTableOnly(root, displayRows(data, currentFilters(root)));
@@ -399,6 +533,7 @@ export const proposalsAgreementsScreen = {
         if (trigger) trigger.setAttribute('aria-expanded', 'false');
       });
     };
+
     const setupActivityPickers = (container) => {
       container?.querySelectorAll?.('[data-pa-activity-picker]')?.forEach((picker) => {
         const trigger = picker.querySelector('[data-pa-activity-toggle]');
@@ -413,7 +548,7 @@ export const proposalsAgreementsScreen = {
           chipsHost.innerHTML = selected.length
             ? selected.map((item) => `<button type="button" class="ds-pa-chip" data-pa-chip-remove="${escapeHtml(item)}">${escapeHtml(item)} <span aria-hidden="true">×</span></button>`).join('')
             : '<span class="ds-muted">לא נבחרו פעילויות</span>';
-          trigger.textContent = selected.length ? `נבחרו ${selected.length} פעילויות` : 'בחרו שמות פעילויות';
+          trigger.textContent = selected.length ? `נבחרו ${selected.length} פעילויות` : 'בחרו פעילויות';
           hiddenInputsHost.innerHTML = selected.map((item) => `<input type="hidden" name="activity_names" value="${escapeHtml(item)}">`).join('');
         };
         sync();
@@ -427,12 +562,72 @@ export const proposalsAgreementsScreen = {
         }, { signal });
       });
     };
+
+    const fillContactFields = (form, contact) => {
+      if (!form || !contact) return;
+      const map = {
+        contact_name: text(contact.contact_name),
+        contact_role: text(contact.contact_role),
+        phone:        text(contact.phone || contact.mobile || ''),
+        email:        text(contact.email || '')
+      };
+      for (const [name, value] of Object.entries(map)) {
+        const input = form.querySelector(`input[name="${name}"]`);
+        if (input) input.value = value;
+      }
+    };
+
+    const setupContactPicker = (container, form) => {
+      const contactSelect = container?.querySelector?.('[data-pa-contact-select]');
+      if (!contactSelect) return;
+      contactSelect.addEventListener('change', () => {
+        const name = contactSelect.value;
+        if (!name) return;
+        const contact = contactOptions.find((c) => text(c.contact_name) === name);
+        if (contact) fillContactFields(form, contact);
+      }, { signal });
+    };
+
+    const setupClientSelector = (container) => {
+      const clientSelect = container?.querySelector?.('[data-pa-client-select]');
+      if (!clientSelect) return;
+      const form = clientSelect.closest('[data-pa-form]');
+      if (!form) return;
+      clientSelect.addEventListener('change', () => {
+        const val = clientSelect.value;
+        if (!val) return;
+        const [authority, school] = val.split('||');
+        const matches = contactOptions.filter(
+          (c) => text(c.authority) === authority && text(c.school) === school
+        );
+        const authInput = form.querySelector('input[name="client_authority"]');
+        const schoolInput = form.querySelector('input[name="school_framework"]');
+        if (authInput) authInput.value = authority;
+        if (schoolInput) schoolInput.value = school;
+        const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
+        if (matches.length > 1) {
+          if (pickerHost) {
+            pickerHost.innerHTML = contactPickerHtml(contactOptions, authority, school, '');
+            setupContactPicker(pickerHost, form);
+          }
+        } else {
+          if (pickerHost) pickerHost.innerHTML = '';
+          if (matches.length === 1) fillContactFields(form, matches[0]);
+        }
+      }, { signal });
+    };
+
     const openForm = (mode, row = {}) => {
       if (!formHost) return;
       formHost.hidden = false;
-      formHost.innerHTML = formHtml(mode, row, activityNameOptions);
+      formHost.innerHTML = formHtml(mode, row, activityNameOptions, contactOptions);
       setupActivityPickers(formHost);
-      formHost.querySelector('input,textarea,select')?.focus?.();
+      setupClientSelector(formHost);
+      const pickerHost = formHost.querySelector('[data-pa-contact-picker-host]');
+      if (pickerHost && pickerHost.children.length) {
+        setupContactPicker(pickerHost, formHost.querySelector('[data-pa-form]'));
+      }
+      formHost.querySelector('select,input,textarea')?.focus?.();
     };
     const closeForm = () => {
       if (!formHost) return;
@@ -440,29 +635,100 @@ export const proposalsAgreementsScreen = {
       formHost.innerHTML = '';
     };
 
+    const saveForm = async (form, statusOverride) => {
+      const errorEl = form.querySelector('[data-pa-form-error]');
+      if (form.dataset.saving === 'yes') return;
+      form.dataset.saving = 'yes';
+      const allBtns = form.querySelectorAll('button');
+      allBtns.forEach((b) => { b.disabled = true; });
+      const payload = payloadFromForm(form);
+      if (statusOverride) payload.status = statusOverride;
+      const validationError = validatePayload(payload);
+      if (validationError) {
+        if (errorEl) errorEl.textContent = validationError;
+        form.dataset.saving = '';
+        allBtns.forEach((b) => { b.disabled = false; });
+        return;
+      }
+      const mode = form.dataset.paMode;
+      const id = text(form.dataset.paId);
+      try {
+        const result = mode === 'edit'
+          ? await api.updateProposalAgreement(id, payload)
+          : await api.addProposalAgreement(payload);
+        replaceLocalRow(data, result?.row || { ...payload, id });
+        refreshTable();
+        closeForm();
+        const drawer = root.querySelector('[data-pa-drawer]');
+        if (drawer && mode === 'edit') {
+          const updated = data.rows.find((item) => text(item.id) === id);
+          drawer.outerHTML = drawerHtml(updated, activityNameOptions, state);
+        }
+      } catch (err) {
+        if (errorEl) errorEl.textContent = `שגיאה בשמירה: ${err?.message || err}`;
+        form.dataset.saving = '';
+        allBtns.forEach((b) => { b.disabled = false; });
+      }
+    };
+
     root.querySelector('[data-pa-add]')?.addEventListener('click', () => openForm('add'), { signal });
+
     root.addEventListener('click', async (event) => {
       const rowEl = event.target.closest?.('[data-pa-row-id]');
       if (rowEl) {
         closeAllActivityDropdowns();
         const row = data.rows.find((item) => text(item.id) === text(rowEl.dataset.paRowId));
         const drawer = root.querySelector('[data-pa-drawer]');
-        if (drawer && row) drawer.outerHTML = drawerHtml(row, activityNameOptions);
+        if (drawer && row) drawer.outerHTML = drawerHtml(row, activityNameOptions, state);
         return;
       }
+
       if (event.target.closest?.('[data-pa-close-drawer]')) {
         const drawer = root.querySelector('[data-pa-drawer]');
-        if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions);
+        if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions, state);
         return;
       }
+
       const editBtn = event.target.closest?.('[data-pa-edit-row]');
       if (editBtn) {
         const row = data.rows.find((item) => text(item.id) === text(editBtn.dataset.paEditRow));
         const host = root.querySelector('[data-pa-inline-form]');
-        if (host && row) host.innerHTML = formHtml('edit', row, activityNameOptions);
-        setupActivityPickers(host);
+        if (host && row) {
+          host.innerHTML = formHtml('edit', row, activityNameOptions, contactOptions);
+          setupActivityPickers(host);
+          setupClientSelector(host);
+          const pickerHost = host.querySelector('[data-pa-contact-picker-host]');
+          if (pickerHost && pickerHost.children.length) {
+            setupContactPicker(pickerHost, host.querySelector('[data-pa-form]'));
+          }
+        }
         return;
       }
+
+      const statusActionBtn = event.target.closest?.('[data-pa-status-action]');
+      if (statusActionBtn) {
+        const newStatus = text(statusActionBtn.dataset.paStatusAction);
+        const id = text(statusActionBtn.dataset.paActionId);
+        if (!newStatus || !id) return;
+        let approvalNote = '';
+        if (newStatus === 'returned_for_changes') {
+          approvalNote = (window.prompt('הערה לתיקון (אופציונלי):') || '').trim();
+        }
+        statusActionBtn.disabled = true;
+        try {
+          const result = await api.updateProposalAgreementStatus(id, newStatus, approvalNote);
+          replaceLocalRow(data, result?.row || { id, status: newStatus, approval_note: approvalNote });
+          refreshTable();
+          const updated = data.rows.find((item) => text(item.id) === id);
+          const drawer = root.querySelector('[data-pa-drawer]');
+          if (drawer && updated) drawer.outerHTML = drawerHtml(updated, activityNameOptions, state);
+        } catch (err) {
+          statusActionBtn.disabled = false;
+          window.alert(`שגיאה בעדכון סטטוס: ${err?.message || err}`);
+        }
+        return;
+      }
+
       const toggleBtn = event.target.closest?.('[data-pa-activity-toggle]');
       if (toggleBtn) {
         const picker = toggleBtn.closest('[data-pa-activity-picker]');
@@ -476,6 +742,7 @@ export const proposalsAgreementsScreen = {
         }
         return;
       }
+
       const chipRemoveBtn = event.target.closest?.('[data-pa-chip-remove]');
       if (chipRemoveBtn) {
         const picker = chipRemoveBtn.closest('[data-pa-activity-picker]');
@@ -488,9 +755,25 @@ export const proposalsAgreementsScreen = {
         }
         return;
       }
+
       if (!event.target.closest?.('[data-pa-activity-picker]')) {
         closeAllActivityDropdowns();
       }
+
+      const saveDraftBtn = event.target.closest?.('[data-pa-save-draft]');
+      if (saveDraftBtn) {
+        const form = saveDraftBtn.closest('[data-pa-form]');
+        if (form) await saveForm(form, 'draft');
+        return;
+      }
+
+      const savePendingBtn = event.target.closest?.('[data-pa-save-pending]');
+      if (savePendingBtn) {
+        const form = savePendingBtn.closest('[data-pa-form]');
+        if (form) await saveForm(form, 'pending_approval');
+        return;
+      }
+
       const deleteBtn = event.target.closest?.('[data-pa-delete-row]');
       if (deleteBtn) {
         const id = text(deleteBtn.dataset.paDeleteRow);
@@ -503,13 +786,24 @@ export const proposalsAgreementsScreen = {
           data.rows = dedupeById((Array.isArray(data.rows) ? data.rows : []).filter((item) => text(item.id) !== id).map(normalizeProposalAgreementRow));
           refreshTable();
           const drawer = root.querySelector('[data-pa-drawer]');
-          if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions);
+          if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions, state);
         } catch (err) {
           deleteBtn.disabled = false;
           window.alert(`שגיאה במחיקה: ${err?.message || err}`);
         }
         return;
       }
+
+      if (event.target.closest?.('[data-pa-new-client-toggle]')) {
+        const form = event.target.closest('[data-pa-form]');
+        const hint = form?.querySelector('[data-pa-new-client-hint]');
+        const clientSelect = form?.querySelector('[data-pa-client-select]');
+        if (clientSelect) clientSelect.value = '';
+        if (hint) hint.hidden = !hint.hidden;
+        form?.querySelector('input[name="client_authority"]')?.focus();
+        return;
+      }
+
       if (event.target.closest?.('[data-pa-cancel-form]')) {
         const inlineForm = event.target.closest('[data-pa-inline-form]');
         if (inlineForm) inlineForm.innerHTML = '';
@@ -527,38 +821,7 @@ export const proposalsAgreementsScreen = {
       const form = event.target.closest?.('[data-pa-form]');
       if (!form) return;
       event.preventDefault();
-      const errorEl = form.querySelector('[data-pa-form-error]');
-      const submitBtn = form.querySelector('button[type="submit"]');
-      if (form.dataset.saving === 'yes') return;
-      form.dataset.saving = 'yes';
-      if (submitBtn) submitBtn.disabled = true;
-      const payload = payloadFromForm(form);
-      const validationError = validatePayload(payload);
-      if (validationError) {
-        if (errorEl) errorEl.textContent = validationError;
-        form.dataset.saving = '';
-        if (submitBtn) submitBtn.disabled = false;
-        return;
-      }
-      const mode = form.dataset.paMode;
-      const id = text(form.dataset.paId);
-      try {
-        const result = mode === 'edit'
-          ? await api.updateProposalAgreement(id, payload)
-          : await api.addProposalAgreement(payload);
-        replaceLocalRow(data, result?.row || { ...payload, id });
-        refreshTable();
-        closeForm();
-        const drawer = root.querySelector('[data-pa-drawer]');
-        if (drawer && mode === 'edit') {
-          const updated = data.rows.find((item) => text(item.id) === id);
-          drawer.outerHTML = drawerHtml(updated, activityNameOptions);
-        }
-      } catch (err) {
-        if (errorEl) errorEl.textContent = `שגיאה בשמירה: ${err?.message || err}`;
-        form.dataset.saving = '';
-        if (submitBtn) submitBtn.disabled = false;
-      }
+      await saveForm(form, null);
     }, { signal });
   }
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 409;
+const CACHE_VERSION = 410;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260521_upgrade_proposals_agreements.sql
+++ b/supabase/migrations/20260521_upgrade_proposals_agreements.sql
@@ -1,0 +1,129 @@
+-- Upgrade proposals_agreements: align column names with API and add status/workflow fields.
+-- Assumes 20260518_create_proposals_agreements.sql has already been applied.
+
+-- 1. Rename activity_type → activity_type_group when the rename has not yet been done.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'proposals_agreements' AND column_name = 'activity_type'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'proposals_agreements' AND column_name = 'activity_type_group'
+  ) THEN
+    ALTER TABLE public.proposals_agreements RENAME COLUMN activity_type TO activity_type_group;
+    ALTER TABLE public.proposals_agreements
+      DROP CONSTRAINT IF EXISTS proposals_agreements_activity_type_not_blank;
+    ALTER TABLE public.proposals_agreements
+      ADD CONSTRAINT proposals_agreements_activity_type_group_not_blank
+        CHECK (btrim(activity_type_group) <> '');
+  END IF;
+END $$;
+
+-- 2. Rename contact_phone → phone.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'proposals_agreements' AND column_name = 'contact_phone'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'proposals_agreements' AND column_name = 'phone'
+  ) THEN
+    ALTER TABLE public.proposals_agreements RENAME COLUMN contact_phone TO phone;
+  END IF;
+END $$;
+
+-- 3. Rename contact_email → email.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'proposals_agreements' AND column_name = 'contact_email'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'proposals_agreements' AND column_name = 'email'
+  ) THEN
+    ALTER TABLE public.proposals_agreements RENAME COLUMN contact_email TO email;
+  END IF;
+END $$;
+
+-- 4. Add proposal_date and activity_names (present in API but missing from original migration).
+ALTER TABLE public.proposals_agreements
+  ADD COLUMN IF NOT EXISTS proposal_date date,
+  ADD COLUMN IF NOT EXISTS activity_names jsonb;
+
+-- 5. Add status and workflow audit fields.
+ALTER TABLE public.proposals_agreements
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'draft',
+  ADD COLUMN IF NOT EXISTS quote_number text,
+  ADD COLUMN IF NOT EXISTS total_amount numeric,
+  ADD COLUMN IF NOT EXISTS client_id uuid,
+  ADD COLUMN IF NOT EXISTS contact_id uuid,
+  ADD COLUMN IF NOT EXISTS created_by uuid,
+  ADD COLUMN IF NOT EXISTS approved_by uuid,
+  ADD COLUMN IF NOT EXISTS approved_at timestamptz,
+  ADD COLUMN IF NOT EXISTS approval_note text NOT NULL DEFAULT '';
+
+-- 6. Status check constraint.
+ALTER TABLE public.proposals_agreements
+  DROP CONSTRAINT IF EXISTS proposals_agreements_status_check;
+ALTER TABLE public.proposals_agreements
+  ADD CONSTRAINT proposals_agreements_status_check
+    CHECK (status IN ('draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'));
+
+-- 7. Indexes for the new filterable columns.
+CREATE INDEX IF NOT EXISTS proposals_agreements_status_idx
+  ON public.proposals_agreements (status);
+CREATE INDEX IF NOT EXISTS proposals_agreements_proposal_date_idx
+  ON public.proposals_agreements (proposal_date);
+CREATE INDEX IF NOT EXISTS proposals_agreements_quote_number_idx
+  ON public.proposals_agreements (quote_number);
+
+-- 8. Recreate sort index using the (possibly renamed) activity_type_group column.
+DROP INDEX IF EXISTS proposals_agreements_default_sort_idx;
+DROP INDEX IF EXISTS proposals_agreements_activity_type_idx;
+CREATE INDEX IF NOT EXISTS proposals_agreements_default_sort_idx
+  ON public.proposals_agreements (client_authority, school_framework, document_type, activity_type_group);
+CREATE INDEX IF NOT EXISTS proposals_agreements_activity_type_group_idx
+  ON public.proposals_agreements (activity_type_group);
+
+-- 9. proposal_agreement_items: future line-item table (not yet used by the UI).
+CREATE TABLE IF NOT EXISTS public.proposal_agreement_items (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  proposal_agreement_id uuid NOT NULL REFERENCES public.proposals_agreements(id) ON DELETE CASCADE,
+  item_name             text NOT NULL,
+  item_type             text NOT NULL DEFAULT '',
+  gefen_number          text NOT NULL DEFAULT '',
+  meetings_count        numeric,
+  hours_count           numeric,
+  quantity              numeric NOT NULL DEFAULT 1,
+  unit_price            numeric,
+  total_price           numeric,
+  description           text NOT NULL DEFAULT '',
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.proposal_agreement_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS proposal_agreement_items_select ON public.proposal_agreement_items;
+DROP POLICY IF EXISTS proposal_agreement_items_insert ON public.proposal_agreement_items;
+DROP POLICY IF EXISTS proposal_agreement_items_update ON public.proposal_agreement_items;
+
+CREATE POLICY proposal_agreement_items_select
+  ON public.proposal_agreement_items FOR SELECT TO authenticated
+  USING (public.app_can_use_proposals_agreements());
+
+CREATE POLICY proposal_agreement_items_insert
+  ON public.proposal_agreement_items FOR INSERT TO authenticated
+  WITH CHECK (public.app_can_use_proposals_agreements());
+
+CREATE POLICY proposal_agreement_items_update
+  ON public.proposal_agreement_items FOR UPDATE TO authenticated
+  USING (public.app_can_use_proposals_agreements())
+  WITH CHECK (public.app_can_use_proposals_agreements());
+
+REVOKE ALL ON public.proposal_agreement_items FROM anon;
+GRANT SELECT, INSERT, UPDATE ON public.proposal_agreement_items TO authenticated;
+REVOKE DELETE ON public.proposal_agreement_items FROM authenticated;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 409;
+const SW_ENTRY_VERSION = 410;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -24,13 +24,41 @@ if (!globalThis.localStorage) {
   };
 }
 
+/**
+ * Runs fn(root, dom) inside a JSDOM context with all required globals patched.
+ * AbortController is swapped to JSDOM's version so { signal } in addEventListener works.
+ * A real URL is set so localStorage is available.
+ */
+async function withJSDOM(html, fn) {
+  const dom = new JSDOM(`<main id="root">${html}</main>`, { url: 'http://localhost/' });
+  const saved = {
+    document: globalThis.document,
+    window: globalThis.window,
+    FormData: globalThis.FormData,
+    AbortController: globalThis.AbortController
+  };
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.FormData = dom.window.FormData;
+  globalThis.AbortController = dom.window.AbortController;
+  try {
+    const root = dom.window.document.getElementById('root');
+    await fn(root, dom);
+  } finally {
+    globalThis.document = saved.document;
+    globalThis.window = saved.window;
+    globalThis.FormData = saved.FormData;
+    globalThis.AbortController = saved.AbortController;
+  }
+}
+
 const MAIN_FILE = new URL('../frontend/src/main.js', import.meta.url);
 const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
 const ACT_NAV_FILE = new URL('../frontend/src/screens/shared/act-nav-grid.js', import.meta.url);
 const SCREEN_FILE = new URL('../frontend/src/screens/proposals-agreements.js', import.meta.url);
 const MIGRATION_FILE = new URL('../supabase/migrations/20260518_create_proposals_agreements.sql', import.meta.url);
 
-const { proposalsAgreementsScreen, canAccessProposalsAgreements } = await import('../frontend/src/screens/proposals-agreements.js');
+const { proposalsAgreementsScreen, canAccessProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS } = await import('../frontend/src/screens/proposals-agreements.js');
 
 function stateFor(role) {
   return {
@@ -51,12 +79,13 @@ const sampleRows = [
     id: '11111111-1111-1111-1111-111111111111',
     client_authority: 'רשות א',
     school_framework: 'בית ספר א',
-    document_type: 'הצעה',
-    activity_type: 'רובוטיקה',
+    document_type: 'הצעת מחיר',
+    activity_type_group: 'פעילויות קיץ',
+    status: 'draft',
     contact_name: 'דנה קשר',
     contact_role: 'מנהלת',
-    contact_phone: '050-1111111',
-    contact_email: 'dana@example.com',
+    phone: '050-1111111',
+    email: 'dana@example.com',
     notes: 'הערה קצרה'
   },
   {
@@ -64,10 +93,38 @@ const sampleRows = [
     client_authority: 'רשות ב',
     school_framework: 'מסגרת ב',
     document_type: 'הסכם',
-    activity_type: 'יזמות',
+    activity_type_group: 'שנה הבאה',
+    status: 'pending_approval',
     contact_name: 'יוסי קשר',
-    contact_phone: '050-2222222',
+    phone: '050-2222222',
     notes: 'רשומה שנייה'
+  }
+];
+
+const sampleContactOptions = [
+  {
+    authority: 'רשות א',
+    school: 'בית ספר א',
+    contact_name: 'דנה קשר',
+    contact_role: 'מנהלת',
+    phone: '050-1111111',
+    email: 'dana@example.com'
+  },
+  {
+    authority: 'רשות א',
+    school: 'בית ספר א',
+    contact_name: 'מיכל כהן',
+    contact_role: 'רכזת',
+    phone: '050-3333333',
+    email: 'michal@example.com'
+  },
+  {
+    authority: 'רשות ב',
+    school: 'מסגרת ב',
+    contact_name: 'יוסי קשר',
+    contact_role: '',
+    phone: '050-2222222',
+    email: ''
   }
 ];
 
@@ -89,7 +146,7 @@ test('screen authorization allows only domain_manager, operation_manager and adm
 test('proposals-agreements route is registered and role-gated in route definitions', async () => {
   const mainSource = await readFile(MAIN_FILE, 'utf8');
   const apiSource = await readFile(API_FILE, 'utf8');
-  assert.match(mainSource, /'proposals-agreements': 'הצעות'/);
+  assert.match(mainSource, /'proposals-agreements': 'הצעות/);
   assert.match(mainSource, /'proposals-agreements': \(\) => import\('\.\/screens\/proposals-agreements\.js'\)/);
   assert.match(apiSource, /admin: \[[^\]]*'proposals-agreements'/);
   assert.match(apiSource, /operation_manager: \[[^\]]*'proposals-agreements'/);
@@ -98,11 +155,17 @@ test('proposals-agreements route is registered and role-gated in route definitio
   assert.doesNotMatch(apiSource, /instructor: \[[^\]]*'proposals-agreements'/);
 });
 
-test('table structure includes required outer columns', () => {
+test('table structure includes all required columns including status', () => {
   const html = proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') });
-  assert.match(html, /<th>לקוח \/ רשות<\/th><th>בית ספר \/ מסגרת<\/th><th>סוג מסמך<\/th><th>סוג פעילות<\/th><th>הערות<\/th>/);
+  assert.match(html, /<th>לקוח \/ רשות<\/th>/);
+  assert.match(html, /<th>בית ספר \/ מסגרת<\/th>/);
+  assert.match(html, /<th>סוג מסמך<\/th>/);
+  assert.match(html, /<th>סוג פעילות<\/th>/);
+  assert.match(html, /<th>תאריך הצעה<\/th>/);
+  assert.match(html, /<th>סטטוס<\/th>/);
+  assert.match(html, /<th>הערות<\/th>/);
   assert.match(html, /data-pa-table-region/);
-  assert.match(html, /table-layout: fixed|ds-pa-table/);
+  assert.match(html, /ds-pa-table/);
 });
 
 test('contact details are hidden from the outer table and available only in drawer markup', () => {
@@ -127,16 +190,7 @@ test('page is excluded from header nav and ACT_SUBNAV_ITEMS', async () => {
 });
 
 test('local search debounces 280ms and updates only table region and counter', async () => {
-  const dom = new JSDOM(`<main id="root">${proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') })}</main>`);
-  const previousDocument = globalThis.document;
-  const previousWindow = globalThis.window;
-  const previousFormData = globalThis.FormData;
-  globalThis.window = dom.window;
-  globalThis.document = dom.window.document;
-  globalThis.FormData = dom.window.FormData;
-
-  try {
-    const root = dom.window.document.getElementById('root');
+  await withJSDOM(proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') }), async (root, dom) => {
     proposalsAgreementsScreen.bind({ root, data: { rows: [...sampleRows] }, state: stateFor('admin'), api: {} });
     const headerNode = root.querySelector('.ds-page-header');
     const toolbarNode = root.querySelector('.ds-pa-toolbar');
@@ -155,11 +209,7 @@ test('local search debounces 280ms and updates only table region and counter', a
     assert.match(root.querySelector('[data-pa-results-count]').textContent, /^1$/);
     assert.match(tableRegion.textContent, /רשות ב/);
     assert.doesNotMatch(tableRegion.textContent, /רשות א/);
-  } finally {
-    globalThis.document = previousDocument;
-    globalThis.window = previousWindow;
-    globalThis.FormData = previousFormData;
-  }
+  });
 });
 
 test('screen and API source enforce authorization before API/Supabase calls', async () => {
@@ -182,4 +232,322 @@ test('migration creates proposals_agreements with indexes, updated_at trigger an
   assert.match(migration, /for select[\s\S]*to authenticated[\s\S]*app_can_use_proposals_agreements\(\)/);
   assert.match(migration, /for insert[\s\S]*with check \(public\.app_can_use_proposals_agreements\(\)\)/);
   assert.match(migration, /for update[\s\S]*using \(public\.app_can_use_proposals_agreements\(\)\)/);
+});
+
+test('add button opens compact form with draft and pending-approval actions', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: sampleRows, contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [...sampleRows], activityNameOptions: ['רובוטיקה', 'יזמות'], contactOptions: sampleContactOptions },
+        state: stateFor('admin'),
+        api: {}
+      });
+      const formHost = root.querySelector('[data-pa-form-host]');
+      assert.ok(formHost.hidden, 'form host should be hidden initially');
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+      assert.equal(formHost.hidden, false, 'form host should be visible after clicking add');
+      const form = formHost.querySelector('[data-pa-form]');
+      assert.ok(form, 'form element should exist');
+      assert.match(form.innerHTML, /שמירת טיוטה/);
+      assert.match(form.innerHTML, /שליחה לאישור/);
+      assert.match(form.innerHTML, /data-pa-client-select/);
+      assert.match(form.innerHTML, /לקוח חדש/);
+    }
+  );
+});
+
+test('client selector auto-fills contact fields when existing client is chosen', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form = root.querySelector('[data-pa-form]');
+      const clientSelect = form.querySelector('[data-pa-client-select]');
+
+      // Select "רשות ב" which has exactly one contact
+      clientSelect.value = 'רשות ב||מסגרת ב';
+      clientSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+      const authorityInput = form.querySelector('input[name="client_authority"]');
+      const schoolInput = form.querySelector('input[name="school_framework"]');
+      const contactInput = form.querySelector('input[name="contact_name"]');
+      const phoneInput = form.querySelector('input[name="phone"]');
+
+      assert.equal(authorityInput.value, 'רשות ב', 'authority should be filled');
+      assert.equal(schoolInput.value, 'מסגרת ב', 'school should be filled');
+      assert.equal(contactInput.value, 'יוסי קשר', 'contact_name should be auto-filled');
+      assert.equal(phoneInput.value, '050-2222222', 'phone should be auto-filled');
+    }
+  );
+});
+
+test('multiple contacts for same client shows contact picker dropdown', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form = root.querySelector('[data-pa-form]');
+      const clientSelect = form.querySelector('[data-pa-client-select]');
+
+      // "רשות א" has 2 contacts → should show contact picker
+      clientSelect.value = 'רשות א||בית ספר א';
+      clientSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+      const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
+      assert.ok(pickerHost, 'contact picker host should exist');
+      assert.match(pickerHost.innerHTML, /data-pa-contact-select/, 'contact picker select should appear');
+      assert.match(pickerHost.innerHTML, /דנה קשר/, 'first contact should be in picker');
+      assert.match(pickerHost.innerHTML, /מיכל כהן/, 'second contact should be in picker');
+    }
+  );
+});
+
+test('new client toggle button shows hint and clears client selector', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form = root.querySelector('[data-pa-form]');
+      const clientSelect = form.querySelector('[data-pa-client-select]');
+
+      // Pre-select a client
+      clientSelect.value = 'רשות ב||מסגרת ב';
+
+      // Click new client toggle
+      form.querySelector('[data-pa-new-client-toggle]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+      const hint = form.querySelector('[data-pa-new-client-hint]');
+      assert.equal(hint.hidden, false, 'hint should be visible after toggle');
+      assert.equal(clientSelect.value, '', 'client selector should be cleared');
+    }
+  );
+});
+
+test('save draft sends status=draft and send-for-approval sends status=pending_approval', async () => {
+  const savedPayloads = [];
+  const mockApi = {
+    addProposalAgreement: async (payload) => {
+      savedPayloads.push({ ...payload });
+      return { ok: true, row: { ...payload, id: 'new-id-123' } };
+    }
+  };
+
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: [] }, { state: stateFor('admin') }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: [] },
+        state: stateFor('admin'),
+        api: mockApi
+      });
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form = root.querySelector('[data-pa-form]');
+
+      form.querySelector('input[name="client_authority"]').value = 'רשות בדיקה';
+      form.querySelector('input[name="school_framework"]').value = 'בית ספר בדיקה';
+      form.querySelector('select[name="document_type"]').value = 'הצעת מחיר';
+      form.querySelector('select[name="activity_type_group"]').value = 'פעילויות קיץ';
+
+      form.querySelector('[data-pa-save-draft]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      assert.equal(savedPayloads.length, 1, 'one save call');
+      assert.equal(savedPayloads[0].status, 'draft', 'draft save should set status=draft');
+
+      // Re-open form for pending_approval test
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form2 = root.querySelector('[data-pa-form]');
+      form2.querySelector('input[name="client_authority"]').value = 'רשות בדיקה 2';
+      form2.querySelector('input[name="school_framework"]').value = 'בית ספר בדיקה 2';
+      form2.querySelector('select[name="document_type"]').value = 'הסכם';
+      form2.querySelector('select[name="activity_type_group"]').value = 'שנה הבאה';
+
+      form2.querySelector('[data-pa-save-pending]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      assert.equal(savedPayloads.length, 2, 'second save call');
+      assert.equal(savedPayloads[1].status, 'pending_approval', 'pending save should set status=pending_approval');
+    }
+  );
+});
+
+test('status filter shows only matching rows', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({ root, data: { rows: [...sampleRows] }, state: stateFor('admin'), api: {} });
+
+      const statusFilter = root.querySelector('[data-pa-filter="status"]');
+      assert.ok(statusFilter, 'status filter should exist');
+
+      statusFilter.value = 'draft';
+      statusFilter.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+      assert.match(root.querySelector('[data-pa-results-count]').textContent, /^1$/);
+      assert.match(root.querySelector('[data-pa-table-region]').textContent, /רשות א/);
+      assert.doesNotMatch(root.querySelector('[data-pa-table-region]').textContent, /רשות ב/);
+
+      statusFilter.value = '';
+      statusFilter.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      assert.match(root.querySelector('[data-pa-results-count]').textContent, /^2$/);
+    }
+  );
+});
+
+test('status badge is rendered in table rows with correct labels', () => {
+  const html = proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') });
+  assert.match(html, /טיוטה/);
+  assert.match(html, /ממתין לאישור/);
+  // Badge markup
+  assert.match(html, /ds-pa-badge/);
+});
+
+test('multiple activity selections are preserved on save', async () => {
+  const savedPayloads = [];
+  const mockApi = {
+    addProposalAgreement: async (payload) => {
+      savedPayloads.push({ ...payload });
+      return { ok: true, row: { ...payload, id: 'act-id-001' } };
+    }
+  };
+
+  await withJSDOM(
+    proposalsAgreementsScreen.render(
+      { rows: [], activityNameOptions: ['רובוטיקה', 'יזמות', 'מייקרים'] },
+      { state: stateFor('admin') }
+    ),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: ['רובוטיקה', 'יזמות', 'מייקרים'], contactOptions: [] },
+        state: stateFor('admin'),
+        api: mockApi
+      });
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form = root.querySelector('[data-pa-form]');
+
+      form.querySelector('input[name="client_authority"]').value = 'רשות ג';
+      form.querySelector('input[name="school_framework"]').value = 'בית ספר ג';
+      form.querySelector('select[name="document_type"]').value = 'הצעת מחיר';
+      form.querySelector('select[name="activity_type_group"]').value = 'הצעה משולבת';
+
+      const checkboxes = form.querySelectorAll('.ds-pa-activity-option input[type="checkbox"]');
+      const first = [...checkboxes].find((cb) => cb.value === 'רובוטיקה');
+      const second = [...checkboxes].find((cb) => cb.value === 'יזמות');
+      if (first) { first.checked = true; first.dispatchEvent(new dom.window.Event('change', { bubbles: true })); }
+      if (second) { second.checked = true; second.dispatchEvent(new dom.window.Event('change', { bubbles: true })); }
+
+      form.querySelector('[data-pa-save-draft]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      assert.equal(savedPayloads.length, 1, 'one save call');
+      const saved = savedPayloads[0];
+      assert.ok(Array.isArray(saved.activity_names), 'activity_names should be array');
+      assert.equal(saved.activity_names.length, 2, 'two activities should be saved');
+      assert.ok(saved.activity_names.includes('רובוטיקה'), 'רובוטיקה should be in saved activities');
+      assert.ok(saved.activity_names.includes('יזמות'), 'יזמות should be in saved activities');
+    }
+  );
+});
+
+test('no duplicate rows after save and update', async () => {
+  const existingRow = {
+    id: 'dup-test-id-001',
+    client_authority: 'רשות קיימת',
+    school_framework: 'בית ספר קיים',
+    document_type: 'הצעת מחיר',
+    activity_type_group: 'פעילויות קיץ',
+    status: 'draft',
+    notes: ''
+  };
+  const updatedRow = { ...existingRow, notes: 'הערה חדשה', status: 'pending_approval' };
+  const mockApi = {
+    updateProposalAgreement: async () => ({ ok: true, row: updatedRow })
+  };
+
+  const localData = { rows: [existingRow] };
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [existingRow] }, { state: stateFor('admin') }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: localData,
+        state: stateFor('admin'),
+        api: mockApi
+      });
+
+      const rowEl = root.querySelector(`[data-pa-row-id="${existingRow.id}"]`);
+      rowEl.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const editBtn = root.querySelector(`[data-pa-edit-row="${existingRow.id}"]`);
+      assert.ok(editBtn, 'edit button should exist');
+      editBtn.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+      const inlineForm = root.querySelector('[data-pa-inline-form]');
+      const form = inlineForm?.querySelector('[data-pa-form]');
+      assert.ok(form, 'inline form should exist');
+
+      form.querySelector('[data-pa-save-pending]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      const ids = localData.rows.map((r) => r.id);
+      const uniqueIds = new Set(ids);
+      assert.equal(ids.length, uniqueIds.size, 'no duplicate IDs in data.rows after update');
+      assert.equal(ids.length, 1, 'still exactly one row');
+    }
+  );
+});
+
+test('status constants exported and complete', () => {
+  assert.ok(Array.isArray(STATUS_OPTIONS), 'STATUS_OPTIONS should be an array');
+  assert.ok(typeof STATUS_LABELS === 'object', 'STATUS_LABELS should be an object');
+  for (const s of STATUS_OPTIONS) {
+    assert.ok(STATUS_LABELS[s], `${s} should have a Hebrew label`);
+  }
+  assert.ok(STATUS_OPTIONS.includes('draft'));
+  assert.ok(STATUS_OPTIONS.includes('pending_approval'));
+  assert.ok(STATUS_OPTIONS.includes('approved'));
+  assert.ok(STATUS_OPTIONS.includes('cancelled'));
+  assert.ok(STATUS_OPTIONS.includes('returned_for_changes'));
+});
+
+test('upgrade migration adds status column with constraint and new indexes', async () => {
+  const upgradeMigration = await readFile(
+    new URL('../supabase/migrations/20260521_upgrade_proposals_agreements.sql', import.meta.url),
+    'utf8'
+  );
+  assert.match(upgradeMigration, /add column if not exists status text/i);
+  assert.match(upgradeMigration, /proposals_agreements_status_check/);
+  assert.match(upgradeMigration, /'draft'[\s\S]*'pending_approval'[\s\S]*'returned_for_changes'[\s\S]*'approved'[\s\S]*'cancelled'/);
+  assert.match(upgradeMigration, /proposals_agreements_status_idx/);
+  assert.match(upgradeMigration, /proposals_agreements_proposal_date_idx/);
+  assert.match(upgradeMigration, /add column if not exists approval_note/i);
+  assert.match(upgradeMigration, /proposal_agreement_items/);
 });


### PR DESCRIPTION
## Summary
This PR adds a complete status workflow system to the proposals-agreements screen, enabling draft/pending approval/approval workflows. It also introduces a smart client picker that auto-fills contact details from existing clients and allows creating new clients inline.

## Key Changes

### Status Workflow System
- Added `STATUS_OPTIONS` and `STATUS_LABELS` constants with five statuses: draft, pending_approval, returned_for_changes, approved, cancelled
- Status is now a required field on all proposals/agreements, defaulting to 'draft'
- Added status badge rendering in table rows with color-coded visual indicators
- Implemented status filtering in the toolbar
- Added status-based action buttons in the drawer (edit, approve, return for changes, cancel) with role-based visibility

### Form Improvements
- Split form submission into two actions: "Save Draft" (status=draft) and "Send for Approval" (status=pending_approval)
- Added client selector dropdown that auto-populates authority and school fields from existing clients
- Implemented contact picker that appears when multiple contacts exist for a selected client
- Added "New Client" toggle to allow inline creation of new clients
- Refactored form field generation for better organization and maintainability

### Database & API
- Added migration to upgrade proposals_agreements table with status, approval_note, and other workflow fields
- Renamed columns for consistency: activity_type → activity_type_group, contact_phone → phone, contact_email → email
- Added indexes on status, proposal_date, and quote_number for better query performance
- Extended API to support status updates via new `updateProposalAgreementStatus` action
- Updated column selection to include status and approval_note in API queries

### UI/UX Enhancements
- Status badge with color coding (gray=draft, orange=pending, red=returned, green=approved, gray=cancelled)
- Improved form layout with client selection section at the top
- Contact details section title changed from "אנשי קשר" to "פרטי קשר"
- Table colspan updated to accommodate new status column
- Status is now searchable via the main search field

### Testing
- Added comprehensive test suite for new functionality including client selection, contact picker, status filtering, and multi-activity selection
- Refactored test utilities with `withJSDOM` helper for cleaner JSDOM context management
- Tests verify role-based action visibility and status persistence

## Notable Implementation Details
- Status filtering integrates seamlessly with existing search and document_type/activity_type_group filters
- Client picker uses a compound key (authority||school) to identify unique client-school combinations
- Contact auto-fill only triggers when exactly one contact exists for a client; multiple contacts show a picker dropdown
- Form maintains backward compatibility by normalizing rows with missing status to 'draft'
- Activity names continue to support both array and comma-separated string formats

https://claude.ai/code/session_016V52VwZXFjNtPwn48C27EL