### PR TITLE
תקן scope של dateInputs ב-submitAddActivityForm (meeting_dates)

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1265,6 +1265,7 @@ export const activitiesScreen = {
       const sessionsValue = get('sessions') || '1';
       const isOneDay = isOneDayActivityTypeValue(get('activity_type'));
       const oneDayDate = String(get('one_day_date') || get('start_date') || get('end_date') || '').trim();
+      let meetingDateValues = [];
       const payload = {
         source: familySource,
         activity_manager: get('activity_manager'),
@@ -1292,6 +1293,7 @@ export const activitiesScreen = {
       if (isOneDay) {
         const selectedDate = String(oneDayDate || payload.start_date || payload.end_date || '').trim();
         if (selectedDate) {
+          meetingDateValues = [selectedDate];
           payload.start_date = selectedDate;
           payload.end_date = selectedDate;
           payload.Date1 = selectedDate;
@@ -1299,13 +1301,13 @@ export const activitiesScreen = {
         }
       } else {
         const dateInputs = Array.from(form.querySelectorAll('input[data-add-session-date]'));
+        meetingDateValues = dateInputs.map((input) => String(input.value || '').trim());
         dateInputs.forEach((input, index) => {
           payload[`Date${index + 1}`] = String(input.value || '').trim();
         });
       }
       if (!payload.end_date) {
-        const dateInputs = isOneDay ? [] : Array.from(form.querySelectorAll('input[data-add-session-date]'));
-        const lastDate = [...dateInputs].map((input) => String(input.value || '').trim()).filter(Boolean).pop();
+        const lastDate = meetingDateValues.filter(Boolean).pop();
         payload.end_date = lastDate || payload.start_date || null;
       }
 
@@ -1351,7 +1353,7 @@ export const activitiesScreen = {
           end_date: payload.end_date,
           status: 'פעיל',
           private_note: '',
-          meeting_dates: dateInputs.map((input) => String(input.value || '').trim()).filter(Boolean)
+          meeting_dates: meetingDateValues.filter(Boolean)
         };
         if (localRow.RowID) activitiesRows.unshift(localRow);
         rerenderLocal();


### PR DESCRIPTION
### Motivation
- תיקון של `ReferenceError` שנגרם כיוון שמשתנה `dateInputs` הוגדר רק בתוך בלוק פנימי ונעשה בו שימוש מחוץ ל-scope בעת בניית `localRow.meeting_dates`.

### Description
- הוספתי משתנה מפורש `let meetingDateValues = [];` בתחילת `submitAddActivityForm` והעברתי אליו את הערכים במקום להשתמש ב-`dateInputs` מחוץ לבלוק.
- במסלול של פעילות חד-יומית הוכנס התאריך הנבחר ל-`meetingDateValues` תוך שמירה על מיפוי ל-`Date1`/`date_1` כפי שהיה קודם.
- במסלול של פעילות רגילה נאספו כל ה-`input[data-add-session-date]` אל `meetingDateValues` ובאותו זמן נשמרו `payload.Date1/Date2/...` ללא שינוי לוגי אחר.
- בבניית השורה המקומית אחרי שמירה הוחלף `meeting_dates: dateInputs.map(...)` ל-`meeting_dates: meetingDateValues.filter(Boolean)` והימנעתי משינויים נוספים בסכימה, הרשאות או עיצוב; תיקון ה-bigint/null נשמר כפי שהיה.

### Testing
- הרצתי את חבילת הבדיקות האוטומטיות עם `npm test` וראיתי שאחוז גדול מהבדיקות עברו אך ישנן כמה בדיקות קיימות שנתקלו בכשלים לא קשורים (למשל: `activities render: operation_manager sees add activity button` וסט בדיקות `activities-snapshot.gs`).
- בדיקת הזרימה הרלוונטית לעדכון שמירה עברת: `activities screen wires add-activity form submit to api.addActivity flow` הוצגה כמעוברת בלוג הבדיקות.
- ביצעתי בניית production עם `npm run build` שנעשתה בהצלחה ועלתה חבילת JS מהודקת; הופק bundle מחושב (`dist/assets/index-*.js`) התומך ב-cache-busting כדי לסייע בטעינת הגרסה החדשה של `activities.js` אחרי deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a02eb108832bacc08a2c6acc5aa0)