### PR TITLE
Integrate `proposal_activity_pricing` into proposals item editor

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 411;
+const CACHE_VERSION = 412;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DiYDSe54.js",
+  "./assets/index-DYsGBSC8.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DiYDSe54.js"></script>
+  <script type="module" crossorigin src="./assets/index-DYsGBSC8.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BDA1wyx9.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 411;
+const CACHE_VERSION = 412;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DiYDSe54.js",
+  "./assets/index-DYsGBSC8.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1529,6 +1529,32 @@ async function readProposalActivityNamesFromSupabase() {
   }
 }
 
+async function readProposalActivityPricingFromSupabase() {
+  try {
+    const { data, error } = await supabase
+      .from('proposal_activity_pricing')
+      .select('activity_name,proposal_group,item_type,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order')
+      .eq('is_active_for_proposals', true)
+      .order('sort_order', { ascending: true });
+    if (error) return [];
+    return (Array.isArray(data) ? data : []).map((row) => ({
+      activity_name: cleanProposalAgreementText(row?.activity_name),
+      proposal_group: cleanProposalAgreementText(row?.proposal_group),
+      item_type: cleanProposalAgreementText(row?.item_type),
+      gefen_number: cleanProposalAgreementText(row?.gefen_number),
+      hours_count: row?.hours_count != null ? Number(row.hours_count) || null : null,
+      meetings_count: row?.meetings_count != null ? Number(row.meetings_count) || null : null,
+      unit_duration: row?.unit_duration != null ? Number(row.unit_duration) || null : null,
+      unit_price: row?.unit_price != null ? Number(row.unit_price) || null : null,
+      hourly_price: row?.hourly_price != null ? Number(row.hourly_price) || null : null,
+      description_for_proposal: cleanProposalAgreementText(row?.description_for_proposal),
+      sort_order: Number(row?.sort_order) || 0
+    }));
+  } catch {
+    return [];
+  }
+}
+
 async function readContactsSchoolsForProposals() {
   try {
     const { data, error } = await supabase
@@ -1551,7 +1577,7 @@ async function readContactsSchoolsForProposals() {
 
 async function readProposalsAgreementsFromSupabase() {
   assertCanUseProposalsAgreementsApi();
-  const [paResult, activityNameOptions, contactOptions] = await Promise.all([
+  const [paResult, activityNameOptions, contactOptions, proposalActivityPricing] = await Promise.all([
     supabase
       .from('proposals_agreements')
       .select(PROPOSALS_AGREEMENTS_COLUMNS)
@@ -1560,13 +1586,15 @@ async function readProposalsAgreementsFromSupabase() {
       .order('document_type', { ascending: true })
       .order('activity_type_group', { ascending: true }),
     readProposalActivityNamesFromSupabase(),
-    readContactsSchoolsForProposals()
+    readContactsSchoolsForProposals(),
+    readProposalActivityPricingFromSupabase()
   ]);
   if (paResult.error) throw new Error(paResult.error.message || 'proposals_agreements_read_failed');
   return {
     rows: (Array.isArray(paResult.data) ? paResult.data : []).map(normalizeProposalAgreementRow),
     activityNameOptions,
     contactOptions,
+    proposalActivityPricing,
     _source: 'supabase'
   };
 }
@@ -2489,6 +2517,10 @@ export const api = {
       description:    cleanProposalAgreementText(item.description),
       sort_order:     Number(item.sort_order) || 0
     }));
+  },
+  readProposalActivityPricing: async () => {
+    assertCanUseProposalsAgreementsApi();
+    return readProposalActivityPricingFromSupabase();
   },
   saveProposalAgreementItems: async (proposalId, items) => {
     assertCanUseProposalsAgreementsApi();

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -303,13 +303,15 @@ function contactPickerHtml(contactOptions, authority, school, selectedContactNam
 
 // ─── Items editor ────────────────────────────────────────────────────────────
 
-function itemRowHtml(item = {}, idx = 0) {
+function itemRowHtml(item = {}, idx = 0, pricingOptions = []) {
   const n = (v) => (v != null && v !== '' && !isNaN(Number(v))) ? escapeHtml(String(v)) : '';
   const calcTotal = (Number(item.quantity) || 0) && (Number(item.unit_price) || 0)
     ? String(((Number(item.quantity) || 0) * (Number(item.unit_price) || 0)).toFixed(2))
     : n(item.total_price);
+  const selectedPricingName = text(item.pricing_activity_name || item.item_name);
+  const pricingSelectOptions = ['<option value="">— בחירה מהירה —</option>', ...pricingOptions.map((row) => optionHtml(row.activity_name, selectedPricingName))].join('');
   return `<tr class="ds-pa-item-row" data-pa-item-row data-pa-item-idx="${idx}">
-    <td class="ds-pa-ic-name"><input class="ds-input ds-input--sm" name="item_name" value="${escapeHtml(item.item_name || '')}" placeholder="שם פעילות"></td>
+    <td class="ds-pa-ic-name"><select class="ds-input ds-input--sm" name="pricing_activity_name" data-pa-pricing-select>${pricingSelectOptions}</select><input class="ds-input ds-input--sm" name="item_name" value="${escapeHtml(item.item_name || '')}" placeholder="שם פעילות"></td>
     <td class="ds-pa-ic-type"><input class="ds-input ds-input--sm" name="item_type" value="${escapeHtml(item.item_type || '')}" list="pa-item-type-list" placeholder="סוג"></td>
     <td class="ds-pa-ic-gefen"><input class="ds-input ds-input--sm" name="gefen_number" value="${escapeHtml(item.gefen_number || '')}" placeholder="גפ״ן"></td>
     <td class="ds-pa-ic-num"><input class="ds-input ds-input--sm" type="number" name="meetings_count" value="${n(item.meetings_count)}" min="0" step="1" placeholder="—"></td>
@@ -322,9 +324,9 @@ function itemRowHtml(item = {}, idx = 0) {
   </tr>`;
 }
 
-function itemsEditorHtml(items = []) {
+function itemsEditorHtml(items = [], pricingOptions = []) {
   const startItems = items.length ? items : [{}];
-  const rowsHtml = startItems.map((item, idx) => itemRowHtml(item, idx)).join('');
+  const rowsHtml = startItems.map((item, idx) => itemRowHtml(item, idx, pricingOptions)).join('');
   return `<div class="ds-pa-items-section">
     <div class="ds-pa-items-header">
       <span style="font-size:0.76rem;color:var(--ds-color-text-muted,#64748b);font-weight:600">שורות הצעה</span>
@@ -512,7 +514,7 @@ function proposalPreviewBodyHtml(row, items = []) {
 
 // ─── Form ─────────────────────────────────────────────────────────────────────
 
-function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [], items = []) {
+function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [], items = [], pricingOptions = []) {
   const title = mode === 'edit' ? 'עריכת הצעה / הסכם' : 'יצירת הצעת מחיר / הסכם';
   const rowActivity = Array.isArray(row.activity_names) ? row.activity_names : [];
   const currentStatus = STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft';
@@ -551,7 +553,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
 
     <label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(FIELD_LABELS.notes)}</span><textarea class="ds-input ds-input--sm" name="notes" rows="2">${escapeHtml(text(row.notes))}</textarea></label>
 
-    ${itemsEditorHtml(items)}
+    ${itemsEditorHtml(items, pricingOptions)}
 
     <input type="hidden" name="status" data-pa-status-input value="${escapeHtml(currentStatus)}">
     <p class="ds-pa-form-error" data-pa-form-error role="alert"></p>
@@ -672,7 +674,9 @@ function payloadFromForm(form) {
   });
   payload.status = text(formData.get('status')) || 'draft';
   const items = extractItemsFromForm(form);
-  payload.total_amount = items.reduce((s, i) => s + (Number(i.total_price) || 0), 0) || null;
+  const itemNames = Array.from(new Set(items.map((i) => text(i.item_name)).filter(Boolean)));
+  if (itemNames.length) payload.activity_names = itemNames;
+  payload.total_amount = items.reduce((s, i) => s + (Number(i.total_price) || ((Number(i.quantity) || 0) * (Number(i.unit_price) || 0))), 0) || null;
   return payload;
 }
 
@@ -731,6 +735,7 @@ export const proposalsAgreementsScreen = {
       .map(normalizeProposalAgreementRow)
       .filter((r) => { const k = text(r.id); if (!k || seenIds.has(k)) return false; seenIds.add(k); return true; }));
     const activityNameOptions = Array.from(new Set((Array.isArray(data?.activityNameOptions) ? data.activityNameOptions : []).map((v) => text(v)).filter(Boolean)));
+    const proposalActivityPricing = Array.isArray(data?.proposalActivityPricing) ? data.proposalActivityPricing : [];
     const contactOptions = Array.isArray(data?.contactOptions) ? data.contactOptions : [];
     let debounceTimer = null;
 
@@ -853,6 +858,7 @@ export const proposalsAgreementsScreen = {
     };
 
     const setupItemCalc = (container) => { calcGrandTotal(container); };
+    const pricingByName = new Map(proposalActivityPricing.map((row) => [text(row.activity_name), row]));
 
     // ── Form open/close ───────────────────────────────────────────────────────
     const openForm = async (mode, row = {}, preloadedItems = []) => {
@@ -866,7 +872,7 @@ export const proposalsAgreementsScreen = {
         } catch { items = []; }
       }
       formHost.hidden = false;
-      formHost.innerHTML = formHtml(mode, row, activityNameOptions, contactOptions, items);
+      formHost.innerHTML = formHtml(mode, row, activityNameOptions, contactOptions, items, proposalActivityPricing);
       setupActivityPickers(formHost);
       setupClientSelector(formHost);
       setupItemCalc(formHost);
@@ -961,6 +967,27 @@ export const proposalsAgreementsScreen = {
         if (form) calcGrandTotal(form);
       }
     }, { signal });
+    root.addEventListener('change', (event) => {
+      const pricingSelect = event.target.closest?.('[data-pa-pricing-select]');
+      if (!pricingSelect) return;
+      const itemRow = pricingSelect.closest('[data-pa-item-row]');
+      const form = pricingSelect.closest('[data-pa-form]');
+      const picked = pricingByName.get(text(pricingSelect.value));
+      if (!itemRow || !picked) return;
+      const setValue = (name, value) => {
+        const input = itemRow.querySelector(`[name="${name}"]`);
+        if (input) input.value = value == null ? '' : String(value);
+      };
+      setValue('item_name', picked.activity_name || '');
+      setValue('item_type', picked.item_type || '');
+      setValue('gefen_number', picked.gefen_number || '');
+      setValue('hours_count', picked.hours_count);
+      setValue('meetings_count', picked.meetings_count);
+      setValue('unit_price', picked.unit_price);
+      setValue('description', picked.description_for_proposal || '');
+      calcItemRow(itemRow);
+      if (form) calcGrandTotal(form);
+    }, { signal });
 
     // ── Click handler ─────────────────────────────────────────────────────────
     root.addEventListener('click', async (event) => {
@@ -1003,7 +1030,7 @@ export const proposalsAgreementsScreen = {
               items = await api.readProposalAgreementItems(text(row.id));
             }
           } catch { items = []; }
-          host.innerHTML = formHtml('edit', row, activityNameOptions, contactOptions, items);
+          host.innerHTML = formHtml('edit', row, activityNameOptions, contactOptions, items, proposalActivityPricing);
           setupActivityPickers(host);
           setupClientSelector(host);
           setupItemCalc(host);
@@ -1112,7 +1139,7 @@ export const proposalsAgreementsScreen = {
         if (!tbody) return;
         const idx = tbody.querySelectorAll('[data-pa-item-row]').length;
         const tmp = document.createElement('tbody');
-        tmp.innerHTML = itemRowHtml({}, idx);
+        tmp.innerHTML = itemRowHtml({}, idx, proposalActivityPricing);
         tbody.appendChild(tmp.firstElementChild);
         if (form) calcGrandTotal(form);
         tbody.querySelector(`[data-pa-item-idx="${idx}"] [name="item_name"]`)?.focus();

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -790,10 +790,20 @@ test('api source has readProposalAgreementItems and saveProposalAgreementItems',
   const apiSource = await readFile(API_FILE, 'utf8');
   assert.match(apiSource, /readProposalAgreementItems/);
   assert.match(apiSource, /saveProposalAgreementItems/);
+  assert.match(apiSource, /readProposalActivityPricing/);
+  assert.match(apiSource, /proposal_activity_pricing/);
+  assert.match(apiSource, /is_active_for_proposals/);
   assert.match(apiSource, /saveProposalAgreementItems: true/);
   assert.match(apiSource, /upsertProposalClientContactIfNeeded/);
   assert.match(apiSource, /payload\?\.is_new_client === true/);
   assert.match(apiSource, /total_amount.*payload\.total_amount/);
+});
+
+test('items editor includes pricing selector and uses pricing autofill fields', async () => {
+  const screenSource = await readFile(SCREEN_FILE, 'utf8');
+  assert.match(screenSource, /data-pa-pricing-select/);
+  assert.match(screenSource, /description_for_proposal/);
+  assert.match(screenSource, /payload\.activity_names = itemNames/);
 });
 
 test('upgrade migration adds status column with constraint and new indexes', async () => {


### PR DESCRIPTION
### Motivation
- Provide a fast, compact way for users to pick existing activities/pricing when adding proposal lines so proposal rows are populated from authoritative pricing data. 
- Keep UI lightweight and editable while avoiding hardcoded pricing in the code; all values come from `public.proposal_activity_pricing`.
- Ensure proposal totals and searchable activity names are correct and persisted to the existing items/agreements tables.

### Description
- Added a Supabase reader `readProposalActivityPricingFromSupabase()` and exposed `readProposalActivityPricing` in the API to fetch only rows where `is_active_for_proposals = true` ordered by `sort_order`; fields returned include `activity_name`, `proposal_group`, `item_type`, `gefen_number`, `hours_count`, `meetings_count`, `unit_duration`, `unit_price`, `hourly_price`, `description_for_proposal`, and `sort_order` (file: `frontend/src/api.js`).
- Wired the `proposalActivityPricing` payload into `readProposalsAgreementsFromSupabase()` so the proposals screen receives pricing options alongside other bootstrap data (file: `frontend/src/api.js`).
- Updated the proposals item editor (`frontend/src/screens/proposals-agreements.js`) to render a compact per-row pricing selector (`data-pa-pricing-select`) that sources options from `proposalActivityPricing`, and to autofill selected fields into the item row while leaving every field editable afterwards; autofill maps: `item_name` ← `activity_name`, `item_type`, `gefen_number`, `hours_count`, `meetings_count`, `unit_price`, and `description` ← `description_for_proposal`.
- Kept row totals computed as `quantity × unit_price` and recompute grand total on changes; ensured `payload.total_amount` is computed from row totals (falling back to `quantity × unit_price` if no explicit `total_price`).
- When saving a proposal, item lines continue to be persisted to `proposal_agreement_items` via `saveProposalAgreementItems`, and `activity_names` saved on `proposals_agreements` are derived from current item row names for quick search/display (no hardcoded lists used).
- Minor build/cache updates (service-worker precache entries and cache version bumped) produced updated `dist` files during the build.
- Tests updated to verify the new API/source wiring and presence of the pricing selector/autofill hooks (file: `tests/proposals-agreements-screen.test.mjs`).

### Testing
- Ran focused unit tests: `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and they passed (all checks in those files succeeded). 
- Ran production build: `npm run build` and the build completed successfully (precache generation updated). 
- Note: an earlier run of the broader `npm test` command (covering many suites) surfaced unrelated pre-existing failures; the focused tests for this change and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f74cc1374832ba03cdd98df6da922)