### PR TITLE
Fix invitation A5 fit fallback and restore default typography

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -99,35 +99,35 @@ function ensureStyles() {
 .invitation-screen-root .c-logo-item{width:32mm;height:14mm;display:flex;align-items:center;justify-content:center;gap:4px;font-size:10px;font-weight:800;color:#1a3a5c;line-height:1.2}
 .invitation-screen-root .c-logo-sep{width:1px;height:26px;background:rgba(26,58,92,.2);flex-shrink:0}
 .invitation-screen-root .c-logo-item img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain}
-.invitation-screen-root .c-main{padding:1.5mm 6mm 2mm;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center}
-.invitation-screen-root .c-title{font-weight:900;line-height:1;margin-bottom:0;font-size:10.5mm}
-.invitation-screen-root .c-sub-event{font-weight:700;line-height:1.05;margin-bottom:1mm;font-size:5.5mm}
-.invitation-screen-root .c-course{font-weight:500;line-height:1.08;margin-bottom:1mm;font-size:6mm}
-.invitation-screen-root .c-course .course-main{display:block;font-size:6mm;line-height:1.05;font-weight:500}
-.invitation-screen-root .c-course .course-sub{display:block;font-size:5mm;line-height:1.05;font-weight:500}
-.invitation-screen-root .c-course .course-company{display:block;font-size:3.8mm;line-height:1.1;font-weight:500;margin-top:.8mm}
+.invitation-screen-root .c-main{padding:2mm 6.5mm 2.5mm;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center}
+.invitation-screen-root .c-title{font-weight:900;line-height:1;margin-bottom:0;font-size:12.5mm}
+.invitation-screen-root .c-sub-event{font-weight:700;line-height:1.08;margin-bottom:1mm;font-size:6.2mm}
+.invitation-screen-root .c-course{font-weight:500;line-height:1.08;margin-bottom:1mm;font-size:6.8mm}
+.invitation-screen-root .c-course .course-main{display:block;font-size:6.8mm;line-height:1.06;font-weight:500}
+.invitation-screen-root .c-course .course-sub{display:block;font-size:5.6mm;line-height:1.06;font-weight:500}
+.invitation-screen-root .c-course .course-company{display:block;font-size:4mm;line-height:1.1;font-weight:500;margin-top:.8mm}
 .invitation-screen-root .c-year{font-size:4.8mm;font-weight:700;margin-bottom:2mm}
 .invitation-screen-root .c-school{font-size:4mm;color:#333;margin:1.5mm 0}
 .invitation-screen-root .c-school strong{font-weight:700}
 .invitation-screen-root .c-divider{width:100%;height:1px;background:rgba(26,58,92,.1);margin:1.5mm 0}
-.invitation-screen-root .c-opening{font-size:3.55mm;color:#333;line-height:1.24;margin:1mm auto;max-width:none;width:84%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
+.invitation-screen-root .c-opening{font-size:3.85mm;color:#333;line-height:1.28;margin:1mm auto;max-width:none;width:82%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
 .invitation-screen-root .c-opening strong{font-weight:700;color:var(--accent-color,#1a8c6e)}
-.invitation-screen-root .c-para{font-size:3.55mm;color:#333;line-height:1.24;margin:.5mm auto;text-align:right;max-width:none;width:84%;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
-.invitation-screen-root .c-section-title{font-size:3.15mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1mm auto .4mm;max-width:none;width:80%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
-.invitation-screen-root .c-box{background:rgba(255,255,255,.5);border:1px solid rgba(26,140,110,.22);border-radius:8px;padding:1.3mm 3.5mm;margin:1mm 0;width:100%;text-align:right}
+.invitation-screen-root .c-para{font-size:3.85mm;color:#333;line-height:1.28;margin:.5mm auto;text-align:right;max-width:none;width:82%;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
+.invitation-screen-root .c-section-title{font-size:3.3mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1.2mm auto .5mm;max-width:none;width:80%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
+.invitation-screen-root .c-box{background:rgba(255,255,255,.5);border:1px solid rgba(26,140,110,.22);border-radius:8px;padding:1.6mm 4mm;margin:1.2mm 0;width:100%;text-align:right}
 .invitation-screen-root .c-participants-box{width:80%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1.2mm 3.5mm}
-.invitation-screen-root .c-details-box{width:78%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.7mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.2mm 3mm}
+.invitation-screen-root .c-details-box{width:76%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.9mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.4mm 3.5mm}
 .invitation-screen-root .c-details-top{display:flex;align-items:center;justify-content:center;gap:4mm;width:100%;flex-wrap:wrap}
 .invitation-screen-root .c-details-location{justify-content:center;text-align:center;width:100%;font-size:4.4mm;line-height:1.5}
 .invitation-screen-root .c-details-box .c-info-row{justify-content:center;text-align:center}
-.invitation-screen-root .c-info-row{display:flex;align-items:center;gap:4px;font-size:4mm;color:#333;line-height:1.35}
+.invitation-screen-root .c-info-row{display:flex;align-items:center;gap:4px;font-size:4.3mm;color:#333;line-height:1.4}
 .invitation-screen-root .c-info-row strong{font-weight:700}
-.invitation-screen-root .c-part-title{font-size:2.9mm;font-weight:700;margin-bottom:1px;line-height:1.3}
-.invitation-screen-root .c-part-line{font-size:2.9mm;color:#333;line-height:1.3}
+.invitation-screen-root .c-part-title{font-size:3.05mm;font-weight:700;margin-bottom:1px;line-height:1.35}
+.invitation-screen-root .c-part-line{font-size:3.05mm;color:#333;line-height:1.35}
 .invitation-screen-root .c-part-line strong{font-weight:700;color:#333}
-.invitation-screen-root .c-closing{font-size:5.2mm;font-weight:900;margin-top:auto;padding-top:1mm;text-align:center;line-height:1.05}
-.invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:.8mm 6mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:4.5mm;position:relative;z-index:4;width:100%}
-.invitation-screen-root .c-footer-sentence{font-size:2.65mm;font-weight:600;line-height:1.1;letter-spacing:.035em;text-shadow:-.3px -.3px 0 rgba(30,38,46,.25),.3px -.3px 0 rgba(30,38,46,.25),-.3px .3px 0 rgba(30,38,46,.25),.3px .3px 0 rgba(30,38,46,.25),0 1px 1.5px rgba(0,0,0,.08);display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:.35mm}
+.invitation-screen-root .c-closing{font-size:5.7mm;font-weight:900;margin-top:auto;padding-top:1.4mm;text-align:center;line-height:1.05}
+.invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:1mm 6mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:5mm;position:relative;z-index:4;width:100%}
+.invitation-screen-root .c-footer-sentence{font-size:2.8mm;font-weight:600;line-height:1.12;letter-spacing:.035em;text-shadow:-.3px -.3px 0 rgba(30,38,46,.25),.3px -.3px 0 rgba(30,38,46,.25),-.3px .3px 0 rgba(30,38,46,.25),.3px .3px 0 rgba(30,38,46,.25),0 1px 1.5px rgba(0,0,0,.08);display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:.35mm}
 .invitation-screen-root #card.fit-a5-compact .c-title{font-size:9.5mm}
 .invitation-screen-root #card.fit-a5-compact .c-sub-event{font-size:5mm}
 .invitation-screen-root #card.fit-a5-compact .c-course,.invitation-screen-root #card.fit-a5-compact .c-course .course-main{font-size:5.4mm}
@@ -838,27 +838,35 @@ export const invitationsScreen = {
 
       card.classList.remove('fit-a5-compact', 'fit-a5-tight');
 
-      const overflow = () => cwrap.scrollHeight > card.clientHeight;
-      if (!overflow()) return Promise.resolve();
-
-      card.classList.add('fit-a5-compact');
+      const OVERFLOW_EPSILON_PX = 1;
+      const overflow = () => (cwrap.scrollHeight - card.clientHeight) > OVERFLOW_EPSILON_PX;
 
       return new Promise((resolve) => {
         requestAnimationFrame(() => {
-          if (!overflow()) {
-            resolve();
-            return;
-          }
-
-          card.classList.add('fit-a5-tight');
           requestAnimationFrame(() => {
-            if (overflow()) {
-              console.warn('[invitations] A5 content still overflows after tight fit', {
-                cardHeight: card.clientHeight,
-                contentHeight: cwrap.scrollHeight
-              });
+            if (!overflow()) {
+              resolve();
+              return;
             }
-            resolve();
+
+            card.classList.add('fit-a5-compact');
+            requestAnimationFrame(() => {
+              if (!overflow()) {
+                resolve();
+                return;
+              }
+
+              card.classList.add('fit-a5-tight');
+              requestAnimationFrame(() => {
+                if (overflow()) {
+                  console.warn('[invitations] A5 content still overflows after tight fit', {
+                    cardHeight: card.clientHeight,
+                    contentHeight: cwrap.scrollHeight
+                  });
+                }
+                resolve();
+              });
+            });
           });
         });
       });
@@ -912,18 +920,23 @@ function fitInvitationToA5(card){
   var cwrap=card.querySelector('.cwrap');
   if(!cwrap) return Promise.resolve();
   card.classList.remove('fit-a5-compact','fit-a5-tight');
-  function overflow(){return cwrap.scrollHeight>card.clientHeight}
-  if(!overflow()) return Promise.resolve();
-  card.classList.add('fit-a5-compact');
+  var OVERFLOW_EPSILON_PX=1;
+  function overflow(){return (cwrap.scrollHeight-card.clientHeight)>OVERFLOW_EPSILON_PX}
   return new Promise(function(resolve){
     requestAnimationFrame(function(){
-      if(!overflow()){resolve();return;}
-      card.classList.add('fit-a5-tight');
       requestAnimationFrame(function(){
-        if(overflow()){
-          console.warn('[invitations] A5 content still overflows after tight fit',{cardHeight:card.clientHeight,contentHeight:cwrap.scrollHeight});
-        }
-        resolve();
+        if(!overflow()){resolve();return;}
+        card.classList.add('fit-a5-compact');
+        requestAnimationFrame(function(){
+          if(!overflow()){resolve();return;}
+          card.classList.add('fit-a5-tight');
+          requestAnimationFrame(function(){
+            if(overflow()){
+              console.warn('[invitations] A5 content still overflows after tight fit',{cardHeight:card.clientHeight,contentHeight:cwrap.scrollHeight});
+            }
+            resolve();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
### Motivation
- לתקן את בעיית הכרטיסים שנראו "קטנים מדי" לאחר השינוי האחרון על ידי החזרת ערכי ברירת המחדל של הטיפוגרפיה והמרווחים.
- למנוע הפעלה שגויה של מצבי `fit-a5-compact` / `fit-a5-tight` כאשר אין overflow אמיתי.
- לשמר `fit-a5-compact` ו-`fit-a5-tight` כמצבי חירום מדורגים בלבד ולא כמצב ברירת מחדל.

### Description
- שוחזרו ערכי ברירת המחדל של טיפוגרפיה ומרווחים ב-`frontend/src/screens/invitations.js` עבור `.c-title`, `.c-sub-event`, `.c-course` (כולל `.course-main`/`.course-sub`/`.course-company`), `.c-opening`/`.c-para`, `.c-section-title`, `.c-main`, `.c-box`, `.c-details-box`, `.c-info-row`, `.c-part-*`, `.c-closing` ו-`.c-footer*` לערכים שנדרשו (גדלים ו-line-height מעודכנים).
- עדכון הלוגיקה של `fitInvitationToA5` כך שהמדידה נעשית עם אפסילון קטן (`OVERFLOW_EPSILON_PX = 1`) ובחינת overflow לאחר שתי קריאות `requestAnimationFrame` כדי לאפשר הסטת layout לפני מדידה; הקלאסים מוחלים מדורג: תחילה ללא קלאס, רק אם יש overflow נכנס `fit-a5-compact`, ורק אם עדיין יש overflow אחרי זה נכנס `fit-a5-tight`.
- אותן שינויים בלוגיקה משוכפלים גם בסקריפט שנזרק לחלון ההדפסה כדי לשמור עקביות בין preview ל-print.
- שינויים הוגשו בקובץ יחיד: `frontend/src/screens/invitations.js` והותאמו ה-CSS וה-JS יחד (אין הסרה של מצבי `fit-*`, רק שינוי מתי הם מופעלים).

### Testing
- רצתה בדיקת תחביר עם `node --check frontend/src/screens/invitations.js`, והבדיקה עברה בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a167ef50832ba16a48d683227378)