### PR TITLE
Improve proposals document-edit UX and bump service-worker cache version

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -746,6 +746,15 @@ export function updateProposalsAgreementsTableOnly(root, rows) {
   if (counter) counter.textContent = String(rows.length);
 }
 
+
+function setDocumentEditMode(root, enabled) {
+  const drawer = root?.querySelector('[data-pa-drawer]');
+  const panel = drawer?.querySelector('.ds-pa-drawer-panel');
+  if (!drawer || !panel) return;
+  drawer.classList.toggle('is-doc-editing', !!enabled);
+  panel.classList.toggle('is-doc-editing', !!enabled);
+}
+
 function payloadFromForm(form) {
   const formData = new FormData(form);
   const payload = {};
@@ -1106,6 +1115,7 @@ export const proposalsAgreementsScreen = {
       if (event.target.closest?.('[data-pa-close-drawer]')) {
         const drawer = root.querySelector('[data-pa-drawer]');
         if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions, state);
+        setDocumentEditMode(root, false);
         return;
       }
 
@@ -1121,6 +1131,7 @@ export const proposalsAgreementsScreen = {
             }
           } catch { items = []; }
           host.innerHTML = formHtml('edit', row, activityNameOptions, contactOptions, items, proposalActivityPricing);
+          setDocumentEditMode(root, false);
           setupActivityPickers(host);
           setupClientSelector(host);
           setupItemCalc(host);
@@ -1147,13 +1158,14 @@ export const proposalsAgreementsScreen = {
         }));
         const host = root.querySelector('[data-pa-inline-form]');
         if (!host) return;
-        host.innerHTML = `<div class="ds-pa-form" data-pa-doc-edit-wrap>
+        host.innerHTML = `<div class="ds-pa-form ds-pa-doc-edit-form" data-pa-doc-edit-wrap>
           <h4>עריכת מסמך</h4>${documentSectionsEditorHtml(workingSections)}
           <div class="ds-pa-form-actions">
             <button type="button" class="ds-btn ds-btn--sm ds-btn--primary" data-pa-doc-save="${escapeHtml(id)}">שמירת עריכת מסמך</button>
             <button type="button" class="ds-btn ds-btn--sm" data-pa-doc-reset="${escapeHtml(id)}">איפוס לתבנית מקור</button>
             <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-doc-cancel>ביטול</button>
           </div></div>`;
+        setDocumentEditMode(root, true);
         return;
       }
 
@@ -1175,6 +1187,7 @@ export const proposalsAgreementsScreen = {
           : await api.updateProposalAgreement(id, { ...row, custom_document_sections: sections });
         replaceLocalRow(data, result?.row || { ...row, custom_document_sections: sections });
         wrap.remove();
+        setDocumentEditMode(root, false);
         refreshTable();
         return;
       }
@@ -1189,12 +1202,14 @@ export const proposalsAgreementsScreen = {
           : await api.updateProposalAgreement(id, { ...row, custom_document_sections: [] });
         replaceLocalRow(data, result?.row || { ...row, custom_document_sections: [] });
         docResetBtn.closest('[data-pa-doc-edit-wrap]')?.remove();
+        setDocumentEditMode(root, false);
         refreshTable();
         return;
       }
 
       if (event.target.closest?.('[data-pa-doc-cancel]')) {
         event.target.closest('[data-pa-doc-edit-wrap]')?.remove();
+        setDocumentEditMode(root, false);
         return;
       }
 
@@ -1339,6 +1354,7 @@ export const proposalsAgreementsScreen = {
           refreshTable();
           const drawer = root.querySelector('[data-pa-drawer]');
           if (drawer) drawer.outerHTML = drawerHtml(null, activityNameOptions, state);
+        setDocumentEditMode(root, false);
         } catch (err) {
           deleteBtn.disabled = false;
           window.alert(`שגיאה במחיקה: ${err?.message || err}`);

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9977,6 +9977,20 @@ select.ds-input {
   padding: 16px;
 }
 
+.ds-pa-drawer.is-doc-editing {
+  justify-content: center;
+}
+
+.ds-pa-drawer-panel.is-doc-editing {
+  width: min(1200px, 92vw);
+  border-inline-start: 0;
+  border-radius: 16px;
+  margin: 2vh auto;
+  height: 96vh;
+  max-height: 96vh;
+  padding: 20px;
+}
+
 .ds-pa-drawer-head,
 .ds-pa-form-actions,
 .ds-pa-drawer-actions {
@@ -10065,6 +10079,59 @@ select.ds-input {
 .ds-pa-form-field textarea.ds-input {
   min-height: 62px;
   resize: vertical;
+}
+
+.ds-pa-doc-edit-form {
+  width: 100%;
+  max-width: 100%;
+  background: var(--ds-color-surface, #fff);
+  border: 1px solid var(--ds-color-border, #dbe5ef);
+  padding: 14px;
+}
+
+.ds-pa-doc-edit-form h4 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.ds-pa-doc-editor {
+  display: grid;
+  gap: 10px;
+}
+
+.ds-pa-doc-editor .ds-pa-form-field {
+  max-width: 100%;
+  padding: 10px;
+  border: 1px solid var(--ds-color-border-subtle, #e6edf5);
+  border-radius: 10px;
+  background: var(--ds-color-surface-soft, #f8fafc);
+  gap: 6px;
+}
+
+.ds-pa-doc-editor .ds-pa-form-field > span {
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--ds-color-text, #0f172a);
+}
+
+.ds-pa-doc-editor textarea.ds-input {
+  width: 100%;
+  max-width: 100%;
+  min-height: 140px;
+  line-height: 1.6;
+  font-size: 0.9rem;
+  padding: 10px;
+}
+
+.ds-pa-doc-edit-form .ds-pa-form-actions {
+  justify-content: flex-start;
+  gap: 10px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.ds-pa-doc-edit-form .ds-pa-form-actions .ds-btn--primary {
+  order: -1;
 }
 .ds-pa-form-field--wide {
   grid-column: 1 / -1;
@@ -10165,6 +10232,15 @@ select.ds-input {
 }
 
 @media (max-width: 720px) {
+  .ds-pa-drawer-panel.is-doc-editing {
+    width: 100vw;
+    height: 100vh;
+    max-height: 100vh;
+    margin: 0;
+    border-radius: 0;
+    padding: 14px;
+  }
+
   .ds-pa-form {
     width: 100%;
     padding: 8px;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 426;
+const CACHE_VERSION = 427;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 425;
+const SW_ENTRY_VERSION = 427;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- שיפור חוויית העריכה של "עריכת מסמך" במסך הצעות/הסכמים כי המגירה הימנית הנוכחית צרה מדי לעריכת טקסטים ארוכים; יש לספק אזור עריכה רחב ונוח ללא שינוי בלוגיקת שמירה.
- לוודא שמשתמשים מקבלים גרסת CSS/JS חדשה אחרי הפרסום על ידי invalidation של ה־Service Worker (מניעת cache stale).

### Description
- הוספתי ניהול מצב עריכה `setDocumentEditMode(root, enabled)` ב־`frontend/src/screens/proposals-agreements.js` שמוסיף/מסיר את המחלקות `is-doc-editing` על המגירה והפאנל בקלקולים מתאימים (שמירה/איפוס/ביטול/סגירה). 
- הרחבתי את המגירה למצב עריכת מסמך רחב וממוקד באמצעות CSS חדש ב־`frontend/src/styles/main.css` (`.ds-pa-drawer-panel.is-doc-editing`), ושיפרתי את עיצוב העורך עם `ds-pa-doc-edit-form` ו־`ds-pa-doc-editor` (textareas ברוחב 100%, גובה מינימלי גדול יותר, אזורי סעיפים עם border ורקע עדין, סידור פעולות עם הדגשת כפתור שמירה). 
- שמרתי על הזרימה הקיימת של `custom_document_sections` והקריאות ל־API/עדכונים, כך שלא שונתה לוגיקת שמירה או מבני נתונים בשרת (רק מהות התצוגה/UX השתנתה). 
- עדכנתי גרסאות cache כדי לאלץ רענון נכסים סטטיים על הלקוח על ידי העלאת `CACHE_VERSION` ב־`frontend/sw.js` ל־`427` והעלאת `SW_ENTRY_VERSION` ב־`sw.js` ל־`427`.
- קבצים ששונו: `frontend/src/screens/proposals-agreements.js`, `frontend/src/styles/main.css`, `frontend/sw.js`, `sw.js`.

### Testing
- הרצתי `node --test tests/proposals-agreements-screen.test.mjs` והתוצאה: עבר בהצלחה.
- הרצתי `node --test tests/service-worker-pwa-cache.test.mjs` והתוצאה: עבר בהצלחה (אימות תיאום גרסאות SW ופעולות clean-up של cache).
- ניטרתי שהרצת הסוויטה המלאה (`npm test`) חשפה כושלים קיימים שאינם קשורים לשינויים אלו, כך שלא דווחו כ־regression על התיקון הזה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1121a3218c832b8effec29d148ba20)