### PR TITLE
Fix invitation printing by cloning to isolated print root + bump SW cache version

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 415;
+const CACHE_VERSION = 418;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CVlUjPpJ.js",
+  "./assets/index-DyWFjVIl.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-8sMRWaf6.css",
+  "./assets/style-X3ypGff7.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CVlUjPpJ.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-8sMRWaf6.css">
+  <script type="module" crossorigin src="./assets/index-DyWFjVIl.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-X3ypGff7.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 415;
+const CACHE_VERSION = 418;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CVlUjPpJ.js",
+  "./assets/index-DyWFjVIl.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-8sMRWaf6.css",
+  "./assets/style-X3ypGff7.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -58,8 +58,9 @@ function ensureInvitationStyles() {
     @page{size:A4 portrait;margin:0}
     html,body{width:210mm!important;height:297mm!important;margin:0!important;padding:0!important;overflow:hidden!important;background:white!important}
     body.printing-invitation *{visibility:hidden!important}
-    body.printing-invitation .invitation-print-page,body.printing-invitation .invitation-print-page *{visibility:visible!important}
-    .invitation-print-page{
+    body.printing-invitation #print-root,body.printing-invitation #print-root *{visibility:visible!important}
+    #print-root{position:fixed!important;inset:0!important;display:flex!important;align-items:flex-start!important;justify-content:center!important;overflow:hidden!important;background:white!important;z-index:2147483647!important}
+    #print-root .invitation-print-page{
       position:fixed!important;
       top:0!important;
       right:0!important;
@@ -82,7 +83,7 @@ function ensureInvitationStyles() {
       -webkit-print-color-adjust:exact!important;
       print-color-adjust:exact!important
     }
-    .invitation-preview-viewport,.invitation-preview-scale,.invitation-preview-wrapper{
+    #print-root .invitation-preview-viewport,#print-root .invitation-preview-scale,#print-root .invitation-preview-wrapper{
       transform:none!important;
       scale:none!important;
       overflow:visible!important
@@ -118,15 +119,37 @@ export const invitationsScreen = { load: async () => ({}), render() { ensureInvi
     host.querySelector('[data-background-preset]')?.addEventListener('change', (e) => { state.backgroundCss = PRESET_BACKGROUNDS[e.target.value] || PRESET_BACKGROUNDS.soft; state.hasBackground = true; repaint(); });
     host.querySelector('[data-background-upload]')?.addEventListener('change', (e) => { const file = e.target.files?.[0]; if (!file) return; const r = new FileReader(); r.onload = () => { state.backgroundCss = `url('${r.result}')`; state.hasBackground = true; repaint(); }; r.readAsDataURL(file); });
     host.querySelectorAll('[data-logo-upload]').forEach((i) => i.addEventListener('change', (e) => { const k = e.target.dataset.logoUpload; const f = e.target.files?.[0]; if (!k || !f) return; const r = new FileReader(); r.onload = () => { state.logos[k] = String(r.result || ''); repaint(); }; r.readAsDataURL(f); }));
+    const ensurePrintRoot = () => {
+      let printRoot = document.getElementById('print-root');
+      if (!printRoot) {
+        printRoot = document.createElement('div');
+        printRoot.id = 'print-root';
+        document.body.appendChild(printRoot);
+      }
+      return printRoot;
+    };
+    const cleanupPrintRoot = () => {
+      const printRoot = document.getElementById('print-root');
+      if (printRoot) printRoot.innerHTML = '';
+      document.body.classList.remove('printing-invitation');
+    };
     host.querySelector('[data-print]')?.addEventListener('click', () => {
       if (!state.course || !state.type) return;
+      const sourcePage = host.querySelector('.invitation-print-page');
+      if (!sourcePage) return;
+      const printRoot = ensurePrintRoot();
+      printRoot.innerHTML = '';
+      const clonedPage = sourcePage.cloneNode(true);
+      clonedPage.removeAttribute('id');
+      clonedPage.style.transform = 'none';
+      clonedPage.style.scale = 'none';
+      printRoot.appendChild(clonedPage);
       document.body.classList.add('printing-invitation');
       const cleanup = () => {
-        document.body.classList.remove('printing-invitation');
+        cleanupPrintRoot();
         window.removeEventListener('afterprint', cleanup);
       };
-      window.addEventListener('afterprint', cleanup);
+      window.addEventListener('afterprint', cleanup, { once: true });
       window.print();
-      setTimeout(cleanup, 1200);
     }); window.addEventListener('resize', repaint); repaint(); }
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 417;
+const CACHE_VERSION = 418;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 416;
+const SW_ENTRY_VERSION = 418;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Printing an invitation from inside the dashboard preview produced a white page because `@media print` hid the main `body` and the preview structure produced an unstable print preview. 
- The change isolates the printed content into an independent print root so `window.print()` renders a single clean A4 page without sidebars, transforms or stale cached assets.

### Description
- Added a dynamic `div#print-root` and helper functions `ensurePrintRoot` / `cleanupPrintRoot` used during the print flow. 
- Replaced direct printing from the preview with a handler that finds `.invitation-print-page`, clones it via `cloneNode(true)`, strips the `id`, forces `transform/scale` to `none`, appends the clone to `#print-root`, adds `body.classList.add('printing-invitation')`, and calls `window.print()` with an `afterprint` cleanup registered (`once: true`).
- Updated `@media print` CSS to hide all content and reveal only `#print-root` and its descendants, enforce A4 sizing, and disable any transforms/scales for the printed clone. 
- Bumped service worker versions (`SW_ENTRY_VERSION` / `CACHE_VERSION`) and updated precache entries to ensure PWA/SW cache invalidation after deploy; updated build outputs reference the new hashed asset names.

### Testing
- Ran `npm run build` which completed successfully. 
- Ran `node --test tests/service-worker-pwa-cache.test.mjs` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc4b1c588832bb9188e007b9d2197)