### PR TITLE
תיקון `normalizeProgram` ל־catalog_programs_tashpaz.json ועדכון גרסת SW

### DIFF
--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -46,21 +46,44 @@ function normalizeProgram(item, idx) {
   const p = item && typeof item === 'object' ? item : {};
   return {
     id: String(p.id || p.programId || p.slug || `program-${idx + 1}`),
-    name: String(p.name || p.programName || 'ללא שם'),
+    name: String(p.name || p.programName || p.title || 'ללא שם'),
     audienceLevel: String(p.audienceLevel || 'לא צוין'),
     productType: String(p.productType || 'תוכנית'),
     grades: String(p.grades || 'לא צוין'),
     scope: String(p.scope || p.meetings || 'לא צוין'),
-    sessionDuration: String(p.sessionDuration || 'לא צוין'),
+    sessionDuration: String(p.sessionDuration || p.duration || 'לא צוין'),
     gefenNumber: String(p.gefenNumber || p.gefen || ''),
-    shortDescription: String(p.shortDescription || p.openingLine || ''),
-    coreIdea: String(p.coreIdea || p.description || ''),
-    goals: String(p.goals || ''),
-    schoolValue: String(p.schoolValue || ''),
+    shortDescription: String(
+      p.shortDescription ||
+      p.openingLine ||
+      p.subtitle ||
+      p.sections?.openingStatement ||
+      ''
+    ),
+    coreIdea: String(
+      p.coreIdea ||
+      p.description ||
+      p.sections?.mainIdea ||
+      ''
+    ),
+    goals: String(
+      p.goals ||
+      p.sections?.programFlow ||
+      ''
+    ),
+    schoolValue: String(
+      p.schoolValue ||
+      p.sections?.schoolValue ||
+      ''
+    ),
     syllabus: Array.isArray(p.syllabus) ? p.syllabus : [],
     stations: Array.isArray(p.stations) ? p.stations : [],
     participantsReceive: Array.isArray(p.participantsReceive) ? p.participantsReceive : [],
-    closingBox: String(p.closingBox || ''),
+    closingBox: String(
+      p.closingBox ||
+      p.sections?.finalOutcome ||
+      ''
+    ),
     footer: String(p.footer || ''),
     pageTemplate: String(p.pageTemplate || 'default')
   };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 429;
+const CACHE_VERSION = 430;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- לתקן את מיפוי השדות בעמוד הקטלוג כך שהעמוד יקרא נכון את השדות במבנה האמיתי של `catalog_programs_tashpaz.json` ולא יציג כרטיסים עם `"ללא שם"` או תכנים חסרים.
- למנוע הצגת גרסאות ישנות מהמטמון של PWA/Service Worker אחרי העדכון של מיפוי השדות.

### Description
- שודרגה פונקציית `normalizeProgram` ב־`frontend/src/screens/catalog.js` כדי לתמוך ב־fallbacks נוספים: `title` עבור `name`, `duration` עבור `sessionDuration`, ו־שדות בתוך `sections` (`openingStatement`, `mainIdea`, `programFlow`, `schoolValue`, `finalOutcome`) עבור `shortDescription`, `coreIdea`, `goals`, `schoolValue` ו־`closingBox` בהתאמה, תוך שמירה על כל השדות הקיימים ותצוגה זהה.
- לא שונו מבנה ה־JSON, SQL או עיצוב/תווי UI; השינוי מוגבל למיפוי הנתונים בלבד.
- עודכן קוד ה־Service Worker ב־`frontend/sw.js` על ידי העלאת `CACHE_VERSION` מ־`429` ל־`430` כדי לגרום לביטול caches ישנים ולכפות טעינה של הקבצים המעודכנים.

### Testing
- הופעלה בדיקת sanity באמצעות Node על `frontend/public/catalog/catalog_programs_tashpaz.json` שמריצה את המיפוי החדש, והתוצאה הייתה `programs 13 missing_name 0` (אותו בדיקה אוטומטית עברה בהצלחה).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117e09afb8832baaf44e88fb954f51)