### PR TITLE
Fix invitations A4 preview layout and bump service-worker cache version

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 414;
+const CACHE_VERSION = 415;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-IU-ri94m.js",
+  "./assets/index-CVlUjPpJ.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DpgemWAs.css",
+  "./assets/style-8sMRWaf6.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-IU-ri94m.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DpgemWAs.css">
+  <script type="module" crossorigin src="./assets/index-CVlUjPpJ.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-8sMRWaf6.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 414;
+const CACHE_VERSION = 415;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-IU-ri94m.js",
+  "./assets/index-CVlUjPpJ.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DpgemWAs.css",
+  "./assets/style-8sMRWaf6.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -58,8 +58,9 @@ function ensureInvitationStyles() {
     .inv-field textarea{min-height:54px;resize:vertical}
     .inv-actions{display:grid;gap:8px;margin-top:10px}.inv-btn{border:0;border-radius:10px;padding:10px;font-weight:800;cursor:pointer}
     .inv-btn.print{background:linear-gradient(135deg,#14b8a6,#0ea5e9);color:#fff}
-    .inv-preview-wrap{display:flex;justify-content:center;align-items:flex-start;padding:8px 0}
-    .inv-a4{width:794px;min-height:1123px;background:#fffdf6;position:relative;box-shadow:0 18px 48px rgba(2,8,23,.24);padding:102px 76px 70px;overflow:hidden;display:flex;justify-content:center;align-items:center}
+    .inv-preview-wrap{display:flex;justify-content:center;align-items:flex-start;overflow:auto;max-height:calc(100vh - 32px);padding:14px}
+    .inv-a4-stage{display:flex;justify-content:center;align-items:flex-start;min-width:100%}
+    .inv-a4{width:794px;min-height:1123px;background:#fffdf6;position:relative;box-shadow:0 18px 48px rgba(2,8,23,.24);padding:102px 76px 70px;overflow:hidden;display:flex;justify-content:center;align-items:center;transform-origin:top center}
     .inv-ribbon{position:absolute;top:0;bottom:0;width:66px;opacity:.92;pointer-events:none}.inv-ribbon.right{right:0;background:radial-gradient(circle at 50% 14%, rgba(255,255,255,.92) 0 6px, transparent 7px),radial-gradient(circle at 45% 31%, rgba(18,185,129,.42), transparent 26px),linear-gradient(180deg, rgba(18,185,129,.4), rgba(14,165,233,.18))}.inv-ribbon.left{left:0;background:radial-gradient(circle at 50% 80%, rgba(255,255,255,.9) 0 7px, transparent 8px),radial-gradient(circle at 50% 22%, rgba(14,165,233,.35), transparent 28px),linear-gradient(180deg, rgba(14,165,233,.22), rgba(18,185,129,.34))}
     .inv-logos{position:absolute;top:24px;left:50%;transform:translateX(-50%);display:flex;gap:18px;padding:8px 20px;background:rgba(255,255,255,.76);border-radius:999px;border:1px solid rgba(255,255,255,.72);z-index:3}
     .inv-logo-slot{width:118px;height:42px;border-radius:12px;background:rgba(248,250,252,.72);border:1px dashed rgba(148,163,184,.5);display:flex;align-items:center;justify-content:center;overflow:hidden;color:#94a3b8;font-size:11px;font-weight:800}.inv-logo-slot img{display:none;width:100%;height:100%;object-fit:contain}.inv-logo-slot.has-logo img{display:block}.inv-logo-slot.has-logo span{display:none}
@@ -71,8 +72,9 @@ function ensureInvitationStyles() {
     .inv-body{font-size:22px;line-height:1.7;text-align:right;margin:12px 0}.inv-body p{margin:0 0 8px}.inv-event{background:linear-gradient(135deg, rgba(255,255,255,.96), rgba(240,249,255,.92));padding:13px 22px;border-radius:18px;border:2px solid rgba(20,184,166,.18);font-size:20px;line-height:1.6;margin:12px 0}
     .inv-participants{width:100%;text-align:right;background:rgba(248,250,252,.72);border:1px solid rgba(226,232,240,.88);border-radius:18px;padding:14px 18px;font-size:16px;line-height:1.8}
     .inv-closing{font-size:34px;color:#058669;font-weight:800;margin-top:12px}
-    @media print{@page{size:A4 portrait;margin:0} .inv-panel{display:none !important}.inv-shell{display:block}.inv-a4{width:210mm;height:297mm;min-height:0;margin:0;box-shadow:none;padding:28mm 20mm 18mm;-webkit-print-color-adjust:exact;print-color-adjust:exact}}
-    @media (max-width:1200px){.inv-shell{grid-template-columns:1fr}.inv-panel{position:static;max-height:none}}
+    @media print{@page{size:A4 portrait;margin:0} .inv-panel{display:none !important}.inv-shell{display:block}.inv-preview-wrap{overflow:visible !important;max-height:none !important;padding:0 !important}.inv-a4-stage{min-width:0 !important}.inv-a4{width:210mm;height:297mm;min-height:0;margin:0;box-shadow:none;padding:28mm 20mm 18mm;transform:none !important;-webkit-print-color-adjust:exact;print-color-adjust:exact}}
+    @media (max-width:1380px){.inv-a4{transform:scale(.82)}}
+    @media (max-width:1200px){.inv-shell{grid-template-columns:1fr}.inv-panel{position:static;max-height:none}.inv-preview-wrap{max-height:none}.inv-a4{transform:scale(.76)}}
   `;
   document.head.appendChild(style);
 }
@@ -84,7 +86,7 @@ const showSpeakerField = (s) => s.type === 'lecture';
 
 function invitationPreviewHtml(s) {
   const tpl = getTemplate(s);
-  return `<article class="inv-a4" id="invitation-page" style="background:${s.backgroundCss};background-size:cover;background-position:center;">
+  return `<div class="inv-a4-stage"><article class="inv-a4" id="invitation-page" style="background:${s.backgroundCss};background-size:cover;background-position:center;">
       <div class="inv-ribbon right"></div><div class="inv-ribbon left"></div>
       <header class="inv-logos">
         ${['education','taasiyeda','school'].map((k) => `<div class="inv-logo-slot ${s.logos[k] ? 'has-logo' : ''}"><span>${k === 'education' ? 'משרד החינוך' : k === 'taasiyeda' ? 'תעשיידע' : 'בית הספר'}</span>${s.logos[k] ? `<img src="${s.logos[k]}" alt="${k}"/>` : '<img alt=""/>'}</div>`).join('')}
@@ -100,7 +102,7 @@ function invitationPreviewHtml(s) {
         <div class="inv-participants"><strong>בהשתתפות:</strong><br>${(s.participants || tpl.participants || 'משתתפים / נציגים').replace(/\n/g, '<br>')}</div>
         <div class="inv-closing">${s.closing || tpl.closing || 'נשמח לראותכם!'}</div>
       </section>
-    </article>`;
+    </article></div>`;
 }
 
 export const invitationsScreen = {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 414;
+const CACHE_VERSION = 415;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 414;
+const SW_ENTRY_VERSION = 415;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The Invitations preview on the dashboard was clipped at the top and did not show the full A4 page, so the preview wrapper and scrolling needed to be adjusted while preserving the existing render/print behavior. 
- The preview should fit inside the dashboard with an optional screen-only scale while keeping print/PDF output as a true single A4 page. 
- Service Worker cache version needed bumping so updated CSS/JS are invalidated by PWA clients after deploy. 

### Description
- Updated `frontend/src/screens/invitations.js` to move scrolling to the outer preview container (`.inv-preview-wrap`), add a centered internal stage wrapper (`.inv-a4-stage`), and wrap the A4 `article` inside that stage so the A4 page renders top-to-bottom without clipping. 
- Added `transform`-based scaling via responsive media queries for screen view only and added print rules to disable scaling and ensure `width:210mm;height:297mm` for true A4 output. 
- Preserved and verified existing logo/background upload controls and the print/PDF button (`data-logo-upload`, `data-background-upload`, `data-print`) without changing text/templates. 
- Bumped SW cache version in `frontend/sw.js` and the root SW entry `sw.js` (`CACHE_VERSION` / `SW_ENTRY_VERSION` -> `415`) so the service worker will purge old caches after this deploy. 

### Testing
- Ran `npm run build` which completed successfully and produced the production assets (build warnings only for large chunk sizes). 
- Ran `node --test tests/service-worker-pwa-cache.test.mjs` and all tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f94e4395c832baa3f99d8d3511815)