### PR TITLE
Fix proposal preview print output to match on-screen document

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10569,42 +10569,135 @@ select.ds-input {
 }
 
 /* ═══════════════════════════════════════════════════════════════════
-   Print styles — show only the preview overlay
+   Print styles — render proposal preview as-is
    ═══════════════════════════════════════════════════════════════════ */
 @media print {
-  @page { size: A4; margin: 18mm 16mm; }
-  body > *:not(#pa-preview-overlay) { display: none !important; }
-  body, html {
+  @page {
+    size: A4;
+    margin: 18mm 16mm;
+  }
+
+  html,
+  body {
     background: #fff !important;
     margin: 0 !important;
     padding: 0 !important;
   }
-  #pa-preview-overlay {
-    position: static !important; background: #fff !important; overflow: visible !important;
+
+  body * {
+    visibility: hidden !important;
   }
-  #pa-preview-overlay * { visibility: visible !important; }
-  .ds-pa-preview-toolbar { display: none !important; }
-  .ds-pa-preview-doc {
+
+  #pa-preview-overlay,
+  #pa-preview-overlay * {
+    visibility: visible !important;
+  }
+
+  #pa-preview-overlay {
+    position: static !important;
+    inset: auto !important;
     width: auto !important;
-    min-height: 0 !important;
-    box-shadow: none !important;
+    height: auto !important;
+    overflow: visible !important;
+    background: #fff !important;
+    padding: 0 !important;
+    margin: 0 !important;
     border: none !important;
+    box-shadow: none !important;
+  }
+
+  #pa-preview-overlay .pa-preview-toolbar,
+  #pa-preview-overlay .ds-pa-preview-toolbar,
+  #pa-preview-overlay button,
+  #pa-preview-overlay .ds-btn,
+  #pa-preview-overlay [data-pa-print],
+  #pa-preview-overlay [data-pa-preview-close] {
+    display: none !important;
+  }
+
+  .ds-pa-preview-doc {
+    position: static !important;
+    width: auto !important;
+    max-width: none !important;
+    min-height: 0 !important;
     margin: 0 !important;
     padding: 0 !important;
-    max-width: none !important;
+    box-shadow: none !important;
+    border: none !important;
+    background: #fff !important;
+    color: #111827 !important;
+    direction: rtl !important;
+    font-family: Arial, "Noto Sans Hebrew", sans-serif !important;
     font-size: 10pt !important;
     line-height: 1.5 !important;
     letter-spacing: 0.15px !important;
   }
-  .pa-doc-date { font-size: 9pt !important; line-height: 1.5 !important; }
-  .pa-doc-signature-simple { font-size: 9pt !important; line-height: 1.5 !important; }
-  .pa-doc-footer {
-    margin-top: 28px !important;
-    padding-top: 0 !important;
+
+  .pa-section {
+    margin: 8pt 0 !important;
+    break-inside: avoid !important;
     page-break-inside: avoid !important;
   }
-  .pa-doc-logo--header,
-  .pa-doc-logo--footer {
+
+  .pa-section h3 {
+    font-size: 10pt !important;
+    font-weight: 700 !important;
+    text-decoration: underline !important;
+    color: #1f4e79 !important;
+    margin: 0 0 3pt !important;
+    line-height: 1.5 !important;
+  }
+
+  .pa-section p,
+  .pa-doc-intro,
+  .pa-proposal-lines {
+    font-size: 10pt !important;
+    line-height: 1.5 !important;
+    margin: 0 0 4pt !important;
+    white-space: pre-line !important;
+  }
+
+  .pa-doc-date {
+    font-size: 9pt !important;
+    text-align: left !important;
+    direction: ltr !important;
+    line-height: 1.5 !important;
+  }
+
+  .pa-doc-address {
+    text-align: right !important;
+    direction: rtl !important;
+    font-size: 10pt !important;
+  }
+
+  .pa-doc-subject {
+    text-align: center !important;
+    font-size: 11pt !important;
+    font-weight: 700 !important;
+    color: #1f4e79 !important;
+    text-decoration: underline !important;
+    margin: 10pt 0 8pt !important;
+  }
+
+  .pa-doc-logo--header {
+    width: 155px !important;
+    max-width: 32% !important;
+    height: auto !important;
     display: block !important;
+  }
+
+  .pa-doc-logo--footer {
+    width: 230px !important;
+    max-width: 55% !important;
+    height: auto !important;
+    opacity: 0.95 !important;
+    display: block !important;
+  }
+
+  .pa-doc-signature-simple {
+    text-align: left !important;
+    font-size: 9pt !important;
+    line-height: 1.5 !important;
+    margin-top: 28pt !important;
   }
 }


### PR DESCRIPTION
### Motivation
- The printed PDF / `window.print()` output diverged from the on-screen proposal preview due to existing print rules hiding or reflowing the preview overlay and applying different layout/typography.
- The goal is to ensure print/PDF output closely matches the preview without touching DB, business logic, or `dist` content.

### Description
- Reworked and consolidated the `@media print` rules in `frontend/src/styles/main.css` so only the proposal preview overlay (`#pa-preview-overlay`) is visible when printing and all non-document UI is hidden.
- Aligned print typography and spacing with the preview: `font-size: 10pt`, `line-height: 1.5`, `letter-spacing: 0.15px`, bold underlined section headings, `9pt` date/signature, RTL text direction, and stabilized container sizing to avoid browser reflow differences.
- Explicitly ensured header/footer logos remain visible and sized consistently in print and removed modal/box framing that caused layout drift.
- Kept all other constraints from the request: no database, business-logic, or `dist` changes were committed.

### Testing
- Ran proposal-related unit tests with `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (36 passed, 0 failed).
- Built production assets with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff65a6280832b8de3beeb0a5e1fd8)