### PR TITLE
Polish proposal preview logos and header/footer spacing

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -465,12 +465,12 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
         class="pa-doc-logo pa-doc-logo--header"
         loading="eager"
         decoding="async"
-        onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
+        onerror="this.style.display='none'; this.nextElementSibling.hidden = false; var doc = this.closest('.ds-pa-preview-doc'); if (doc) { var companyBlock = doc.querySelector('.pa-doc-company-block'); if (companyBlock) companyBlock.hidden = false; }"
       >
       <div class="pa-doc-logo-fallback" hidden>תעשיידע — חינוך מקצועי וחוויות למידה</div>
     </div>
     <div class="pa-doc-header">
-      <div class="pa-doc-company-block">
+      <div class="pa-doc-company-block" hidden>
         <div class="pa-doc-company">תעשיידע</div>
         <div class="pa-doc-tagline">חינוך מקצועי וחוויות למידה</div>
       </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10433,10 +10433,10 @@ select.ds-input {
   display: block; max-width: 100%; height: auto;
 }
 .pa-doc-logo--header {
-  width: min(360px, 72%);
+  width: min(260px, 55%);
 }
 .pa-doc-logo--footer {
-  width: min(180px, 42%);
+  width: min(260px, 55%);
 }
 .pa-doc-logo-fallback {
   font-size: 0.88rem; color: #334155; font-weight: 600;
@@ -10468,7 +10468,9 @@ select.ds-input {
 .pa-cost-table thead { background: #f8fafc; font-weight: 600; }
 .pa-cost-total-row { background: #f0f9ff; }
 .pa-doc-footer {
-  margin-top: 26px; padding-top: 12px; border-top: 1px solid #e5e7eb;
+  margin-top: 18px; padding-top: 10px; border-top: 1px solid #e5e7eb;
+  break-inside: avoid;
+  page-break-inside: avoid;
 }
 .pa-doc-signature {
   display: flex; gap: 40px; margin-top: 40px; flex-wrap: wrap;
@@ -10490,6 +10492,10 @@ select.ds-input {
   .ds-pa-preview-doc {
     box-shadow: none !important; border: none !important;
     margin: 0 !important; padding: 20px !important; max-width: 100% !important;
+  }
+  .pa-doc-footer {
+    margin-top: 14px !important;
+    padding-top: 8px !important;
   }
   .pa-doc-divider { border-top: 1.5px solid #000; }
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated company text in the proposal preview when the header logo loads while keeping a clear fallback if the image fails, and ensure footer/logo spacing is print-safe to avoid clipping in PDF/print.
- Reduce visual weight of the header logo and improve footer legibility for a cleaner print and preview layout.

### Description
- Hide the `.pa-doc-company-block` by default and update the header logo `onerror` handler to reveal the company block only when the header image fails to load. 
- Adjust CSS sizes for `.pa-doc-logo--header` and `.pa-doc-logo--footer` to `width: min(260px, 55%);` and tighten footer spacing. 
- Add `break-inside: avoid` and `page-break-inside: avoid` for the footer and small print-specific footer spacing tweaks to reduce logo clipping when printing or exporting to PDF. 
- Files changed: `frontend/src/screens/proposals-agreements.js` and `frontend/src/styles/main.css`.

### Testing
- Ran unit/feature tests with `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (`36 passed, 0 failed`).
- Ran `npm run build` which completed successfully (build produced a Vite chunk-size warning but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f91596bd4832ba29d8183f0b2dc1a)