### PR TITLE
Invitation print: add preview modal and isolate print root

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 419;
+const CACHE_VERSION = 420;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-C7iFRNKN.js",
+  "./assets/index-DEI6uRsA.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-X3ypGff7.css",
+  "./assets/style-C-SNCWTl.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-C7iFRNKN.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-X3ypGff7.css">
+  <script type="module" crossorigin src="./assets/index-DEI6uRsA.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-C-SNCWTl.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 419;
+const CACHE_VERSION = 420;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-C7iFRNKN.js",
+  "./assets/index-DEI6uRsA.js",
   "./assets/logo1-sNrSbLi9.png",
   "./assets/logo1.png",
   "./assets/logo2.png",
@@ -30,7 +30,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-X3ypGff7.css",
+  "./assets/style-C-SNCWTl.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -43,6 +43,12 @@ function ensureInvitationStyles() {
   .invitation-preview-wrapper{width:100%;display:flex;justify-content:center;align-items:flex-start}
   .invitation-preview-scale{width:794px;height:1123px;display:flex;justify-content:center;align-items:flex-start;transform:scale(var(--a4-scale,1));transform-origin:top center}
   .invitation-print-page{width:794px;min-height:1123px;padding:102px 76px 70px;position:relative;overflow:hidden;display:flex;align-items:center;justify-content:center;background-color:#fffdf6;background-image:none;background-size:cover;background-position:center;box-shadow:0 18px 42px rgba(15,23,42,.16)}
+  .inv-print-modal{position:fixed;inset:0;z-index:2147483600;background:rgba(15,23,42,.56);display:flex;align-items:center;justify-content:center;padding:20px}
+  .inv-print-modal[hidden]{display:none}
+  .inv-print-dialog{width:min(980px,96vw);max-height:94vh;overflow:auto;border-radius:20px;background:#fff;border:1px solid #dbe5ef;box-shadow:0 20px 48px rgba(2,6,23,.35);padding:16px;display:grid;gap:12px}
+  .inv-print-actions{display:flex;justify-content:flex-start;gap:8px;position:sticky;top:0;background:#fff;padding-bottom:6px;z-index:2}
+  .inv-print-preview{display:flex;justify-content:center;overflow:auto;padding:8px}
+  .inv-print-preview .invitation-print-page{box-shadow:0 10px 24px rgba(2,6,23,.2)}
   .page-ribbon{position:absolute;top:0;bottom:0;width:66px;z-index:1;opacity:.92}.page-ribbon.right{right:0;background:radial-gradient(circle at 50% 14%, rgba(255,255,255,0.92) 0 6px, transparent 7px),radial-gradient(circle at 45% 31%, rgba(18,185,129,0.42), transparent 26px),radial-gradient(circle at 60% 60%, rgba(14,165,233,0.28), transparent 30px),linear-gradient(180deg, rgba(18,185,129,0.4), rgba(14,165,233,0.18))}.page-ribbon.left{left:0;background:radial-gradient(circle at 50% 80%, rgba(255,255,255,0.9) 0 7px, transparent 8px),radial-gradient(circle at 50% 22%, rgba(14,165,233,0.35), transparent 28px),radial-gradient(circle at 56% 58%, rgba(217,249,157,0.45), transparent 28px),linear-gradient(180deg, rgba(14,165,233,0.22), rgba(18,185,129,0.34))}
   .decor-bubble{position:absolute;border-radius:999px;border:1px solid rgba(255,255,255,0.68);background:rgba(255,255,255,0.42);box-shadow:0 10px 24px rgba(15,23,42,0.08);z-index:1}.bubble-1{width:118px;height:118px;top:62px;right:64px}.bubble-2{width:88px;height:88px;bottom:86px;left:78px}.bubble-3{width:54px;height:54px;top:170px;left:92px}
   .logos-header{position:absolute;top:24px;left:50%;transform:translateX(-50%);z-index:3;display:flex;gap:18px;padding:8px 20px;border-radius:999px;background:rgba(255,255,255,0.76);border:1px solid rgba(255,255,255,0.72)}
@@ -114,7 +120,7 @@ function invitationPreviewHtml(s) {
 }
 
 export const invitationsScreen = { load: async () => ({}), render() { ensureInvitationStyles(); const s = { course: '', type: '', school: '', className: '', title: '', subtitle: '', schoolYear: '', day: '', date: '', time: '', location: '', body1: '', body2: '', participants: '', closing: '', backgroundCss: PRESET_BACKGROUNDS.soft, hasBackground: false, logos: { education: '', taasiyeda: '', school: '' } }; return `<section class="inv-shell" data-invitations-root><aside class="inv-panel"><h2 class="inv-title">מחולל הזמנות</h2><div class="inv-grid">${COURSE_OPTIONS.map((c) => `<button type="button" class="inv-chip ${s.course === c.key ? 'active' : ''}" data-course="${c.key}">${c.icon} ${c.label}</button>`).join('')}</div><div class="inv-grid" style="grid-template-columns:1fr">${INVITATION_TYPES.map((t) => `<button type="button" class="inv-chip ${s.type === t.key ? 'active' : ''}" data-type="${t.key}">${t.label}</button>`).join('')}</div>${[['schoolYear','שנת לימודים'],['className','כיתה'],['school','בית ספר'],['title','כותרת'],['subtitle','כותרת משנה'],['day','יום'],['date','תאריך'],['time','שעה'],['location','מיקום'],['body1','פסקה 1'],['body2','פסקה 2'],['participants','משתתפים'],['closing','סיום']].map(([k,l])=>`<label class="inv-field"><span>${l}</span>${['subtitle','participants','body1','body2'].includes(k)?`<textarea data-field="${k}"></textarea>`:`<input data-field="${k}"/>`}</label>`).join('')}<label class="inv-field"><span>רקע מובנה</span><select data-background-preset><option value="soft">רקע עדין</option><option value="clean">רקע בהיר</option></select></label><label class="inv-field"><span>העלאת תמונת רקע</span><input type="file" accept="image/*" data-background-upload /></label>${['education','taasiyeda','school'].map((k)=>`<label class="inv-field"><span>לוגו ${k}</span><input type="file" accept="image/*" data-logo-upload="${k}"/></label>`).join('')}<button type="button" class="inv-btn" data-print>הפק / שמור כ-PDF</button></aside><main class="invitation-preview-viewport" data-inv-preview>${invitationEmptyStateHtml()}</main></section>`; },
-  bind({ root }) { const host = root?.querySelector('[data-invitations-root]'); if (!host) return; const state = { course: '', type: '', school: '', className: '', title: '', subtitle: '', schoolYear: '', day: '', date: '', time: '', location: '', body1: '', body2: '', participants: '', closing: '', backgroundCss: PRESET_BACKGROUNDS.soft, hasBackground: false, logos: { education: '', taasiyeda: '', school: '' } }; const repaint = () => { host.querySelectorAll('[data-course]').forEach((el) => el.classList.toggle('active', el.dataset.course === state.course)); host.querySelectorAll('[data-type]').forEach((el) => el.classList.toggle('active', el.dataset.type === state.type)); const p = host.querySelector('[data-inv-preview]'); const canPreview = Boolean(state.course && state.type); if (p) p.innerHTML = canPreview ? invitationPreviewHtml(state) : invitationEmptyStateHtml(); const wrap = p?.querySelector('.invitation-preview-scale'); const availWidth = p?.clientWidth || 980; const availHeight = p?.clientHeight || 1200; if (wrap) { const widthScale = (availWidth - 24) / 794; const heightScale = (availHeight - 24) / 1123; const nextScale = Math.max(0.68, Math.min(0.72, widthScale, heightScale)); wrap.style.setProperty('--a4-scale', String(nextScale)); wrap.style.width = '794px'; wrap.style.height = '1123px'; } if (p) p.scrollTop = 0; };
+  bind({ root }) { const host = root?.querySelector('[data-invitations-root]'); if (!host) return; const state = { course: '', type: '', school: '', className: '', title: '', subtitle: '', schoolYear: '', day: '', date: '', time: '', location: '', body1: '', body2: '', participants: '', closing: '', backgroundCss: PRESET_BACKGROUNDS.soft, hasBackground: false, logos: { education: '', taasiyeda: '', school: '' } }; const repaint = () => { host.querySelectorAll('[data-course]').forEach((el) => el.classList.toggle('active', el.dataset.course === state.course)); host.querySelectorAll('[data-type]').forEach((el) => el.classList.toggle('active', el.dataset.type === state.type)); const p = host.querySelector('[data-inv-preview]'); const canPreview = Boolean(state.course && state.type); if (p) p.innerHTML = canPreview ? invitationPreviewHtml(state) : invitationEmptyStateHtml(); const wrap = p?.querySelector('.invitation-preview-scale'); const availWidth = p?.clientWidth || 980; const availHeight = p?.clientHeight || 1200; if (wrap) { const widthScale = (availWidth - 24) / 794; const heightScale = (availHeight - 24) / 1123; const nextScale = Math.max(0.78, Math.min(1, widthScale, heightScale)); wrap.style.setProperty('--a4-scale', String(nextScale)); wrap.style.width = '794px'; wrap.style.height = '1123px'; } if (p) p.scrollTop = 0; };
     host.querySelectorAll('[data-course]').forEach((el) => el.addEventListener('click', () => { state.course = el.dataset.course || state.course; repaint(); })); host.querySelectorAll('[data-type]').forEach((el) => el.addEventListener('click', () => { state.type = el.dataset.type || state.type; repaint(); })); host.querySelectorAll('[data-field]').forEach((el) => el.addEventListener('input', (e) => { const f = e.target?.dataset?.field; if (!f) return; state[f] = e.target.value || ''; repaint(); }));
     host.querySelector('[data-background-preset]')?.addEventListener('change', (e) => { state.backgroundCss = PRESET_BACKGROUNDS[e.target.value] || PRESET_BACKGROUNDS.soft; state.hasBackground = true; repaint(); });
     host.querySelector('[data-background-upload]')?.addEventListener('change', (e) => { const file = e.target.files?.[0]; if (!file) return; const r = new FileReader(); r.onload = () => { state.backgroundCss = `url('${r.result}')`; state.hasBackground = true; repaint(); }; r.readAsDataURL(file); });
@@ -134,19 +140,53 @@ export const invitationsScreen = { load: async () => ({}), render() { ensureInvi
       if (printRoot) printRoot.innerHTML = '';
       document.body.classList.remove('printing-invitation');
     };
+    const ensurePrintModal = () => {
+      let modal = document.getElementById('inv-print-modal');
+      if (modal) return modal;
+      modal = document.createElement('div');
+      modal.id = 'inv-print-modal';
+      modal.className = 'inv-print-modal';
+      modal.hidden = true;
+      modal.innerHTML = `<div class="inv-print-dialog" role="dialog" aria-modal="true" aria-label="תצוגה מוקדמת להדפסה">
+        <div class="inv-print-actions">
+          <button type="button" class="inv-btn" data-modal-print>הדפס / שמור כ־PDF</button>
+          <button type="button" class="inv-btn" data-modal-close>סגירה</button>
+        </div>
+        <div class="inv-print-preview" data-modal-preview></div>
+      </div>`;
+      document.body.appendChild(modal);
+      modal.addEventListener('click', (e) => {
+        if (e.target === modal || e.target?.closest('[data-modal-close]')) modal.hidden = true;
+      });
+      modal.querySelector('[data-modal-print]')?.addEventListener('click', () => {
+        const previewPage = modal.querySelector('[data-modal-preview] .invitation-print-page');
+        if (!previewPage) return;
+        const printRoot = ensurePrintRoot();
+        printRoot.innerHTML = '';
+        const clonedPage = previewPage.cloneNode(true);
+        clonedPage.removeAttribute('id');
+        clonedPage.style.transform = 'none';
+        clonedPage.style.scale = 'none';
+        printRoot.appendChild(clonedPage);
+        document.body.classList.add('printing-invitation');
+        window.print();
+      });
+      return modal;
+    };
     host.querySelector('[data-print]')?.addEventListener('click', () => {
       if (!state.course || !state.type) return;
       const sourcePage = host.querySelector('.invitation-print-page');
       if (!sourcePage) return;
-      const printRoot = ensurePrintRoot();
-      printRoot.innerHTML = '';
+      const modal = ensurePrintModal();
+      const previewTarget = modal.querySelector('[data-modal-preview]');
+      if (!previewTarget) return;
+      previewTarget.innerHTML = '';
       const clonedPage = sourcePage.cloneNode(true);
       clonedPage.removeAttribute('id');
       clonedPage.style.transform = 'none';
       clonedPage.style.scale = 'none';
-      printRoot.appendChild(clonedPage);
-      document.body.classList.add('printing-invitation');
-      window.print();
+      previewTarget.appendChild(clonedPage);
+      modal.hidden = false;
     });
     window.addEventListener('afterprint', cleanupPrintRoot);
     window.addEventListener('resize', repaint);


### PR DESCRIPTION
### Motivation
- The print/export button must not call `window.print()` directly from the main screen and instead show a preview modal before printing.
- Printing must run from an independent `#print-root` so dashboard/sidebar/form UI is not printed and the result is a single A4 page.
- The on-screen preview must remain readable (no overly-small default scale) while keeping A4 aspect ratio for print.

### Description
- Reworked `frontend/src/screens/invitations.js` to replace the direct `window.print()` call with a preview modal that contains a cloned copy of the current invitation and two actions: `הדפס / שמור כ־PDF` and close.
- Added `ensurePrintModal()` and modal styles (`.inv-print-modal`, `.inv-print-dialog`, `.inv-print-preview`, etc.) and changed the sidebar print button to open the modal with a cloned invitation instead of printing immediately.
- Kept print isolation to `#print-root`: the modal's print button clones the preview into `#print-root`, applies `printing-invitation` then invokes `window.print()`; `afterprint` cleaning remains intact.
- Adjusted preview scale logic to avoid a too-small default (changed bounds from ~0.68–0.72 to ~0.78–1) and ensured `@media print` shows only `#print-root`, cancels `transform/scale`, and sets A4 sizing to avoid extra pages.
- Build generated updated distribution artifacts (`dist/index.html`, `dist/sw.js`, `dist/frontend/sw.js`) which include bumped cache version and updated asset names as part of the production build output.

### Testing
- Ran `npm run build`, which completed successfully and produced new `dist` assets.
- Ran `node --test tests/service-worker-pwa-cache.test.mjs`, which passed all tests (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff4158200832b8abf3f6accc4e1e8)