### PR TITLE
Fix proposal preview to use actual proposal_template_sections keys

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CIZiO6K5.js",
+  "./assets/index-3dkcCYM7.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CIZiO6K5.js"></script>
+  <script type="module" crossorigin src="./assets/index-3dkcCYM7.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BDA1wyx9.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CIZiO6K5.js",
+  "./assets/index-3dkcCYM7.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -442,12 +442,19 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     ? `<section class="pa-section"><h3>הפעילות המוצעת</h3><ul>${row.activity_names.map((n) => `<li>${escapeHtml(n)}</li>`).join('')}</ul></section>`
     : '';
 
-  const openingText = sectionBody('opening', '—');
-  const orgResponsibility = sectionBody('organization_responsibility', '—');
+  const introText = sectionBody('intro', '—');
+  const orgResponsibility = sectionBody('taasiyeda_responsibility', '—');
   const schoolResponsibility = sectionBody('school_responsibility', '');
   const paymentTerms = sectionBody('payment_terms', '—');
-  const changesCancellation = sectionBody('changes_cancellations', '');
-  const remarks = sectionBody('remarks', '');
+  const changesCancellation = sectionBody('cancellation_terms', '');
+  const remarks = sectionBody('notes', '');
+  const activityIntro = sectionBody('activity_intro', '');
+  const summerActivityIntro = sectionBody('summer_activity_intro', '');
+  const nextYearActivityIntro = sectionBody('next_year_activity_intro', '');
+  const activityIntroSections = activityTypeGroup === 'הצעה משולבת'
+    ? [summerActivityIntro, nextYearActivityIntro].filter(Boolean)
+    : [activityIntro].filter(Boolean);
+  const signatureText = sectionBody('signature', '');
 
   return `
     <div class="pa-doc-header">
@@ -468,26 +475,16 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
       ${row.contact_name ? `<p>לידי: ${escapeHtml(row.contact_name)}${row.contact_role ? ', ' + escapeHtml(row.contact_role) : ''}</p>` : ''}
     </div>
     <p class="pa-doc-subject"><strong>הנדון: ${escapeHtml(row.document_type || 'הצעת מחיר')} — ${escapeHtml(activityTypeGroup || '')}</strong></p>
-    <section class="pa-section"><h3>${escapeHtml(sectionTitle('opening', 'פתיח'))}</h3><p>${escapeHtml(openingText || '—')}</p></section>
+    <section class="pa-section"><h3>${escapeHtml(sectionTitle('intro', 'פתיח'))}</h3><p>${escapeHtml(introText || '—')}</p></section>
     ${actNamesHtml}
+    ${activityIntroSections.map((sectionText) => `<section class="pa-section"><h3>${escapeHtml(sectionTitle('activity_intro', 'מבוא פעילות'))}</h3><p>${escapeHtml(sectionText)}</p></section>`).join('')}
     <section class="pa-section"><h3>טבלת עלויות</h3>${costTableHtml}</section>
-    <section class="pa-section"><h3>${escapeHtml(sectionTitle('organization_responsibility', 'אחריות תעשיידע'))}</h3><p>${escapeHtml(orgResponsibility || '—')}</p></section>
+    <section class="pa-section"><h3>${escapeHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'))}</h3><p>${escapeHtml(orgResponsibility || '—')}</p></section>
     ${schoolResponsibility ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'))}</h3><p>${escapeHtml(schoolResponsibility)}</p></section>` : ''}
     <section class="pa-section"><h3>${escapeHtml(sectionTitle('payment_terms', 'תנאי תשלום'))}</h3><p>${escapeHtml(paymentTerms || '—')}</p></section>
-    ${changesCancellation ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('changes_cancellations', 'שינויים וביטולים'))}</h3><p>${escapeHtml(changesCancellation)}</p></section>` : ''}
-    ${remarks ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('remarks', 'הערות'))}</h3><p>${escapeHtml(remarks)}</p></section>` : ''}
-    <div class="pa-doc-signature">
-      <div class="pa-sig-block">
-        <div class="pa-sig-line"></div>
-        <div>חתימה ושם</div>
-        <div style="font-size:0.85rem;color:#6b7280">תעשיידע</div>
-      </div>
-      <div class="pa-sig-block">
-        <div class="pa-sig-line"></div>
-        <div>חתימה ושם</div>
-        <div style="font-size:0.85rem;color:#6b7280">${escapeHtml(row.school_framework || row.client_authority || '')}</div>
-      </div>
-    </div>`;
+    ${changesCancellation ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('cancellation_terms', 'שינויים וביטולים'))}</h3><p>${escapeHtml(changesCancellation)}</p></section>` : ''}
+    ${remarks ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('notes', 'הערות'))}</h3><p>${escapeHtml(remarks)}</p></section>` : ''}
+    ${signatureText ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('signature', 'חתימה'))}</h3><p>${escapeHtml(signatureText)}</p></section>` : ''}`;
 }
 
 // ─── Form ─────────────────────────────────────────────────────────────────────

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -234,6 +234,23 @@ test('migration creates proposals_agreements with indexes, updated_at trigger an
   assert.match(migration, /for update[\s\S]*using \(public\.app_can_use_proposals_agreements\(\)\)/);
 });
 
+
+test('preview uses only existing proposal template section keys and required keys are referenced', async () => {
+  const screenSource = await readFile(SCREEN_FILE, 'utf8');
+  const calledKeys = new Set();
+  const re = /section(?:Body|Title)\('([^']+)'/g;
+  let m;
+  while ((m = re.exec(screenSource)) !== null) calledKeys.add(m[1]);
+
+  for (const requiredKey of ['intro', 'activity_intro', 'taasiyeda_responsibility', 'school_responsibility', 'payment_terms', 'cancellation_terms', 'notes', 'signature']) {
+    assert.ok(calledKeys.has(requiredKey), `missing expected template key usage: ${requiredKey}`);
+  }
+
+  for (const legacyKey of ['opening', 'organization_responsibility', 'changes_cancellations', 'remarks']) {
+    assert.equal(calledKeys.has(legacyKey), false, `legacy key should not be used: ${legacyKey}`);
+  }
+});
+
 test('add button opens compact form with draft and pending-approval actions', async () => {
   await withJSDOM(
     proposalsAgreementsScreen.render({ rows: sampleRows, contactOptions: sampleContactOptions }, { state: stateFor('admin') }),


### PR DESCRIPTION
### Motivation
- Exist mismatch between preview code and the `proposal_template_sections` keys caused wrong/empty sections in the proposal preview, so the preview must reference the real keys from the DB without changing the DB.
- Ensure activity-intro content is shown correctly for single/grouped proposal types and replace a hard-coded signature block with the template-provided `signature` content.

### Description
- Replaced legacy key usages in `frontend/src/screens/proposals-agreements.js`: `opening`→`intro`, `organization_responsibility`→`taasiyeda_responsibility`, `changes_cancellations`→`cancellation_terms`, and `remarks`→`notes`.
- Added support for `activity_intro` rendering and for `summer_activity_intro` + `next_year_activity_intro` in combined proposals and built `activityIntroSections` selection logic.
- Removed the hard-coded double-signature block and now render signature content from the `signature` template section via `sectionBody('signature')` and `sectionTitle('signature')`.
- Added an automated test `preview uses only existing proposal template section keys and required keys are referenced` in `tests/proposals-agreements-screen.test.mjs` that asserts required keys are referenced and legacy keys are not used; updated built assets (`dist/index.html`, `dist/sw.js`, `dist/frontend/sw.js`) after the build.

### Testing
- Ran `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (`36 passed, 0 failed`).
- Ran `npm run build` and the production build completed successfully (vite build finished with non-blocking chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7dd9e6fc832b83dbb363c2b42d01)