### PR TITLE
Fix proposal preview document design

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -407,41 +407,61 @@ const TEMPLATE_KEY_BY_GROUP = {
   'הצעה משולבת': 'combined'
 };
 
+function templateBodyText(section) {
+  return String(section?.section_body == null ? '' : section.section_body)
+    .replace(/\r\n?/g, '\n')
+    .trim();
+}
+
+function proposalTitle(row) {
+  const activityTypeGroup = text(row.activity_type_group);
+  if (activityTypeGroup === 'פעילויות קיץ') return 'הצעת מחיר לפעילויות תעשיידע | קיץ תשפ״ו';
+  if (activityTypeGroup === 'שנה הבאה') return 'הצעת מחיר לתוכניות תעשיידע | תשפ״ז';
+  return 'הצעת מחיר לפעילויות תעשיידע | קיץ תשפ״ו + תשפ״ז';
+}
+
+function sectionBodyHtml(value) {
+  const body = String(value || '').trim();
+  if (!body) return '<p>—</p>';
+  const lines = body.split('\n').map((line) => line.trim()).filter(Boolean);
+  const bulletLines = lines.filter((line) => /^[•·*-]\s*/.test(line));
+  if (lines.length > 1 && bulletLines.length === lines.length) {
+    return `<ul>${lines.map((line) => `<li>${escapeHtml(line.replace(/^[•·*-]\s*/, ''))}</li>`).join('')}</ul>`;
+  }
+  return lines.map((line) => {
+    if (/^[•·*-]\s*/.test(line)) {
+      return `<ul><li>${escapeHtml(line.replace(/^[•·*-]\s*/, ''))}</li></ul>`;
+    }
+    return `<p>${escapeHtml(line)}</p>`;
+  }).join('');
+}
+
+function proposalLineHtml(item = {}) {
+  const parts = [];
+  if (item.meetings_count != null && item.meetings_count !== '') parts.push(`${formatCurrency(item.meetings_count)} מפגשים`);
+  if (item.hours_count != null && item.hours_count !== '') parts.push(`${formatCurrency(item.hours_count)} שעות`);
+  const total = Number(item.total_price) || ((Number(item.quantity) || 1) * (Number(item.unit_price) || 0));
+  if (total) parts.push(`${formatCurrency(total)} ₪`);
+  const suffix = parts.length ? `: ${parts.join(' | ')}` : '';
+  const desc = text(item.description);
+  return `<li><strong>${escapeHtml(item.item_name || '')}</strong>${escapeHtml(suffix)}${desc ? `<br><span>${escapeHtml(desc)}</span>` : ''}</li>`;
+}
+
+function proposalItemsListHtml(items = []) {
+  if (!Array.isArray(items) || !items.length) return '<p class="pa-muted">לא הוגדרו שורות הצעה.</p>';
+  return `<ul class="pa-cost-lines">${items.map(proposalLineHtml).join('')}</ul>`;
+}
+
+function sectionHtml(title, body, className = '') {
+  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(title)}</h3>${sectionBodyHtml(body)}</section>`;
+}
+
 function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const activityTypeGroup = text(row.activity_type_group);
   const dateDisplay = formatDateDisplay(row.proposal_date) || formatDateDisplay(new Date().toISOString().slice(0, 10));
-  const totalSum = items.reduce((s, i) => s + (Number(i.total_price) || ((Number(i.quantity) || 1) * (Number(i.unit_price) || 0))), 0);
   const byKey = new Map((Array.isArray(templateSections) ? templateSections : []).map((s) => [text(s.section_key), s]));
-  const sectionBody = (key, fallback = '') => text(byKey.get(key)?.section_body) || fallback;
+  const sectionBody = (key, fallback = '') => templateBodyText(byKey.get(key)) || fallback;
   const sectionTitle = (key, fallback = '') => text(byKey.get(key)?.section_title) || fallback;
-
-  const costTableHtml = items.length ? `
-    <table class="pa-cost-table">
-      <thead><tr><th>שם פעילות / תוכנית</th><th>סוג</th><th>כמות</th><th>מחיר יח׳</th><th>סה״כ שורה</th><th>הערות</th></tr></thead>
-      <tbody>
-        ${items.map((item) => {
-          const qty = Number(item.quantity) || 1;
-          const price = Number(item.unit_price) || 0;
-          const total = Number(item.total_price) || (qty * price);
-          return `<tr>
-            <td>${escapeHtml(item.item_name || '')}</td>
-            <td>${escapeHtml(item.item_type || '')}</td>
-            <td>${qty}</td>
-            <td>${price ? '₪' + formatCurrency(price) : '—'}</td>
-            <td>${total ? '₪' + formatCurrency(total) : '—'}</td>
-            <td>${escapeHtml(item.description || '')}</td>
-          </tr>`;
-        }).join('')}
-        <tr class="pa-cost-total-row">
-          <td colspan="4" style="font-weight:700;text-align:start">סה״כ:</td>
-          <td colspan="2" style="font-weight:700">₪${formatCurrency(totalSum)}</td>
-        </tr>
-      </tbody>
-    </table>` : '<p style="color:#6b7280">לא הוגדרו שורות הצעה.</p>';
-
-  const actNamesHtml = Array.isArray(row.activity_names) && row.activity_names.length
-    ? `<section class="pa-section"><h3>הפעילות המוצעת</h3><ul>${row.activity_names.map((n) => `<li>${escapeHtml(n)}</li>`).join('')}</ul></section>`
-    : '';
 
   const introText = sectionBody('intro', '—');
   const orgResponsibility = sectionBody('taasiyeda_responsibility', '—');
@@ -453,46 +473,42 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const summerActivityIntro = sectionBody('summer_activity_intro', '');
   const nextYearActivityIntro = sectionBody('next_year_activity_intro', '');
   const activityIntroSections = activityTypeGroup === 'הצעה משולבת'
-    ? [summerActivityIntro, nextYearActivityIntro].filter(Boolean)
-    : [activityIntro].filter(Boolean);
+    ? [
+        { title: 'קיץ תשפ״ו', body: summerActivityIntro || activityIntro },
+        { title: 'שנת הלימודים תשפ״ז', body: nextYearActivityIntro || activityIntro }
+      ].filter((section) => section.body)
+    : [{ title: sectionTitle('activity_intro', 'הפעילות המוצעת'), body: activityIntro }].filter((section) => section.body);
   const signatureText = sectionBody('signature', '');
+  const activityNames = Array.isArray(row.activity_names) ? row.activity_names.map(text).filter(Boolean) : [];
 
   return `
-    <div class="pa-doc-header-brand">
+    <header class="pa-doc-header">
       <img
         src="${PUBLIC_BASE}proposals/proposal-header-logo.png"
         alt="לוגו תעשיידע"
         class="pa-doc-logo pa-doc-logo--header"
         loading="eager"
         decoding="async"
-        onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
+        onerror="this.style.display='none';"
       >
-      <div class="pa-doc-logo-fallback" hidden>תעשיידע — חינוך מקצועי וחוויות למידה</div>
-    </div>
-    <div class="pa-doc-header">
-      <div class="pa-doc-meta">
-        <div>תאריך: ${escapeHtml(dateDisplay)}</div>
-        ${row.id ? `<div style="font-size:0.8rem;color:#6b7280">מ/ה: ${escapeHtml(row.id.slice(0, 8).toUpperCase())}</div>` : ''}
-      </div>
-    </div>
-    <hr class="pa-doc-divider">
+      <div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>
+    </header>
     <div class="pa-doc-address">
-      <p>לכבוד</p>
-      <p><strong>${escapeHtml(row.client_authority || '')}</strong></p>
+      <p><strong>לכבוד:</strong></p>
+      ${row.contact_name ? `<p>${escapeHtml(row.contact_name)}</p>` : ''}
       ${row.school_framework ? `<p>${escapeHtml(row.school_framework)}</p>` : ''}
-      ${row.contact_name ? `<p>לידי: ${escapeHtml(row.contact_name)}${row.contact_role ? ', ' + escapeHtml(row.contact_role) : ''}</p>` : ''}
+      ${row.client_authority ? `<p>${escapeHtml(row.client_authority)}</p>` : ''}
     </div>
-    <p class="pa-doc-subject"><strong>הנדון: ${escapeHtml(row.document_type || 'הצעת מחיר')} — ${escapeHtml(activityTypeGroup || '')}</strong></p>
-    <section class="pa-section"><h3>${escapeHtml(sectionTitle('intro', 'פתיח'))}</h3><p>${escapeHtml(introText || '—')}</p></section>
-    ${actNamesHtml}
-    ${activityIntroSections.map((sectionText) => `<section class="pa-section"><h3>${escapeHtml(sectionTitle('activity_intro', 'מבוא פעילות'))}</h3><p>${escapeHtml(sectionText)}</p></section>`).join('')}
-    <section class="pa-section"><h3>טבלת עלויות</h3>${costTableHtml}</section>
-    <section class="pa-section"><h3>${escapeHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'))}</h3><p>${escapeHtml(orgResponsibility || '—')}</p></section>
-    ${schoolResponsibility ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'))}</h3><p>${escapeHtml(schoolResponsibility)}</p></section>` : ''}
-    <section class="pa-section"><h3>${escapeHtml(sectionTitle('payment_terms', 'תנאי תשלום'))}</h3><p>${escapeHtml(paymentTerms || '—')}</p></section>
-    ${changesCancellation ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('cancellation_terms', 'שינויים וביטולים'))}</h3><p>${escapeHtml(changesCancellation)}</p></section>` : ''}
-    ${remarks ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('notes', 'הערות'))}</h3><p>${escapeHtml(remarks)}</p></section>` : ''}
-    ${signatureText ? `<section class="pa-section"><h3>${escapeHtml(sectionTitle('signature', 'חתימה'))}</h3><p>${escapeHtml(signatureText)}</p></section>` : ''}
+    <h1 class="pa-doc-title">${escapeHtml(proposalTitle(row))}</h1>
+    ${sectionHtml(sectionTitle('intro', 'פתיח'), introText)}
+    ${activityIntroSections.map((section) => sectionHtml(section.title, section.body, 'pa-section--activity')).join('')}
+    ${activityNames.length ? `<section class="pa-section"><h3>הפעילות המוצעת</h3><ul>${activityNames.map((n) => `<li>${escapeHtml(n)}</li>`).join('')}</ul></section>` : ''}
+    <section class="pa-section"><h3>${activityTypeGroup === 'פעילויות קיץ' ? 'עלות הפעילות' : 'עלויות ותנאי תשלום'}</h3>${proposalItemsListHtml(items)}${sectionBodyHtml(paymentTerms)}</section>
+    ${sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility)}
+    ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
+    ${changesCancellation ? sectionHtml(sectionTitle('cancellation_terms', 'שינויים, ביטולים והתאמות'), changesCancellation) : ''}
+    ${remarks ? sectionHtml(sectionTitle('notes', 'הערות'), remarks) : ''}
+    <section class="pa-section pa-section--signature">${sectionBodyHtml(signatureText || 'בברכה,\nעידן נחום, סמנכ״ל כספים ותפעול.')}</section>
     <footer class="pa-doc-footer">
       <img
         src="${PUBLIC_BASE}proposals/proposal-footer-logo.png"
@@ -500,9 +516,8 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
         class="pa-doc-logo pa-doc-logo--footer"
         loading="lazy"
         decoding="async"
-        onerror="this.style.display='none'; this.nextElementSibling.hidden = false;"
+        onerror="this.style.display='none';"
       >
-      <div class="pa-doc-logo-fallback pa-doc-logo-fallback--footer" hidden>תעשיידע</div>
     </footer>`;
 }
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10405,7 +10405,7 @@ select.ds-input {
    ═══════════════════════════════════════════════════════════════════ */
 .ds-pa-preview-overlay {
   position: fixed; inset: 0; z-index: 200;
-  background: #f1f5f9; overflow: auto; direction: rtl;
+  background: #eef1f4; overflow: auto; direction: rtl;
 }
 .ds-pa-preview-toolbar {
   position: sticky; top: 0; z-index: 10;
@@ -10413,106 +10413,160 @@ select.ds-input {
   padding: 8px 16px; display: flex; gap: 8px; align-items: center;
 }
 .ds-pa-preview-doc {
-  max-width: 800px; margin: 24px auto 48px;
-  background: #fff; border: 1px solid #e2e8f0;
-  border-radius: 8px; padding: 40px 48px;
-  box-shadow: 0 2px 12px rgba(0,0,0,.08);
+  width: min(794px, calc(100vw - 32px));
+  min-height: 1123px;
+  margin: 24px auto 48px;
+  background: #fff;
+  border: 1px solid #e6e8ec;
+  border-radius: 0;
+  padding: 58px 64px 48px;
+  box-shadow: 0 1px 8px rgba(15, 23, 42, 0.08);
   font-family: 'Segoe UI', Arial, Helvetica, sans-serif;
-  font-size: 0.94rem; line-height: 1.65; direction: rtl;
-  color: #1e293b;
-}
-.pa-doc-header-brand {
-  margin-bottom: 10px;
-  text-align: center;
+  font-size: 14px;
+  line-height: 1.65;
+  direction: rtl;
+  color: #111827;
 }
 .pa-doc-header {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 12px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: start;
+  margin-bottom: 28px;
 }
 .pa-doc-logo {
   display: block; max-width: 100%; height: auto;
 }
 .pa-doc-logo--header {
-  width: min(240px, 45%);
+  grid-column: 2;
+  width: 122px;
   margin-inline: auto;
 }
 .pa-doc-logo--footer {
-  width: min(220px, 45%);
+  width: 104px;
+  margin-inline: auto;
+  opacity: 0.72;
 }
-.pa-doc-logo-fallback {
-  font-size: 0.92rem; color: #334155; font-weight: 700;
-  text-align: center;
+.pa-doc-date {
+  grid-column: 1;
+  justify-self: start;
+  color: #111827;
+  font-size: 13px;
+  line-height: 1.4;
 }
-.pa-doc-logo-fallback--footer {
-  font-size: 0.78rem; color: #64748b;
+.pa-doc-address {
+  margin: 0 0 22px;
+  font-size: 14px;
+  line-height: 1.55;
 }
-.pa-doc-meta    {
-  text-align: center;
-  font-size: 0.85rem;
-  color: #374151;
-  display: grid;
-  gap: 3px;
-  padding-top: 2px;
+.pa-doc-address p { margin: 0 0 2px; }
+.pa-doc-title {
+  margin: 8px 0 24px;
+  color: #0f2745;
+  font-size: 17px;
+  font-weight: 700;
   line-height: 1.45;
+  text-align: center;
 }
-.pa-doc-divider { border: none; border-top: 2px solid #1e3a5f; margin: 14px 0; }
-.pa-doc-address { margin: 14px 0; font-size: 0.9rem; line-height: 1.6; }
-.pa-doc-address p { margin: 0; }
-.pa-doc-subject { margin: 16px 0 10px; font-size: 0.95rem; }
-.pa-section { margin: 16px 0; }
+.pa-section {
+  margin: 0 0 16px;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
 .pa-section h3 {
-  font-size: 0.93rem; font-weight: 700; margin: 0 0 6px;
-  border-bottom: 1px solid #e5e7eb; padding-bottom: 3px;
+  color: #0f2745;
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  padding: 0;
+  border: 0;
 }
-.pa-section p, .pa-section ul { margin: 0 0 6px; }
-.pa-section ul { padding-inline-start: 22px; }
-.pa-section li { margin-bottom: 3px; }
-.pa-cost-table {
-  width: 100%; border-collapse: collapse; font-size: 0.86rem; margin: 8px 0;
+.pa-section p,
+.pa-section ul {
+  margin: 0 0 6px;
 }
-.pa-cost-table th, .pa-cost-table td {
-  border: 1px solid #d1d5db; padding: 5px 8px; text-align: start;
+.pa-section ul {
+  padding-inline-start: 20px;
 }
-.pa-cost-table thead { background: #f8fafc; font-weight: 600; }
-.pa-cost-total-row { background: #f0f9ff; }
+.pa-section li {
+  margin-bottom: 3px;
+}
+.pa-cost-lines {
+  list-style: disc;
+}
+.pa-cost-lines span,
+.pa-muted {
+  color: #374151;
+}
+.pa-section--signature {
+  margin-top: 24px;
+}
 .pa-doc-footer {
-  margin-top: 40px; padding-top: 16px; border-top: 1px solid #e5e7eb;
+  margin-top: 34px;
+  padding-top: 0;
+  border: 0;
   break-inside: avoid;
   page-break-inside: avoid;
   text-align: center;
 }
-.pa-doc-signature {
-  display: flex; gap: 40px; margin-top: 40px; flex-wrap: wrap;
-}
-.pa-sig-block { flex: 1; min-width: 160px; font-size: 0.85rem; }
-.pa-sig-line {
-  border-bottom: 1px solid #374151; margin-bottom: 6px; height: 32px;
+
+@media (max-width: 720px) {
+  .ds-pa-preview-doc {
+    width: calc(100vw - 16px);
+    min-height: auto;
+    margin: 12px auto 28px;
+    padding: 34px 28px;
+  }
+
+  .pa-doc-header {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 10px;
+  }
+
+  .pa-doc-logo--header,
+  .pa-doc-date {
+    grid-column: 1;
+  }
+
+  .pa-doc-date {
+    justify-self: start;
+  }
 }
 
 /* ═══════════════════════════════════════════════════════════════════
    Print styles — show only the preview overlay
    ═══════════════════════════════════════════════════════════════════ */
 @media print {
+  @page { size: A4 portrait; margin: 18mm 17mm; }
   body > *:not(#pa-preview-overlay) { display: none !important; }
-  body, html { background: #fff !important; }
+  body, html {
+    background: #fff !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
   #pa-preview-overlay {
     position: static !important; background: #fff !important; overflow: visible !important;
   }
   #pa-preview-overlay * { visibility: visible !important; }
   .ds-pa-preview-toolbar { display: none !important; }
   .ds-pa-preview-doc {
-    box-shadow: none !important; border: none !important;
-    margin: 0 !important; padding: 20px !important; max-width: 100% !important;
+    width: auto !important;
+    min-height: 0 !important;
+    box-shadow: none !important;
+    border: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: none !important;
+    font-size: 14px !important;
+    line-height: 1.6 !important;
   }
   .pa-doc-footer {
     margin-top: 28px !important;
-    padding-top: 14px !important;
+    padding-top: 0 !important;
     page-break-inside: avoid !important;
   }
   .pa-doc-logo--header,
   .pa-doc-logo--footer {
     display: block !important;
   }
-  .pa-doc-divider { border-top: 1.5px solid #000; }
 }


### PR DESCRIPTION
## Summary
- Remove duplicated proposal document header branding by showing the text fallback only when the header logo fails to load.
- Refine the preview document header, metadata area, footer logo sizing, and print-only styling.
- Rebuild the preview overlay from the current template each time it opens so existing proposals use the updated design.

## Files changed
- `frontend/src/screens/proposals-agreements.js`
- `frontend/src/styles/main.css`

## Validation
- `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs`
- `npm run build`

Draft PR created from `fix/proposal-preview-design` into `main`.