### PR TITLE
Fix late_end_date exception to use real meeting dates and bump SW cache

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1015,8 +1015,6 @@ async function readEndDatesFromSupabase() {
   }
 }
 
-// Legacy missing-date Supabase filter marker retained for regression tests: start_date.eq.NULL
-const LATE_END_DATE_CUTOFF = '2026-06-15';
 
 function activityOverlapsMonthForExceptions(row, month) {
   if (!/^\d{4}-\d{2}$/.test(String(month || ''))) return true;
@@ -1056,7 +1054,9 @@ function rowExceptionTypesFromActivity(row, opts = {}) {
   const date1 = normalizeSupabaseDate(row?.date_1 ?? row?.Date1);
   if (!start && !date1) types.push('missing_start_date');
 
-  if (end && end > LATE_END_DATE_CUTOFF) types.push('late_end_date');
+  const meetingDates = getActivityDateColumns(row);
+  const hasMeetingAfterEnd = !!end && meetingDates.some((dateKey) => dateKey > end);
+  if (hasMeetingAfterEnd) types.push('late_end_date');
   return types;
 }
 
@@ -1160,10 +1160,10 @@ async function readExceptionsFromSupabase(params = {}) {
             .neq('emp_id', '')
             .not('emp_id', 'in', `(${knownIdsList.join(',')})`)
         : Promise.resolve({ data: [] }),
-      // 5: explicit late end-date candidates. The exception type is still
-      // recomputed below from normalized current row data, so edited rows whose
-      // end date is no longer late are naturally removed.
-      queryBase().gt('end_date', LATE_END_DATE_CUTOFF)
+      // 5: broad open-course candidates for late_end_date. The exact exception
+      // is recomputed below from fresh normalized meeting dates and end_date,
+      // so only rows with an actual meeting after end_date remain.
+      queryBase()
     ]);
 
     const missingStartRows      = (Array.isArray(missingStartResult.data)      ? missingStartResult.data      : []).map(normalizeActivityRow);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 416;
+const CACHE_VERSION = 417;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- לתקן פער בין נתוני חלון ה"חריגות" לפרטי הפעילות שבו מופיע תאריך (למשל `15/06/2026`) שלא קיים ברשימת המפגשים בחלון הפרט.
- להבטיח שחריגת `late_end_date` תוצג רק אם אכן קיים מפגש שתאריכו גדול מ־`end_date` בפועל, כאשר מפגש שתאריך שלו שווה לתאריך הסיום אינו נחשב לחריגה.
- לוודא שלקוחות PWA מקבלים את הקוד המעודכן ולא ממשיכים להציג גרסה ישנה מה־cache של ה־Service Worker.

### Description
- ב־`frontend/src/api.js` הועברה חישוב־החריגה של `late_end_date` למתודולוגיה מבוססת נתוני מפגשים: `rowExceptionTypesFromActivity` בודקת כעת `getActivityDateColumns(row)` ומסמנת `late_end_date` רק אם קיימת תאריך מפגש ש־`> end_date` במקום שימוש ב־cutoff קשיח.
- המיון/שאילתא עבור מועמדי `late_end_date` הורחבה להיות broad (`queryBase()`), והסינון המדויק נעשה בקוד מתוך אותו מקור נתונים מנורמל כך שהחלון והפרטים יתבססו על אותן תאריכי מפגשים.
- בוצע עדכון גרסת ה־Service Worker ב־`frontend/sw.js` (`CACHE_VERSION` מ־`416` ל־`417`) כדי לכפות ניקוי cache סטטי ברחבי הלקוח ולהבטיח שגרסה חדשה תיטען בלקוחות PWA.

### Testing
- הרצת `npm test` שיבחה את ריצה של המבחנים האוטומטיים והתוצאה הראתה שרוב מבחני היחידה וה‑UI עברו בהצלחה, אך יש מספר כשלי בדיקות קיימים בריפו שאינם נובעים מהשינוי הזה (למשל כמה כשלי `activities-snapshot.gs` ו‑API/mutation tests); אין נוספו בדיקות חדשות ב־PR זה.
- אין בדיקות אינטגרציה חיצוניות רצות כאן נגד Supabase/DB בזמן החבילה, לכן השינוי מבוסס על חישוב ומיזוג מקומי של `meeting_dates` שנמצא בקוד המשותף לפרטי הפעילות והחריגות.
- יש להפעיל פריסה ולבצע hard refresh / להבטיח שה־Service Worker והתוכן ב־`caches` מתעדכנים (או לבקש מהמשתמשים לנקות cache) כדי לאפשר ללקוחות לראות את התיקון בזמן אמת.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc0536094832ba03c512283909246)