### PR TITLE
Sync new proposal clients into contacts_schools and bump SW cache

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1491,6 +1491,28 @@ function sanitizeProposalAgreementPayload(payload = {}) {
   return row;
 }
 
+
+async function upsertProposalClientContactIfNeeded(payload = {}, options = {}) {
+  const isNewClient = options?.isNewClient === true;
+  if (!isNewClient) return;
+  const authority = cleanProposalAgreementText(payload.client_authority);
+  const school = cleanProposalAgreementText(payload.school_framework);
+  const contact_name = cleanProposalAgreementText(payload.contact_name);
+  if (!authority || !school || !contact_name) return;
+  const contactRow = {
+    authority,
+    school,
+    contact_name,
+    contact_role: cleanProposalAgreementText(payload.contact_role),
+    phone: cleanProposalAgreementText(payload.phone),
+    email: cleanProposalAgreementText(payload.email)
+  };
+  const { error } = await supabase
+    .from('contacts_schools')
+    .upsert(contactRow, { onConflict: 'authority,school,contact_name' });
+  if (error) throw new Error(error.message || 'proposal_contact_upsert_failed');
+}
+
 async function readProposalActivityNamesFromSupabase() {
   try {
     const { data, error } = await supabase
@@ -2392,6 +2414,7 @@ export const api = {
   addProposalAgreement: async (payload) => {
     assertCanUseProposalsAgreementsApi();
     const insert = sanitizeProposalAgreementPayload(payload);
+    await upsertProposalClientContactIfNeeded(insert, { isNewClient: payload?.is_new_client === true });
     const { data, error } = await supabase
       .from('proposals_agreements')
       .insert(insert)
@@ -2405,6 +2428,7 @@ export const api = {
     const rowId = cleanProposalAgreementText(id);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
     const patch = sanitizeProposalAgreementPayload(payload);
+    await upsertProposalClientContactIfNeeded(patch, { isNewClient: payload?.is_new_client === true });
     const { data, error } = await supabase
       .from('proposals_agreements')
       .update(patch)

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -817,6 +817,7 @@ export const proposalsAgreementsScreen = {
       clientSelect.addEventListener('change', () => {
         const val = clientSelect.value;
         if (!val) return;
+        form.dataset.paNewClient = 'no';
         const [authority, school] = val.split('||');
         const matches = contactOptions.filter((c) => text(c.authority) === authority && text(c.school) === school);
         const authInput = form.querySelector('input[name="client_authority"]');
@@ -910,6 +911,7 @@ export const proposalsAgreementsScreen = {
       const allBtns = form.querySelectorAll('button');
       allBtns.forEach((b) => { b.disabled = true; });
       const payload = payloadFromForm(form);
+      payload.is_new_client = form.dataset.paNewClient === 'yes';
       if (statusOverride) payload.status = statusOverride;
       const validationError = validatePayload(payload);
       if (validationError) {
@@ -1166,7 +1168,9 @@ export const proposalsAgreementsScreen = {
         const hint = form?.querySelector('[data-pa-new-client-hint]');
         const clientSelect = form?.querySelector('[data-pa-client-select]');
         if (clientSelect) clientSelect.value = '';
-        if (hint) hint.hidden = !hint.hidden;
+        const isNewClient = form?.dataset.paNewClient === 'yes';
+        if (form) form.dataset.paNewClient = isNewClient ? 'no' : 'yes';
+        if (hint) hint.hidden = isNewClient;
         form?.querySelector('input[name="client_authority"]')?.focus();
         return;
       }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 411;
+const CACHE_VERSION = 412;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 411;
+const SW_ENTRY_VERSION = 412;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -344,6 +344,7 @@ test('new client toggle button shows hint and clears client selector', async () 
       const hint = form.querySelector('[data-pa-new-client-hint]');
       assert.equal(hint.hidden, false, 'hint should be visible after toggle');
       assert.equal(clientSelect.value, '', 'client selector should be cleared');
+      assert.equal(form.dataset.paNewClient, 'yes', 'form should mark new client mode');
     }
   );
 });
@@ -380,6 +381,7 @@ test('save draft sends status=draft and send-for-approval sends status=pending_a
 
       assert.equal(savedPayloads.length, 1, 'one save call');
       assert.equal(savedPayloads[0].status, 'draft', 'draft save should set status=draft');
+      assert.equal(savedPayloads[0].is_new_client, false, 'default save should not mark as new client');
 
       // Re-open form for pending_approval test
       root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
@@ -394,6 +396,46 @@ test('save draft sends status=draft and send-for-approval sends status=pending_a
 
       assert.equal(savedPayloads.length, 2, 'second save call');
       assert.equal(savedPayloads[1].status, 'pending_approval', 'pending save should set status=pending_approval');
+    }
+  );
+});
+
+
+
+test('saving after new client toggle sends is_new_client=true', async () => {
+  const savedPayloads = [];
+  const mockApi = {
+    addProposalAgreement: async (payload) => {
+      savedPayloads.push({ ...payload });
+      return { ok: true, row: { ...payload, id: 'new-client-id' } };
+    }
+  };
+
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        state: stateFor('admin'),
+        api: mockApi
+      });
+
+      root.querySelector('[data-pa-add]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const form = root.querySelector('[data-pa-form]');
+      form.querySelector('[data-pa-new-client-toggle]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+      form.querySelector('input[name="client_authority"]').value = 'רשות חדשה';
+      form.querySelector('input[name="school_framework"]').value = 'בית ספר חדש';
+      form.querySelector('select[name="document_type"]').value = 'הצעת מחיר';
+      form.querySelector('select[name="activity_type_group"]').value = 'פעילויות קיץ';
+      form.querySelector('input[name="contact_name"]').value = 'שרון חדש';
+
+      form.querySelector('[data-pa-save-draft]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      assert.equal(savedPayloads.length, 1);
+      assert.equal(savedPayloads[0].is_new_client, true, 'new-client save should mark is_new_client=true');
     }
   );
 });
@@ -749,6 +791,8 @@ test('api source has readProposalAgreementItems and saveProposalAgreementItems',
   assert.match(apiSource, /readProposalAgreementItems/);
   assert.match(apiSource, /saveProposalAgreementItems/);
   assert.match(apiSource, /saveProposalAgreementItems: true/);
+  assert.match(apiSource, /upsertProposalClientContactIfNeeded/);
+  assert.match(apiSource, /payload\?\.is_new_client === true/);
   assert.match(apiSource, /total_amount.*payload\.total_amount/);
 });
 


### PR DESCRIPTION
### Motivation
- Ensure that when a user creates a new client from the "הצעה חדשה" form the contact is persisted into the shared `contacts_schools` store so it appears in Contacts and future proposal client pickers. 
- Avoid creating duplicate or empty contacts and keep the existing proposals flow and UX intact. 

### Description
- Added `upsertProposalClientContactIfNeeded` helper in `frontend/src/api.js` that performs an `upsert` into `contacts_schools` using the conflict key `(authority,school,contact_name)` and only runs when explicitly marked as a new client. 
- Call the helper from `addProposalAgreement` and `updateProposalAgreement` paths to synchronize contact data before writing `proposals_agreements`. 
- Track new-client mode in the UI by setting `form.dataset.paNewClient` and include `is_new_client` in the payload sent to the API when saving the form. 
- UI changes reset new-client mode when an existing client is selected and toggle the mode via the existing "+ לקוח חדש" button so users can opt in to creating a contact. 
- Prevent creating a contact if `contact_name` is missing even when `authority`/`school` are present. 
- Bumped service-worker cache versions in `frontend/sw.js` and `sw.js` to force client cache refresh after the frontend change. 
- Updated and added unit tests in `tests/proposals-agreements-screen.test.mjs` to assert `is_new_client` propagation and presence of the new helper in the API source. 

### Testing
- Ran targeted test suites with `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests in those files passed. 
- Executing the project's `npm test` (which runs the full test set) surfaced unrelated failures in other areas; the changes in this PR were validated by the focused tests above which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2a0051bc832bbb29fa575deea650)