### PR TITLE
Refine proposal preview/print to match Word-style A4 layout

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -422,34 +422,28 @@ function proposalTitle(row) {
 
 function sectionBodyHtml(value) {
   const body = String(value || '').trim();
-  if (!body) return '<p>—</p>';
-  const lines = body.split('\n').map((line) => line.trim()).filter(Boolean);
-  const bulletLines = lines.filter((line) => /^[•·*-]\s*/.test(line));
-  if (lines.length > 1 && bulletLines.length === lines.length) {
-    return `<ul>${lines.map((line) => `<li>${escapeHtml(line.replace(/^[•·*-]\s*/, ''))}</li>`).join('')}</ul>`;
-  }
-  return lines.map((line) => {
-    if (/^[•·*-]\s*/.test(line)) {
-      return `<ul><li>${escapeHtml(line.replace(/^[•·*-]\s*/, ''))}</li></ul>`;
-    }
-    return `<p>${escapeHtml(line)}</p>`;
-  }).join('');
+  if (!body) return '';
+  return `<p>${escapeHtml(body)}</p>`;
 }
 
 function proposalLineHtml(item = {}) {
   const parts = [];
+  const duration = text(item.unit_duration);
   if (item.meetings_count != null && item.meetings_count !== '') parts.push(`${formatCurrency(item.meetings_count)} מפגשים`);
   if (item.hours_count != null && item.hours_count !== '') parts.push(`${formatCurrency(item.hours_count)} שעות`);
+  else if (duration) parts.push(duration);
   const total = Number(item.total_price) || ((Number(item.quantity) || 1) * (Number(item.unit_price) || 0));
   if (total) parts.push(`${formatCurrency(total)} ₪`);
+  const itemName = text(item.item_name);
+  if (!itemName) return '';
   const suffix = parts.length ? `: ${parts.join(' | ')}` : '';
-  const desc = text(item.description);
-  return `<li><strong>${escapeHtml(item.item_name || '')}</strong>${escapeHtml(suffix)}${desc ? `<br><span>${escapeHtml(desc)}</span>` : ''}</li>`;
+  return `<p class="pa-cost-line">· ${escapeHtml(itemName)}${escapeHtml(suffix)}</p>`;
 }
 
 function proposalItemsListHtml(items = []) {
-  if (!Array.isArray(items) || !items.length) return '<p class="pa-muted">לא הוגדרו שורות הצעה.</p>';
-  return `<ul class="pa-cost-lines">${items.map(proposalLineHtml).join('')}</ul>`;
+  if (!Array.isArray(items) || !items.length) return '';
+  const lines = items.map(proposalLineHtml).filter(Boolean).join('');
+  return lines || '';
 }
 
 function sectionHtml(title, body, className = '') {
@@ -463,8 +457,8 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const sectionBody = (key, fallback = '') => templateBodyText(byKey.get(key)) || fallback;
   const sectionTitle = (key, fallback = '') => text(byKey.get(key)?.section_title) || fallback;
 
-  const introText = sectionBody('intro', '—');
-  const orgResponsibility = sectionBody('taasiyeda_responsibility', '—');
+  const introText = sectionBody('intro', '');
+  const orgResponsibility = sectionBody('taasiyeda_responsibility', '');
   const schoolResponsibility = sectionBody('school_responsibility', '');
   const paymentTerms = sectionBody('payment_terms', '—');
   const changesCancellation = sectionBody('cancellation_terms', '');
@@ -472,46 +466,52 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const activityIntro = sectionBody('activity_intro', '');
   const summerActivityIntro = sectionBody('summer_activity_intro', '');
   const nextYearActivityIntro = sectionBody('next_year_activity_intro', '');
-  const activityIntroSections = activityTypeGroup === 'הצעה משולבת'
-    ? [
-        { title: 'קיץ תשפ״ו', body: summerActivityIntro || activityIntro },
-        { title: 'שנת הלימודים תשפ״ז', body: nextYearActivityIntro || activityIntro }
-      ].filter((section) => section.body)
-    : [{ title: sectionTitle('activity_intro', 'הפעילות המוצעת'), body: activityIntro }].filter((section) => section.body);
   const signatureText = sectionBody('signature', '');
-  const activityNames = Array.isArray(row.activity_names) ? row.activity_names.map(text).filter(Boolean) : [];
+  const itemsByGroup = Array.isArray(items) ? items.reduce((acc, item) => {
+    const group = text(item.activity_type_group) || activityTypeGroup;
+    if (!acc[group]) acc[group] = [];
+    acc[group].push(item);
+    return acc;
+  }, {}) : {};
+  const activitySectionHtml = activityTypeGroup === 'הצעה משולבת'
+    ? `${summerActivityIntro ? sectionBodyHtml(summerActivityIntro) : ''}${proposalItemsListHtml(itemsByGroup['פעילויות קיץ'] || [])}${nextYearActivityIntro ? sectionBodyHtml(nextYearActivityIntro) : ''}${proposalItemsListHtml(itemsByGroup['שנה הבאה'] || [])}`
+    : `${activityIntro ? sectionBodyHtml(activityIntro) : ''}${proposalItemsListHtml(itemsByGroup[activityTypeGroup] || items)}`;
 
   return `
     <header class="pa-doc-header">
-      <img
-        src="${PUBLIC_BASE}proposals/proposal-header-logo.png"
-        alt="לוגו תעשיידע"
-        class="pa-doc-logo pa-doc-logo--header"
-        loading="eager"
-        decoding="async"
-        onerror="this.style.display='none';"
-      >
-      <div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>
+      <div class="pa-doc-header-brand">
+        <img
+          src="${PUBLIC_BASE}proposal-header-logo.png"
+          alt="לוגו תעשיידע"
+          class="pa-doc-logo pa-doc-logo--header"
+          loading="eager"
+          decoding="async"
+          onerror="this.style.display='none';this.parentElement?.querySelector('.pa-doc-company-block')?.removeAttribute('hidden');"
+        >
+        <div class="pa-doc-company-block" hidden>תעשיידע</div>
+      </div>
+      <div class="pa-doc-head-meta">
+        <div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>
+        <div class="pa-doc-address">
+          <p><strong>לכבוד:</strong></p>
+          ${row.contact_name ? `<p>${escapeHtml(row.contact_name)}</p>` : ''}
+          ${row.school_framework ? `<p>${escapeHtml(row.school_framework)}</p>` : ''}
+          ${row.client_authority ? `<p>${escapeHtml(row.client_authority)}</p>` : ''}
+        </div>
+      </div>
     </header>
-    <div class="pa-doc-address">
-      <p><strong>לכבוד:</strong></p>
-      ${row.contact_name ? `<p>${escapeHtml(row.contact_name)}</p>` : ''}
-      ${row.school_framework ? `<p>${escapeHtml(row.school_framework)}</p>` : ''}
-      ${row.client_authority ? `<p>${escapeHtml(row.client_authority)}</p>` : ''}
-    </div>
-    <h1 class="pa-doc-title">${escapeHtml(proposalTitle(row))}</h1>
-    ${sectionHtml(sectionTitle('intro', 'פתיח'), introText)}
-    ${activityIntroSections.map((section) => sectionHtml(section.title, section.body, 'pa-section--activity')).join('')}
-    ${activityNames.length ? `<section class="pa-section"><h3>הפעילות המוצעת</h3><ul>${activityNames.map((n) => `<li>${escapeHtml(n)}</li>`).join('')}</ul></section>` : ''}
-    <section class="pa-section"><h3>${activityTypeGroup === 'פעילויות קיץ' ? 'עלות הפעילות' : 'עלויות ותנאי תשלום'}</h3>${proposalItemsListHtml(items)}${sectionBodyHtml(paymentTerms)}</section>
-    ${sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility)}
+    <h1 class="pa-doc-subject">${escapeHtml(proposalTitle(row))}</h1>
+    ${introText ? sectionBodyHtml(introText) : ''}
+    ${activitySectionHtml ? `<section class="pa-section"><h3>${sectionTitle('activity_intro', 'הפעילות המוצעת')}:</h3>${activitySectionHtml}</section>` : ''}
+    ${(paymentTerms || proposalItemsListHtml(items)) ? `<section class="pa-section"><h3>${activityTypeGroup === 'פעילויות קיץ' ? 'עלויות ותנאי תשלום' : 'עלויות ותנאי תשלום'}:</h3>${proposalItemsListHtml(items)}${paymentTerms ? sectionBodyHtml(paymentTerms) : ''}</section>` : ''}
+    ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility) : ''}
     ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
     ${changesCancellation ? sectionHtml(sectionTitle('cancellation_terms', 'שינויים, ביטולים והתאמות'), changesCancellation) : ''}
     ${remarks ? sectionHtml(sectionTitle('notes', 'הערות'), remarks) : ''}
-    <section class="pa-section pa-section--signature">${sectionBodyHtml(signatureText || 'בברכה,\nעידן נחום, סמנכ״ל כספים ותפעול.')}</section>
+    ${(signatureText || 'בברכה,\n\nעידן נחום, סמנכ״ל כספים ותפעול.') ? `<section class="pa-section pa-section--signature">${sectionBodyHtml(signatureText || 'בברכה,\n\nעידן נחום, סמנכ״ל כספים ותפעול.')}</section>` : ''}
     <footer class="pa-doc-footer">
       <img
-        src="${PUBLIC_BASE}proposals/proposal-footer-logo.png"
+        src="${PUBLIC_BASE}proposal-footer-logo.png"
         alt="לוגו תחתון תעשיידע"
         class="pa-doc-logo pa-doc-logo--footer"
         loading="lazy"

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10413,95 +10413,93 @@ select.ds-input {
   padding: 8px 16px; display: flex; gap: 8px; align-items: center;
 }
 .ds-pa-preview-doc {
-  width: min(794px, calc(100vw - 32px));
+  width: 794px;
+  max-width: 100%;
   min-height: 1123px;
   margin: 24px auto 48px;
   background: #fff;
-  border: 1px solid #e6e8ec;
+  border: none;
   border-radius: 0;
-  padding: 58px 64px 48px;
-  box-shadow: 0 1px 8px rgba(15, 23, 42, 0.08);
-  font-family: 'Segoe UI', Arial, Helvetica, sans-serif;
-  font-size: 14px;
-  line-height: 1.65;
+  padding: 36px 58px 44px;
+  box-shadow: none;
+  font-family: Arial, "Noto Sans Hebrew", sans-serif;
+  font-size: 13.5px;
+  line-height: 1.55;
   direction: rtl;
   color: #111827;
 }
 .pa-doc-header {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: start;
-  margin-bottom: 28px;
+  margin-bottom: 8px;
+}
+.pa-doc-header-brand {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 8px;
+}
+.pa-doc-head-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-bottom: 1px solid #8b8f97;
+  padding-bottom: 8px;
+  margin-bottom: 12px;
 }
 .pa-doc-logo {
   display: block; max-width: 100%; height: auto;
 }
 .pa-doc-logo--header {
-  grid-column: 2;
-  width: 122px;
-  margin-inline: auto;
+  width: 150px;
+  max-width: 32%;
+  margin-inline: 0;
 }
 .pa-doc-logo--footer {
-  width: 104px;
+  width: 170px;
+  max-width: 42%;
   margin-inline: auto;
-  opacity: 0.72;
+  opacity: 0.9;
 }
 .pa-doc-date {
-  grid-column: 1;
   justify-self: start;
   color: #111827;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.4;
 }
 .pa-doc-address {
-  margin: 0 0 22px;
-  font-size: 14px;
+  margin: 0;
+  font-size: 13.5px;
   line-height: 1.55;
+  text-align: right;
 }
 .pa-doc-address p { margin: 0 0 2px; }
-.pa-doc-title {
-  margin: 8px 0 24px;
-  color: #0f2745;
-  font-size: 17px;
+.pa-doc-subject {
+  margin: 14px 0 10px;
+  color: #1f4e79;
+  font-size: 14px;
   font-weight: 700;
-  line-height: 1.45;
+  text-decoration: underline;
   text-align: center;
 }
 .pa-section {
-  margin: 0 0 16px;
+  margin: 13px 0;
   break-inside: avoid;
   page-break-inside: avoid;
 }
 .pa-section h3 {
-  color: #0f2745;
-  font-size: 14px;
+  color: #1f4e79;
+  font-size: 13.5px;
   font-weight: 700;
-  margin: 0 0 4px;
+  text-decoration: underline;
+  margin: 0 0 5px;
   padding: 0;
   border: 0;
 }
-.pa-section p,
-.pa-section ul {
-  margin: 0 0 6px;
-}
-.pa-section ul {
-  padding-inline-start: 20px;
-}
-.pa-section li {
-  margin-bottom: 3px;
-}
-.pa-cost-lines {
-  list-style: disc;
-}
-.pa-cost-lines span,
-.pa-muted {
-  color: #374151;
-}
+.pa-section p { margin: 0; white-space: pre-line; }
+.pa-cost-line { margin: 0; white-space: pre-line; }
 .pa-section--signature {
   margin-top: 24px;
 }
 .pa-doc-footer {
-  margin-top: 34px;
+  margin-top: 26px;
   padding-top: 0;
   border: 0;
   break-inside: avoid;
@@ -10518,18 +10516,11 @@ select.ds-input {
   }
 
   .pa-doc-header {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    gap: 10px;
+    margin-bottom: 6px;
   }
-
-  .pa-doc-logo--header,
-  .pa-doc-date {
-    grid-column: 1;
-  }
-
-  .pa-doc-date {
-    justify-self: start;
+  .pa-doc-head-meta {
+    flex-direction: column-reverse;
+    gap: 8px;
   }
 }
 
@@ -10537,7 +10528,7 @@ select.ds-input {
    Print styles — show only the preview overlay
    ═══════════════════════════════════════════════════════════════════ */
 @media print {
-  @page { size: A4 portrait; margin: 18mm 17mm; }
+  @page { size: A4; margin: 18mm 16mm; }
   body > *:not(#pa-preview-overlay) { display: none !important; }
   body, html {
     background: #fff !important;
@@ -10557,8 +10548,8 @@ select.ds-input {
     margin: 0 !important;
     padding: 0 !important;
     max-width: none !important;
-    font-size: 14px !important;
-    line-height: 1.6 !important;
+    font-size: 13.5px !important;
+    line-height: 1.55 !important;
   }
   .pa-doc-footer {
     margin-top: 28px !important;


### PR DESCRIPTION
### Motivation
- Make the proposal preview/print closely match the official Word document format (A4, compact typography, white background) rather than a dashboard card view.
- Remove dashboard UI chrome and heavy table styling so the preview/print reproduces the document structure and visual density of the original Word files.
- Preserve data fidelity from Supabase (line breaks and bullet glyphs) and avoid rendering `null`/`undefined` or heavy tables for cost lines.

### Description
- Adjusted preview CSS (`.ds-pa-preview-doc`, `.pa-*`) to an A4-like fixed width with white background, compact font/spacing, no shadow or outer borders, and updated print margins to `@page size: A4; margin: 18mm 16mm;` in `frontend/src/styles/main.css`.
- Reworked preview markup in `frontend/src/screens/proposals-agreements.js` to: place a small header logo on the right with a textual fallback shown only when the logo fails to load, render date/recipient together with a single thin divider, and use a centered underlined dark-blue subject instead of a dashboard title.
- Simplified section rendering so stored template text is output as paragraphs with `white-space: pre-line` (preserving Supabase line breaks and `·` bullets) by replacing the previous aggressive UL/LI conversions with `sectionBodyHtml` returning simple paragraph markup.
- Rendered activity/cost lines as plain text lines in Word style (e.g. `· Activity: X מפגשים | Y שעות | Z ₪`), added support for `unit_duration` when `hours_count` is absent, grouped items by `activity_type_group` for combined proposals, and avoided showing empty/`null` fields.
- Simplified signature/footer to a plain Word-like signature block with dynamic template fallback and updated footer logo path handling (removed `/proposals` prefix) to avoid incorrect asset routes.

### Testing
- Ran `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (`36 passed`).
- Ran `npm run build` successfully and validated the build output; generated `dist` changes were reverted before committing source changes to comply with the no-dist rule.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcc638d98832ba35e32a60a69998e)