### PR TITLE
Revamp catalog landing UX, import syllabus from Excel, and update SW cache handling

### DIFF
--- a/frontend/public/catalog.html
+++ b/frontend/public/catalog.html
@@ -1,736 +1,130 @@
-
 <!DOCTYPE html>
 <html lang="he" dir="rtl">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>קטלוג תוכניות תעשיידע | אתר</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <title>קטלוג תוכניות תלמידים תשפ״ז</title>
   <style>
-    :root {
-      --accent: #7f5aa2;
-      --accent-dark: #4d2f68;
-      --accent-soft: #f4eff9;
-      --accent-line: #d8c8e6;
-      --accent-warm: #eef7f5;
-      --accent-warm-line: #c9e3dd;
-      --text: #2d2b31;
-      --muted: #6f6678;
-      --line: #e2dae9;
-      --paper: #ffffff;
-      --bg: #f3f4f6;
-    }
-
-    * { box-sizing: border-box; }
-
-    body {
-      margin: 0;
-      background: var(--bg);
-      font-family: "Assistant", "Segoe UI", Arial, sans-serif;
-      color: var(--text);
-    }
-
-    .toolbar {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      background: rgba(255,255,255,.94);
-      border-bottom: 1px solid var(--line);
-      padding: 10px 16px;
-      display: flex;
-      gap: 10px;
-      align-items: center;
-      justify-content: center;
-      direction: rtl;
-    }
-
-    .toolbar label {
-      font-size: 14px;
-      font-weight: 800;
-      color: var(--accent-dark);
-    }
-
-    .toolbar select,
-    .toolbar button {
-      font-family: inherit;
-      border: 1px solid var(--accent-line);
-      background: #fff;
-      color: var(--text);
-      border-radius: 8px;
-      padding: 7px 12px;
-      font-size: 14px;
-      font-weight: 700;
-    }
-
-    .toolbar button {
-      cursor: pointer;
-      background: var(--accent-soft);
-      color: var(--accent-dark);
-    }
-
-    .load-status {
-      font-size: 12px;
-      font-weight: 700;
-      color: var(--muted);
-    }
-
-    .page {
-      width: 210mm;
-      min-height: 297mm;
-      margin: 16px auto;
-      background: var(--paper);
-      padding: 10mm 11mm 9mm;
-      box-shadow: 0 8px 24px rgba(0,0,0,.08);
-      border: 1px solid #e8e3ec;
-      display: flex;
-      flex-direction: column;
-      gap: 4.2mm;
-    }
-
-    .hero {
-      min-height: 35mm;
-      background: linear-gradient(120deg, #f3ecfb 0%, #f7f1fb 54%, #eef7f5 100%);
-      color: var(--text);
-      border: 1px solid var(--accent-line);
-      padding: 6mm 7mm;
-      display: grid;
-      grid-template-columns: 31mm 1fr;
-      gap: 6mm;
-      align-items: center;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .hero::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(135deg, transparent 58%, rgba(127,90,162,.10) 58.2%, transparent 59%),
-                  linear-gradient(55deg, transparent 66%, rgba(78,154,139,.08) 66.2%, transparent 67%);
-      pointer-events: none;
-    }
-
-    .logo-box {
-      height: 22mm;
-      border: 1px solid var(--accent-line);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-weight: 800;
-      font-size: 11px;
-      line-height: 1.35;
-      text-align: center;
-      color: var(--accent-dark);
-      background: rgba(255,255,255,.58);
-      opacity: .96;
-      z-index: 1;
-    }
-
-    .hero-content { z-index: 1; }
-
-    .eyebrow {
-      font-size: 12px;
-      font-weight: 800;
-      margin-bottom: 2mm;
-      color: var(--accent-dark);
-    }
-
-    h1 {
-      margin: 0;
-      font-size: 26px;
-      line-height: 1.05;
-      font-weight: 900;
-      letter-spacing: -.3px;
-      color: #3d3743;
-    }
-
-    .subtitle {
-      margin-top: 3mm;
-      background: rgba(255,255,255,.72);
-      border-right: 4px solid var(--accent);
-      border-top: 1px solid var(--accent-line);
-      border-bottom: 1px solid var(--accent-line);
-      border-left: 1px solid var(--accent-line);
-      padding: 2.5mm 4mm;
-      font-size: 14px;
-      font-weight: 700;
-      line-height: 1.35;
-      color: #443a4d;
-    }
-
-    .info-grid {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      border: 1px solid var(--accent-line);
-      background: #fff;
-    }
-
-    .info-item {
-      padding: 2.5mm 2mm;
-      min-height: 14mm;
-      border-left: 1px solid var(--accent-line);
-      text-align: center;
-      background: linear-gradient(180deg, #ffffff 0%, #fbf8fd 100%);
-    }
-
-    .info-item:last-child { border-left: 0; }
-
-    .info-label {
-      font-size: 10.5px;
-      color: var(--muted);
-      font-weight: 800;
-      margin-bottom: 1mm;
-    }
-
-    .info-value {
-      font-size: 13px;
-      color: var(--accent-dark);
-      font-weight: 900;
-      line-height: 1.25;
-    }
-
-    .top-grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 4mm;
-    }
-
-    .card {
-      border: 1px solid var(--line);
-      background: linear-gradient(180deg, #ffffff 0%, #fcfafe 100%);
-      padding: 3.8mm;
-      min-height: 38mm;
-    }
-
-    .card.tint {
-      background: var(--accent-soft);
-      border-color: var(--accent-line);
-    }
-
-    .section-title {
-      color: var(--accent-dark);
-      font-size: 13.5px;
-      font-weight: 900;
-      margin: 0 0 2.2mm;
-      padding-bottom: 1.4mm;
-      border-bottom: 2px solid var(--accent-line);
-    }
-
-    .card p,
-    .card li {
-      font-size: 11.7px;
-      line-height: 1.45;
-    }
-
-    .card p { margin: 0; }
-
-    ul {
-      margin: 0;
-      padding: 0 4mm 0 0;
-    }
-
-    li {
-      margin-bottom: 1.1mm;
-    }
-
-    .why-strip {
-      border: 1px solid var(--accent-warm-line);
-      background: var(--accent-warm);
-    }
-
-    .strip-title {
-      background: #dff0ec;
-      color: #315f58;
-      padding: 2mm 4mm;
-      font-size: 13.5px;
-      font-weight: 900;
-      border-bottom: 1px solid var(--accent-warm-line);
-    }
-
-    .strip-grid {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-    }
-
-    .strip-item {
-      padding: 3mm 4mm;
-      border-left: 1px solid var(--accent-warm-line);
-      min-height: 22mm;
-      background: rgba(255,255,255,.42);
-    }
-
-    .strip-item:last-child { border-left: 0; }
-
-    .strip-question {
-      color: #315f58;
-      font-size: 12.5px;
-      font-weight: 900;
-      margin-bottom: 1.5mm;
-    }
-
-    .strip-answer {
-      font-size: 11.6px;
-      line-height: 1.45;
-      color: var(--text);
-    }
-
-    .syllabus {
-      border: 1px solid var(--line);
-      overflow: hidden;
-    }
-
-    .syllabus-title {
-      background: #efe6f6;
-      color: var(--accent-dark);
-      padding: 2mm 4mm;
-      font-size: 13.5px;
-      font-weight: 900;
-      border-bottom: 1px solid var(--accent-line);
-    }
-
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      table-layout: fixed;
-    }
-
-    th, td {
-      border-top: 1px solid var(--line);
-      padding: 1.7mm 2.2mm;
-      vertical-align: top;
-      font-size: 10.8px;
-      line-height: 1.35;
-    }
-
-    th {
-      background: #f6effa;
-      color: var(--accent-dark);
-      font-weight: 900;
-      text-align: right;
-    }
-
-    .num { width: 15mm; text-align: center; font-weight: 900; color: var(--accent-dark); }
-    .topic { width: 36mm; font-weight: 900; }
-
-    .takeaways-box {
-      border: 1px solid var(--accent-line);
-      background: #fbf8fd;
-      padding: 3mm 4mm;
-    }
-
-    .takeaways-title {
-      color: var(--accent-dark);
-      font-size: 13.5px;
-      font-weight: 900;
-      margin-bottom: 2mm;
-    }
-
-    .takeaways-list {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 2.2mm;
-      align-items: stretch;
-    }
-
-    .takeaway-item {
-      border: 1px solid var(--accent-line);
-      background: #ffffff;
-      padding: 2.4mm 2mm;
-      min-height: 14mm;
-      font-size: 11.5px;
-      line-height: 1.25;
-      font-weight: 800;
-      color: var(--accent-dark);
-      text-align: center;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .closing-box {
-      border: 1px solid var(--accent-line);
-      background: linear-gradient(120deg, #f7f1fb 0%, #eef7f5 100%);
-      padding: 3.2mm 4.5mm;
-      display: grid;
-      grid-template-columns: 1fr auto;
-      gap: 5mm;
-      align-items: center;
-    }
-
-    .closing-title {
-      color: var(--accent-dark);
-      font-size: 14px;
-      font-weight: 900;
-      margin-bottom: 1mm;
-    }
-
-    .closing-text {
-      font-size: 12.2px;
-      line-height: 1.45;
-      color: #3f3946;
-      font-weight: 700;
-    }
-
-    .closing-mark {
-      width: 18mm;
-      height: 18mm;
-      border-radius: 50%;
-      border: 1px solid var(--accent-line);
-      background: rgba(255,255,255,.62);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: var(--accent-dark);
-      font-size: 18px;
-      font-weight: 900;
-    }
-
-    .footer-note {
-      margin-top: auto;
-      padding-top: 2.5mm;
-      border-top: 1px solid var(--line);
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      color: var(--muted);
-      font-size: 10.5px;
-    }
-
-    .empty-note {
-      color: var(--muted);
-      font-size: 11px;
-      line-height: 1.4;
-    }
-
-    @page { size: A4; margin: 0; }
-
+    :root { --primary:#5e3f80; --line:#ddd4e7; --bg:#f6f5f8; --paper:#fff; --text:#2e2a33; }
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Arial,sans-serif;background:var(--bg);color:var(--text)}
+    .wrap{max-width:1100px;margin:0 auto;padding:16px}
+    .toolbar{display:flex;gap:8px;justify-content:center;align-items:center;position:sticky;top:0;background:#ffffffde;border-bottom:1px solid var(--line);padding:10px;backdrop-filter: blur(3px)}
+    button{border:1px solid var(--line);background:#fff;padding:8px 12px;border-radius:8px;font-weight:700;cursor:pointer}
+    .primary{background:#f1ebf8;color:var(--primary);border-color:#cdb9e3}
+    h1{margin:6px 0 2px;text-align:center;font-size:28px}
+    .subtitle{text-align:center;margin:0 0 18px;color:#62576f}
+    .group{background:var(--paper);border:1px solid var(--line);padding:14px;border-radius:12px;margin-bottom:14px}
+    .group h2{margin:0 0 10px;color:var(--primary);font-size:20px}
+    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:8px}
+    .program-btn{min-height:52px;display:flex;align-items:center;justify-content:center;text-align:center;padding:8px 10px;line-height:1.2;font-size:15px;font-weight:700;background:#fff;border:1px solid var(--line);border-radius:10px}
+    .program-btn:hover{border-color:#b79ad4;background:#faf7fe}
+    #programView{display:none;background:#fff;border:1px solid var(--line);border-radius:12px;padding:18px}
+    .head{border-bottom:1px solid var(--line);padding-bottom:10px;margin-bottom:12px}
+    .meta{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;font-size:14px}
+    .meta div{background:#f8f6fc;padding:8px;border-radius:8px}
+    table{width:100%;border-collapse:collapse;margin-top:8px;font-size:14px}
+    th,td{border:1px solid #d9d0e5;padding:7px;vertical-align:top}
+    th{background:#f2ecf9}
+    .muted{color:#736982;font-size:13px}
     @media print {
-      body { background: #fff; }
-      .toolbar { display: none; }
-      .page {
-        margin: 0;
-        width: 210mm;
-        min-height: 297mm;
-        box-shadow: none;
-        border: 0;
-        page-break-after: always;
-      }
+      body{background:#fff}
+      .toolbar,#catalogView{display:none!important}
+      #programView{display:block!important;border:none;padding:0}
+      .wrap{max-width:100%;padding:0}
     }
   </style>
 </head>
 <body>
   <div class="toolbar">
-    <label for="programSelect">בחירת תוכנית:</label>
-    <select id="programSelect"></select>
-    <button type="button" onclick="window.print()">הדפסה / PDF</button>
-    <span id="loadStatus" class="load-status" aria-live="polite"></span>
+    <button id="backBtn" class="primary" style="display:none">חזרה לכל התוכניות</button>
+    <button id="printBtn">הדפסה / PDF</button>
+    <span id="status" class="muted">טוען נתונים…</span>
   </div>
+  <div class="wrap">
+    <section id="catalogView">
+      <h1>קטלוג תוכניות תלמידים תשפ״ז</h1>
+      <p class="subtitle">בחרו תוכנית להצגת עמוד מלא</p>
+      <div class="group">
+        <h2>יסודי</h2>
+        <div id="elementaryGrid" class="grid"></div>
+      </div>
+      <div class="group">
+        <h2>חטיבות</h2>
+        <div id="middleGrid" class="grid"></div>
+      </div>
+    </section>
 
-  <main class="page" id="page"></main>
+    <section id="programView"></section>
+  </div>
+<script>
+let programs=[]; let activeProgram=null;
+const statusEl=document.getElementById('status');
+const catalogView=document.getElementById('catalogView');
+const programView=document.getElementById('programView');
+const backBtn=document.getElementById('backBtn');
 
-  <script>
-    const DATA_FILE = "./catalog_programs_tashpaz.json";
+function normalizeLevel(v){
+  if(!v) return 'לא משויך';
+  if(String(v).includes('יסודי')) return 'יסודי';
+  if(String(v).includes('חטיבה')) return 'חטיבות';
+  return 'לא משויך';
+}
+function createProgramButton(p){
+  const b=document.createElement('button');
+  b.className='program-btn'; b.textContent=p.title;
+  b.onclick=()=>openProgram(p.id);
+  return b;
+}
+function renderCatalog(){
+  const e=document.getElementById('elementaryGrid');
+  const m=document.getElementById('middleGrid');
+  e.innerHTML='';m.innerHTML='';
+  const elementary=programs.filter(p=>normalizeLevel(p.audienceLevel)==='יסודי');
+  const middle=programs.filter(p=>normalizeLevel(p.audienceLevel)==='חטיבות');
+  elementary.forEach(p=>e.appendChild(createProgramButton(p)));
+  middle.forEach(p=>m.appendChild(createProgramButton(p)));
+  if(!elementary.length)e.innerHTML='<div class="muted">אין תוכניות משויכות.</div>';
+  if(!middle.length)m.innerHTML='<div class="muted">אין תוכניות משויכות.</div>';
+}
+function openProgram(id){
+  const p=programs.find(x=>x.id===id); if(!p) return;
+  activeProgram=p;
+  backBtn.style.display='inline-block'; catalogView.style.display='none'; programView.style.display='block';
+  const syllabusRows=(p.syllabus||[]).map(s=>`<tr><td>${s.meeting||''}</td><td>${s.topic||''}</td><td>${s.description||''}</td><td>${s.sourcePage||''}</td></tr>`).join('');
+  programView.innerHTML=`<div class="head"><h2>${p.title}</h2><div class="muted">${p.subtitle||''}</div></div>
+  <div class="meta">
+    <div><strong>שכבה:</strong> ${p.audienceLevel||'לא משויך'}</div>
+    <div><strong>סוג מוצר:</strong> ${p.productType||''}</div>
+    <div><strong>מס׳ תוכנית:</strong> ${p.gefenNumber||''}</div>
+    <div><strong>היקף:</strong> ${p.scope||''}</div>
+  </div>
+  <h3>סילבוס</h3>
+  <table><thead><tr><th>מפגש</th><th>נושא</th><th>תיאור קצר לקטלוג</th><th>עמוד מקור</th></tr></thead><tbody>${syllabusRows}</tbody></table>`;
+  history.replaceState({},'',`?program=${encodeURIComponent(p.id)}`);
+}
+function backToCatalog(){
+  activeProgram=null; programView.style.display='none'; catalogView.style.display='block'; backBtn.style.display='none'; history.replaceState({},'',location.pathname);
+}
+backBtn.onclick=backToCatalog;
+document.getElementById('printBtn').onclick=()=>{
+  if(!activeProgram){ alert('יש לבחור תוכנית לפני הדפסה.'); return; }
+  window.print();
+};
 
-    const fallbackData = {
-      metadata: { catalog: "קטלוג תוכניות תשפ״ז" },
-      programs: [{
-        title: "המצאות בהשראה מן הטבע – ביומימיקרי",
-        subtitle: "חדשנות טכנולוגית בהשראת הטבע",
-        audienceLevel: "יסודי",
-        productType: "תוכנית",
-        pageTemplate: "program_elementary",
-        grades: "ד׳–ו׳",
-        scope: "10 מפגשים",
-        duration: "90 דקות",
-        gefenNumber: "6089",
-        domain: ["ביומימיקרי", "STEM", "יזמות"],
-        sections: {
-          openingStatement: "הטבע לא רק יפה – הוא גם חכם. בתוכנית זו התלמידים לומדים להתבונן בטבע כמאגר רעיונות לפתרונות טכנולוגיים חדשניים.",
-          mainIdea: "תוכנית חקר ויזמות המחברת בין טבע, מדע וטכנולוגיה. התלמידים מגלים כיצד בעלי חיים, צמחים ותופעות טבע יכולים לשמש השראה לפיתוח פתרונות שימושיים ובני־קיימא.",
-          programFlow: "המשתתפים חוקרים תופעות מן הטבע, מזהים מנגנונים ועקרונות פעולה, משווים אותם למערכות טכנולוגיות, מפתחים רעיון לפתרון, בונים אב־טיפוס ומציגים את תהליך החשיבה שלהם.",
-          studentDevelopment: ["חשיבה ביומימטית", "חקר מדעי", "פתרון בעיות", "עבודת צוות"],
-          schoolValue: "תוכנית מובנית המחזקת למידה פעילה, סקרנות מדעית וחיבור בין STEM, קיימות וחדשנות.",
-          finalOutcome: "אב־טיפוס ביומימטי, מצגת קבוצתית והצגת תהליך החקר והפיתוח."
-        },
-        syllabus: []
-      }]
-    };
-
-    const page = document.getElementById("page");
-    const programSelect = document.getElementById("programSelect");
-    const loadStatus = document.getElementById("loadStatus");
-    let catalogData = fallbackData;
-
-    function safe(value, fallback = "") {
-      if (Array.isArray(value)) return value.filter(Boolean).join(", ");
-      return value == null || value === "" ? fallback : String(value);
-    }
-
-    function escapeHTML(value) {
-      return safe(value)
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;")
-        .replaceAll('"', "&quot;")
-        .replaceAll("'", "&#039;");
-    }
-
-    function asList(items) {
-      if (!items) return [];
-      if (Array.isArray(items)) return items.filter(Boolean);
-      return String(items).split(/[,\n•]+/).map(item => item.trim()).filter(Boolean);
-    }
-
-    function getEyebrow(program) {
-      const parts = [
-        safe(program.productType, "תוכנית"),
-        safe(program.audienceLevel),
-        safe(program.domain)
-      ].filter(Boolean);
-      return parts.join(" | ");
-    }
-
-    function getTemplateLabels(program) {
-      const type = safe(program.productType, "תוכנית");
-      if (type.includes("סיור")) {
-        return {
-          flowTitle: "מה קורה בסיור",
-          finalTitle: "שיא הסיור / תוצר מסכם",
-          valueTitle: "הערך לבית הספר",
-          takeawaysTitle: "מה מקבלים המשתתפים",
-          closingTitle: "סיור שמחבר בין למידה, חוויה ועולם אמיתי"
-        };
-      }
-      if (type.includes("סדנה")) {
-        return {
-          flowTitle: "מה עושים בסדנה",
-          finalTitle: "תוצר הסדנה",
-          valueTitle: "הערך לבית הספר",
-          takeawaysTitle: "מה מקבלים המשתתפים",
-          closingTitle: "סדנה קצרה שמחברת בין התנסות, ידע והנאה"
-        };
-      }
-      return {
-        flowTitle: "מה קורה בתוכנית",
-        finalTitle: "תוצר מסכם / שיא תהליך",
-        valueTitle: "הערך לבית הספר",
-        takeawaysTitle: "מה מקבלים המשתתפים",
-        closingTitle: "תוכנית שמתחילה בהתבוננות — ומובילה לחשיבה חדשנית"
-      };
-    }
-
-    function getTakeaways(program) {
-      const s = program.sections || {};
-      const type = safe(program.productType, "תוכנית");
-
-      if (Array.isArray(program.participantsReceive) && program.participantsReceive.length) {
-        return program.participantsReceive.slice(0, 4);
-      }
-
-      if (type.includes("סיור")) {
-        return [
-          "חשיפה לעולם תוכן אמיתי",
-          "למידה מחוץ לכיתה",
-          "חיבור לתעשייה / סביבה",
-          safe(s.finalOutcome, "פעילות מסכמת")
-        ];
-      }
-
-      return [
-        "מפגשי חקר והתנסות פעילה",
-        "עבודה קבוצתית מונחית",
-        safe(s.studentDevelopment?.[0], "פיתוח רעיון"),
-        safe(s.finalOutcome, "תוצר מסכם להצגה")
-      ];
-    }
-
-    function getClosingText(program) {
-      const s = program.sections || {};
-      const type = safe(program.productType, "תוכנית");
-
-      if (type.includes("סיור")) {
-        return safe(s.finalOutcome, "דרך מפגש עם עולם אמיתי, התלמידים מחברים בין ידע, סקרנות וחוויה לימודית משמעותית.");
-      }
-
-      if (type.includes("סדנה")) {
-        return safe(s.finalOutcome, "דרך עשייה והתנסות, התלמידים מגלים רעיון מדעי בדרך נגישה, פעילה וחווייתית.");
-      }
-
-      return safe(
-        s.finalOutcome,
-        "דרך חקר, דמיון ופיתוח רעיונות, התלמידים מגלים שהלמידה היא נקודת פתיחה לפתרונות חדשים."
-      );
-    }
-
-    function renderInfoItem(label, value) {
-      return `
-        <div class="info-item">
-          <div class="info-label">${escapeHTML(label)}</div>
-          <div class="info-value">${escapeHTML(value || "—")}</div>
-        </div>
-      `;
-    }
-
-    function renderList(items) {
-      const cleanItems = asList(items);
-      if (!cleanItems.length) return `<p class="empty-note">המידע יושלם בהמשך.</p>`;
-      return `<ul>${cleanItems.map(item => `<li>${escapeHTML(item)}</li>`).join("")}</ul>`;
-    }
-
-    function renderSyllabus(program) {
-      const syllabus = Array.isArray(program.syllabus) ? program.syllabus : [];
-      if (!syllabus.length) return "";
-
-      return `
-        <section class="syllabus">
-          <div class="syllabus-title">${safe(program.productType).includes("סיור") ? "מבנה הסיור" : "סילבוס התוכנית"}</div>
-          <table>
-            <thead>
-              <tr>
-                <th class="num">${safe(program.productType).includes("סיור") ? "תחנה" : "מפגש"}</th>
-                <th class="topic">נושא</th>
-                <th>מה עושים</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${syllabus.map(item => `
-                <tr>
-                  <td class="num">${escapeHTML(item.meeting || item.stop || "")}</td>
-                  <td class="topic">${escapeHTML(item.topic || "")}</td>
-                  <td>${escapeHTML(item.description || "")}</td>
-                </tr>
-              `).join("")}
-            </tbody>
-          </table>
-        </section>
-      `;
-    }
-
-    function renderProgram(program) {
-      const s = program.sections || {};
-      const labels = getTemplateLabels(program);
-      const takeaways = getTakeaways(program);
-
-      page.innerHTML = `
-        <section class="hero">
-          <div class="logo-box">תעשיידע<br>חינוך טכנולוגי<br>וחדשנות</div>
-          <div class="hero-content">
-            <div class="eyebrow">${escapeHTML(getEyebrow(program))}</div>
-            <h1>${escapeHTML(program.title)}</h1>
-            <div class="subtitle">${escapeHTML(s.openingStatement || program.subtitle)}</div>
-          </div>
-        </section>
-
-        <section class="info-grid" aria-label="פרטי התוכנית">
-          ${renderInfoItem("כיתות", program.grades)}
-          ${renderInfoItem("היקף", program.scope)}
-          ${renderInfoItem("משך מפגש", program.duration)}
-          ${renderInfoItem("מספר גפ״ן", program.gefenNumber)}
-        </section>
-
-        <section class="top-grid">
-          <article class="card tint">
-            <h2 class="section-title">${escapeHTML(labels.flowTitle)}</h2>
-            <p>${escapeHTML(s.programFlow || "המידע יושלם בהמשך.")}</p>
-          </article>
-
-          <article class="card">
-            <h2 class="section-title">הרעיון המרכזי</h2>
-            <p>${escapeHTML(s.mainIdea || "המידע יושלם בהמשך.")}</p>
-          </article>
-
-          <article class="card">
-            <h2 class="section-title">מה התלמידים מפתחים</h2>
-            ${renderList(s.studentDevelopment)}
-          </article>
-
-          <article class="card tint">
-            <h2 class="section-title">${escapeHTML(labels.finalTitle)}</h2>
-            <p>${escapeHTML(s.finalOutcome || "המידע יושלם בהמשך.")}</p>
-          </article>
-        </section>
-
-        <section class="why-strip">
-          <div class="strip-title">${escapeHTML(labels.valueTitle)}</div>
-          <div class="strip-grid">
-            <div class="strip-item">
-              <div class="strip-question">למה לבחור בזה?</div>
-              <div class="strip-answer">${escapeHTML(s.schoolValue || "המידע יושלם בהמשך.")}</div>
-            </div>
-            <div class="strip-item">
-              <div class="strip-question">איך זה נראה בכיתה?</div>
-              <div class="strip-answer">${escapeHTML(s.programFlow || "למידה פעילה, חקר, שיח, התנסות והצגה מסכמת.")}</div>
-            </div>
-            <div class="strip-item">
-              <div class="strip-question">מה התלמידים לוקחים איתם?</div>
-              <div class="strip-answer">${escapeHTML(asList(s.studentDevelopment).join(", ") || "סקרנות, ביטחון להתנסות וכלים לחשיבה עצמאית.")}</div>
-            </div>
-          </div>
-        </section>
-
-        ${renderSyllabus(program)}
-
-        <section class="takeaways-box">
-          <div class="takeaways-title">${escapeHTML(labels.takeawaysTitle)}</div>
-          <div class="takeaways-list">
-            ${takeaways.slice(0, 4).map(item => `<div class="takeaway-item">${escapeHTML(item)}</div>`).join("")}
-          </div>
-        </section>
-
-        <section class="closing-box">
-          <div>
-            <div class="closing-title">${escapeHTML(labels.closingTitle)}</div>
-            <div class="closing-text">${escapeHTML(getClosingText(program))}</div>
-          </div>
-          <div class="closing-mark">✓</div>
-        </section>
-
-        <div class="footer-note">
-          <span>עמותת תעשיידע — חינוך טכנולוגי, חדשנות ויזמות</span>
-          <span>${escapeHTML(catalogData.metadata?.catalog || "קטלוג תוכניות תשפ״ז")}</span>
-        </div>
-      `;
-    }
-
-    function setupSelector(programs) {
-      programSelect.innerHTML = programs.map((program, index) => {
-        const label = `${program.title || "ללא שם"} — ${program.audienceLevel || ""} / ${program.productType || ""}`;
-        return `<option value="${index}">${escapeHTML(label)}</option>`;
-      }).join("");
-
-      const params = new URLSearchParams(window.location.search);
-      const requestedSlug = params.get("program") || params.get("slug");
-      const requestedIndex = requestedSlug
-        ? programs.findIndex(program => program.slug === requestedSlug || String(program.id) === requestedSlug)
-        : 0;
-
-      programSelect.value = String(requestedIndex >= 0 ? requestedIndex : 0);
-      renderProgram(programs[Number(programSelect.value)]);
-
-      programSelect.addEventListener("change", event => {
-        renderProgram(programs[Number(event.target.value)]);
-      });
-    }
-
-    async function init() {
-      try {
-        const response = await fetch(DATA_FILE, { cache: "no-store" });
-        if (!response.ok) throw new Error("JSON file not found");
-        catalogData = await response.json();
-        if (loadStatus) loadStatus.textContent = "";
-      } catch (error) {
-        console.warn("Using fallback data because JSON could not be loaded:", error);
-        catalogData = fallbackData;
-        if (loadStatus) loadStatus.textContent = "לא נמצא קובץ JSON — מוצגים נתוני דוגמה";
-      }
-
-      const programs = Array.isArray(catalogData.programs) ? catalogData.programs : fallbackData.programs;
-      setupSelector(programs);
-    }
-
-    init();
-  </script>
+(async function init(){
+  try{
+    const res=await fetch('./catalog_programs_tashpaz.json?v=2026-05-23-1',{cache:'no-store'});
+    const data=await res.json();
+    programs=Array.isArray(data.programs)?data.programs:[];
+    renderCatalog();
+    const qp=new URLSearchParams(location.search).get('program');
+    if(qp) openProgram(qp);
+    statusEl.textContent=`נטענו ${programs.length} תוכניות`;
+  }catch(e){
+    console.error(e); statusEl.textContent='שגיאה בטעינת הקטלוג';
+  }
+})();
+</script>
 </body>
 </html>

--- a/frontend/public/catalog_programs_tashpaz.json
+++ b/frontend/public/catalog_programs_tashpaz.json
@@ -1,59 +1,7519 @@
 {
   "metadata": {
-    "catalog": "קטלוג תוכניות תשפ״ז"
+    "catalog": "קטלוג תוכניות תלמידים תשפ״ז",
+    "sourceFile": "attached_assets/system_dashboard_(1)_1776579794224.xlsx",
+    "note": "קובץ המקור אינו כולל עמודות מפגש/נושא/תיאור/עמוד מקור בפורמט המבוקש; נדרש תיקוף ידני."
   },
   "programs": [
     {
-      "id": "biomimicry-6089",
-      "slug": "biomimicry",
-      "title": "המצאות בהשראת הטבע – ביומימיקרי",
-      "subtitle": "חדשנות טכנולוגית בהשראת הטבע",
-      "audienceLevel": "יסודי",
+      "id": "program-1",
+      "slug": "program-1",
+      "title": "פורצות דרך",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
       "productType": "תוכנית",
-      "pageTemplate": "program_elementary",
-      "grades": "ד׳–ו׳",
-      "scope": "10 מפגשים",
-      "duration": "90 דקות",
-      "gefenNumber": "6089",
-      "domain": [
-        "ביומימיקרי",
-        "STEM",
-        "יזמות"
-      ],
-      "sections": {
-        "openingStatement": "הטבע לא רק יפה – הוא גם חכם. בתוכנית זו התלמידים לומדים להתבונן בטבע כמאגר רעיונות לפתרונות טכנולוגיים חדשניים.",
-        "mainIdea": "תוכנית חקר ויזמות המחברת בין טבע, מדע וטכנולוגיה. התלמידים מגלים כיצד בעלי חיים, צמחים ותופעות טבע יכולים לשמש השראה לפיתוח פתרונות שימושיים ובני־קיימא.",
-        "programFlow": "המשתתפים חוקרים תופעות מן הטבע, מזהים מנגנונים ועקרונות פעולה, משווים אותם למערכות טכנולוגיות, מפתחים רעיון לפתרון, בונים אב־טיפוס ומציגים את תהליך החשיבה שלהם.",
-        "studentDevelopment": [
-          "חשיבה ביומימטית",
-          "חקר מדעי",
-          "פתרון בעיות",
-          "עבודת צוות"
-        ],
-        "schoolValue": "תוכנית מובנית המחזקת למידה פעילה, סקרנות מדעית וחיבור בין STEM, קיימות וחדשנות.",
-        "finalOutcome": "אב־טיפוס ביומימטי, מצגת קבוצתית והצגת תהליך החקר והפיתוח."
-      },
-      "participantsReceive": [
-        "מפגשי חקר והתנסות פעילה",
-        "עבודה קבוצתית מונחית",
-        "פיתוח רעיון מקורי",
-        "תוצר מסכם להצגה"
-      ],
+      "grades": "",
+      "scope": "12 מפגשים",
+      "duration": "",
+      "gefenNumber": "3604",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
       "syllabus": [
         {
           "meeting": "1",
-          "topic": "ביו־מי?",
-          "description": "היכרות עם ביומימיקרי ועם הטבע כמקור השראה לפתרונות טכנולוגיים."
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
         },
         {
           "meeting": "2",
-          "topic": "השראה מהטבע",
-          "description": "חוקרים דוגמאות מהטבע ומזהים מבנים ותהליכים שפותרים בעיות."
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
         },
         {
           "meeting": "3",
-          "topic": "חשיבה יזמית",
-          "description": "לומדים לזהות צורך, לשאול שאלות ולחפש כיוון לפתרון מקורי."
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-113"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-047"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-116"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-117"
+        }
+      ]
+    },
+    {
+      "id": "program-2",
+      "slug": "program-2",
+      "title": "ביומימיקרי",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "10 מפגשים",
+      "duration": "",
+      "gefenNumber": "6089",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-014"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-016"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-017"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-024"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-025"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-029"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-032"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-033"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-036"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-043"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-060"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-061"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-062"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-063"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-104"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-106"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-107"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-108"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-109"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-110"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-114"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-015"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-019"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-026"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-042"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-105"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-121"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-008"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-009"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-010"
+        }
+      ]
+    },
+    {
+      "id": "program-3",
+      "slug": "program-3",
+      "title": "בינה מלאכותית",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "8 מפגשים",
+      "duration": "",
+      "gefenNumber": "9545",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-094"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-094"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-094"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-094"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-103"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-005"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-006"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-013"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-018"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-035"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-041"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-065"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-066"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-067"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-069"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-076"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-077"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-078"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-081"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-098"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-120"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-044"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-045"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-111"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-122"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-011"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-012"
+        }
+      ]
+    },
+    {
+      "id": "program-4",
+      "slug": "program-4",
+      "title": "רוקחים עולם",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "12 מפגשים",
+      "duration": "",
+      "gefenNumber": "46091",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-068"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-003"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-004"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-031"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-034"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-079"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-112"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "16",
+          "topic": "מפגש 16",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "17",
+          "topic": "מפגש 17",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "18",
+          "topic": "מפגש 18",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "19",
+          "topic": "מפגש 19",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "20",
+          "topic": "מפגש 20",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "21",
+          "topic": "מפגש 21",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "22",
+          "topic": "מפגש 22",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "23",
+          "topic": "מפגש 23",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "24",
+          "topic": "מפגש 24",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        },
+        {
+          "meeting": "25",
+          "topic": "מפגש 25",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-020"
+        }
+      ]
+    },
+    {
+      "id": "program-5",
+      "slug": "program-5",
+      "title": "יישומי AI",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "10 מפגשים",
+      "duration": "",
+      "gefenNumber": "53819",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-072"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-073"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-075"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-070"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-071"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-074"
+        }
+      ]
+    },
+    {
+      "id": "program-6",
+      "slug": "program-6",
+      "title": "ביומימיקרי לחטיבה",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "7 מפגשים",
+      "duration": "",
+      "gefenNumber": "53828",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-021"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-027"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-037"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-038"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-040"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-046"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-059"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-080"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-115"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-088"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-089"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-039"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-085"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-086"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-087"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-090"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-092"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-095"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-096"
+        }
+      ]
+    },
+    {
+      "id": "program-7",
+      "slug": "program-7",
+      "title": "השמיים אינם הגבול",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "10 מפגשים",
+      "duration": "",
+      "gefenNumber": "57646",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-007"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-064"
+        }
+      ]
+    },
+    {
+      "id": "program-8",
+      "slug": "program-8",
+      "title": "טכנולוגיות החלל",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "9 מפגשים",
+      "duration": "",
+      "gefenNumber": "57651",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-097"
+        }
+      ]
+    },
+    {
+      "id": "program-9",
+      "slug": "program-9",
+      "title": "מנהיגות ירוקה",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "10 מפגשים",
+      "duration": "",
+      "gefenNumber": "90001",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-048"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-049"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-051"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-052"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-053"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-054"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-055"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-056"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-057"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-058"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-082"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-083"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-084"
+        }
+      ]
+    },
+    {
+      "id": "program-10",
+      "slug": "program-10",
+      "title": "תלמידים להייטק",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "28 מפגשים",
+      "duration": "",
+      "gefenNumber": "90002",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "16",
+          "topic": "מפגש 16",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "16",
+          "topic": "מפגש 16",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "17",
+          "topic": "מפגש 17",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "17",
+          "topic": "מפגש 17",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "18",
+          "topic": "מפגש 18",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "18",
+          "topic": "מפגש 18",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "19",
+          "topic": "מפגש 19",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "19",
+          "topic": "מפגש 19",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "20",
+          "topic": "מפגש 20",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "20",
+          "topic": "מפגש 20",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "21",
+          "topic": "מפגש 21",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "21",
+          "topic": "מפגש 21",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "22",
+          "topic": "מפגש 22",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "22",
+          "topic": "מפגש 22",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "23",
+          "topic": "מפגש 23",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "23",
+          "topic": "מפגש 23",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "24",
+          "topic": "מפגש 24",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "24",
+          "topic": "מפגש 24",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        },
+        {
+          "meeting": "25",
+          "topic": "מפגש 25",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-101"
+        },
+        {
+          "meeting": "25",
+          "topic": "מפגש 25",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-102"
+        }
+      ]
+    },
+    {
+      "id": "program-11",
+      "slug": "program-11",
+      "title": "מייקרים",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "34 מפגשים",
+      "duration": "",
+      "gefenNumber": "90003",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "12",
+          "topic": "מפגש 12",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "13",
+          "topic": "מפגש 13",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "14",
+          "topic": "מפגש 14",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-030"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "15",
+          "topic": "מפגש 15",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "16",
+          "topic": "מפגש 16",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "16",
+          "topic": "מפגש 16",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "17",
+          "topic": "מפגש 17",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "17",
+          "topic": "מפגש 17",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "18",
+          "topic": "מפגש 18",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "18",
+          "topic": "מפגש 18",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "19",
+          "topic": "מפגש 19",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "19",
+          "topic": "מפגש 19",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "20",
+          "topic": "מפגש 20",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "20",
+          "topic": "מפגש 20",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "21",
+          "topic": "מפגש 21",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "21",
+          "topic": "מפגש 21",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "22",
+          "topic": "מפגש 22",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "22",
+          "topic": "מפגש 22",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "23",
+          "topic": "מפגש 23",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "23",
+          "topic": "מפגש 23",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "24",
+          "topic": "מפגש 24",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "24",
+          "topic": "מפגש 24",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "25",
+          "topic": "מפגש 25",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "25",
+          "topic": "מפגש 25",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "26",
+          "topic": "מפגש 26",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "26",
+          "topic": "מפגש 26",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "27",
+          "topic": "מפגש 27",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "27",
+          "topic": "מפגש 27",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "28",
+          "topic": "מפגש 28",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "28",
+          "topic": "מפגש 28",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "29",
+          "topic": "מפגש 29",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "29",
+          "topic": "מפגש 29",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "30",
+          "topic": "מפגש 30",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "30",
+          "topic": "מפגש 30",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "31",
+          "topic": "מפגש 31",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "31",
+          "topic": "מפגש 31",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "32",
+          "topic": "מפגש 32",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "32",
+          "topic": "מפגש 32",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "33",
+          "topic": "מפגש 33",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "33",
+          "topic": "מפגש 33",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        },
+        {
+          "meeting": "34",
+          "topic": "מפגש 34",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-022"
+        },
+        {
+          "meeting": "34",
+          "topic": "מפגש 34",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-023"
+        }
+      ]
+    },
+    {
+      "id": "program-12",
+      "slug": "program-12",
+      "title": "פרימיום",
+      "subtitle": "",
+      "audienceLevel": "לא משויך",
+      "productType": "תוכנית",
+      "grades": "",
+      "scope": "11 מפגשים",
+      "duration": "",
+      "gefenNumber": "90004",
+      "domain": [],
+      "sections": {},
+      "participantsReceive": [],
+      "sourceMappingStatus": "needs_manual_audience_mapping",
+      "syllabus": [
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "1",
+          "topic": "מפגש 1",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "2",
+          "topic": "מפגש 2",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "3",
+          "topic": "מפגש 3",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "4",
+          "topic": "מפגש 4",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "5",
+          "topic": "מפגש 5",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "6",
+          "topic": "מפגש 6",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "7",
+          "topic": "מפגש 7",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "8",
+          "topic": "מפגש 8",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "9",
+          "topic": "מפגש 9",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "10",
+          "topic": "מפגש 10",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-118"
+        },
+        {
+          "meeting": "11",
+          "topic": "מפגש 11",
+          "description": "ללא תיאור בקובץ המקור",
+          "sourcePage": "LONG-119"
         }
       ]
     }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 432;
+const CACHE_VERSION = 433;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -176,7 +176,7 @@ self.addEventListener('fetch', (event) => {
     url.pathname.endsWith('.html') ||
     url.pathname.endsWith('.js') ||
     url.pathname.endsWith('.css') ||
-    url.pathname.endsWith('/manifest.json') || isManifestUrl(url)
+    url.pathname.endsWith('/manifest.json') || isManifestUrl(url) || url.pathname.endsWith('/catalog_programs_tashpaz.json')
   );
 
   event.respondWith(

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 427;
+const SW_ENTRY_VERSION = 428;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Provide a compact, symmetric catalog entry screen that shows only course names so users pick a program before seeing its full page. 
- Populate the system JSON from the supplied Excel (`attached_assets/system_dashboard_(1)_1776579794224.xlsx`) and merge with existing catalog metadata where titles match. 
- Ensure the site serves the fresh `catalog_programs_tashpaz.json` after deploy by updating the Service Worker to avoid stale cached catalog data.

### Description
- Replaced `frontend/public/catalog.html` with a two-step UX: a compact landing page with two groups (`יסודי`, `חטיבות`) of uniform course tiles, and an in-page full program view that opens only after a tile is selected, including a clear `חזרה לכל התוכניות` back button and a print guard that only allows printing when a program is open. 
- Implemented program rendering of syllabus and metadata in the in-page program view and support for direct linking via query string (`?program=...`). 
- Regenerated `frontend/public/catalog_programs_tashpaz.json` from the provided Excel workbook by joining `data_long` and `activity_meetings`, merging existing program fields when titles matched, defaulting unknown `audienceLevel` to `"לא משויך"`, and adding `sourceMappingStatus` to flag manual validation. 
- Updated Service Worker versions and behavior by bumping `SW_ENTRY_VERSION` in `sw.js`, bumping `CACHE_VERSION` in `frontend/sw.js`, and treating `catalog_programs_tashpaz.json` as network-first so a reload post-deploy fetches the new JSON.

### Testing
- Ran the import/generation script that reads the Excel and wrote `frontend/public/catalog_programs_tashpaz.json`, which completed successfully and reported `programs 12` created. 
- Verified JSON validity with `node -e "JSON.parse(require('fs').readFileSync('frontend/public/catalog_programs_tashpaz.json','utf8'))"` which succeeded. 
- Checked that the new page contains the back button string with `node -e` file inspection which returned success. 
- Searched for the SW version and the catalog JSON handling changes with `rg` and confirmed the updated `CACHE_VERSION`, `SW_ENTRY_VERSION` and the network-first rule for `catalog_programs_tashpaz.json` were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c2795098832bb1b587a2ba87bd87)