### PR TITLE
Use settings `late_end_date_threshold` to compute late_end_date exceptions

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1036,6 +1036,7 @@ function activityOverlapsMonthForExceptions(row, month) {
 function rowExceptionTypesFromActivity(row, opts = {}) {
   const types = [];
   const knownIds    = opts.knownInstructorIds; // Set<string> | undefined
+  const lateEndThreshold = normalizeSupabaseDate(opts.lateEndDateThreshold);
   const emp1        = nullStr(row?.emp_id);
   const emp2        = nullStr(row?.emp_id_2);
   const instructorName = resolveActivityInstructorName(row);
@@ -1055,8 +1056,17 @@ function rowExceptionTypesFromActivity(row, opts = {}) {
   if (!start && !date1) types.push('missing_start_date');
 
   const meetingDates = getActivityDateColumns(row);
-  const hasMeetingAfterEnd = !!end && meetingDates.some((dateKey) => dateKey > end);
-  if (hasMeetingAfterEnd) types.push('late_end_date');
+  const lateMeetingDates = lateEndThreshold
+    ? meetingDates.filter((dateKey) => dateKey > lateEndThreshold)
+    : [];
+  if (lateMeetingDates.length > 0) {
+    types.push('late_end_date');
+    row._late_end_date_threshold = lateEndThreshold;
+    row._late_end_date_hits = lateMeetingDates;
+  } else {
+    row._late_end_date_threshold = lateEndThreshold || '';
+    row._late_end_date_hits = [];
+  }
   return types;
 }
 
@@ -1071,7 +1081,10 @@ function buildExceptionsModelFromRows(activityRows = [], month = '', opts = {}) 
     if (isActivityClosed(row)) continue;
     if (rowActivityType(row) !== 'course') continue;
     if (!activityOverlapsMonthForExceptions(row, month)) continue;
-    const types = rowExceptionTypesFromActivity(row, { knownInstructorIds });
+    const types = rowExceptionTypesFromActivity(row, {
+      knownInstructorIds,
+      lateEndDateThreshold: opts.lateEndDateThreshold
+    });
     if (!types.length) continue;
     const manager = cleanActivityManagerName(row?.activity_manager) || NO_ACTIVITY_MANAGER_LABEL;
     byManager[manager] = (byManager[manager] || 0) + 1;
@@ -1107,6 +1120,11 @@ async function readExceptionsFromSupabase(params = {}) {
   const COURSE_TYPE_VALUES = ['course', 'קורס', 'קורסים'];
   try {
     const range = monthDateRange(month);
+    const settingsPromise = supabase
+      .from('settings')
+      .select('key,value')
+      .eq('key', 'late_end_date_threshold')
+      .maybeSingle();
 
     // Query 1: courses active in the chosen month (date-range based)
     const dateRangeRowsRaw = await selectActivitiesByDateRangeFromSupabase({
@@ -1138,7 +1156,7 @@ async function readExceptionsFromSupabase(params = {}) {
 
     const knownIdsList = [...knownInstructorIds];
 
-    const [missingStartResult, missingInstructorResult, invalidInstructorResult, lateEndDateResult] = await Promise.all([
+    const [missingStartResult, missingInstructorResult, invalidInstructorResult, lateEndDateResult, lateEndThresholdResult] = await Promise.all([
       // 2: broad missing-start candidates. This query is intentionally
       // not constrained by month: undated courses must stay visible as
       // missing_start_date exceptions even while a month filter is active.
@@ -1161,10 +1179,19 @@ async function readExceptionsFromSupabase(params = {}) {
             .not('emp_id', 'in', `(${knownIdsList.join(',')})`)
         : Promise.resolve({ data: [] }),
       // 5: broad open-course candidates for late_end_date. The exact exception
-      // is recomputed below from fresh normalized meeting dates and end_date,
-      // so only rows with an actual meeting after end_date remain.
-      queryBase()
+      // is recomputed below from fresh normalized meeting dates and the
+      // configurable late_end_date_threshold.
+      queryBase(),
+      settingsPromise
     ]);
+    const lateEndDateThresholdRaw = lateEndThresholdResult?.data?.value;
+    const lateEndDateThreshold = normalizeSupabaseDate(lateEndDateThresholdRaw);
+    if (!lateEndDateThreshold) {
+      console.warn('[exceptions] late_end_date_threshold missing/invalid in settings; late_end_date exceptions disabled until key is fixed.', {
+        key: 'late_end_date_threshold',
+        raw: lateEndDateThresholdRaw ?? null
+      });
+    }
 
     const missingStartRows      = (Array.isArray(missingStartResult.data)      ? missingStartResult.data      : []).map(normalizeActivityRow);
     const missingInstructorRows = (Array.isArray(missingInstructorResult.data) ? missingInstructorResult.data : []).map(normalizeActivityRow);
@@ -1183,9 +1210,10 @@ async function readExceptionsFromSupabase(params = {}) {
 
     const exceptionSummary = buildExceptionsModelFromRows(allRows, month, {
       include_rows: true,
-      knownInstructorIds: knownInstructorIds.size > 0 ? knownInstructorIds : undefined
+      knownInstructorIds: knownInstructorIds.size > 0 ? knownInstructorIds : undefined,
+      lateEndDateThreshold
     });
-    return { month, ...exceptionSummary, _source: 'supabase' };
+    return { month, late_end_date_threshold: lateEndDateThreshold || '', ...exceptionSummary, _source: 'supabase' };
   } catch (error) {
     return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0 }, error);
   }

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -114,6 +114,9 @@ function exceptionDrawerHtml(row, hideRowId) {
   const grade = String(row.grade || '').trim();
   const classGroup = String(row.class_group || '').trim();
   const classDisplay = [grade, classGroup].filter(Boolean).join(' ');
+  const lateThreshold = String(row?._late_end_date_threshold || '').trim();
+  const lateHits = Array.isArray(row?._late_end_date_hits) ? row._late_end_date_hits : [];
+  const lateHitsHe = lateHits.map((date) => formatDateHe(date) || String(date || '').trim()).filter(Boolean).join(', ');
 
   return `<div class="ds-details-grid" dir="rtl">
     ${hideRowId ? '' : `<p><strong>${escapeHtml(hebrewColumn('RowID'))}:</strong> ${escapeHtml(String(row.RowID || '—'))}</p>`}
@@ -132,6 +135,8 @@ function exceptionDrawerHtml(row, hideRowId) {
     ${fieldRow(hebrewColumn('end_date'),    endDate)}
     ${fieldRow(hebrewColumn('sessions'),    row.sessions)}
     ${fieldRow(hebrewColumn('status'),      row.status)}
+    ${lateThreshold ? fieldRow('סף חריגת תאריך סיום מאוחר', formatDateHe(lateThreshold) || lateThreshold) : ''}
+    ${lateHitsHe ? fieldRow('מפגשים אחרי הסף', lateHitsHe) : ''}
     ${row.notes ? fieldRow('הערות', row.notes) : ''}
   </div>`;
 }

--- a/tests/api-undated-activities.test.mjs
+++ b/tests/api-undated-activities.test.mjs
@@ -85,6 +85,32 @@ test('entering a valid start_date or date_1 removes missing_start_date automatic
   assert.equal(rowExceptionTypesFromActivity(activeCourse({ start_date: '', date_1: '2026-05-10' })).includes('missing_start_date'), false);
 });
 
+test('late_end_date is computed from threshold and date_1..date_35 (not end_date)', () => {
+  const row = activeCourse({
+    RowID: 'A-10',
+    start_date: '2026-05-01',
+    end_date: '2026-05-31',
+    date_1: '2026-06-16',
+    date_2: '2026-06-10'
+  });
+  const types = rowExceptionTypesFromActivity(row, { lateEndDateThreshold: '2026-06-15' });
+  assert.equal(types.includes('late_end_date'), true);
+  assert.deepEqual(row._late_end_date_hits, ['2026-06-16']);
+  assert.equal(row._late_end_date_threshold, '2026-06-15');
+});
+
+test('without valid threshold, late_end_date is not inferred and keeps safe fallback metadata', () => {
+  const row = activeCourse({
+    RowID: 'A-11',
+    end_date: '2026-05-01',
+    date_1: '2026-06-20'
+  });
+  const types = rowExceptionTypesFromActivity(row, { lateEndDateThreshold: 'not-a-date' });
+  assert.equal(types.includes('late_end_date'), false);
+  assert.deepEqual(row._late_end_date_hits, []);
+  assert.equal(row._late_end_date_threshold, '');
+});
+
 
 test('textual null markers in start_date/date_1 are treated as missing_start_date', () => {
   const bothTextual = activeCourse({ RowID: 'A-5', start_date: 'NULL', date_1: '' });


### PR DESCRIPTION
### Motivation
- Make the "late end date" exception deterministic and configurable by using the `late_end_date_threshold` key from `public.settings` instead of comparing meeting dates to each activity's `end_date`.
- Surface the threshold and the meeting dates that triggered the exception to the user for clarity.
- Provide a safe fallback when the setting is missing or invalid and avoid inventing dates.

### Description
- Read `late_end_date_threshold` from `public.settings` in `readExceptionsFromSupabase` and thread it into the exceptions model as `lateEndDateThreshold` and return it in the exceptions payload as `late_end_date_threshold`.
- Update `rowExceptionTypesFromActivity` to compute `late_end_date` by comparing `date_1..date_35` (via `getActivityDateColumns`) against the normalized threshold and record per-row metadata `_late_end_date_threshold` and `_late_end_date_hits` when matches are found.
- Add a console `warn` when the threshold is missing/invalid and disable threshold-based `late_end_date` inference in that case.
- Show the configured threshold and the matching meeting dates in the exceptions drawer UI (`frontend/src/screens/exceptions.js`).
- Add regression tests in `tests/api-undated-activities.test.mjs` that verify threshold-driven classification and the invalid-threshold fallback.

### Testing
- Ran targeted Node tests: `node --test tests/api-undated-activities.test.mjs tests/service-worker-pwa-cache.test.mjs`, and all targeted tests passed (16 passed, 0 failed).
- Ran the project test script `npm test` which runs the full test suite; this run surfaced unrelated test failures outside the scope of this change, while the targeted exception tests still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc752fa30832b8c687a38f96d2277)