### PR TITLE
Fix proposal preview logo paths for GitHub Pages base URL

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -7,6 +7,7 @@ const SEARCH_DEBOUNCE_MS = 280;
 const DOCUMENT_TYPE_OPTIONS = ['הצעת מחיר', 'הסכם'];
 const ACTIVITY_TYPE_GROUP_OPTIONS = ['הצעה משולבת', 'פעילויות קיץ', 'שנה הבאה'];
 const ITEM_TYPE_OPTIONS = ['סדנה', 'קורס', 'הדרכה', 'פעילות', 'ייעוץ', 'ליווי'];
+const PUBLIC_BASE = import.meta.env?.BASE_URL || './';
 
 export const STATUS_OPTIONS = ['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'];
 export const STATUS_LABELS = {
@@ -459,7 +460,7 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   return `
     <div class="pa-doc-header-brand">
       <img
-        src="/proposals/proposal-header-logo.png"
+        src="${PUBLIC_BASE}proposals/proposal-header-logo.png"
         alt="לוגו תעשיידע"
         class="pa-doc-logo pa-doc-logo--header"
         loading="eager"
@@ -498,7 +499,7 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     ${signatureText ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('signature', 'חתימה'))}</h3><p>${escapeHtml(signatureText)}</p></section>` : ''}
     <footer class="pa-doc-footer">
       <img
-        src="/proposals/proposal-footer-logo.png"
+        src="${PUBLIC_BASE}proposals/proposal-footer-logo.png"
         alt="לוגו תחתון תעשיידע"
         class="pa-doc-logo pa-doc-logo--footer"
         loading="lazy"


### PR DESCRIPTION
### Motivation
- Make the proposal preview header/footer logos load correctly when the site is hosted under a non-root base (e.g. GitHub Pages under `/dashboard_system/`) by avoiding root-absolute `/proposals/...` URLs.

### Description
- Add `const PUBLIC_BASE = import.meta.env?.BASE_URL || './';` and replace the preview logo `src` values with `${PUBLIC_BASE}proposals/proposal-header-logo.png` and `${PUBLIC_BASE}proposals/proposal-footer-logo.png` in `frontend/src/screens/proposals-agreements.js` so paths work both locally and under a Vite/GitHub Pages base.

### Testing
- Ran `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f83b49750832ba9f97ea2f3b13ce3)