### PR TITLE
Fix invitations screen export to match loader contract (add load/render/bind)

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-59wKCn-R.js",
+  "./assets/index-gcSCz63i.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-59wKCn-R.js"></script>
+  <script type="module" crossorigin src="./assets/index-gcSCz63i.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DpgemWAs.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-59wKCn-R.js",
+  "./assets/index-gcSCz63i.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",

--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -34,62 +34,108 @@ function ensureInvitationStyles() {
   document.head.appendChild(style);
 }
 
-export function invitationsScreen() {
-  ensureInvitationStyles();
-  const selectedCourse = COURSE_OPTIONS[0].key;
-  const selectedType = INVITATION_TYPES[0].key;
-  const formState = {
-    course: selectedCourse,
-    type: selectedType,
-    school: '', className: '', host: '', title: '', date: '', time: '', location: '', notes: ''
-  };
-
-  const typeLabel = () => INVITATION_TYPES.find((t) => t.key === formState.type)?.label || '';
-  const courseLabel = () => COURSE_OPTIONS.find((c) => c.key === formState.course)?.label || '';
-
-  const render = () => `
-    <section class="inv-shell">
-      <aside class="inv-panel">
-        <h2 class="inv-title">מחולל הזמנות</h2>
-        <p class="inv-muted">בחירת קורס וסוג הזמנה + עריכת פרטי ההזמנה.</p>
-
-        <div><strong>קורס</strong></div>
-        <div class="inv-grid">${COURSE_OPTIONS.map((c) => `<button class="inv-chip ${formState.course===c.key?'active':''}" data-course="${c.key}">${c.icon} ${c.label}</button>`).join('')}</div>
-
-        <div><strong>סוג הזמנה</strong></div>
-        <div class="inv-grid" style="grid-template-columns:1fr;">${INVITATION_TYPES.map((t) => `<button class="inv-chip ${formState.type===t.key?'active':''}" data-type="${t.key}">${t.label}</button>`).join('')}</div>
-
-        ${[
-          ['school','בית ספר'],['className','כיתה'],['host','חברה מארחת'],['title','כותרת אירוע'],['date','תאריך'],['time','שעה'],['location','מיקום']
-        ].map(([k,label])=>`<label class="inv-field"><span>${label}</span><input data-field="${k}" value="${formState[k]||''}"/></label>`).join('')}
-        <label class="inv-field"><span>תיאור / הערות</span><textarea data-field="notes">${formState.notes||''}</textarea></label>
-      </aside>
-
-      <div class="inv-preview">
-        <article class="inv-card">
-          <span class="inv-badge">${typeLabel()}</span>
-          <h1 class="inv-head">${formState.title || `הזמנה ל${typeLabel()}`}</h1>
-          <div class="inv-sub">קורס: <strong>${courseLabel()}</strong></div>
-          <div class="inv-meta">
-            <div><strong>בית ספר</strong><br>${formState.school || '—'}</div>
-            <div><strong>כיתה</strong><br>${formState.className || '—'}</div>
-            <div><strong>חברה מארחת</strong><br>${formState.host || '—'}</div>
-            <div><strong>מיקום</strong><br>${formState.location || '—'}</div>
-            <div><strong>תאריך</strong><br>${formState.date || '—'}</div>
-            <div><strong>שעה</strong><br>${formState.time || '—'}</div>
-          </div>
-          <p>${formState.notes || 'נשמח לראותכם באירוע.'}</p>
-        </article>
-      </div>
-    </section>`;
-
-  const root = document.createElement('div');
-  function mount() {
-    root.innerHTML = render();
-    root.querySelectorAll('[data-course]').forEach((el) => el.addEventListener('click', () => { formState.course = el.dataset.course; mount(); }));
-    root.querySelectorAll('[data-type]').forEach((el) => el.addEventListener('click', () => { formState.type = el.dataset.type; mount(); }));
-    root.querySelectorAll('[data-field]').forEach((el) => el.addEventListener('input', (e) => { formState[e.target.dataset.field] = e.target.value; mount(); }));
-  }
-  mount();
-  return root;
+function typeLabel(formState) {
+  return INVITATION_TYPES.find((t) => t.key === formState.type)?.label || '';
 }
+
+function courseLabel(formState) {
+  return COURSE_OPTIONS.find((c) => c.key === formState.course)?.label || '';
+}
+
+function invitationPreviewHtml(formState) {
+  return `
+    <article class="inv-card">
+      <span class="inv-badge">${typeLabel(formState)}</span>
+      <h1 class="inv-head">${formState.title || `הזמנה ל${typeLabel(formState)}`}</h1>
+      <div class="inv-sub">קורס: <strong>${courseLabel(formState)}</strong></div>
+      <div class="inv-meta">
+        <div><strong>בית ספר</strong><br>${formState.school || '—'}</div>
+        <div><strong>כיתה</strong><br>${formState.className || '—'}</div>
+        <div><strong>חברה מארחת</strong><br>${formState.host || '—'}</div>
+        <div><strong>מיקום</strong><br>${formState.location || '—'}</div>
+        <div><strong>תאריך</strong><br>${formState.date || '—'}</div>
+        <div><strong>שעה</strong><br>${formState.time || '—'}</div>
+      </div>
+      <p>${formState.notes || 'נשמח לראותכם באירוע.'}</p>
+    </article>`;
+}
+
+export const invitationsScreen = {
+  async load() {
+    return {};
+  },
+  render() {
+    ensureInvitationStyles();
+    const formState = {
+      course: COURSE_OPTIONS[0].key,
+      type: INVITATION_TYPES[0].key,
+      school: '', className: '', host: '', title: '', date: '', time: '', location: '', notes: ''
+    };
+
+    return `
+      <section class="inv-shell" data-invitations-root>
+        <aside class="inv-panel">
+          <h2 class="inv-title">מחולל הזמנות</h2>
+          <p class="inv-muted">בחירת קורס וסוג הזמנה + עריכת פרטי ההזמנה.</p>
+
+          <div><strong>קורס</strong></div>
+          <div class="inv-grid">${COURSE_OPTIONS.map((c) => `<button type="button" class="inv-chip ${formState.course === c.key ? 'active' : ''}" data-course="${c.key}">${c.icon} ${c.label}</button>`).join('')}</div>
+
+          <div><strong>סוג הזמנה</strong></div>
+          <div class="inv-grid" style="grid-template-columns:1fr;">${INVITATION_TYPES.map((t) => `<button type="button" class="inv-chip ${formState.type === t.key ? 'active' : ''}" data-type="${t.key}">${t.label}</button>`).join('')}</div>
+
+          ${[
+            ['school', 'בית ספר'], ['className', 'כיתה'], ['host', 'חברה מארחת'], ['title', 'כותרת אירוע'], ['date', 'תאריך'], ['time', 'שעה'], ['location', 'מיקום']
+          ].map(([k, label]) => `<label class="inv-field"><span>${label}</span><input data-field="${k}" value="${formState[k] || ''}"/></label>`).join('')}
+          <label class="inv-field"><span>תיאור / הערות</span><textarea data-field="notes">${formState.notes || ''}</textarea></label>
+        </aside>
+
+        <div class="inv-preview" data-inv-preview>${invitationPreviewHtml(formState)}</div>
+      </section>`;
+  },
+  bind({ root }) {
+    if (!root) return;
+    const host = root.querySelector('[data-invitations-root]');
+    if (!host) return;
+
+    const formState = {
+      course: COURSE_OPTIONS[0].key,
+      type: INVITATION_TYPES[0].key,
+      school: '', className: '', host: '', title: '', date: '', time: '', location: '', notes: ''
+    };
+
+    const repaint = () => {
+      host.querySelectorAll('[data-course]').forEach((el) => {
+        el.classList.toggle('active', el.dataset.course === formState.course);
+      });
+      host.querySelectorAll('[data-type]').forEach((el) => {
+        el.classList.toggle('active', el.dataset.type === formState.type);
+      });
+      const preview = host.querySelector('[data-inv-preview]');
+      if (preview) preview.innerHTML = invitationPreviewHtml(formState);
+    };
+
+    host.querySelectorAll('[data-course]').forEach((el) => {
+      el.addEventListener('click', () => {
+        formState.course = el.dataset.course || formState.course;
+        repaint();
+      });
+    });
+
+    host.querySelectorAll('[data-type]').forEach((el) => {
+      el.addEventListener('click', () => {
+        formState.type = el.dataset.type || formState.type;
+        repaint();
+      });
+    });
+
+    host.querySelectorAll('[data-field]').forEach((el) => {
+      el.addEventListener('input', (e) => {
+        const field = e?.target?.dataset?.field;
+        if (!field) return;
+        formState[field] = e?.target?.value || '';
+        repaint();
+      });
+    });
+  }
+};


### PR DESCRIPTION
### Motivation
- The dashboard route loader expects a screen object with `render(...)` (and optional `load`/`bind`) but `frontend/src/screens/invitations.js` previously exported a factory that returned an `HTMLElement`, causing `t.render is not a function` at runtime.
- The change aligns `invitations` with the same screen contract used by existing screens so the loader can render and bind it like the rest of the app.

### Description
- Reworked `frontend/src/screens/invitations.js` to export `export const invitationsScreen = { load, render, bind }` instead of returning a DOM node. 
- Implemented a `load()` method that returns an empty data object to follow the pattern of other screens and kept `render()` as a pure HTML string generator. 
- Moved runtime interactivity into `bind()` which attaches event listeners, updates local `formState`, and repaints the preview without changing the visual design. 
- Ran a production build which produced updated dist artifacts (including service worker precache entries pointing at the new hashed asset names). 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `node --test tests/service-worker-pwa-cache.test.mjs` and all tests passed (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f86f0dd3c832b9411478c1a2978d9)