### PR TITLE
Catalog screen redesign with audience-based visual themes

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 425;
+const CACHE_VERSION = 431;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BeWxngqA.js",
+  "./assets/index-DrRlXsex.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-CFzctr1w.css",
+  "./assets/style-DnXVVcrs.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BeWxngqA.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-CFzctr1w.css">
+  <script type="module" crossorigin src="./assets/index-DrRlXsex.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-DnXVVcrs.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 425;
+const CACHE_VERSION = 431;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BeWxngqA.js",
+  "./assets/index-DrRlXsex.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-CFzctr1w.css",
+  "./assets/style-DnXVVcrs.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -9,37 +9,78 @@ function ensureCatalogStyles() {
   const style = document.createElement('style');
   style.id = 'catalog-screen-styles';
   style.textContent = `
-.catalog-screen{direction:rtl;display:flex;flex-direction:column;gap:14px}
-.catalog-toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-.catalog-filter{display:flex;align-items:center;gap:6px;background:#fff;border:1px solid #d9e2ec;border-radius:999px;padding:4px 10px;font-size:13px}
-.catalog-filter select{border:none;background:transparent;font:inherit;color:#1f2937;min-width:92px;outline:none}
-.catalog-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:10px}
-.catalog-card{border:1px solid #dce3ea;background:#fff;border-radius:12px;padding:12px;display:flex;flex-direction:column;gap:8px;min-height:190px;cursor:pointer}
-.catalog-card:hover{border-color:#9eb7d2;box-shadow:0 4px 16px rgba(15,23,42,.08)}
-.catalog-chipline{display:flex;gap:6px;flex-wrap:wrap}
-.catalog-chip{font-size:12px;background:#eef3f8;border-radius:999px;padding:2px 8px;color:#334155}
-.catalog-meta{display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:13px;color:#374151}
+.catalog-screen{direction:rtl;display:flex;flex-direction:column;gap:16px;color:#0f172a}
+.catalog-header h2{margin:0 0 6px;font-size:28px;line-height:1.2}
+.catalog-header .ds-muted{margin:0}
+.catalog-toolbar{display:flex;gap:10px;flex-wrap:wrap;align-items:center;background:linear-gradient(180deg,#f8fbff,#f4f8fc);border:1px solid #dce6f2;border-radius:14px;padding:10px 12px}
+.catalog-filter{display:flex;align-items:center;gap:8px;background:#fff;border:1px solid #d6e3f0;border-radius:999px;padding:5px 12px;font-size:13px;color:#334155}
+.catalog-filter select{border:none;background:transparent;font:inherit;color:#0f172a;min-width:96px;outline:none}
+.catalog-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:14px;align-items:stretch}
+.catalog-card{position:relative;border:1px solid #dbe6f1;background:#fff;border-radius:14px;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:250px;cursor:pointer;transition:.18s ease box-shadow,.18s ease transform,.18s ease border-color;overflow:hidden}
+.catalog-card::before{content:'';position:absolute;inset:0 0 auto 0;height:6px;background:#c7d2fe}
+.catalog-card:hover{transform:translateY(-2px);border-color:#94a3b8;box-shadow:0 10px 24px rgba(15,23,42,.10)}
+.catalog-card h3{margin:0;font-size:21px;line-height:1.25;color:#0f172a}
+.catalog-lead{min-height:54px;margin:0;font-size:14px;line-height:1.45;color:#475569}
+.catalog-chipline{display:flex;gap:7px;flex-wrap:wrap}
+.catalog-chip{font-size:11px;border-radius:999px;padding:3px 9px;color:#1e293b;background:#e7eef7;border:1px solid #d2deec;font-weight:600}
+.catalog-meta{display:grid;grid-template-columns:1fr 1fr;gap:7px;font-size:13px;color:#334155}
+.catalog-meta div{background:#f8fafc;border:1px solid #e2e8f0;border-radius:9px;padding:7px 8px;line-height:1.3}
+.catalog-meta strong{display:block;margin-bottom:2px;color:#0f172a;font-size:11px}
+.catalog-card--elementary{background:linear-gradient(180deg,#fbfeff 0,#f4fbff 100%);border-color:#cce5f4}
+.catalog-card--elementary::before{background:linear-gradient(90deg,#7dd3fc,#67e8f9,#5eead4)}
+.catalog-card--elementary .catalog-chip{background:#ecfeff;border-color:#bae6fd;color:#0f3b57}
+.catalog-card--elementary .catalog-meta div{background:#f7fdff;border-color:#d7eef7}
+.catalog-card--middle{background:linear-gradient(180deg,#f8fbff 0,#eff5ff 100%);border-color:#b8cceb}
+.catalog-card--middle::before{background:linear-gradient(90deg,#1e3a8a,#1d4ed8,#2563eb)}
+.catalog-card--middle h3{color:#102040}
+.catalog-card--middle .catalog-chip{background:#e6eefc;border-color:#bfdbfe;color:#1e3a8a}
+.catalog-card--middle .catalog-meta div{background:#f2f7ff;border-color:#d7e4fb}
+.catalog-card--neutral::before{background:linear-gradient(90deg,#94a3b8,#cbd5e1)}
 .catalog-detail-actions{display:flex;gap:8px;flex-wrap:wrap}
 .catalog-btn{border:1px solid #cbd5e1;background:#fff;border-radius:8px;padding:8px 12px;cursor:pointer;font:inherit}
 .catalog-btn--primary{background:#1d4ed8;color:#fff;border-color:#1d4ed8}
 .catalog-a4-wrap{display:flex;justify-content:center}
-.catalog-a4{width:210mm;min-height:297mm;background:#fff;color:#1f2937;border:1px solid #d7dee7;border-radius:8px;padding:14mm;box-shadow:0 8px 24px rgba(15,23,42,.08)}
-.catalog-top-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.catalog-a4{width:210mm;min-height:297mm;background:#fff;color:#1f2937;border:1px solid #d7dee7;border-radius:8px;padding:12mm;box-shadow:0 8px 24px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:10px}
+.catalog-a4-header{border-radius:14px;padding:14px;border:1px solid transparent}
+.catalog-a4-header h1{margin:0;font-size:29px;line-height:1.2}
+.catalog-a4-header p{margin:6px 0 0;font-size:15px;line-height:1.45;max-width:95%}
+.catalog-a4-badge{display:inline-flex;padding:4px 10px;border-radius:999px;font-size:12px;font-weight:700;margin-bottom:8px}
+.catalog-a4--elementary .catalog-a4-header{background:linear-gradient(135deg,#effbff,#dcf4ff);border-color:#c5e7f8;color:#11394f}
+.catalog-a4--elementary .catalog-a4-badge{background:#ccfbf1;color:#0f766e;border:1px solid #99f6e4}
+.catalog-a4--middle .catalog-a4-header{background:linear-gradient(135deg,#1e3a8a,#1e40af 58%,#2563eb);border-color:#1d4ed8;color:#f8fbff}
+.catalog-a4--middle .catalog-a4-badge{background:#dbeafe;color:#1e3a8a;border:1px solid #bfdbfe}
+.catalog-a4--middle .catalog-a4-header p{color:#e2e8f0}
+.catalog-a4--neutral .catalog-a4-header{background:linear-gradient(135deg,#f8fafc,#eef2f7);border-color:#dbe3ec;color:#0f172a}
+.catalog-a4--neutral .catalog-a4-badge{background:#e2e8f0;color:#334155;border:1px solid #cbd5e1}
+.catalog-frame-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
 .catalog-box{background:#f8fafc;border:1px solid #d8e1eb;border-radius:10px;padding:10px}
-.catalog-frame-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:10px}
-.catalog-list4{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
-@media (max-width:900px){.catalog-a4{width:100%;min-height:auto;padding:14px}.catalog-top-grid,.catalog-frame-grid,.catalog-list4{grid-template-columns:1fr 1fr}}
-@media (max-width:640px){.catalog-meta,.catalog-top-grid,.catalog-frame-grid,.catalog-list4{grid-template-columns:1fr}}
+.catalog-box h3{margin:0 0 6px;font-size:15px}
+.catalog-box p{margin:0;line-height:1.55}
+.catalog-box ul{margin:0;padding-inline-start:18px;line-height:1.5}
+.catalog-list-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.catalog-a4--elementary .catalog-box{background:#fbfeff;border-color:#d8edf8}
+.catalog-a4--middle .catalog-box{background:#f6f9ff;border-color:#d8e3f9}
+.catalog-a4--neutral .catalog-box{background:#f8fafc}
+@media (max-width:900px){.catalog-a4{width:100%;min-height:auto;padding:14px}.catalog-frame-grid{grid-template-columns:1fr 1fr}.catalog-list-grid{grid-template-columns:1fr}}
+@media (max-width:760px){.catalog-grid{grid-template-columns:1fr}.catalog-header h2{font-size:23px}}
+@media (max-width:640px){.catalog-meta,.catalog-frame-grid,.catalog-list-grid{grid-template-columns:1fr}}
 @media print {
   body *{visibility:hidden !important}
   .catalog-print-zone,.catalog-print-zone *{visibility:visible !important}
   .catalog-print-hide{display:none !important}
   .catalog-print-zone{position:absolute;inset:0;background:#fff}
-  .catalog-a4{margin:0;border:none;box-shadow:none;border-radius:0;width:210mm;min-height:297mm;page-break-after:avoid}
+  .catalog-a4{margin:0;border:none;box-shadow:none;border-radius:0;width:210mm;min-height:297mm;page-break-after:avoid;padding:10mm}
+  .catalog-box{break-inside:avoid-page}
   @page{size:A4;margin:8mm}
 }
 `;
   document.head.appendChild(style);
+}
+
+function toneClassForProgram(program, prefix) {
+  if (program.audienceLevel === 'יסודי') return `${prefix}--elementary`;
+  if (program.audienceLevel === 'חטיבה') return `${prefix}--middle`;
+  return `${prefix}--neutral`;
 }
 
 function normalizeProgram(item, idx) {
@@ -53,37 +94,14 @@ function normalizeProgram(item, idx) {
     scope: String(p.scope || p.meetings || 'לא צוין'),
     sessionDuration: String(p.sessionDuration || p.duration || 'לא צוין'),
     gefenNumber: String(p.gefenNumber || p.gefen || ''),
-    shortDescription: String(
-      p.shortDescription ||
-      p.openingLine ||
-      p.subtitle ||
-      p.sections?.openingStatement ||
-      ''
-    ),
-    coreIdea: String(
-      p.coreIdea ||
-      p.description ||
-      p.sections?.mainIdea ||
-      ''
-    ),
-    goals: String(
-      p.goals ||
-      p.sections?.programFlow ||
-      ''
-    ),
-    schoolValue: String(
-      p.schoolValue ||
-      p.sections?.schoolValue ||
-      ''
-    ),
+    shortDescription: String(p.shortDescription || p.openingLine || p.subtitle || p.sections?.openingStatement || ''),
+    coreIdea: String(p.coreIdea || p.description || p.sections?.mainIdea || ''),
+    goals: String(p.goals || p.sections?.programFlow || ''),
+    schoolValue: String(p.schoolValue || p.sections?.schoolValue || ''),
     syllabus: Array.isArray(p.syllabus) ? p.syllabus : [],
     stations: Array.isArray(p.stations) ? p.stations : [],
     participantsReceive: Array.isArray(p.participantsReceive) ? p.participantsReceive : [],
-    closingBox: String(
-      p.closingBox ||
-      p.sections?.finalOutcome ||
-      ''
-    ),
+    closingBox: String(p.closingBox || p.sections?.finalOutcome || ''),
     footer: String(p.footer || ''),
     pageTemplate: String(p.pageTemplate || 'default')
   };
@@ -118,18 +136,17 @@ export const catalogScreen = {
     if (!selected) {
       const filtered = data.programs.filter((p) => (audience === 'הכול' || p.audienceLevel === audience) && (type === 'הכול' || p.productType === type));
       return `<section class="catalog-screen">
-        <h2>קטלוג תוכניות תלמידים תשפ״ז</h2>
-        <p class="ds-muted">בחירת תוכנית לפי שכבת גיל וסוג פעילות</p>
+        <header class="catalog-header"><h2>קטלוג תוכניות תלמידים תשפ״ז</h2><p class="ds-muted">בחירת תוכנית לפי שכבת גיל וסוג פעילות</p></header>
         <div class="catalog-toolbar">
           <label class="catalog-filter">שכבת גיל <select data-catalog-filter="audience">${AUDIENCE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === audience ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
           <label class="catalog-filter">סוג פעילות <select data-catalog-filter="type">${TYPE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === type ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
         </div>
         <div class="catalog-grid">
-          ${filtered.map((p) => `<article class="catalog-card" data-catalog-open="${escapeHtml(p.id)}">
+          ${filtered.map((p) => `<article class="catalog-card ${toneClassForProgram(p, 'catalog-card')}" data-audience-level="${escapeHtml(p.audienceLevel)}" data-page-template="${escapeHtml(p.pageTemplate)}" data-catalog-open="${escapeHtml(p.id)}">
             <h3>${escapeHtml(p.name)}</h3>
-            <div class="catalog-chipline"><span class="catalog-chip">${escapeHtml(p.audienceLevel)}</span><span class="catalog-chip">${escapeHtml(p.productType)}</span></div>
-            <div class="catalog-meta"><div><strong>כיתות:</strong> ${escapeHtml(p.grades)}</div><div><strong>היקף:</strong> ${escapeHtml(p.scope)}</div><div><strong>משך מפגש:</strong> ${escapeHtml(p.sessionDuration)}</div><div><strong>מס׳ גפ״ן:</strong> ${escapeHtml(p.gefenNumber || '—')}</div></div>
-            <p class="ds-muted">${escapeHtml(p.shortDescription || p.coreIdea || '')}</p>
+            <p class="catalog-lead">${escapeHtml(p.shortDescription || p.coreIdea || 'לא סופק תיאור')}</p>
+            <div class="catalog-chipline"><span class="catalog-chip">${escapeHtml(p.audienceLevel)}</span><span class="catalog-chip">${escapeHtml(p.productType)}</span><span class="catalog-chip">${escapeHtml(p.grades)}</span></div>
+            <div class="catalog-meta"><div><strong>כיתות</strong>${escapeHtml(p.grades)}</div><div><strong>היקף</strong>${escapeHtml(p.scope)}</div><div><strong>משך מפגש</strong>${escapeHtml(p.sessionDuration)}</div><div><strong>מס׳ גפ״ן</strong>${escapeHtml(p.gefenNumber || '—')}</div></div>
           </article>`).join('') || '<p class="ds-muted">לא נמצאו תוכניות עבור הסינון שנבחר.</p>'}
         </div>
       </section>`;
@@ -137,19 +154,20 @@ export const catalogScreen = {
 
     const labels = sectionLabelsByType(selected.productType);
     const syllabusSource = selected.productType === 'סיור' ? selected.stations : selected.syllabus;
+    const a4ToneClass = toneClassForProgram(selected, 'catalog-a4');
     return `<section class="catalog-screen catalog-print-zone">
       <div class="catalog-detail-actions catalog-print-hide">
         <button class="catalog-btn" data-catalog-back>חזרה לקטלוג</button>
         <button class="catalog-btn catalog-btn--primary" data-catalog-print>הדפסה / PDF</button>
       </div>
-      <div class="catalog-a4-wrap"><article class="catalog-a4">
-        <header><h1>${escapeHtml(selected.name)}</h1><p>${escapeHtml(selected.shortDescription || '')}</p></header>
-        <section class="catalog-top-grid"><div class="catalog-box"><h3>תיאור / הרעיון המרכזי</h3><p>${escapeHtml(selected.coreIdea || 'לא סופק מידע')}</p></div><div class="catalog-box"><h3>מטרות / מה לומדים ואיך לומדים</h3><p>${escapeHtml(selected.goals || 'לא סופק מידע')}</p></div></section>
+      <div class="catalog-a4-wrap"><article class="catalog-a4 ${a4ToneClass}" data-audience-level="${escapeHtml(selected.audienceLevel)}" data-page-template="${escapeHtml(selected.pageTemplate)}">
+        <header class="catalog-a4-header"><span class="catalog-a4-badge">${escapeHtml(selected.audienceLevel)}</span><h1>${escapeHtml(selected.name)}</h1><p>${escapeHtml(selected.shortDescription || 'תוכנית לימודית מותאמת לבית הספר')}</p></header>
         <section class="catalog-frame-grid"><div class="catalog-box"><strong>כיתות</strong><p>${escapeHtml(selected.grades)}</p></div><div class="catalog-box"><strong>היקף</strong><p>${escapeHtml(selected.scope)}</p></div><div class="catalog-box"><strong>משך מפגש</strong><p>${escapeHtml(selected.sessionDuration)}</p></div><div class="catalog-box"><strong>מספר גפ״ן</strong><p>${escapeHtml(selected.gefenNumber || '—')}</p></div></section>
+        <section class="catalog-list-grid"><div class="catalog-box"><h3>תיאור / רעיון מרכזי</h3><p>${escapeHtml(selected.coreIdea || 'לא סופק מידע')}</p></div><div class="catalog-box"><h3>מה לומדים ואיך לומדים</h3><p>${escapeHtml(selected.goals || 'לא סופק מידע')}</p></div></section>
         <section class="catalog-box"><h3>הערך לבית הספר</h3><p>${escapeHtml(selected.schoolValue || 'לא סופק מידע')}</p></section>
         <section class="catalog-box"><h3>${escapeHtml(labels.syllabus)}</h3><ul>${listFromTextOrArray(syllabusSource)}</ul></section>
-        <section class="catalog-box"><h3>${escapeHtml(labels.happening)}</h3><p>${escapeHtml(selected.shortDescription || selected.coreIdea || 'לא סופק מידע')}</p></section>
-        <section class="catalog-box"><h3>מה מקבלים המשתתפים</h3><div class="catalog-list4"><ul>${listFromTextOrArray(selected.participantsReceive)}</ul><div><strong>${escapeHtml(labels.outcome)}</strong><p>${escapeHtml(selected.closingBox || 'לא סופק מידע')}</p></div></div></section>
+        <section class="catalog-list-grid"><div class="catalog-box"><h3>${escapeHtml(labels.happening)}</h3><p>${escapeHtml(selected.shortDescription || selected.coreIdea || 'לא סופק מידע')}</p></div><div class="catalog-box"><h3>מה מקבלים המשתתפים</h3><ul>${listFromTextOrArray(selected.participantsReceive)}</ul></div></section>
+        <section class="catalog-box"><h3>${escapeHtml(labels.outcome)}</h3><p>${escapeHtml(selected.closingBox || 'לא סופק מידע')}</p></section>
         <footer class="catalog-box"><p>${escapeHtml(selected.footer || 'תעשיידע | קטלוג תוכניות תלמידים תשפ״ז')}</p></footer>
       </article></div>
     </section>`;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 430;
+const CACHE_VERSION = 431;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- לשדרג את מראה ו‑UX של עמוד הקטלוג בלבד כדי לקבל כרטיסים סימטריים, קריאים ונעימים לקריאה במסך ובהדפסה, בלי לשנות נתונים או לוגיקה.
- ליצור הבחנה חזותית ברורה בין תוכניות `יסודי` ל־`חטיבה` שנראית גם ברשימה וגם בעמוד פנימי/A4, ולהשאיר מצב ניטרלי לערכים אחרים.
- למנוע מטמון ישן של העיצוב החדש על ידי עדכון גרסת ה‑PWA/Service Worker בתהליך הפריסה.

### Description
- עדכון מלא של `frontend/src/screens/catalog.js` הכולל CSS scoped בתוך `ensureCatalogStyles`, ארגון גריד רספונסיבי, היררכיית טקסט משופרת וכרטיסי מידע אחידים ומונגשים (כל השינוי עיצובי בלבד).
- הוספת מחלקות טון לפי קהל יעד באמצעות הפונקציה `toneClassForProgram` ויישום המחלקות `catalog-card--elementary|middle|neutral` ו־`catalog-a4--elementary|middle|neutral` יחד עם `data-*` attributes (`data-audience-level`, `data-page-template`) ללא שינוי ב־JSON או במיפוי הנתונים.
- שיפורים בעמוד A4 להדפסה/PDF: Header מובחן לפי קהל יעד, גריד 4 תיבות לנתונים, חלוקת תכנים בתיבות מאוזנות והסתרת כפתורי פעולה בהדפסה.
- עדכון Service Worker (`frontend/sw.js`) להעלאת `CACHE_VERSION` ל־`431` כדי לאלץ רענון מטמון של נכסים חדשים לאחר פריסה.

### Testing
- הרצת יחידות: `npm run test` רצה אך יש כשלונות קיימים בפרויקט שאינם קשורים לשינוי (אוטומטיים, לא שונו על ידינו). 
- בנייה לפרודקשן: `npm run build` הושלמה בהצלחה כולל `vite build` ו־`postbuild-dist`.
- לא שונו SQL או מבני JSON והעיצוב מוגבל אך ורק ל־`catalog-screen` לפי הדרישות.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119480945c832b848cff2d805e1ea6)