### PR TITLE
fix(proposal-print): pin footer to A4 bottom and bump SW cache version

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10503,9 +10503,9 @@ select.ds-input {
   direction: rtl;
   width: 794px;
   max-width: 100%;
-  min-height: 1123px;
+  min-height: 297mm;
   margin: 24px auto 48px;
-  padding: 36px 58px 44px;
+  padding: 36px 58px 18mm;
   font-family: Arial, "Noto Sans Hebrew", sans-serif;
   font-size: 10pt;
   line-height: 1.5;
@@ -10513,6 +10513,8 @@ select.ds-input {
   box-shadow: none;
   border: none;
   border-radius: 0;
+  display: flex;
+  flex-direction: column;
 }
 .pa-doc-header {
   margin-bottom: 8px;
@@ -10537,10 +10539,12 @@ select.ds-input {
   margin-inline: 0;
 }
 .pa-doc-logo--footer {
-  width: 230px;
-  max-width: 55%;
+  width: auto;
+  height: auto;
+  max-width: 48mm;
   margin-inline: auto;
   opacity: 0.95;
+  transform: none;
 }
 .pa-doc-date {
   justify-self: start;
@@ -10640,12 +10644,16 @@ select.ds-input {
   padding-top: 4pt;
 }
 .pa-doc-footer {
-  margin-top: 26px;
-  padding-top: 0;
+  margin-top: auto;
+  width: 100%;
+  padding-top: 10mm;
   border: 0;
   break-inside: avoid;
   page-break-inside: avoid;
   text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 @media (max-width: 720px) {
@@ -10716,9 +10724,11 @@ select.ds-input {
     position: static !important;
     width: auto !important;
     max-width: none !important;
-    min-height: 0 !important;
+    min-height: 297mm !important;
     margin: 0 !important;
-    padding: 0 !important;
+    padding: 0 0 14mm !important;
+    display: flex !important;
+    flex-direction: column !important;
     box-shadow: none !important;
     border: none !important;
     background: #fff !important;
@@ -10792,12 +10802,22 @@ select.ds-input {
     display: block !important;
   }
 
+  .pa-doc-footer {
+    margin-top: auto !important;
+    width: 100% !important;
+    padding-top: 10mm !important;
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+  }
+
   .pa-doc-logo--footer {
-    width: 230px !important;
-    max-width: 55% !important;
+    width: auto !important;
+    max-width: 48mm !important;
     height: auto !important;
     opacity: 0.95 !important;
     display: block !important;
+    transform: none !important;
   }
 
   .pa-doc-signature-simple {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 425;
+const CACHE_VERSION = 426;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- The proposal preview/footer appeared tiny and centered in the page body instead of behaving as a normal footer attached to the bottom of an A4 page when printing or exporting to PDF.
- The fix must be scoped to the proposal preview/print layout and footer sizing only, avoiding global scaling or unrelated document changes.
- Ensure clients pick up the CSS/JS change and do not keep serving an old cached shell after deploy.

### Description
- Made the preview document a full-height A4-like flex column by setting `.ds-pa-preview-doc` to `min-height: 297mm`, adjusted padding, and enabled `display:flex; flex-direction:column` so content can push the footer to the bottom.
- Anchored the footer with `.pa-doc-footer { margin-top: auto; width: 100%; padding-top: 10mm; display:flex; justify-content:center; align-items:center; }` so it sits at the page bottom in preview and print.
- Prevented the footer logo from being rendered as a miniature by changing `.pa-doc-logo--footer` to `width: auto; height: auto; max-width: 48mm; transform: none;` and applying the same sizing rules in `@media print`.
- Mirrored the flex + footer-behavior inside the `@media print` block (including `min-height: 297mm` and bottom padding) so PDF/export matches the preview.
- Bumped `CACHE_VERSION` in `frontend/sw.js` from `425` to `426` to invalidate old service-worker caches and force clients to fetch the updated CSS/JS.

### Testing
- No unit/CI tests were added for this visual change; validation was done via code inspection and diff review using `git diff` and file listing commands which succeeded.
- Commit of the changes completed successfully with the message `fix(proposal-print): pin footer to A4 bottom and bump SW cache version`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a111a34d894832bb577d24962f27ac8)