### PR TITLE
Auto-complete past meetings & dedupe date chips; bump service worker cache

### DIFF
--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -44,8 +44,14 @@ function todayStr() {
 }
 
 function countDoneMeetings(schedule) {
+  const today = todayStr();
   return Array.isArray(schedule)
-    ? schedule.filter((m) => String(m?.performed || '').trim().toLowerCase() === 'yes').length
+    ? schedule.filter((m) => {
+      const performed = String(m?.performed || '').trim().toLowerCase() === 'yes';
+      const date = String(m?.date || '').trim();
+      const autoDoneByDate = /^\d{4}-\d{2}-\d{2}$/.test(date) && date < today;
+      return performed || autoDoneByDate;
+    }).length
     : 0;
 }
 
@@ -459,12 +465,28 @@ function blockSupplementalView(row, { settings = {}, hideFunding = false } = {})
 }
 
 function buildDateChipsHtml(schedule, isOnce) {
-  return (isOnce ? schedule.slice(0, 1) : schedule)
-    .map((item) => {
-      const isDone = String(item?.performed || '').toLowerCase() === 'yes';
+  const source = isOnce ? schedule.slice(0, 1) : schedule;
+  const grouped = source.reduce((acc, item) => {
+    const date = String(item?.date || '').trim();
+    const key = date || '__empty__';
+    if (!acc.has(key)) {
+      acc.set(key, { item, count: 0, doneCount: 0 });
+    }
+    const entry = acc.get(key);
+    entry.count += 1;
+    const performed = String(item?.performed || '').toLowerCase() === 'yes';
+    const autoDoneByDate = /^\d{4}-\d{2}-\d{2}$/.test(date) && date < todayStr();
+    if (performed || autoDoneByDate) entry.doneCount += 1;
+    return acc;
+  }, new Map());
+
+  return Array.from(grouped.values())
+    .map(({ item, count, doneCount }) => {
+      const isDone = doneCount > 0;
+      const countLabel = count > 1 ? ` · ${count} מפגשים` : '';
       return `
         <div class="activity-drawer__date-chip ${isDone ? 'is-done' : ''}" data-date-card>
-          <span>${escapeHtml(formatDateHeWithWeekday(item?.date || ''))}</span>
+          <span>${escapeHtml(`${formatDateHeWithWeekday(item?.date || '')}${countLabel}`)}</span>
         </div>
       `;
     })

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 415;
+const CACHE_VERSION = 416;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 415;
+const SW_ENTRY_VERSION = 416;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -208,6 +208,13 @@ test('activity drawer uses instructor emp_id fallback for display consistency', 
   assert.match(source, /resolveInstructorDisplayName\(row\.instructor_name,\s*row\.emp_id,\s*instructorLookup\)/);
 });
 
+test('activity drawer progress auto-counts past dates and groups duplicate dates in view chips', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/screens/shared/activity-detail-html.js', import.meta.url), 'utf8');
+  assert.match(source, /const autoDoneByDate = \/\^\\d\{4\}-\\d\{2\}-\\d\{2\}\$\/\.test\(date\) && date < today/);
+  assert.match(source, /const countLabel = count > 1 \? ` · \$\{count\} מפגשים` : '';/);
+});
+
 
 test('admin all-activities Excel export is imported and logs failures', async () => {
   const fs = await import('node:fs/promises');


### PR DESCRIPTION
### Motivation
- Fix activity progress showing `0 מתוך X` when meeting dates have already passed but were not marked performed, and remove confusing duplicate date chips when multiple meetings share the same date.
- Ensure clients pick up the updated frontend behavior by bumping the Service Worker cache version.

### Description
- Change meeting completion logic in `frontend/src/screens/shared/activity-detail-html.js` so `countDoneMeetings` treats a meeting as done when `performed === 'yes'` OR the meeting `date` is before today (`autoDoneByDate`).
- Replace repeated date chips with grouped chips in `buildDateChipsHtml`, showing a single chip per date and a count label like ` · 2 מפגשים` when multiple meetings share that date.
- Bump Service Worker versions by updating `CACHE_VERSION` in `frontend/sw.js` and `SW_ENTRY_VERSION` in `sw.js` to force cache refresh on clients.
- Add a regression test in `tests/activities-screen.test.mjs` that asserts the presence of the auto-complete-by-date logic and the grouped-date count label.

### Testing
- Ran the targeted tests with `node --test tests/activities-screen.test.mjs tests/service-worker-pwa-cache.test.mjs`, where the new/modified tests and service worker tests passed and validated the changes, while one pre-existing unrelated test (`activities render: operation_manager sees add activity button`) still fails.
- Also executed `npm test -- tests/activities-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` (broader suite); affected tests ran but unrelated baseline failures remain in other areas of the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb93745f4832b8f43b0ad301bf835)