### PR TITLE
Add header and footer logos to proposal preview and print with fallbacks

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -457,8 +457,19 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const signatureText = sectionBody('signature', '');
 
   return `
+    <div class="pa-doc-header-brand">
+      <img
+        src="/proposals/proposal-header-logo.png"
+        alt="לוגו תעשיידע"
+        class="pa-doc-logo pa-doc-logo--header"
+        loading="eager"
+        decoding="async"
+        onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
+      >
+      <div class="pa-doc-logo-fallback" hidden>תעשיידע — חינוך מקצועי וחוויות למידה</div>
+    </div>
     <div class="pa-doc-header">
-      <div>
+      <div class="pa-doc-company-block">
         <div class="pa-doc-company">תעשיידע</div>
         <div class="pa-doc-tagline">חינוך מקצועי וחוויות למידה</div>
       </div>
@@ -484,7 +495,18 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     <section class="pa-section"><h3>${escapeHtml(sectionTitle('payment_terms', 'תנאי תשלום'))}</h3><p>${escapeHtml(paymentTerms || '—')}</p></section>
     ${changesCancellation ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('cancellation_terms', 'שינויים וביטולים'))}</h3><p>${escapeHtml(changesCancellation)}</p></section>` : ''}
     ${remarks ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('notes', 'הערות'))}</h3><p>${escapeHtml(remarks)}</p></section>` : ''}
-    ${signatureText ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('signature', 'חתימה'))}</h3><p>${escapeHtml(signatureText)}</p></section>` : ''}`;
+    ${signatureText ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('signature', 'חתימה'))}</h3><p>${escapeHtml(signatureText)}</p></section>` : ''}
+    <footer class="pa-doc-footer">
+      <img
+        src="/proposals/proposal-footer-logo.png"
+        alt="לוגו תחתון תעשיידע"
+        class="pa-doc-logo pa-doc-logo--footer"
+        loading="lazy"
+        decoding="async"
+        onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
+      >
+      <div class="pa-doc-logo-fallback pa-doc-logo-fallback--footer" hidden>תעשיידע</div>
+    </footer>`;
 }
 
 // ─── Form ─────────────────────────────────────────────────────────────────────

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10421,9 +10421,28 @@ select.ds-input {
   font-size: 0.94rem; line-height: 1.65; direction: rtl;
   color: #1e293b;
 }
+.pa-doc-header-brand {
+  margin-bottom: 10px;
+}
 .pa-doc-header {
   display: flex; justify-content: space-between; align-items: flex-start;
   margin-bottom: 12px;
+}
+.pa-doc-company-block { display: block; }
+.pa-doc-logo {
+  display: block; max-width: 100%; height: auto;
+}
+.pa-doc-logo--header {
+  width: min(360px, 72%);
+}
+.pa-doc-logo--footer {
+  width: min(180px, 42%);
+}
+.pa-doc-logo-fallback {
+  font-size: 0.88rem; color: #334155; font-weight: 600;
+}
+.pa-doc-logo-fallback--footer {
+  font-size: 0.78rem; color: #64748b;
 }
 .pa-doc-company { font-size: 1.5rem; font-weight: 800; color: #1e3a5f; }
 .pa-doc-tagline { font-size: 0.82rem; color: #6b7280; }
@@ -10448,6 +10467,9 @@ select.ds-input {
 }
 .pa-cost-table thead { background: #f8fafc; font-weight: 600; }
 .pa-cost-total-row { background: #f0f9ff; }
+.pa-doc-footer {
+  margin-top: 26px; padding-top: 12px; border-top: 1px solid #e5e7eb;
+}
 .pa-doc-signature {
   display: flex; gap: 40px; margin-top: 40px; flex-wrap: wrap;
 }


### PR DESCRIPTION
### Motivation
- להציג בלוגו עליון ותחתון במסמך ההצעה כדי שייראו גם בתצוגה מקדימה וגם בהדפסה/שמירה כ‑PDF ללא שקיעת תמונות בקוד.
- למנוע שבירה של המסמך אם התמונות לא נטענות על‑ידי הצגת טקסט חלופי בטוח במקום התמונה.
- לשמור על שימוש בנתיבי קבצים סטטיים ולא להטמיע תמונות כ‑base64 או לשנות קבצי `dist`.

### Description
- הוספתי את הלוגו העליון בקובץ ה‑preview באמצעות תמונת `<img src="/proposals/proposal-header-logo.png">` עם `onerror` שמחליף לתצוגת טקסט חלופי במקום השבירה, וכן הוספתי בלוק תצוגה מתאים ב־`proposalPreviewBodyHtml` ב־`frontend/src/screens/proposals-agreements.js`.
- הוספתי לוגו תחתון בסוף התבנית כ־`<img src="/proposals/proposal-footer-logo.png">` עם אותו מנגנון fallback ועטפתי אותו ב־`<footer class="pa-doc-footer">` ב־אותו קובץ.
- עדכנתי את ה‑CSS ב־`frontend/src/styles/main.css` כדי להוסיף כללים ל־`.pa-doc-header-brand`, `.pa-doc-logo`, `.pa-doc-logo--header`, `.pa-doc-logo--footer` ו־fallback text, כולל `max-width: 100%` ו־`height: auto` וגדלים סבירים לכותרת ולפוטר כדי למנוע חיתוכים/עיוותים.
- שמרתי על נתיבי קבצים סטטיים בלבד ולא הוספתי תמונות ל־JS או כבקודת base64, ולא הופעלו שינויים קבועים ב־`dist` (הוחזרו לאחר ה‑build).

### Testing
- הרצתי את הבדיקות האוטומטיות עם `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` והן עברו בהצלחה (36 tests passed).
- ביצעתי `npm run build` והבנייה הושלמה בהצלחה; שינויים שנוצרו ב־`dist` שוחזרו לאחר הבנייה כדי לא לכלול קבצי הפצה בשינוי.
- אין בדיקות אוטומטיות נוספות שנכנסו לשינוי זה, והפיצ׳ר נשמר בתצוגת ה‑preview/הדפסה הנוכחית.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f80ffffc0832ba41bea3712723223)