### PR TITLE
Refine proposal preview typography and signature; sync SW cache version

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -450,6 +450,25 @@ function sectionHtml(title, body, className = '') {
   return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(title)}</h3>${sectionBodyHtml(body)}</section>`;
 }
 
+function signatureSectionHtml(signatureText) {
+  const fallback = 'בברכה,\n\nעידן נחום, סמנכ״ל כספים ותפעול.';
+  const raw = text(signatureText) ? signatureText : fallback;
+  const lines = String(raw || '')
+    .split(/\r?\n/)
+    .map((line) => String(line || '').trim())
+    .filter(Boolean);
+  if (!lines.length) return '';
+  const [closingLine, ...nameLines] = lines;
+  const signerName = nameLines.join(' ');
+  return `<section class="pa-doc-signature-simple">
+    <p>${escapeHtml(closingLine)}</p>
+    <div class="pa-doc-signature-line-wrap">
+      <span class="pa-doc-signature-line"></span>
+      ${signerName ? `<p>${escapeHtml(signerName)}</p>` : ''}
+    </div>
+  </section>`;
+}
+
 function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const activityTypeGroup = text(row.activity_type_group);
   const dateDisplay = formatDateDisplay(row.proposal_date) || formatDateDisplay(new Date().toISOString().slice(0, 10));
@@ -508,7 +527,7 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
     ${changesCancellation ? sectionHtml(sectionTitle('cancellation_terms', 'שינויים, ביטולים והתאמות'), changesCancellation) : ''}
     ${remarks ? sectionHtml(sectionTitle('notes', 'הערות'), remarks) : ''}
-    ${(signatureText || 'בברכה,\n\nעידן נחום, סמנכ״ל כספים ותפעול.') ? `<section class="pa-section pa-section--signature">${sectionBodyHtml(signatureText || 'בברכה,\n\nעידן נחום, סמנכ״ל כספים ותפעול.')}</section>` : ''}
+    ${signatureSectionHtml(signatureText)}
     <footer class="pa-doc-footer">
       <img
         src="${PUBLIC_BASE}proposal-footer-logo.png"

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10413,20 +10413,21 @@ select.ds-input {
   padding: 8px 16px; display: flex; gap: 8px; align-items: center;
 }
 .ds-pa-preview-doc {
+  background: #fff;
+  color: #111827;
+  direction: rtl;
   width: 794px;
   max-width: 100%;
   min-height: 1123px;
   margin: 24px auto 48px;
-  background: #fff;
+  padding: 36px 58px 44px;
+  font-family: Arial, "Noto Sans Hebrew", sans-serif;
+  font-size: 10pt;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+  box-shadow: none;
   border: none;
   border-radius: 0;
-  padding: 36px 58px 44px;
-  box-shadow: none;
-  font-family: Arial, "Noto Sans Hebrew", sans-serif;
-  font-size: 13.5px;
-  line-height: 1.55;
-  direction: rtl;
-  color: #111827;
 }
 .pa-doc-header {
   margin-bottom: 8px;
@@ -10448,58 +10449,90 @@ select.ds-input {
   display: block; max-width: 100%; height: auto;
 }
 .pa-doc-logo--header {
-  width: 150px;
+  width: 155px;
   max-width: 32%;
   margin-inline: 0;
 }
 .pa-doc-logo--footer {
   width: 170px;
-  max-width: 42%;
+  max-width: 40%;
   margin-inline: auto;
   opacity: 0.9;
 }
 .pa-doc-date {
   justify-self: start;
   color: #111827;
-  font-size: 12px;
-  line-height: 1.4;
+  font-size: 9pt;
+  line-height: 1.5;
+  text-align: left;
+  margin-bottom: 4pt;
 }
 .pa-doc-address {
   margin: 0;
-  font-size: 13.5px;
-  line-height: 1.55;
+  font-size: 10pt;
+  line-height: 1.5;
   text-align: right;
+  margin-bottom: 4pt;
 }
 .pa-doc-address p { margin: 0 0 2px; }
 .pa-doc-subject {
-  margin: 14px 0 10px;
+  margin: 10pt 0 8pt;
   color: #1f4e79;
-  font-size: 14px;
+  font-size: 11pt;
   font-weight: 700;
   text-decoration: underline;
+  line-height: 1.5;
   text-align: center;
 }
 .pa-section {
-  margin: 13px 0;
+  margin: 8pt 0;
   break-inside: avoid;
   page-break-inside: avoid;
 }
 .pa-section h3 {
-  color: #1f4e79;
-  font-size: 13.5px;
+  font-size: 10pt;
   font-weight: 700;
   text-decoration: underline;
-  margin: 0 0 5px;
+  color: #1f4e79;
+  margin: 0 0 4pt;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
   padding: 0;
   border: 0;
+  background: transparent;
 }
-.pa-section p { margin: 0; white-space: pre-line; }
-.pa-cost-line { margin: 0; white-space: pre-line; }
-.pa-section--signature {
-  margin-top: 24px;
+.pa-section p,
+.pa-doc-intro,
+.pa-proposal-lines,
+.pa-cost-line {
+  font-size: 10pt;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+  margin: 0 0 4pt;
+  white-space: pre-line;
+}
+.pa-doc-signature-simple {
+  margin-top: 28pt;
+  text-align: left;
+  font-size: 9pt;
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+}
+.pa-doc-signature-line-wrap {
+  display: inline-block;
+  text-align: left;
+}
+.pa-doc-signature-simple p {
+  margin: 0 0 4pt;
+}
+.pa-doc-signature-line {
+  display: inline-block;
+  min-width: 160px;
+  border-top: 1px solid #111827;
+  padding-top: 4pt;
 }
 .pa-doc-footer {
-  margin-top: 26px;
+  margin-top: 18pt;
   padding-top: 0;
   border: 0;
   break-inside: avoid;
@@ -10548,9 +10581,12 @@ select.ds-input {
     margin: 0 !important;
     padding: 0 !important;
     max-width: none !important;
-    font-size: 13.5px !important;
-    line-height: 1.55 !important;
+    font-size: 10pt !important;
+    line-height: 1.5 !important;
+    letter-spacing: 0.15px !important;
   }
+  .pa-doc-date { font-size: 9pt !important; line-height: 1.5 !important; }
+  .pa-doc-signature-simple { font-size: 9pt !important; line-height: 1.5 !important; }
   .pa-doc-footer {
     margin-top: 28px !important;
     padding-top: 0 !important;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 419;
+const SW_ENTRY_VERSION = 420;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Make the proposal / PDF preview visually match the original Word settings (10pt body, 1.5 line-height, subtle letter-spacing, compact section spacing, small header/footer logos) while restricting changes to the proposal preview only.
- Render the `signature` template section as a simple left-aligned signature block with a signature line and signer text instead of the previous styled/duplicated signature block.
- Ensure service worker entry and frontend SW cache version stay in sync to avoid serving stale app shell after the CSS/screen changes.

### Description
- Updated proposal preview styles in `frontend/src/styles/main.css` under `.ds-pa-preview-doc` and related classes to apply `font-size: 10pt`, `line-height: 1.5`, `letter-spacing: 0.15px`, compact section margins, subject/header/date sizing, and print (`@page`) rules for A4.
- Added `signatureSectionHtml` helper in `frontend/src/screens/proposals-agreements.js` to parse the `signature` `section_key` body and render a left-aligned simple signature block with a horizontal line and signer name, and replaced the old signature injection with this helper.
- Adjusted header/footer logo max sizes and minor spacing so the preview stays compact and avoids duplicated brand text when the logo image loads.
- Bumped the root SW entry version in `sw.js` to match the frontend `CACHE_VERSION` to keep SW cache-busting consistent; no data-source or pricing logic was changed and `dist/` artifacts were not committed.

### Testing
- Ran `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (36 passed, 0 failed).
- Ran `npm run build` and the production build completed successfully (Vite emitted a chunk-size warning but build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe027a098832b8b56336fe92f6c8b)