### PR TITLE
שיפור פורמט סעיפי אחריות/תשלום/ביטולים בתבנית הצעת מחיר + עדכון SW

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -460,9 +460,9 @@ function sectionLinesHtml(value, options = {}) {
     const original = String(line || '');
     const trimmed = original.trim();
     if (!trimmed) return '<span class="pa-section-line pa-section-line--empty">&nbsp;</span>';
-    const bulletMatch = trimmed.match(/^[·•-]\s*(.*)$/);
+    const bulletMatch = trimmed.match(/^[·•-]\s+(.+)$/);
     const isBullet = alwaysBullet || Boolean(bulletMatch);
-    const body = isBullet ? (bulletMatch ? bulletMatch[1] : trimmed) : trimmed;
+    const body = isBullet ? (bulletMatch ? bulletMatch[1].trim() : trimmed) : trimmed;
     const marker = isBullet ? '<span class="pa-section-bullet-marker">·</span>' : '';
     return `<span class="pa-section-line${isBullet ? ' pa-section-line--bullet' : ''}">${marker}${escapeHtml(body)}</span>`;
   }).join('');

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10660,6 +10660,8 @@ select.ds-input {
 }
 .pa-section h3 {
   font-size: 10pt;
+  break-after: avoid;
+  page-break-after: avoid;
   font-weight: 700;
   text-decoration: underline;
   color: #1f4e79;
@@ -10686,15 +10688,20 @@ select.ds-input {
 }
 .pa-section-line--bullet {
   margin: 0 0 3pt;
-  padding-right: 12pt;
-  text-indent: -8pt;
+  padding-right: 14pt;
+  text-indent: -10pt;
+  white-space: normal;
+  word-break: break-word;
+  break-inside: avoid;
+  page-break-inside: avoid;
 }
 .pa-section-line--empty {
   margin: 0 0 3pt;
 }
 .pa-section-bullet-marker {
   display: inline-block;
-  width: 8pt;
+  width: 10pt;
+  margin-left: 2pt;
 }
 .pa-proposal-lines {
   margin-top: 2pt;
@@ -10824,6 +10831,8 @@ select.ds-input {
 
   .pa-section h3 {
     font-size: 10pt !important;
+    break-after: avoid !important;
+    page-break-after: avoid !important;
     font-weight: 700 !important;
     text-decoration: underline !important;
     color: #1f4e79 !important;
@@ -10845,8 +10854,11 @@ select.ds-input {
 
   .pa-section-line--bullet {
     margin: 0 0 3pt !important;
-    padding-right: 12pt !important;
-    text-indent: -8pt !important;
+    padding-right: 14pt !important;
+    text-indent: -10pt !important;
+    word-break: break-word !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
   }
 
   .pa-doc-date {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 427;
+const CACHE_VERSION = 428;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- לעשות את סעיפי "אחריות תעשיידע", "אחריות בית הספר", "עלויות ותנאי תשלום" ו"שינויים, ביטולים והתאמות" לקריאים, אחידים ומוכנים להדפסה/PDF מבלי לשנות ניסוחים אחרים או שדות דינמיים, ולוודא שהשינויים נטענים בפועל על ידי עדכון ה-Service Worker.

### Description
- כווננתי את זיהוי נקודות (bullet parsing) ב`frontend/src/screens/proposals-agreements.js` כדי לדרוש רווח אחרי הסימן ולנקות את גוף השורה; שיפרתי כך אחידות וריווח בטקסט.
- עדכנתי `frontend/src/styles/main.css` כדי לאחד הזחה/ריווח של שורות נקודות וכותרות משנה ולהוסיף הגנות `page-break` להדפסה/ייצוא ל-PDF כדי למנוע שבירות אסתטיות של הסעיף.
- הגבתי את גרסת ה-Service Worker ב`frontend/sw.js` (`CACHE_VERSION`) כדי לגרום לדפדפן להוריד את ה-JS/CSS המעודכנים במקום להישאר על גרסה ישנה מה-cache.

### Testing
- הרצתי את המבחן הממוקד עם `node --test tests/proposals-agreements-screen.test.mjs` והבדיקות הרלוונטיות למסך ההצעות/הסכמים עברו בהצלחה.
- ביצוע `npm test` (הסוויטה הרחבה) הריץ גם בדיקות שלא קשורות ישירות לשינויים האלה וחלו בכשלונות לא קשורים; לא זיהיתי שגיאה חדשה בקוד העריכה/הצגת הסעיפים לאחר השינויים.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a115e8cef78832ba4d1f0ac1024bce5)