### PR TITLE
Proposal preview: enforce document structure and render activity lines as text

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -417,20 +417,30 @@ function sectionBodyHtml(value) {
   return `<p class="pa-doc-paragraph">${escapeHtml(body)}</p>`;
 }
 
+function sectionHeadingText(rawTitle, fallback = '') {
+  const title = text(rawTitle) || fallback;
+  if (!title) return '';
+  return /[:：]\s*$/.test(title) ? title : `${title}:`;
+}
+
 function proposalLineHtml(item = {}) {
   const parts = [];
   const duration = text(item.unit_duration);
-  if (item.meetings_count != null && item.meetings_count !== '') parts.push(`${formatCurrency(item.meetings_count)} מפגשים`);
-  if (item.hours_count != null && item.hours_count !== '') parts.push(`${formatCurrency(item.hours_count)} שעות`);
-  else if (duration) parts.push(duration);
+  const meetings = item.meetings_count != null && item.meetings_count !== '' ? `${formatCurrency(item.meetings_count)} מפגשים` : '';
+  const hours = item.hours_count != null && item.hours_count !== '' ? `${formatCurrency(item.hours_count)} שעות` : '';
+  if (duration) parts.push(duration);
+  else {
+    if (meetings) parts.push(meetings);
+    if (hours) parts.push(hours);
+  }
   const total = Number(item.total_price) || ((Number(item.quantity) || 1) * (Number(item.unit_price) || 0));
   if (total) parts.push(`${formatCurrency(total)} ₪`);
   const gefenNumber = text(item.gefen_number);
   if (gefenNumber) parts.push(`גפ״ן ${gefenNumber}`);
   const itemName = text(item.item_name);
   if (!itemName) return '';
-  const suffix = parts.length ? `: ${parts.join(' | ')}` : '';
-  return `<p class="pa-cost-line">· ${escapeHtml(itemName)}${escapeHtml(suffix)}</p>`;
+  const suffix = parts.length ? `: ${parts.join(' | ')}` : ':';
+  return `<p class="pa-cost-line">· <strong>${escapeHtml(itemName)}</strong>${escapeHtml(suffix)}</p>`;
 }
 
 function proposalItemsListHtml(items = []) {
@@ -440,7 +450,7 @@ function proposalItemsListHtml(items = []) {
 }
 
 function sectionHtml(title, body, className = '') {
-  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(title)}</h3>${sectionBodyHtml(body)}</section>`;
+  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body)}</section>`;
 }
 
 function signatureSectionHtml(signatureText) {
@@ -479,15 +489,31 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const summerActivityIntro = sectionBody('summer_activity_intro', '');
   const nextYearActivityIntro = sectionBody('next_year_activity_intro', '');
   const signatureText = sectionBody('signature', '');
+
   const itemsByGroup = Array.isArray(items) ? items.reduce((acc, item) => {
-    const group = text(item.activity_type_group) || activityTypeGroup;
+    const itemType = text(item.item_type);
+    const unitDuration = text(item.unit_duration);
+    const explicitGroup = text(item.activity_type_group);
+    let group = explicitGroup || activityTypeGroup;
+    if (activityTypeGroup === 'הצעה משולבת' && !explicitGroup) {
+      if (unitDuration === '45 דקות' || /סדנה|חדר בריחה/.test(itemType)) group = 'פעילויות קיץ';
+      else group = 'שנה הבאה';
+    }
     if (!acc[group]) acc[group] = [];
     acc[group].push(item);
     return acc;
   }, {}) : {};
-  const activitySectionHtml = activityTypeGroup === 'הצעה משולבת'
-    ? `${summerActivityIntro ? sectionBodyHtml(summerActivityIntro) : ''}${proposalItemsListHtml(itemsByGroup['פעילויות קיץ'] || [])}${nextYearActivityIntro ? sectionBodyHtml(nextYearActivityIntro) : ''}${proposalItemsListHtml(itemsByGroup['שנה הבאה'] || [])}`
-    : `${activityIntro ? sectionBodyHtml(activityIntro) : ''}${proposalItemsListHtml(itemsByGroup[activityTypeGroup] || items)}`;
+
+  const sections = [];
+  if (activityTypeGroup === 'הצעה משולבת') {
+    const summerBlock = `${summerActivityIntro ? sectionBodyHtml(summerActivityIntro) : ''}${proposalItemsListHtml(itemsByGroup['פעילויות קיץ'] || [])}`;
+    const nextYearBlock = `${nextYearActivityIntro ? sectionBodyHtml(nextYearActivityIntro) : ''}${proposalItemsListHtml(itemsByGroup['שנה הבאה'] || [])}`;
+    if (summerBlock) sections.push(`<section class="pa-section"><h3>${escapeHtml(sectionHeadingText('הפעילות המוצעת – קיץ תשפ״ו'))}</h3>${summerBlock}</section>`);
+    if (nextYearBlock) sections.push(`<section class="pa-section"><h3>${escapeHtml(sectionHeadingText('הפעילות המוצעת – שנת הלימודים תשפ״ז'))}</h3>${nextYearBlock}</section>`);
+  } else {
+    const activityBlock = `${activityIntro ? sectionBodyHtml(activityIntro) : ''}${proposalItemsListHtml(itemsByGroup[activityTypeGroup] || items)}`;
+    if (activityBlock) sections.push(`<section class="pa-section"><h3>${escapeHtml(sectionHeadingText(sectionTitle('activity_intro', 'הפעילות המוצעת')))}</h3>${activityBlock}</section>`);
+  }
 
   return `
     <header class="pa-doc-header">
@@ -515,7 +541,7 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     <hr class="pa-doc-divider">
     <h1 class="pa-doc-subject">${escapeHtml(proposalTitle(row))}</h1>
     ${introText ? `<p class="pa-doc-intro">${escapeHtml(introText)}</p>` : ''}
-    ${activitySectionHtml ? `<section class="pa-section"><h3>${sectionTitle('activity_intro', 'הפעילות המוצעת')}</h3>${activitySectionHtml}</section>` : ''}
+    ${sections.join('')}
     ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility) : ''}
     ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
     ${paymentTerms ? sectionHtml(sectionTitle('payment_terms', 'עלויות ותנאי תשלום'), paymentTerms) : ''}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10603,7 +10603,7 @@ select.ds-input {
 }
 .pa-doc-paragraph { margin: 0 0 4pt; }
 .pa-doc-signature-simple {
-  margin-top: 28pt;
+  margin-top: 8pt;
   text-align: left;
   font-size: 9pt;
   line-height: 1.5;
@@ -10778,6 +10778,6 @@ select.ds-input {
     text-align: left !important;
     font-size: 9pt !important;
     line-height: 1.5 !important;
-    margin-top: 28pt !important;
+    margin-top: 8pt !important;
   }
 }


### PR DESCRIPTION
### Motivation
- Implement fixed structural rules for proposal preview rendering so the document layout follows semantic rules (intro as paragraph, section headings, activity lines, signature area) rather than relying only on CSS.
- Preserve Word-like textual lists and avoid converting activity lines into tables or showing empty `null`/`undefined` fields.
- Support combined (summer + next-year) proposals with a deterministic fallback grouping when items lack an explicit group.
- Improve printed output consistency for signature spacing and line behavior.

### Description
- Add `sectionHeadingText` to normalize section titles and append a trailing colon only for section headings, and keep `intro` rendered as a simple paragraph using `pa-doc-intro`. (modified `frontend/src/screens/proposals-agreements.js`)
- Rewrite `proposalLineHtml` to render activity lines as text bullets starting with `·`, bold the activity name, show duration/meetings/hours/price/gefen only when present, and avoid `null`/`undefined` output. (modified `frontend/src/screens/proposals-agreements.js`)
- Rework `proposalPreviewBodyHtml` to build explicit section blocks, add separate summer / next-year blocks for combined proposals, and implement fallback grouping by `item_type` / `unit_duration` when `activity_type_group` is missing. (modified `frontend/src/screens/proposals-agreements.js`)
- Keep the signature area as a dedicated signature block (not a normal section) and reduce top spacing in screen and print CSS to better match Word-like flow. (modified `frontend/src/styles/main.css`)

### Testing
- Ran `node --test tests/proposals-agreements-screen.test.mjs` which executed the proposals-agreements screen tests and they all passed (31 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d1a2c224832baaa8fc0bf98d97d8)