### PR TITLE
Fix 22P02 on activity save by normalizing bigint/time payload fields

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2019,6 +2019,20 @@ function normalizeDateFieldForSupabase(value) {
   return normalized || null;
 }
 
+function normalizeBigintFieldForSupabase(value) {
+  if (value === null || value === undefined) return null;
+  const clean = String(value).trim();
+  if (!clean) return null;
+  const parsed = Number(clean);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeTimeFieldForSupabase(value) {
+  const clean = String(value ?? '').trim();
+  if (!clean) return null;
+  return /^\d{2}:\d{2}$/.test(clean) ? clean : null;
+}
+
 /**
  * Given a sanitized payload that may contain date_1..date_35,
  * returns the latest non-empty YYYY-MM-DD value, or null if none found.
@@ -2035,14 +2049,20 @@ function deriveEndDateFromDates(sanitized = {}) {
 function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true } = {}) {
   const sanitized = {};
   const source = payload && typeof payload === 'object' ? payload : {};
+  const bigintFields = new Set(['activity_no', 'sessions', 'price', 'emp_id']);
+  const timeFields = new Set(['start_time', 'end_time']);
   for (const [key, rawValue] of Object.entries(source)) {
     if (!ALLOWED_ACTIVITY_COLUMNS.has(key)) continue;
     if (!includeRowId && key === 'row_id') continue;
     let nextValue = rawValue;
     if (key === 'start_date' || key === 'end_date' || /^date_\d+$/.test(key)) {
       nextValue = normalizeDateFieldForSupabase(rawValue);
+    } else if (bigintFields.has(key)) {
+      nextValue = normalizeBigintFieldForSupabase(rawValue);
+    } else if (timeFields.has(key)) {
+      nextValue = normalizeTimeFieldForSupabase(rawValue);
     }
-    sanitized[key] = nextValue === undefined ? '' : nextValue;
+    sanitized[key] = nextValue === undefined ? null : nextValue;
   }
   return sanitized;
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 434;
+const CACHE_VERSION = 435;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 428;
+const SW_ENTRY_VERSION = 429;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/api-mutations.test.mjs
+++ b/tests/api-mutations.test.mjs
@@ -111,6 +111,16 @@ test('api mutation cache invalidation map includes required keys', async () => {
   assert.match(source, /addActivity:\s*\['activities:',\s*'activityDetail:'/);
 });
 
+test('sanitizeActivityPayloadForSupabase normalizes bigint/time empty values to null', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  assert.match(source, /function normalizeBigintFieldForSupabase\(value\)/);
+  assert.match(source, /function normalizeTimeFieldForSupabase\(value\)/);
+  assert.match(source, /const bigintFields = new Set\(\['activity_no', 'sessions', 'price', 'emp_id'\]\)/);
+  assert.match(source, /const timeFields = new Set\(\['start_time', 'end_time'\]\)/);
+  assert.match(source, /sanitized\[key\] = nextValue === undefined \? null : nextValue;/);
+});
+
 test('read-model rollout excludes finance from normal paths and keeps end-dates', async () => {
   const fs = await import('node:fs/promises');
   const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');


### PR DESCRIPTION
### Motivation
- Inserting/updating activities could send empty strings (`""`) for Postgres `bigint`/`time` columns and trigger Postgres `22P02` errors, so the payload must be normalized on the frontend before calling Supabase. 
- The fix must be frontend-only and avoid any schema, RLS, UI, or table-structure changes.

### Description
- Added `normalizeBigintFieldForSupabase` and `normalizeTimeFieldForSupabase` and wired them into `sanitizeActivityPayloadForSupabase` in `frontend/src/api.js` to coerce empty/blank values to `null` and parse numeric strings to `Number` for bigint fields. 
- The bigint fields normalized are `activity_no`, `sessions`, `price`, and `emp_id`, and the time fields normalized are `start_time` and `end_time`, while `emp_id_2` (text) and the existing date mapping logic are left unchanged. 
- Updated `sanitizeActivityPayloadForSupabase` to emit `null` instead of `''` for unspecified/empty normalized values so Supabase/Postgres receives `null` for optional numeric/time columns. 
- Bumped service-worker versions by updating `SW_ENTRY_VERSION` in `sw.js` and `CACHE_VERSION` in `frontend/sw.js` so clients will pick up the new frontend bundle after deploy.

### Testing
- Ran `npm test` which executed the test suite; the environment shows unrelated pre-existing failures, but the new sanitizer test passed. 
- Ran the targeted test command `node --test tests/api-mutations.test.mjs --test-name-pattern "sanitizeActivityPayloadForSupabase normalizes bigint/time empty values to null"` and confirmed the new test passes. 
- Verified service-worker logic and bumped versions to ensure the updated `api.js` will be loaded by clients after deploy, without changing SW caching behavior beyond the version bump.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a129c7aa66c832bbc47db698e9cce8c)