### PR TITLE
Refine proposals/agreement editing UX and Word-style preview output

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -311,18 +311,25 @@ function itemRowHtml(item = {}, idx = 0, pricingOptions = []) {
     : n(item.total_price);
   const selectedPricingName = text(item.pricing_activity_name || item.item_name);
   const pricingSelectOptions = ['<option value="">— בחירה מהירה —</option>', ...pricingOptions.map((row) => optionHtml(row.activity_name, selectedPricingName))].join('');
-  return `<tr class="ds-pa-item-row" data-pa-item-row data-pa-item-idx="${idx}">
-    <td class="ds-pa-ic-name"><select class="ds-input ds-input--sm" name="pricing_activity_name" data-pa-pricing-select>${pricingSelectOptions}</select><input class="ds-input ds-input--sm" name="item_name" value="${escapeHtml(item.item_name || '')}" placeholder="שם פעילות"></td>
-    <td class="ds-pa-ic-type"><input class="ds-input ds-input--sm" name="item_type" value="${escapeHtml(item.item_type || '')}" list="pa-item-type-list" placeholder="סוג"></td>
-    <td class="ds-pa-ic-gefen"><input class="ds-input ds-input--sm" name="gefen_number" value="${escapeHtml(item.gefen_number || '')}" placeholder="גפ״ן"></td>
-    <td class="ds-pa-ic-num"><input class="ds-input ds-input--sm" type="number" name="meetings_count" value="${n(item.meetings_count)}" min="0" step="1" placeholder="—"></td>
-    <td class="ds-pa-ic-num"><input class="ds-input ds-input--sm" type="number" name="hours_count" value="${n(item.hours_count)}" min="0" step="0.5" placeholder="—"></td>
-    <td class="ds-pa-ic-num"><input class="ds-input ds-input--sm" type="number" name="quantity" value="${n(item.quantity) || '1'}" min="0" step="any" data-pa-item-qty></td>
-    <td class="ds-pa-ic-num"><input class="ds-input ds-input--sm" type="number" name="unit_price" value="${n(item.unit_price)}" min="0" step="any" data-pa-item-price></td>
-    <td class="ds-pa-ic-total"><input class="ds-input ds-input--sm" name="total_price" value="${calcTotal}" readonly data-pa-item-total></td>
-    <td class="ds-pa-ic-desc"><input class="ds-input ds-input--sm" name="description" value="${escapeHtml(item.description || '')}" placeholder="תיאור"></td>
-    <td class="ds-pa-ic-del"><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-remove-item aria-label="הסר">×</button></td>
-  </tr>`;
+  return `<article class="ds-pa-item-card ds-pa-item-row" data-pa-item-row data-pa-item-idx="${idx}">
+    <label class="ds-pa-item-field ds-pa-item-field--full"><span>בחירה מהירה</span><select class="ds-input ds-input--sm" name="pricing_activity_name" data-pa-pricing-select>${pricingSelectOptions}</select></label>
+    <div class="ds-pa-item-grid">
+      <label class="ds-pa-item-field"><span>שם פעילות / תוכנית</span><input class="ds-input ds-input--sm" name="item_name" value="${escapeHtml(item.item_name || '')}" placeholder="שם פעילות"></label>
+      <label class="ds-pa-item-field"><span>סוג</span><input class="ds-input ds-input--sm" name="item_type" value="${escapeHtml(item.item_type || '')}" list="pa-item-type-list" placeholder="סוג"></label>
+    </div>
+    <div class="ds-pa-item-grid ds-pa-item-grid--numbers">
+      <label class="ds-pa-item-field"><span>מספר גפ״ן</span><input class="ds-input ds-input--sm" name="gefen_number" value="${escapeHtml(item.gefen_number || '')}" placeholder="גפ״ן"></label>
+      <label class="ds-pa-item-field"><span>מפגשים</span><input class="ds-input ds-input--sm" type="number" name="meetings_count" value="${n(item.meetings_count)}" min="0" step="1" placeholder="—"></label>
+      <label class="ds-pa-item-field"><span>שעות</span><input class="ds-input ds-input--sm" type="number" name="hours_count" value="${n(item.hours_count)}" min="0" step="0.5" placeholder="—"></label>
+    </div>
+    <div class="ds-pa-item-grid ds-pa-item-grid--numbers">
+      <label class="ds-pa-item-field"><span>כמות</span><input class="ds-input ds-input--sm" type="number" name="quantity" value="${n(item.quantity) || '1'}" min="0" step="any" data-pa-item-qty></label>
+      <label class="ds-pa-item-field"><span>מחיר יחידה</span><input class="ds-input ds-input--sm" type="number" name="unit_price" value="${n(item.unit_price)}" min="0" step="any" data-pa-item-price></label>
+      <label class="ds-pa-item-field"><span>סה״כ שורה</span><input class="ds-input ds-input--sm" name="total_price" value="${calcTotal}" readonly data-pa-item-total></label>
+    </div>
+    <label class="ds-pa-item-field ds-pa-item-field--full"><span>תיאור / הערות</span><input class="ds-input ds-input--sm" name="description" value="${escapeHtml(item.description || '')}" placeholder="תיאור"></label>
+    <div class="ds-pa-item-actions"><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-remove-item aria-label="הסר שורה">הסר שורה</button></div>
+  </article>`;
 }
 
 function itemsEditorHtml(items = [], pricingOptions = []) {
@@ -333,23 +340,7 @@ function itemsEditorHtml(items = [], pricingOptions = []) {
       <span style="font-size:0.76rem;color:var(--ds-color-text-muted,#64748b);font-weight:600">שורות הצעה</span>
       <button type="button" class="ds-btn ds-btn--xs" data-pa-add-item>+ הוסף שורה</button>
     </div>
-    <div class="ds-pa-items-table-wrap">
-      <table class="ds-pa-items-table">
-        <thead><tr>
-          <th class="ds-pa-ic-name">שם פעילות / תוכנית</th>
-          <th class="ds-pa-ic-type">סוג</th>
-          <th class="ds-pa-ic-gefen">גפ״ן</th>
-          <th class="ds-pa-ic-num" title="מספר מפגשים">מפגשים</th>
-          <th class="ds-pa-ic-num" title="מספר שעות">שעות</th>
-          <th class="ds-pa-ic-num">כמות</th>
-          <th class="ds-pa-ic-num">מחיר יח׳</th>
-          <th class="ds-pa-ic-total">סה״כ</th>
-          <th class="ds-pa-ic-desc">תיאור</th>
-          <th class="ds-pa-ic-del"></th>
-        </tr></thead>
-        <tbody data-pa-items-body>${rowsHtml}</tbody>
-      </table>
-    </div>
+    <div class="ds-pa-items-list" data-pa-items-body>${rowsHtml}</div>
     <datalist id="pa-item-type-list">${ITEM_TYPE_OPTIONS.map((v) => `<option value="${escapeHtml(v)}">`).join('')}</datalist>
     <div class="ds-pa-items-total-row">סה״כ כללי: <strong data-pa-grand-total></strong></div>
   </div>`;
@@ -434,6 +425,8 @@ function proposalLineHtml(item = {}) {
   else if (duration) parts.push(duration);
   const total = Number(item.total_price) || ((Number(item.quantity) || 1) * (Number(item.unit_price) || 0));
   if (total) parts.push(`${formatCurrency(total)} ₪`);
+  const gefenNumber = text(item.gefen_number);
+  if (gefenNumber) parts.push(`גפ״ן ${gefenNumber}`);
   const itemName = text(item.item_name);
   if (!itemName) return '';
   const suffix = parts.length ? `: ${parts.join(' | ')}` : '';
@@ -498,39 +491,41 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
 
   return `
     <header class="pa-doc-header">
-      <div class="pa-doc-header-brand">
-        <img
-          src="${PUBLIC_BASE}proposal-header-logo.png"
-          alt="לוגו תעשיידע"
-          class="pa-doc-logo pa-doc-logo--header"
-          loading="eager"
-          decoding="async"
-          onerror="this.style.display='none';this.parentElement?.querySelector('.pa-doc-company-block')?.removeAttribute('hidden');"
-        >
-        <div class="pa-doc-company-block" hidden>תעשיידע</div>
-      </div>
-      <div class="pa-doc-head-meta">
-        <div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>
-        <div class="pa-doc-address">
-          <p><strong>לכבוד:</strong></p>
-          ${row.contact_name ? `<p>${escapeHtml(row.contact_name)}</p>` : ''}
-          ${row.school_framework ? `<p>${escapeHtml(row.school_framework)}</p>` : ''}
-          ${row.client_authority ? `<p>${escapeHtml(row.client_authority)}</p>` : ''}
+      <div class="pa-doc-topline">
+        <div class="pa-doc-header-brand">
+          <img
+            src="${PUBLIC_BASE}proposals/proposal-header-logo.png"
+            alt="לוגו תעשיידע"
+            class="pa-doc-logo pa-doc-logo--header"
+            loading="eager"
+            decoding="async"
+            onerror="this.style.display='none';this.parentElement?.querySelector('.pa-doc-company-block')?.removeAttribute('hidden');"
+          >
+          <div class="pa-doc-company-block" hidden>תעשיידע</div>
         </div>
+        <div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>
+      </div>
+      <div class="pa-doc-address">
+        <p><strong>לכבוד:</strong></p>
+        ${row.contact_name ? `<p>${escapeHtml(row.contact_name)}</p>` : ''}
+        ${row.contact_role ? `<p>${escapeHtml(row.contact_role)}</p>` : ''}
+        ${row.school_framework ? `<p>${escapeHtml(row.school_framework)}</p>` : ''}
+        ${row.client_authority ? `<p>${escapeHtml(row.client_authority)}</p>` : ''}
       </div>
     </header>
+    <hr class="pa-doc-divider">
     <h1 class="pa-doc-subject">${escapeHtml(proposalTitle(row))}</h1>
     ${introText ? sectionBodyHtml(introText) : ''}
     ${activitySectionHtml ? `<section class="pa-section"><h3>${sectionTitle('activity_intro', 'הפעילות המוצעת')}:</h3>${activitySectionHtml}</section>` : ''}
-    ${(paymentTerms || proposalItemsListHtml(items)) ? `<section class="pa-section"><h3>${activityTypeGroup === 'פעילויות קיץ' ? 'עלויות ותנאי תשלום' : 'עלויות ותנאי תשלום'}:</h3>${proposalItemsListHtml(items)}${paymentTerms ? sectionBodyHtml(paymentTerms) : ''}</section>` : ''}
     ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility) : ''}
     ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
+    ${paymentTerms ? sectionHtml(sectionTitle('payment_terms', 'עלויות ותנאי תשלום'), paymentTerms) : ''}
     ${changesCancellation ? sectionHtml(sectionTitle('cancellation_terms', 'שינויים, ביטולים והתאמות'), changesCancellation) : ''}
     ${remarks ? sectionHtml(sectionTitle('notes', 'הערות'), remarks) : ''}
     ${signatureSectionHtml(signatureText)}
     <footer class="pa-doc-footer">
       <img
-        src="${PUBLIC_BASE}proposal-footer-logo.png"
+        src="${PUBLIC_BASE}proposals/proposal-footer-logo.png"
         alt="לוגו תחתון תעשיידע"
         class="pa-doc-logo pa-doc-logo--footer"
         loading="lazy"

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10358,33 +10358,33 @@ select.ds-input {
   display: flex; align-items: center; justify-content: space-between;
   margin-bottom: 5px;
 }
-.ds-pa-items-table-wrap { overflow-x: auto; }
-.ds-pa-items-table {
-  width: 100%; border-collapse: collapse;
-  font-size: 0.73rem; white-space: nowrap;
+.ds-pa-items-list { display: grid; gap: 8px; }
+.ds-pa-item-card {
+  border: 1px solid #dbe5ef;
+  border-radius: 12px;
+  padding: 10px;
+  background: #fff;
+  display: grid;
+  gap: 8px;
 }
-.ds-pa-items-table thead tr { background: var(--ds-color-surface-soft, #f8fafc); }
-.ds-pa-items-table th {
-  padding: 3px 5px; font-weight: 600; font-size: 0.71rem;
-  border-bottom: 1px solid var(--ds-color-border, #e2e8f0);
-  color: var(--ds-color-text-muted, #64748b);
-}
-.ds-pa-items-table td { padding: 2px 3px; vertical-align: middle; }
-.ds-pa-items-table .ds-input {
-  min-height: 26px; padding: 2px 5px; font-size: 0.73rem;
+.ds-pa-item-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.ds-pa-item-grid--numbers { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.ds-pa-item-field { display: grid; gap: 4px; min-width: 0; }
+.ds-pa-item-field span { font-size: 0.71rem; color: var(--ds-color-text-muted, #64748b); }
+.ds-pa-item-field--full { grid-column: 1 / -1; }
+.ds-pa-item-card .ds-input {
+  min-height: 30px; padding: 3px 6px; font-size: 0.76rem;
   width: 100%; box-sizing: border-box;
 }
-.ds-pa-ic-name  { min-width: 130px; }
-.ds-pa-ic-type  { width: 80px; }
-.ds-pa-ic-gefen { width: 68px; }
-.ds-pa-ic-num   { width: 62px; }
-.ds-pa-ic-total { width: 76px; }
-.ds-pa-ic-desc  { min-width: 110px; }
-.ds-pa-ic-del   { width: 28px; text-align: center; }
+.ds-pa-item-actions { display: flex; justify-content: flex-start; }
 .ds-pa-items-total-row {
   font-size: 0.82rem; margin: 5px 0 0; color: var(--ds-color-text-muted, #64748b);
 }
 .ds-pa-items-total-row strong { color: var(--ds-color-text, #0f172a); }
+@media (max-width: 520px) {
+  .ds-pa-item-grid,
+  .ds-pa-item-grid--numbers { grid-template-columns: 1fr; }
+}
 
 /* Items summary (drawer) */
 .ds-pa-items-summary { margin: 4px 0; }
@@ -10432,18 +10432,16 @@ select.ds-input {
 .pa-doc-header {
   margin-bottom: 8px;
 }
-.pa-doc-header-brand {
-  display: flex;
-  justify-content: flex-start;
-  margin-bottom: 8px;
+.pa-doc-topline {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: start;
+  margin-top: 4pt;
+  margin-bottom: 8pt;
 }
-.pa-doc-head-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  border-bottom: 1px solid #8b8f97;
-  padding-bottom: 8px;
-  margin-bottom: 12px;
+.pa-doc-header-brand {
+  text-align: right;
+  justify-self: end;
 }
 .pa-doc-logo {
   display: block; max-width: 100%; height: auto;
@@ -10454,10 +10452,10 @@ select.ds-input {
   margin-inline: 0;
 }
 .pa-doc-logo--footer {
-  width: 170px;
-  max-width: 40%;
+  width: 230px;
+  max-width: 55%;
   margin-inline: auto;
-  opacity: 0.9;
+  opacity: 0.95;
 }
 .pa-doc-date {
   justify-self: start;
@@ -10465,6 +10463,7 @@ select.ds-input {
   font-size: 9pt;
   line-height: 1.5;
   text-align: left;
+  direction: ltr;
   margin-bottom: 4pt;
 }
 .pa-doc-address {
@@ -10475,6 +10474,11 @@ select.ds-input {
   margin-bottom: 4pt;
 }
 .pa-doc-address p { margin: 0 0 2px; }
+.pa-doc-divider {
+  border: none;
+  border-top: 1px solid #444;
+  margin: 10px 0 14px;
+}
 .pa-doc-subject {
   margin: 10pt 0 8pt;
   color: #1f4e79;
@@ -10532,7 +10536,7 @@ select.ds-input {
   padding-top: 4pt;
 }
 .pa-doc-footer {
-  margin-top: 18pt;
+  margin-top: 26px;
   padding-top: 0;
   border: 0;
   break-inside: avoid;
@@ -10551,8 +10555,8 @@ select.ds-input {
   .pa-doc-header {
     margin-bottom: 6px;
   }
-  .pa-doc-head-meta {
-    flex-direction: column-reverse;
+  .pa-doc-topline {
+    grid-template-columns: 1fr;
     gap: 8px;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve the edit-mode UX for proposal items so the drawer is compact, readable and avoids horizontal scrolling. 
- Make the preview/PDF output look like a formal Word document (A4, RTL, typography and header/footer layout) rather than a dashboard panel.
- Keep existing data flows intact (autofill from `proposal_activity_pricing`, calculations, and save) without touching DB, permissions or business logic.

### Description
- Replaced the wide table items editor with vertical, compact item cards inside the drawer and kept the same `name`/`data-*` hooks so quick-pick autofill, `quantity × unit_price` row calc, grand total and `saveProposalAgreementItems` flow continue to work (changed `frontend/src/screens/proposals-agreements.js`).
- Switched the items editor DOM from a `<table>` to a grid of `.ds-pa-item-card` elements and added responsive CSS (`.ds-pa-items-list`, `.ds-pa-item-grid`, `.ds-pa-item-grid--numbers`, etc.) in `frontend/src/styles/main.css` to fit drawer width and collapse to one column on narrow screens.
- Reworked preview markup and styles to a Word-like layout: top-line with logo and date, right-aligned “לכבוד” block, thin divider, centered underlined subject, compact section spacing, left-side signature line, and enlarged footer logo; updated logo paths to use `${PUBLIC_BASE}proposals/...` (changes in `frontend/src/screens/proposals-agreements.js` and `frontend/src/styles/main.css`).
- Kept preview content generation logic and template keys intact while simplifying ordering (ensured `payment_terms` section placement), preserved plain-text listing of activity lines (no heavy cost table) and added gentle display of `gefen_number` when present.

### Testing
- Ran unit/integration tests with `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (36 passed, 0 failed).
- Built the app with `npm run build` successfully; `dist/` artefacts were reverted to keep source-only changes.
- Verified that preview overlay, quick-pick autofill, item calculations, add/remove item actions and `saveProposalAgreementItems` integration remain functional via the automated tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0feb2dba6c832b88a1c1047a35269a)