### PR TITLE
Add per-proposal editable document sections (custom_document_sections)

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CYylMSgX.js",
+  "./assets/index-BeWxngqA.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BXK5LL3w.css",
+  "./assets/style-CFzctr1w.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CYylMSgX.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BXK5LL3w.css">
+  <script type="module" crossorigin src="./assets/index-BeWxngqA.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-CFzctr1w.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CYylMSgX.js",
+  "./assets/index-BeWxngqA.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BXK5LL3w.css",
+  "./assets/style-CFzctr1w.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1393,7 +1393,7 @@ function normalizeData(data) {
 
 
 const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
-const PROPOSALS_AGREEMENTS_COLUMNS = 'id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_COLUMNS = 'id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,created_at,updated_at';
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
 function parseActivityNamesFromNotes(notes) {
@@ -1493,6 +1493,7 @@ function normalizeProposalAgreementRow(row = {}) {
     status:              PA_VALID_STATUSES.has(rawStatus) ? rawStatus : 'draft',
     approval_note:       cleanProposalAgreementText(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
+    custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections : [],
     created_at:          cleanProposalAgreementText(row.created_at),
     updated_at:          cleanProposalAgreementText(row.updated_at)
   };
@@ -1519,7 +1520,8 @@ function sanitizeProposalAgreementPayload(payload = {}) {
     notes:               parseActivityNamesFromNotes(payload.notes).notes,
     status:              PA_VALID_STATUSES_SET.has(rawStatus) ? rawStatus : 'draft',
     approval_note:       cleanProposalAgreementText(payload.approval_note),
-    total_amount:        payload.total_amount != null ? Number(payload.total_amount) || null : null
+    total_amount:        payload.total_amount != null ? Number(payload.total_amount) || null : null,
+    custom_document_sections: Array.isArray(payload.custom_document_sections) ? payload.custom_document_sections : []
   };
   const missing = ['client_authority', 'school_framework', 'document_type', 'activity_type_group'].filter((key) => !row[key]);
   if (missing.length) throw new Error(`missing_required_fields:${missing.join(',')}`);
@@ -2585,6 +2587,25 @@ export const api = {
   readProposalTemplateSections: async () => {
     assertCanUseProposalsAgreementsApi();
     return readProposalTemplateSectionsFromSupabase();
+  },
+
+  saveProposalAgreementCustomDocumentSections: async (proposalId, sections) => {
+    assertCanUseProposalsAgreementsApi();
+    const rowId = cleanProposalAgreementText(proposalId);
+    if (!rowId) throw new Error('missing_proposal_agreement_id');
+    const cleanSections = (Array.isArray(sections) ? sections : []).map((section) => ({
+      section_key: cleanProposalAgreementText(section?.section_key),
+      section_title: cleanProposalAgreementText(section?.section_title),
+      section_body: String(section?.section_body == null ? '' : section.section_body).trim()
+    })).filter((section) => section.section_key);
+    const { data, error } = await supabase
+      .from('proposals_agreements')
+      .update({ custom_document_sections: cleanSections })
+      .eq('id', rowId)
+      .select(PROPOSALS_AGREEMENTS_COLUMNS)
+      .single();
+    if (error) throw new Error(error.message || 'proposals_agreement_custom_document_sections_update_failed');
+    return { ok: true, row: normalizeProposalAgreementRow(data) };
   },
   saveProposalAgreementItems: async (proposalId, items) => {
     assertCanUseProposalsAgreementsApi();

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -87,6 +87,7 @@ export function normalizeProposalAgreementRow(row = {}) {
     status:              STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft',
     approval_note:       text(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
+    custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections : [],
     created_at:          text(row.created_at),
     updated_at:          text(row.updated_at)
   };
@@ -488,10 +489,27 @@ function signatureSectionHtml(signatureText) {
   </section>`;
 }
 
+
+function resolveDocumentSections(row, templateSections = []) {
+  const fallback = Array.isArray(templateSections) ? templateSections : [];
+  const custom = Array.isArray(row?.custom_document_sections) ? row.custom_document_sections : [];
+  return custom.length ? custom : fallback;
+}
+
+function documentSectionsEditorHtml(sections = []) {
+  const rows = (Array.isArray(sections) ? sections : []).map((section, idx) => `
+    <label class="ds-pa-form-field ds-pa-form-field--wide">
+      <span>${escapeHtml(text(section.section_title) || text(section.section_key) || `סעיף ${idx + 1}`)}</span>
+      <textarea class="ds-input ds-input--sm" rows="4" data-pa-doc-body="${escapeHtml(text(section.section_key))}">${escapeHtml(String(section.section_body || ''))}</textarea>
+    </label>`).join('');
+  return `<div class="ds-pa-doc-editor" data-pa-doc-editor>${rows}</div>`;
+}
+
 function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const activityTypeGroup = text(row.activity_type_group);
   const dateDisplay = formatDateDisplay(row.proposal_date) || formatDateDisplay(new Date().toISOString().slice(0, 10));
-  const byKey = new Map((Array.isArray(templateSections) ? templateSections : []).map((s) => [text(s.section_key), s]));
+  const sectionsSource = resolveDocumentSections(row, templateSections);
+  const byKey = new Map((Array.isArray(sectionsSource) ? sectionsSource : []).map((s) => [text(s.section_key), s]));
   const sectionBody = (key, fallback = '') => templateBodyText(byKey.get(key)) || fallback;
   const sectionTitle = (key, fallback = '') => text(byKey.get(key)?.section_title) || fallback;
 
@@ -641,6 +659,9 @@ function drawerActionButtons(row, state) {
 
   if (['draft', 'returned_for_changes'].includes(status) || isAdminRole) {
     buttons.push(`<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button>`);
+  }
+  if (['draft', 'returned_for_changes'].includes(status)) {
+    buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-edit-document="${escapeHtml(row.id)}">עריכת מסמך</button>`);
   }
   if (['draft', 'returned_for_changes'].includes(status) && !isAdminRole) {
     buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="pending_approval" data-pa-action-id="${escapeHtml(row.id)}">שליחה לאישור</button>`);
@@ -1108,6 +1129,72 @@ export const proposalsAgreementsScreen = {
             setupContactPicker(pickerHost, host.querySelector('[data-pa-form]'));
           }
         }
+        return;
+      }
+
+
+      const editDocumentBtn = event.target.closest?.('[data-pa-edit-document]');
+      if (editDocumentBtn) {
+        const id = text(editDocumentBtn.dataset.paEditDocument);
+        const row = data.rows.find((r) => text(r.id) === id);
+        if (!row || text(row.status) === 'approved') return;
+        const templateKey = TEMPLATE_KEY_BY_GROUP[text(row.activity_type_group)] || 'combined';
+        const templateSections = proposalTemplateSections.filter((s) => text(s.template_key) === templateKey);
+        const workingSections = resolveDocumentSections(row, templateSections).map((section) => ({
+          section_key: text(section.section_key),
+          section_title: text(section.section_title),
+          section_body: String(section.section_body || '')
+        }));
+        const host = root.querySelector('[data-pa-inline-form]');
+        if (!host) return;
+        host.innerHTML = `<div class="ds-pa-form" data-pa-doc-edit-wrap>
+          <h4>עריכת מסמך</h4>${documentSectionsEditorHtml(workingSections)}
+          <div class="ds-pa-form-actions">
+            <button type="button" class="ds-btn ds-btn--sm ds-btn--primary" data-pa-doc-save="${escapeHtml(id)}">שמירת עריכת מסמך</button>
+            <button type="button" class="ds-btn ds-btn--sm" data-pa-doc-reset="${escapeHtml(id)}">איפוס לתבנית מקור</button>
+            <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-doc-cancel>ביטול</button>
+          </div></div>`;
+        return;
+      }
+
+      const docSaveBtn = event.target.closest?.('[data-pa-doc-save]');
+      if (docSaveBtn) {
+        const id = text(docSaveBtn.dataset.paDocSave);
+        const row = data.rows.find((r) => text(r.id) === id);
+        const wrap = docSaveBtn.closest('[data-pa-doc-edit-wrap]');
+        if (!row || !wrap) return;
+        const templateKey = TEMPLATE_KEY_BY_GROUP[text(row.activity_type_group)] || 'combined';
+        const templateSections = proposalTemplateSections.filter((s) => text(s.template_key) === templateKey);
+        const sections = templateSections.map((section) => ({
+          section_key: text(section.section_key),
+          section_title: text(section.section_title),
+          section_body: String((Array.from(wrap.querySelectorAll('[data-pa-doc-body]')).find((el) => text(el.dataset.paDocBody) === text(section.section_key))?.value) || '')
+        }));
+        const result = typeof api.saveProposalAgreementCustomDocumentSections === 'function'
+          ? await api.saveProposalAgreementCustomDocumentSections(id, sections)
+          : await api.updateProposalAgreement(id, { ...row, custom_document_sections: sections });
+        replaceLocalRow(data, result?.row || { ...row, custom_document_sections: sections });
+        wrap.remove();
+        refreshTable();
+        return;
+      }
+
+      const docResetBtn = event.target.closest?.('[data-pa-doc-reset]');
+      if (docResetBtn) {
+        const id = text(docResetBtn.dataset.paDocReset);
+        const row = data.rows.find((r) => text(r.id) === id);
+        if (!row) return;
+        const result = typeof api.saveProposalAgreementCustomDocumentSections === 'function'
+          ? await api.saveProposalAgreementCustomDocumentSections(id, [])
+          : await api.updateProposalAgreement(id, { ...row, custom_document_sections: [] });
+        replaceLocalRow(data, result?.row || { ...row, custom_document_sections: [] });
+        docResetBtn.closest('[data-pa-doc-edit-wrap]')?.remove();
+        refreshTable();
+        return;
+      }
+
+      if (event.target.closest?.('[data-pa-doc-cancel]')) {
+        event.target.closest('[data-pa-doc-edit-wrap]')?.remove();
         return;
       }
 

--- a/supabase/migrations/20260523_add_custom_document_sections_to_proposals_agreements.sql
+++ b/supabase/migrations/20260523_add_custom_document_sections_to_proposals_agreements.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.proposals_agreements
+  ADD COLUMN IF NOT EXISTS custom_document_sections jsonb NOT NULL DEFAULT '{}'::jsonb;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 424;
+const SW_ENTRY_VERSION = 425;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -839,3 +839,30 @@ test('upgrade migration adds status column with constraint and new indexes', asy
   assert.match(upgradeMigration, /trg_touch_proposal_agreement_items_updated_at/);
   assert.match(upgradeMigration, /proposal_agreement_items/);
 });
+
+test('custom_document_sections migration is present', async () => {
+  const migration = await readFile(new URL('../supabase/migrations/20260523_add_custom_document_sections_to_proposals_agreements.sql', import.meta.url), 'utf8');
+  assert.match(migration, /custom_document_sections jsonb not null default '\{\}'::jsonb/i);
+});
+
+test('preview prefers custom_document_sections when present', async () => {
+  const row = { ...sampleRows[0], custom_document_sections: [{ section_key: 'intro', section_title: 'פתיח', section_body: 'טקסט מותאם להצעה' }] };
+  await withJSDOM(proposalsAgreementsScreen.render({ rows: [row] }, { state: stateFor('admin') }), async (root, dom) => {
+    proposalsAgreementsScreen.bind({ root, data: { rows: [row], proposalTemplateSections: [{ template_key: 'summer', section_key: 'intro', section_title: 'פתיח', section_body: 'טקסט תבנית' }] }, state: stateFor('admin'), api: { readProposalAgreementItems: async () => [] } });
+    root.querySelector(`[data-pa-row-id="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+    root.querySelector(`[data-pa-preview="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+    assert.match(dom.window.document.body.innerHTML, /טקסט מותאם להצעה/);
+  });
+});
+
+test('approved proposal has no edit document button', async () => {
+  const row = { ...sampleRows[0], status: 'approved' };
+  await withJSDOM(proposalsAgreementsScreen.render({ rows: [row] }, { state: stateFor('admin') }), async (root, dom) => {
+    proposalsAgreementsScreen.bind({ root, data: { rows: [row] }, state: stateFor('admin'), api: { readProposalAgreementItems: async () => [] } });
+    root.querySelector(`[data-pa-row-id="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+    assert.equal(Boolean(root.querySelector('[data-pa-edit-document]')), false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Allow creating the proposal document from templates while letting users edit specific document sections per proposal (stored safely), so the final PDF/preview reflects those edits without turning the system into a full HTML/Word editor. 
- Keep numeric/pricing data authoritative in the existing line-items and avoid storing free-form HTML in the DB by saving structured sections in JSON.

### Description
- Add a DB migration `supabase/migrations/20260523_add_custom_document_sections_to_proposals_agreements.sql` that adds `custom_document_sections jsonb not null default '{}'::jsonb` to `proposals_agreements`.
- Extend the API (`frontend/src/api.js`) to include `custom_document_sections` in select/normalize/payload handling and add `saveProposalAgreementCustomDocumentSections` to persist per-proposal section overrides.
- Update the proposals UI (`frontend/src/screens/proposals-agreements.js`) to resolve document sections by preferring `custom_document_sections` when present and falling back to `proposal_template_sections`, add a new “עריכת מסמך” button that opens a simple section-list editor (textarea per section), and implement Save / Cancel / Reset-to-template flows that save structured sections (key, title, body) to `custom_document_sections`.
- Enforce UI rules so the edit-document action is only available in editable statuses and is hidden when a proposal is `approved`, and do not expose numeric/pricing fields for free-form editing (line items remain the single source for numeric data).
- Keep existing `proposal_template_sections` untouched as the canonical defaults, and bump the root service-worker entry version to match the frontend SW cache version so cache-version checks pass.

### Testing
- Ran unit/integration tests: `node --test tests/proposals-agreements-screen.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed (39 passed, 0 failed).
- Built the frontend: `npm run build` and the production build completed successfully (Vite build warning only about chunk size, non-blocking).
- Added automated tests covering migration presence, preview precedence for `custom_document_sections`, and hiding the edit-document action for `approved` proposals (all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1108020280832bae14532b985bc71a)