### PR TITLE
Polish sidebar nav: widen layout, center buttons, subtle scrollbars, bump SW cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 423;
+const CACHE_VERSION = 425;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DSQxidu2.js",
+  "./assets/index-CYylMSgX.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-OopJiR-D.css",
+  "./assets/style-BXK5LL3w.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DSQxidu2.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-OopJiR-D.css">
+  <script type="module" crossorigin src="./assets/index-CYylMSgX.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BXK5LL3w.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 423;
+const CACHE_VERSION = 425;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DSQxidu2.js",
+  "./assets/index-CYylMSgX.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-OopJiR-D.css",
+  "./assets/style-BXK5LL3w.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9294,6 +9294,86 @@ select.ds-input {
   background: color-mix(in srgb, var(--ds-accent) 82%, #fff);
 }
 
+/* ===== Sidebar navigation layout polish (width, spacing, centering, scrolling) ===== */
+:root {
+  --ds-sidebar-w: 148px;
+}
+
+@media (min-width: 960px) {
+  .shell-sidebar {
+    width: var(--ds-sidebar-w);
+    min-width: var(--ds-sidebar-w);
+    padding: var(--ds-space-4) 10px;
+    gap: var(--ds-space-2);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .shell-nav {
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-inline: 2px;
+  }
+}
+
+.shell-nav {
+  gap: 6px;
+}
+
+.shell-nav__btn {
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.shell-nav__btn.is-active {
+  padding-inline: 14px;
+}
+
+.shell-nav__btn.is-active::before {
+  inset-inline-start: 8px;
+  top: 7px;
+  bottom: 7px;
+}
+
+/* Keep scrollbar subtle in sidebar/nav so it doesn't feel like a cramped inner window */
+.shell-sidebar,
+.shell-nav {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(170, 187, 211, 0.45) transparent;
+}
+
+.shell-sidebar::-webkit-scrollbar,
+.shell-nav::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.shell-sidebar::-webkit-scrollbar-track,
+.shell-nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.shell-sidebar::-webkit-scrollbar-thumb,
+.shell-nav::-webkit-scrollbar-thumb {
+  background: rgba(170, 187, 211, 0.45);
+  border: 1px solid transparent;
+}
+
+@media (max-width: 959px) {
+  .shell-sidebar {
+    width: min(84vw, 320px);
+    max-width: 320px;
+  }
+}
+
 .ds-card,
 .ds-interactive-card--kpi,
 .ds-manager-card {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 424;
+const CACHE_VERSION = 425;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- The sidebar felt too narrow so nav labels appeared cramped, some items looked clipped and the active item ("הזמנות") appeared stuck to the edge. 
- Scrolling inside the sidebar looked like a small, dominant inner window rather than a natural overflow region. 
- The change is presentation-only and must not affect routes, permissions, or navigation logic; the Service Worker must be bumped so the new CSS is picked up instead of a stale cache.

### Description
- Increased and stabilized desktop sidebar width via `--ds-sidebar-w` and added mobile width guardrails in `frontend/src/styles/main.css` to avoid pushing main content on narrow screens. 
- Made all sidebar nav buttons full-width with uniform `min-height`, centered labels, consistent padding and compact but readable spacing, and adjusted the active-button padding and activity-indicator offset so labels no longer touch the edge. 
- Softened and reduced scrollbar styling for `.shell-sidebar` and `.shell-nav` so overflow feels subtle and non-dominant. 
- Kept button text centering and overflow handling (`overflow-wrap`) so long labels wrap cleanly. 
- Bumped the Service Worker cache version (`CACHE_VERSION`) in `frontend/sw.js` to force clients to fetch the updated CSS assets.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Verified the Service Worker `CACHE_VERSION` was updated to force new assets to be loaded. 
- Visual/functional checks performed via the build output confirmed the updated CSS is present in the generated assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b91addb8832b92b12dad1c3ffe06)