### PR TITLE
Render proposal sections and bullets as distinct lines in preview

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -412,9 +412,7 @@ function proposalTitle(row) {
 }
 
 function sectionBodyHtml(value) {
-  const body = String(value || '').trim();
-  if (!body) return '';
-  return `<p class="pa-doc-paragraph">${escapeHtml(body)}</p>`;
+  return sectionLinesHtml(value);
 }
 
 function sectionHeadingText(rawTitle, fallback = '') {
@@ -440,17 +438,35 @@ function proposalLineHtml(item = {}) {
   const itemName = text(item.item_name);
   if (!itemName) return '';
   const suffix = parts.length ? `: ${parts.join(' | ')}` : ':';
-  return `<p class="pa-cost-line">· <strong>${escapeHtml(itemName)}</strong>${escapeHtml(suffix)}</p>`;
+  return `· ${itemName}${suffix}`;
 }
 
 function proposalItemsListHtml(items = []) {
   if (!Array.isArray(items) || !items.length) return '';
-  const lines = items.map(proposalLineHtml).filter(Boolean).join('');
-  return lines ? `<div class="pa-proposal-lines">${lines}</div>` : '';
+  const lines = items.map(proposalLineHtml).filter(Boolean).join('\n');
+  return lines ? sectionLinesHtml(lines, { alwaysBullet: true, className: 'pa-proposal-lines' }) : '';
 }
 
 function sectionHtml(title, body, className = '') {
   return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body)}</section>`;
+}
+
+function sectionLinesHtml(value, options = {}) {
+  const { alwaysBullet = false, className = '' } = options;
+  const raw = String(value == null ? '' : value).replace(/\r\n?/g, '\n');
+  const lines = raw.split('\n');
+  const rendered = lines.map((line) => {
+    const original = String(line || '');
+    const trimmed = original.trim();
+    if (!trimmed) return '<span class="pa-section-line pa-section-line--empty">&nbsp;</span>';
+    const bulletMatch = trimmed.match(/^[·•-]\s*(.*)$/);
+    const isBullet = alwaysBullet || Boolean(bulletMatch);
+    const body = isBullet ? (bulletMatch ? bulletMatch[1] : trimmed) : trimmed;
+    const marker = isBullet ? '<span class="pa-section-bullet-marker">·</span>' : '';
+    return `<span class="pa-section-line${isBullet ? ' pa-section-line--bullet' : ''}">${marker}${escapeHtml(body)}</span>`;
+  }).join('');
+  if (!rendered.trim()) return '';
+  return `<div class="pa-section-body${className ? ` ${className}` : ''}">${rendered}</div>`;
 }
 
 function signatureSectionHtml(signatureText) {
@@ -540,7 +556,7 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     </header>
     <hr class="pa-doc-divider">
     <h1 class="pa-doc-subject">${escapeHtml(proposalTitle(row))}</h1>
-    ${introText ? `<p class="pa-doc-intro">${escapeHtml(introText)}</p>` : ''}
+    ${introText ? sectionLinesHtml(introText, { className: 'pa-doc-intro' }) : ''}
     ${sections.join('')}
     ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility) : ''}
     ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10590,18 +10590,35 @@ select.ds-input {
   border: 0;
   background: transparent;
 }
-.pa-section p,
-.pa-doc-paragraph,
 .pa-doc-intro,
-.pa-proposal-lines,
-.pa-cost-line {
+.pa-section-body {
   font-size: 10pt;
   line-height: 1.5;
   letter-spacing: 0.15px;
   margin: 0 0 4pt;
-  white-space: pre-line;
 }
-.pa-doc-paragraph { margin: 0 0 4pt; }
+.pa-section-body {
+  margin: 0;
+}
+.pa-section-line {
+  display: block;
+  margin: 0 0 4pt;
+}
+.pa-section-line--bullet {
+  margin: 0 0 3pt;
+  padding-right: 12pt;
+  text-indent: -8pt;
+}
+.pa-section-line--empty {
+  margin: 0 0 3pt;
+}
+.pa-section-bullet-marker {
+  display: inline-block;
+  width: 8pt;
+}
+.pa-proposal-lines {
+  margin-top: 2pt;
+}
 .pa-doc-signature-simple {
   margin-top: 8pt;
   text-align: left;
@@ -10728,13 +10745,22 @@ select.ds-input {
     line-height: 1.5 !important;
   }
 
-  .pa-section p,
+  .pa-section-body,
+  .pa-section-line,
   .pa-doc-intro,
   .pa-proposal-lines {
     font-size: 10pt !important;
     line-height: 1.5 !important;
+  }
+
+  .pa-section-line {
     margin: 0 0 4pt !important;
-    white-space: pre-line !important;
+  }
+
+  .pa-section-line--bullet {
+    margin: 0 0 3pt !important;
+    padding-right: 12pt !important;
+    text-indent: -8pt !important;
   }
 
   .pa-doc-date {


### PR DESCRIPTION
### Motivation
- The proposal preview previously collapsed `section_body` content into single paragraphs which made the output denser than the original Word-like document and mixed bullets into paragraphs.
- The goal is to present a clear hierarchy (section title, section opening text, bullet lines, activity/cost lines, signature) that matches the original document structure and printing behaviour.
- Intro should remain a plain opening paragraph (no “פתיח” header) while other sections must receive a visible section heading and properly separated lines.

### Description
- Added a `sectionLinesHtml` renderer that splits `section_body` text into lines, preserves blank lines as small spacers, detects leading bullet markers (`·`, `•`, `-`), and renders each line with dedicated markup; it continues to use `escapeHtml` for safety. (file: `frontend/src/screens/proposals-agreements.js`)
- Converted activity/cost rendering to emit one bullet line per selected activity via `proposalLineHtml` + `proposalItemsListHtml` and prevented double-bullet output by stripping original markers before rendering. (file: `frontend/src/screens/proposals-agreements.js`)
- Replaced the previous paragraph renderer with the new line-based renderer for `sectionBodyHtml` and for the `intro` text so opening text is rendered without an extra section heading. (file: `frontend/src/screens/proposals-agreements.js`)
- Adjusted print and screen CSS to introduce `.pa-section-body`, `.pa-section-line`, and related rules so bullets and spacing (3–4pt between bullets, ~8pt between sections) match the requested Word-like layout. (file: `frontend/src/styles/main.css`)

### Testing
- Ran the proposal screen tests with `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` which produced one failing pre-existing test related to service worker cache-version sync (`entry` vs `sw` version mismatch).
- Ran `npm run build` which completed successfully and generated the production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10fe000c34832b99246d5aec34fbd6)