### PR TITLE
הוספת מודול "הזמנות" למחולל הזמנות בדשבורד + עדכון SW

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 412;
+const CACHE_VERSION = 413;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-3dkcCYM7.js",
+  "./assets/index-59wKCn-R.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BDA1wyx9.css",
+  "./assets/style-DpgemWAs.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-3dkcCYM7.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BDA1wyx9.css">
+  <script type="module" crossorigin src="./assets/index-59wKCn-R.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-DpgemWAs.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 412;
+const CACHE_VERSION = 413;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-3dkcCYM7.js",
+  "./assets/index-59wKCn-R.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BDA1wyx9.css",
+  "./assets/style-DpgemWAs.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -511,7 +511,8 @@ const screenLabels = {
   'admin-lists': 'ניהול רשימות',
   archive: 'ארכיון',
   'proposals-agreements': 'הצעות והסכמים',
-  finance: 'כספים / גבייה'
+  finance: 'כספים / גבייה',
+  invitations: 'הזמנות'
 };
 
 function navLabelForRoute(route) {
@@ -554,7 +555,8 @@ const screenLoaders = {
   'admin-lists': () => import('./screens/admin-lists.js').then((m) => m.adminListsScreen),
   archive: () => import('./screens/archive.js').then((m) => m.archiveScreen),
   'proposals-agreements': () => import('./screens/proposals-agreements.js').then((m) => m.proposalsAgreementsScreen),
-  finance: () => import('./screens/finance.js').then((m) => m.financeScreen)
+  finance: () => import('./screens/finance.js').then((m) => m.financeScreen),
+  invitations: () => import('./screens/invitations.js').then((m) => m.invitationsScreen)
 };
 const loadedScreens = new Map();
 const loadingScreens = new Map();
@@ -608,7 +610,9 @@ function applySettingsToRoutes(routes, settings = state.clientSettings) {
   }
   const blocked = navDisabledRoutesSet(settings);
   const seen = new Set();
-  return (Array.isArray(routes) ? routes : []).filter((route) => {
+  const baseRoutes = Array.isArray(routes) ? routes : [];
+  if (!baseRoutes.includes('invitations')) baseRoutes.push('invitations');
+  return baseRoutes.filter((route) => {
     if (!route || blocked.has(route) || seen.has(route)) return false;
     if (!screenLoaders[route]) return false;
     seen.add(route);

--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -1,0 +1,95 @@
+const COURSE_OPTIONS = [
+  { key: 'english', label: 'אנגלית', icon: '📘' },
+  { key: 'computers', label: 'מחשבים', icon: '💻' },
+  { key: 'hebrew', label: 'עברית', icon: '📝' },
+  { key: 'employability', label: 'כישורי תעסוקה', icon: '🧩' }
+];
+
+const INVITATION_TYPES = [
+  { key: 'lecture', label: 'הרצאה' },
+  { key: 'tour', label: 'סיור' },
+  { key: 'graduation', label: 'מפגש סיום קורס' }
+];
+
+function ensureInvitationStyles() {
+  if (document.getElementById('invitations-screen-style')) return;
+  const style = document.createElement('style');
+  style.id = 'invitations-screen-style';
+  style.textContent = `
+    .inv-shell{display:grid;grid-template-columns:320px 1fr;gap:20px;align-items:start;direction:rtl}
+    .inv-panel{background:#fff;border:1px solid #dbe5ef;border-radius:18px;padding:16px;box-shadow:0 10px 26px rgba(15,23,42,.08)}
+    .inv-title{margin:0 0 8px;font-size:24px}.inv-muted{color:#64748b;margin:0 0 14px}
+    .inv-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-bottom:12px}
+    .inv-chip{border:1px solid #dbe5ef;background:#f8fafc;border-radius:12px;padding:10px;cursor:pointer;font-weight:700}
+    .inv-chip.active{border-color:#14b8a6;background:#ecfeff}
+    .inv-field{display:grid;gap:4px;margin-bottom:10px}.inv-field input,.inv-field textarea,.inv-field select{border:1px solid #cbd5e1;border-radius:10px;padding:9px;font:inherit}
+    .inv-field textarea{min-height:80px;resize:vertical}
+    .inv-preview{background:linear-gradient(135deg,#f0fdfa,#f8fafc);min-height:560px;border:1px solid #dbe5ef;border-radius:18px;padding:24px}
+    .inv-card{max-width:760px;margin:0 auto;background:#fff;border-radius:20px;border:1px solid #dbe5ef;padding:30px}
+    .inv-badge{display:inline-block;padding:6px 10px;background:#dcfce7;color:#166534;border-radius:999px;font-weight:800;font-size:12px}
+    .inv-head{font-size:36px;margin:10px 0 4px}.inv-sub{color:#334155;font-size:18px}
+    .inv-meta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px;margin:20px 0}.inv-meta div{background:#f8fafc;padding:10px;border-radius:10px}
+    @media (max-width: 960px){.inv-shell{grid-template-columns:1fr}}
+  `;
+  document.head.appendChild(style);
+}
+
+export function invitationsScreen() {
+  ensureInvitationStyles();
+  const selectedCourse = COURSE_OPTIONS[0].key;
+  const selectedType = INVITATION_TYPES[0].key;
+  const formState = {
+    course: selectedCourse,
+    type: selectedType,
+    school: '', className: '', host: '', title: '', date: '', time: '', location: '', notes: ''
+  };
+
+  const typeLabel = () => INVITATION_TYPES.find((t) => t.key === formState.type)?.label || '';
+  const courseLabel = () => COURSE_OPTIONS.find((c) => c.key === formState.course)?.label || '';
+
+  const render = () => `
+    <section class="inv-shell">
+      <aside class="inv-panel">
+        <h2 class="inv-title">מחולל הזמנות</h2>
+        <p class="inv-muted">בחירת קורס וסוג הזמנה + עריכת פרטי ההזמנה.</p>
+
+        <div><strong>קורס</strong></div>
+        <div class="inv-grid">${COURSE_OPTIONS.map((c) => `<button class="inv-chip ${formState.course===c.key?'active':''}" data-course="${c.key}">${c.icon} ${c.label}</button>`).join('')}</div>
+
+        <div><strong>סוג הזמנה</strong></div>
+        <div class="inv-grid" style="grid-template-columns:1fr;">${INVITATION_TYPES.map((t) => `<button class="inv-chip ${formState.type===t.key?'active':''}" data-type="${t.key}">${t.label}</button>`).join('')}</div>
+
+        ${[
+          ['school','בית ספר'],['className','כיתה'],['host','חברה מארחת'],['title','כותרת אירוע'],['date','תאריך'],['time','שעה'],['location','מיקום']
+        ].map(([k,label])=>`<label class="inv-field"><span>${label}</span><input data-field="${k}" value="${formState[k]||''}"/></label>`).join('')}
+        <label class="inv-field"><span>תיאור / הערות</span><textarea data-field="notes">${formState.notes||''}</textarea></label>
+      </aside>
+
+      <div class="inv-preview">
+        <article class="inv-card">
+          <span class="inv-badge">${typeLabel()}</span>
+          <h1 class="inv-head">${formState.title || `הזמנה ל${typeLabel()}`}</h1>
+          <div class="inv-sub">קורס: <strong>${courseLabel()}</strong></div>
+          <div class="inv-meta">
+            <div><strong>בית ספר</strong><br>${formState.school || '—'}</div>
+            <div><strong>כיתה</strong><br>${formState.className || '—'}</div>
+            <div><strong>חברה מארחת</strong><br>${formState.host || '—'}</div>
+            <div><strong>מיקום</strong><br>${formState.location || '—'}</div>
+            <div><strong>תאריך</strong><br>${formState.date || '—'}</div>
+            <div><strong>שעה</strong><br>${formState.time || '—'}</div>
+          </div>
+          <p>${formState.notes || 'נשמח לראותכם באירוע.'}</p>
+        </article>
+      </div>
+    </section>`;
+
+  const root = document.createElement('div');
+  function mount() {
+    root.innerHTML = render();
+    root.querySelectorAll('[data-course]').forEach((el) => el.addEventListener('click', () => { formState.course = el.dataset.course; mount(); }));
+    root.querySelectorAll('[data-type]').forEach((el) => el.addEventListener('click', () => { formState.type = el.dataset.type; mount(); }));
+    root.querySelectorAll('[data-field]').forEach((el) => el.addEventListener('input', (e) => { formState[e.target.dataset.field] = e.target.value; mount(); }));
+  }
+  mount();
+  return root;
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 412;
+const CACHE_VERSION = 413;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 412;
+const SW_ENTRY_VERSION = 413;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להטמיע את אב־הטיפוס של מחולל ההזמנות בתוך הדשבורד כמודול פנימי ולשמור את השדות כמו "בית ספר / כיתה / חברה מארחת" כשדות בתוך ההזמנה בלבד (ללא קישור לישות בית ספר).
- להציג את המודול בתפריט הניווט ולהבטיח שה-PWA/Service Worker לא יחזיק בקאש ישן לאחר ההוספה.

### Description
- נוסף מסך חדש `frontend/src/screens/invitations.js` שמממש את מחולל ההזמנות כולל בחירת קורס, בחירת סוג הזמנה (`הרצאה` / `סיור` / `מפגש סיום קורס`), שדות פרטי הזמנה ותצוגה מקדימה שמתעדכנת בזמן אמת.
- הוכנס `invitations` ל-`screenLabels` ול-`screenLoaders` ב-`frontend/src/main.js` וכן הובטח שהמסלול יתווסף ל־routes אפקטיביים דרך `applySettingsToRoutes` כך שיופיע בתפריט גם אם לא הגיע מהשרת.
- בוצע bump של גרסאות cache/entry ב-`frontend/sw.js` ו-`sw.js` (וגם בקבצי ה-build ב-`dist`) כדי לנקות caches קיימים ולהבטיח טעינה של הקבצים החדשים.

### Testing
- הפקודה `npm run build` הופעלה בהצלחה בריצה אוטומטית ללא שגיאות.  
- רץ ובוצע בהצלחה מבחן ה-Service Worker/PWA `node --test tests/service-worker-pwa-cache.test.mjs` (כל הבדיקות עברו).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f843108f4832bb09e2fa9e0d6755c)