### PR TITLE
Refine proposals item editor cards and Word-like preview formatting

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -414,7 +414,7 @@ function proposalTitle(row) {
 function sectionBodyHtml(value) {
   const body = String(value || '').trim();
   if (!body) return '';
-  return `<p>${escapeHtml(body)}</p>`;
+  return `<p class="pa-doc-paragraph">${escapeHtml(body)}</p>`;
 }
 
 function proposalLineHtml(item = {}) {
@@ -436,7 +436,7 @@ function proposalLineHtml(item = {}) {
 function proposalItemsListHtml(items = []) {
   if (!Array.isArray(items) || !items.length) return '';
   const lines = items.map(proposalLineHtml).filter(Boolean).join('');
-  return lines || '';
+  return lines ? `<div class="pa-proposal-lines">${lines}</div>` : '';
 }
 
 function sectionHtml(title, body, className = '') {
@@ -499,9 +499,8 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
             class="pa-doc-logo pa-doc-logo--header"
             loading="eager"
             decoding="async"
-            onerror="this.style.display='none';this.parentElement?.querySelector('.pa-doc-company-block')?.removeAttribute('hidden');"
+            onerror="this.style.display='none';"
           >
-          <div class="pa-doc-company-block" hidden>תעשיידע</div>
         </div>
         <div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>
       </div>
@@ -515,8 +514,8 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     </header>
     <hr class="pa-doc-divider">
     <h1 class="pa-doc-subject">${escapeHtml(proposalTitle(row))}</h1>
-    ${introText ? sectionBodyHtml(introText) : ''}
-    ${activitySectionHtml ? `<section class="pa-section"><h3>${sectionTitle('activity_intro', 'הפעילות המוצעת')}:</h3>${activitySectionHtml}</section>` : ''}
+    ${introText ? `<p class="pa-doc-intro">${escapeHtml(introText)}</p>` : ''}
+    ${activitySectionHtml ? `<section class="pa-section"><h3>${sectionTitle('activity_intro', 'הפעילות המוצעת')}</h3>${activitySectionHtml}</section>` : ''}
     ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility) : ''}
     ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
     ${paymentTerms ? sectionHtml(sectionTitle('payment_terms', 'עלויות ותנאי תשלום'), paymentTerms) : ''}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10354,6 +10354,9 @@ select.ds-input {
    Proposals – Items editor
    ═══════════════════════════════════════════════════════════════════ */
 .ds-pa-items-section { margin: 10px 0 8px; }
+.ds-pa-items-section,
+.ds-pa-items-list,
+.ds-pa-item-card { min-width: 0; overflow-x: clip; }
 .ds-pa-items-header {
   display: flex; align-items: center; justify-content: space-between;
   margin-bottom: 5px;
@@ -10368,10 +10371,12 @@ select.ds-input {
   gap: 8px;
 }
 .ds-pa-item-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
-.ds-pa-item-grid--numbers { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.ds-pa-item-grid--numbers { grid-template-columns: repeat(3, minmax(84px, 1fr)); }
 .ds-pa-item-field { display: grid; gap: 4px; min-width: 0; }
 .ds-pa-item-field span { font-size: 0.71rem; color: var(--ds-color-text-muted, #64748b); }
 .ds-pa-item-field--full { grid-column: 1 / -1; }
+.ds-pa-item-field--full .ds-input,
+.ds-pa-item-field--full select { width: 100%; }
 .ds-pa-item-card .ds-input {
   min-height: 30px; padding: 3px 6px; font-size: 0.76rem;
   width: 100%; box-sizing: border-box;
@@ -10506,6 +10511,7 @@ select.ds-input {
   background: transparent;
 }
 .pa-section p,
+.pa-doc-paragraph,
 .pa-doc-intro,
 .pa-proposal-lines,
 .pa-cost-line {
@@ -10515,6 +10521,7 @@ select.ds-input {
   margin: 0 0 4pt;
   white-space: pre-line;
 }
+.pa-doc-paragraph { margin: 0 0 4pt; }
 .pa-doc-signature-simple {
   margin-top: 28pt;
   text-align: left;


### PR DESCRIPTION
### Motivation
- להפוך את עריכת שורות ההצעה בחלונית ה־drawer לנוחה וקומפקטית בלי גלילה אופקית ותצוגת טבלה רחבה.
- לגרום ל־Preview/PDF להיראות כמו מסמך Word רשמי — טיפוגרפיה קומפקטית, פסקאות ברורות וכותרות מדגישות, בלי עיצוב דשבורד או טבלאות כבדות.

### Description
- שינויים ב־`frontend/src/screens/proposals-agreements.js`: הוצג `intro` כפסקת פתיחה רגילה, הוחלפה אריזת שורות העלות לרשימת טקסט פשוטה (`pa-proposal-lines`), והוסר fallback טקסטואלי כפול מתחת ללוגו העליון; שיפורים קלים במבני HTML של הכותרות והפסקאות.
- שינויים ב־`frontend/src/styles/main.css`: הוספת כללים שמונעים overflow אופקי עבור רשימת השורות, קיבוץ כרטיסי פריט קומפקטיים (`.ds-pa-item-card`) עם גריד שתי/שלוש עמודות מותאם, והוספת מחלקת פסקה אחידה (`.pa-doc-paragraph`) כדי לשמור על rhythm של Word (10pt, line-height 1.5).
- שמרתי על הפונקציונליות הקיימת: quick-pick של `proposal_activity_pricing`, חישוב שורה (`quantity × unit_price = total`), סכום כללי (`total_amount`) ושמירת שורות דרך `saveProposalAgreementItems` ללא שינויים בלוגיקה עסקית או DB.
- לא הוספתי מודולים חדשים, לא שיניתי הרשאות, לא פגעתי בקריאות Supabase ולא ערכתי קבצי `dist` בקומיט.

### Testing
- הרצת בדיקות יחידה: `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` — כל הבדיקות עברו (36 passed).
- בנייה לייצור: `npm run build` — הצליחה וה־`dist` שנוצר שוחזר ולא נכלל בקומיט.
- בדיקות אוטומטיות אימתוו שה־preview משתמש במפתחות תבנית קיימים, שה־items editor מתנהג כמצופה (חישובים, הוספה/הסרה, quick-pick) ושה־preview נבנה מחדש על כל פתיחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fefc5a0b4832bb41e831ae2761f86)