### PR TITLE
fix(print): center A5 invitation PDF and prevent sideways drift

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -817,7 +817,7 @@ export const invitationsScreen = {
       return `${baseStyle.replace('.invitation-screen-root .preview #card{zoom:.50}', '')}
 body{font-family:'Heebo',sans-serif;background:#ccc;display:flex;flex-direction:column;align-items:center;padding:20px;direction:rtl}
 @page{size:A5 portrait;margin:0}
-@media print{body{background:none;padding:0}.np{display:none}#card{box-shadow:none!important}}
+@media print{html,body{width:148mm;height:210mm;margin:0;padding:0;overflow:hidden}body{background:none;display:flex;align-items:flex-start;justify-content:center}.np{display:none}#card{width:148mm;height:210mm;min-height:210mm;max-height:210mm;box-shadow:none!important;position:relative;left:50%;transform:translateX(-50%) scale(.99);transform-origin:top center;margin:0 auto}}
 .np{margin-bottom:14px}
 .np button{background:#1a8c6e;color:#fff;border:none;padding:9px 22px;border-radius:7px;font-family:'Heebo',sans-serif;font-size:14px;font-weight:700;cursor:pointer}
 .cbg{${bgStyle}}`;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 423;
+const CACHE_VERSION = 424;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 423;
+const SW_ENTRY_VERSION = 424;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Solve an instability where printing/saving the invitation to A5 PDF with `scale: 99%` causes the page to shift horizontally and risk bottom clipping, while keeping the on-screen preview and layout unchanged.

### Description
- Added print-only CSS in `getPrintCSS` (used by the invitations print window) that forces `html`/`body` to `148mm x 210mm`, centers the print container and applies a `scale(.99)` only for print to avoid clipping and sideways drift without changing the screen preview (`frontend/src/screens/invitations.js`).
- Applied a hard-centering approach for `#card` using `left:50%` + `transform: translateX(-50%) scale(.99)` and `transform-origin: top center` to prevent lateral shifts in PDF rendering.
- Removed print-only box-shadow and ensured min/max heights are fixed for stable A5 layout in print.
- Bumped the service worker cache version (`CACHE_VERSION` and `SW_ENTRY_VERSION`) from `423` to `424` in `frontend/sw.js` and `sw.js` to force clients to fetch the updated CSS and avoid serving stale assets.

### Testing
- Ran the service-worker cache/version regression test: `node --test tests/service-worker-pwa-cache.test.mjs` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b848591c832bbec898abae2e9068)