### PR TITLE
Use permission-based checks for activity workflows and bump SW cache

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1631,8 +1631,8 @@ function buildBootstrapFromUser(userRow) {
   const financeIdx = allowedRoutes.indexOf('finance');
   if (hasFinanceAccess && financeIdx === -1) allowedRoutes.push('finance');
   if (!hasFinanceAccess && financeIdx >= 0) allowedRoutes.splice(financeIdx, 1);
-  const canEditDirect = ROLES_WITH_DIRECT_EDIT.has(role) || permissionFlagYes(flat.can_edit_direct);
-  const canRequestEdit = canEditDirect || permissionFlagYes(flat.can_request_edit) || role !== 'instructor';
+  const canEditDirect = permissionFlagYes(flat.can_edit_direct);
+  const canRequestEdit = canEditDirect || permissionFlagYes(flat.can_request_edit);
   return {
     routes: [...allowedRoutes],
     default_route: allowedRoutes[0] || 'my-data',
@@ -1642,7 +1642,7 @@ function buildBootstrapFromUser(userRow) {
       display_role2: flat.display_role2 || '',
       display_role_label: flat.display_role_label || hebrewRole(role)
     },
-    can_add_activity: permissionFlagYes(flat.can_add_activity) || role === 'admin' || role === 'operation_manager',
+    can_add_activity: permissionFlagYes(flat.can_add_activity),
     can_edit_direct: canEditDirect,
     can_request_edit: canRequestEdit,
     client_settings: {}
@@ -2178,9 +2178,9 @@ export const api = {
         display_role2: flat.display_role2,
         full_name: flat.full_name,
         emp_id: flat.emp_id,
-        can_add_activity: permissionFlagYes(flat.can_add_activity) || flat.role === 'admin' || flat.role === 'operation_manager',
-        can_edit_direct: ROLES_WITH_DIRECT_EDIT.has(flat.role) || permissionFlagYes(flat.can_edit_direct),
-        can_request_edit: (ROLES_WITH_DIRECT_EDIT.has(flat.role) || permissionFlagYes(flat.can_edit_direct) || permissionFlagYes(flat.can_request_edit) || flat.role !== 'instructor'),
+        can_add_activity: permissionFlagYes(flat.can_add_activity),
+        can_edit_direct: permissionFlagYes(flat.can_edit_direct),
+        can_request_edit: (permissionFlagYes(flat.can_edit_direct) || permissionFlagYes(flat.can_request_edit)),
         finance_access: permissionFlagYes(flat.finance_access)
       },
       ...buildBootstrapFromUser(user),
@@ -2344,7 +2344,7 @@ export const api = {
       rows,
       roleDefaults: {
         admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes' },
-        operation_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'no' },
+        operation_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no' },
         authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
         finance: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
         activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
@@ -2501,7 +2501,7 @@ export const api = {
       ? { source_row_id: a, changes: b }
       : a;
     const userRole = String(state?.user?.display_role || state?.user?.role || '').trim();
-    const canEditDirect = permissionFlagYes(state?.user?.can_edit_direct) || ROLES_WITH_DIRECT_EDIT.has(userRole);
+    const canEditDirect = permissionFlagYes(state?.user?.can_edit_direct);
     if (userRole === 'activities_manager' && !canEditDirect) {
       // eslint-disable-next-line no-console
       console.warn('wrong_flow: activities_manager attempted saveActivity; using submitEditRequest instead', {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -727,7 +727,7 @@ const ADMIN_SIDEBAR_HIDDEN_ROUTES = new Set(['admin-home', 'admin-settings', 'ad
 function shell(content) {
   const hiddenSet = navSidebarHiddenRoutesSet();
   const contextualSet = navContextualRoutesSet();
-  const isAdminUser = state?.user?.display_role === 'admin' || state?.user?.display_role === 'operation_manager';
+  const isAdminUser = state?.user?.display_role === 'admin';
   // לאדמין: הנתונים שלי — מוסתר לחלוטין; הרשאות — בסרגל בלבד
   const adminSidebarExclude = isAdminUser ? new Set(['my-data']) : new Set();
   const nav = effectiveRoutes()

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -687,8 +687,7 @@ export const activitiesScreen = {
     const hideEmpIds    = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const canAddActivity = !!state?.user?.can_add_activity
-      || ['admin', 'operation_manager'].includes(String(state?.user?.display_role || ''));
+    const canAddActivity = !!state?.user?.can_add_activity;
     const isAdmin = isAdminUser(state);
 
     const rosterUsers = getRosterUsers(state?.clientSettings || {});
@@ -861,8 +860,7 @@ export const activitiesScreen = {
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const canAddActivity = !!state?.user?.can_add_activity
-      || ['admin', 'operation_manager'].includes(String(state?.user?.display_role || ''));
+    const canAddActivity = !!state?.user?.can_add_activity;
     const isAdmin = isAdminUser(state);
 
     const rerenderLocal = () => {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 410;
+const CACHE_VERSION = 411;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- Align routine activity workflows with explicit permission flags from `users.permissions` instead of granting capabilities via hardcoded role checks like `role === 'admin'` or `operation_manager` fallbacks.
- Ensure users such as `operation_manager` can perform day-to-day activity work when their permissions allow, while preventing them from seeing admin/finance/permissions screens when those permissions are `no`.
- Prevent serving stale frontend assets after deploy by forcing service worker cache invalidation.

### Description
- Replaced role-based fallbacks with permission-based checks so `can_add_activity`, `can_edit_direct` and `can_request_edit` are derived from parsed permissions (`permissionFlagYes(...)`) rather than implicit `admin`/`operation_manager` grants (`frontend/src/api.js`).
- Adjusted login/bootstrap shaping so the client `user` and bootstrap flags no longer gain work permissions from `role` fallbacks and instead reflect `users.permissions` (changes in `api.login` and `buildBootstrapFromUser`).
- Stopped treating `operation_manager` as an admin in UI shell/header by narrowing `isAdminUser` to `admin` only (`frontend/src/main.js`).
- Removed role-based `canAddActivity` fallback in the activities UI so the add button and related flows depend only on `state.user.can_add_activity` (`frontend/src/screens/activities.js`).
- Kept admin-only surfaces protected and updated `roleDefaults` so `operation_manager` does not get `view_admin` enabled (`frontend/src/api.js`).
- Bumped service worker `CACHE_VERSION` from `410` to `411` to force static cache invalidation after deploy (`frontend/sw.js`).

### Testing
- Built the frontend successfully with `npm run -s build` and the production bundle was produced without build errors.
- Ran targeted source scans (`rg`) to verify role-based fallback patterns were removed/updated and found no remaining occurrences in the updated files.
- Confirmed the service worker cache version was updated to `411` to trigger client refresh on next deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1c7b6d64832ba2c3de28659f3875)