### PR TITLE
Add 'end_date_passed' (תאריך סיום חלף) exception for open overdue activities

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -968,6 +968,7 @@ async function dashboardReadModelFromSupabase(month) {
       missing_start_date_count: Number(exceptionCounts.missing_start_date || 0),
       missing_date_count: Number(exceptionCounts.missing_start_date || 0),
       late_end_date_count: Number(exceptionCounts.late_end_date || 0),
+      end_date_passed_count: Number(exceptionCounts.end_date_passed || 0),
       operational_gaps_count: Number(exceptionSummary.operationalUniqueCount || 0),
       operational_gaps_unique_count: Number(exceptionSummary.operationalUniqueCount || 0),
       operationalTotal: Number(exceptionSummary.operationalUniqueCount || 0),
@@ -1042,6 +1043,8 @@ function rowExceptionTypesFromActivity(row, opts = {}) {
   const instructorName = resolveActivityInstructorName(row);
   const start       = firstNormalizedDate(row?.start_date, row?.date_start);
   const end         = firstNormalizedDate(row?.end_date, row?.date_end);
+  const now = new Date();
+  const todayLocalIso = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
   // Instructor check uses the same normalized name source used by the UI.
   // A valid displayed instructor name is sufficient even when guideId/emp_id is
@@ -1059,6 +1062,10 @@ function rowExceptionTypesFromActivity(row, opts = {}) {
   const lateMeetingDates = lateEndThreshold
     ? meetingDates.filter((dateKey) => dateKey > lateEndThreshold)
     : [];
+  if (end && end < todayLocalIso) {
+    types.push('end_date_passed');
+  }
+
   if (lateMeetingDates.length > 0) {
     types.push('late_end_date');
     row._late_end_date_threshold = lateEndThreshold;
@@ -1074,7 +1081,7 @@ function buildExceptionsModelFromRows(activityRows = [], month = '', opts = {}) 
   const includeRows = opts.include_rows !== false;
   const knownInstructorIds = opts.knownInstructorIds; // Set<string> | undefined
   const rows = [];
-  const counts = { missing_instructor: 0, missing_start_date: 0, late_end_date: 0 };
+  const counts = { missing_instructor: 0, missing_start_date: 0, late_end_date: 0, end_date_passed: 0 };
   const byManager = {};
   let operationalUniqueCount = 0;
   for (const row of activityRows) {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -111,6 +111,7 @@ function renderStructuredSummary(summary, ym, byManager) {
   const missingInstructorCount = pickNumericFallback(counts, 'missing_instructor', summary?.missing_instructor_count);
   const missingStartDateCount = pickNumericFallback(counts, 'missing_start_date', summary?.missing_start_date_count ?? summary?.missing_date_count);
   const lateEndCount = pickNumericFallback(counts, 'late_end_date', summary?.late_end_date_count);
+  const endDatePassedCount = pickNumericFallback(counts, 'end_date_passed', summary?.end_date_passed_count);
   const exceptionsTotalField = getStrictNumericField(summary, 'totalExceptionRows');
   const exceptionsTotalFallback = getStrictNumericField(summary, 'exceptions_count');
   const exceptionsTotalResolved = exceptionsTotalField.ok
@@ -123,6 +124,7 @@ function renderStructuredSummary(summary, ym, byManager) {
   const missingInstructor = missingInstructorCount;
   const missingStartDate  = missingStartDateCount;
   const lateEnd = escapeHtml(String(lateEndCount));
+  const endDatePassed = escapeHtml(String(endDatePassedCount));
 
   const typeCounts = summary?.active_type_counts || {};
   const typeRows = ACTIVITY_TYPE_ORDER
@@ -170,6 +172,7 @@ function renderStructuredSummary(summary, ym, byManager) {
         <span class="ds-muted"> (חסר מדריך: ${escapeHtml(String(missingInstructor))} · חסר תאריך התחלה: ${escapeHtml(String(missingStartDate))})</span>
       </p>
       <p class="ds-summary-panel__text">תאריך סיום מאוחר: <strong>${lateEnd}</strong></p>
+      <p class="ds-summary-panel__text">תאריך סיום חלף: <strong>${endDatePassed}</strong></p>
     </div>
   </div>`;
 }

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -73,6 +73,9 @@ function exceptionsOperationalSummaryHtml(data, rows) {
   const lateEndDate = hasRows
     ? exceptionCountFromRows(rows, 'late_end_date')
     : numericCount(counts.late_end_date);
+  const endDatePassed = hasRows
+    ? exceptionCountFromRows(rows, 'end_date_passed')
+    : numericCount(counts.end_date_passed);
   const totalExceptionRows = optionalNumericCount(data?.totalExceptionRows);
   const allExceptionsTotal = totalExceptionRows ?? uniqueExceptionActivityCount(rows);
 
@@ -82,6 +85,7 @@ function exceptionsOperationalSummaryHtml(data, rows) {
       <p class="ds-summary-panel__text">חסר מדריך: <strong>${escapeHtml(String(missingInstructor))}</strong></p>
       <p class="ds-summary-panel__text">חסר תאריך התחלה: <strong>${escapeHtml(String(missingStartDate))}</strong></p>
       <p class="ds-summary-panel__text">תאריך סיום מאוחר: <strong>${escapeHtml(String(lateEndDate))}</strong></p>
+      <p class="ds-summary-panel__text">תאריך סיום חלף: <strong>${escapeHtml(String(endDatePassed))}</strong></p>
       <p class="ds-summary-panel__text"><small>פעילות עם כמה סוגי חריגה נספרת פעם אחת בסה״כ.</small></p>
     </div>`
   });

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -72,7 +72,7 @@ export function financeStatusVariant(value) {
 /** חריגות: עוצמת chip לפי סוג */
 export function exceptionTypeVariant(exceptionType) {
   const k = String(exceptionType || '').trim();
-  if (k === 'late_end_date' || k === 'dangerous_end_date') return 'danger';
+  if (k === 'late_end_date' || k === 'dangerous_end_date' || k === 'end_date_passed') return 'danger';
   if (k === 'missing_instructor' || k === 'missing_start_date') return 'warning';
   return 'neutral';
 }
@@ -81,6 +81,7 @@ export const HEBREW_EXCEPTION_TYPE = {
   missing_instructor:       'חסר מדריך',
   missing_start_date:       'חסר תאריך התחלה',
   late_end_date:            'תאריך סיום מאוחר',
+  end_date_passed:          'תאריך סיום חלף',
   dangerous_end_date:       'תאריך סיום',
   missing_activity_manager: 'חסר מנהל פעילות',
   missing_school:           'חסרה בית ספר',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 419;
+const CACHE_VERSION = 420;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- Surface open activities whose `end_date` is before today as a distinct exception so managers can decide to close or update them. 
- Keep archival behavior unchanged (archive only when `status = 'סגור'`) and avoid any automatic moves or changes to `date_1`–`date_35` or the `late_end_date_threshold` logic. 
- Ensure clients pick up the change after deploy by bumping the service worker cache version.

### Description
- Detect a new exception `end_date_passed` in `rowExceptionTypesFromActivity` when an activity is not closed and `end_date < today`, implemented in `frontend/src/api.js` by adding `todayLocalIso` and pushing `end_date_passed` into the returned `types` array. 
- Add counting and exposure of the new exception via the exceptions model by extending `counts` with `end_date_passed` and `end_date_passed_count` in `frontend/src/api.js`. 
- Show the new exception in the UI: display `תאריך סיום חלף` in the exceptions screen (`frontend/src/screens/exceptions.js`) and the dashboard monthly summary (`frontend/src/screens/dashboard.js`). 
- Add Hebrew label and chip severity mapping for `end_date_passed` in `frontend/src/screens/shared/ui-hebrew.js` so it appears as “תאריך סיום חלף” and uses the `danger` chip variant. 
- Bump the service worker `CACHE_VERSION` in `frontend/sw.js` to force clients to refresh cached assets after deploy. 
- Files changed: `frontend/src/api.js`, `frontend/src/screens/exceptions.js`, `frontend/src/screens/dashboard.js`, `frontend/src/screens/shared/ui-hebrew.js`, `frontend/sw.js`.

### Testing
- Ran the automated test suite with `npm test`; many unit tests passed but the overall test run reported failures and the test command exited non-zero. 
- Failures observed are in existing unrelated tests (examples: `activities render: operation_manager sees add activity button`, several `activities-snapshot.gs` expectations, and some API mutation tests), and not tied to the new `end_date_passed` logic. 
- Commit created and changes staged for review; recommend deploying to a staging environment and verifying the exceptions screen and dashboard show the new `תאריך סיום חלף` counts and that no activities are auto-archived.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcdbe08cc832ba20c9bcde9071585)