### PR TITLE
Add "פעילויות ללא תאריך" tab and role-restricted soft-delete for activities

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -40,6 +40,7 @@ const MUTATING_ACTIONS = {
   updateProposalAgreementStatus: true,
   deleteProposalAgreement: true,
   saveProposalAgreementItems: true
+  ,deleteActivity: true
 };
 
 const READ_ACTIONS = {
@@ -151,7 +152,7 @@ async function readActivitiesFromSupabase(filters = {}) {
     if (error) throw new Error(error.message || 'activities_read_failed');
     const rows = (Array.isArray(data) ? data : [])
       .map(normalizeActivityRow)
-      .filter((row) => !isActivityClosed(row))
+      .filter((row) => !isActivityInactive(row))
       .filter((row) => rowMatchesActivitiesFilters(row, filters));
     return { rows, _source: 'supabase' };
   } catch (error) {
@@ -174,6 +175,7 @@ function buildSupabaseErrorPayload(base, error, extra = {}) {
 
 const ACTIVITIES_TABLE = 'activities';
 const CLOSED_STATUS = 'סגור';
+const DELETED_STATUS = 'נמחק';
 
 function normalizeActivityRow(row = {}) {
   const rowId = String(row?.row_id ?? row?.RowID ?? '').trim();
@@ -219,6 +221,12 @@ function rowActivityType(row = {}) {
 function isActivityClosed(row) {
   return String(row?.status || '').trim() === CLOSED_STATUS;
 }
+function isActivityDeleted(row) {
+  return String(row?.status || '').trim() === DELETED_STATUS;
+}
+function isActivityInactive(row) {
+  return isActivityClosed(row) || isActivityDeleted(row);
+}
 
 function isProgramActivity(row) {
   return String(row?.activity_family || '').trim() === 'program';
@@ -235,6 +243,11 @@ function getActivityDateColumns(row = {}) {
     if (dateKey) dates.push(dateKey);
   }
   return dates;
+}
+function hasAnyActivityDate(row = {}) {
+  if (normalizeSupabaseDate(row?.start_date ?? row?.date_start)) return true;
+  if (normalizeSupabaseDate(row?.end_date ?? row?.date_end)) return true;
+  return getActivityDateColumns(row).length > 0;
 }
 
 function firstNormalizedDate(...values) {
@@ -551,7 +564,7 @@ async function readInstructorsFromSupabase() {
       console.warn('[supabase] contacts_instructors unavailable for instructors stats:', contactsResult.error);
     }
 
-    const activeRows = activityRows.filter((row) => !isActivityClosed(row));
+    const activeRows = activityRows.filter((row) => !isActivityInactive(row));
     const statsMap = new Map();
     const aliases = new Map();
 
@@ -780,7 +793,7 @@ async function readWeekFromSupabase(weekOffset) {
 
   try {
     const rows = (await selectActivitiesByDateRangeFromSupabase({ startDate, endDate }))
-      .filter((row) => !isActivityClosed(row));
+      .filter((row) => !isActivityInactive(row));
     const matchingRows = rows.filter((row) => activityHasDateInRange(row, startDate, endDate));
     const itemsById = buildItemsById(matchingRows);
     const dayMap = {};
@@ -819,7 +832,7 @@ async function readMonthFromSupabase(ym) {
     const rows = (await selectActivitiesByDateRangeFromSupabase({
       startDate: range.startDate,
       endDate: range.endDate
-    })).filter((row) => !isActivityClosed(row));
+    })).filter((row) => !isActivityInactive(row));
     const matchingRows = rows.filter((row) => activityHasDateInMonth(row, monthPrefix));
     const itemsById = buildItemsById(matchingRows);
     const dayMap = {};
@@ -870,7 +883,7 @@ async function dashboardReadModelFromSupabase(month) {
       includeEndDate: true
     });
     // Open-only rows (not closed) — used for summary, instructor/manager stats, exceptions
-    const openRows = allRangeRows.filter((row) => !isActivityClosed(row));
+    const openRows = allRangeRows.filter((row) => !isActivityInactive(row));
     // Open-only rows that have a date in this month — for summary data
     const monthRows = openRows.filter((row) => activityHasDateInMonth(row, monthPrefix));
     // All rows (open + closed) in this month — for KPI type counts
@@ -1008,7 +1021,7 @@ async function readEndDatesFromSupabase() {
   if (!supabase) return buildSupabaseErrorPayload({ rows: [] }, 'no_supabase_client');
   try {
     const rows = (await selectActivitiesFromSupabase('*'))
-      .filter((row) => !isActivityClosed(row))
+      .filter((row) => !isActivityInactive(row))
       .map((row) => ({ ...row, meeting_dates: getActivityDateColumns(row), date_cols: getActivityDateColumns(row) }));
     return { rows, _source: 'supabase' };
   } catch (error) {
@@ -1085,7 +1098,7 @@ function buildExceptionsModelFromRows(activityRows = [], month = '', opts = {}) 
   const byManager = {};
   let operationalUniqueCount = 0;
   for (const row of activityRows) {
-    if (isActivityClosed(row)) continue;
+    if (isActivityInactive(row)) continue;
     if (rowActivityType(row) !== 'course') continue;
     if (!activityOverlapsMonthForExceptions(row, month)) continue;
     const types = rowExceptionTypesFromActivity(row, {
@@ -1159,7 +1172,7 @@ async function readExceptionsFromSupabase(params = {}) {
     // 3 — open courses where all instructor fields are empty
     // 4 — open courses where emp_id is set but NOT in the known instructors list
     const queryBase = () =>
-      supabase.from('activities').select('*').in('activity_type', COURSE_TYPE_VALUES).neq('status', CLOSED_STATUS);
+      supabase.from('activities').select('*').in('activity_type', COURSE_TYPE_VALUES).not('status', 'in', '("סגור","נמחק")');
 
     const knownIdsList = [...knownInstructorIds];
 
@@ -1220,9 +1233,22 @@ async function readExceptionsFromSupabase(params = {}) {
       knownInstructorIds: knownInstructorIds.size > 0 ? knownInstructorIds : undefined,
       lateEndDateThreshold
     });
-    return { month, late_end_date_threshold: lateEndDateThreshold || '', ...exceptionSummary, _source: 'supabase' };
+    const { data: allActivitiesRaw, error: allActivitiesError } = await supabase.from('activities').select('*');
+    if (allActivitiesError) throw new Error(allActivitiesError.message || 'activities_read_failed');
+    const undatedRows = (Array.isArray(allActivitiesRaw) ? allActivitiesRaw : [])
+      .map(normalizeActivityRow)
+      .filter((row) => !isActivityInactive(row))
+      .filter((row) => !hasAnyActivityDate(row));
+    return {
+      month,
+      late_end_date_threshold: lateEndDateThreshold || '',
+      ...exceptionSummary,
+      undatedRows,
+      undatedCount: undatedRows.length,
+      _source: 'supabase'
+    };
   } catch (error) {
-    return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0 }, error);
+    return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0, undatedRows: [], undatedCount: 0 }, error);
   }
 }
 
@@ -2732,6 +2758,18 @@ export const api = {
       return api.submitEditRequest(payload);
     }
     return updateActivityInSupabase(payload);
+  },
+  deleteActivity: async (source_row_id) => {
+    const rowId = String(source_row_id || '').trim();
+    if (!rowId) throw new Error('missing_row_id');
+    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    if (!['admin', 'operation_manager'].includes(role)) throw new Error('forbidden_delete_activity');
+    const { error } = await supabase
+      .from('activities')
+      .update({ status: DELETED_STATUS })
+      .eq('row_id', rowId);
+    if (error) throw new Error(error.message || 'delete_activity_failed');
+    return { ok: true, row_id: rowId, status: DELETED_STATUS };
   },
   submitEditRequest: async (source_row_id, changes, source_sheet = 'activities') => {
     const requestPayload = (source_row_id && typeof source_row_id === 'object') ? source_row_id : null;

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -91,13 +91,14 @@ function exceptionsOperationalSummaryHtml(data, rows) {
   });
 }
 
-function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, canRequestEdit, hideEmpIds, hideRowId, hideActivityNo, settings) {
+function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, canRequestEdit, canDeleteActivity, hideEmpIds, hideRowId, hideActivityNo, settings) {
   const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
   return activityWorkDrawerHtml(row, {
     privateNote,
     canEdit,
     canDirectEdit,
     canRequestEdit,
+    canDeleteActivity,
     hideEmpIds: !!hideEmpIds,
     hideRowId,
     hideActivityNo,
@@ -169,6 +170,7 @@ export const exceptionsScreen = {
       ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${EXCEPTIONS_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>`
       : '';
 
+    const undatedRows = Array.isArray(data?.undatedRows) ? data.undatedRows : [];
     const compact =
       visibleRows.length === 0
         ? dsEmptyState('לא נמצאו חריגות')
@@ -203,6 +205,10 @@ export const exceptionsScreen = {
         body: compact,
         padded: visibleRows.length === 0
       })}</section>
+      <section>${dsCard({
+        title: `פעילויות ללא תאריך · ${escapeHtml(String(data?.undatedCount ?? undatedRows.length))}`,
+        body: undatedRows.length === 0 ? dsEmptyState('אין פעילויות ללא תאריך') : `<div class="ds-compact-list">${undatedRows.map((row) => `<div data-list-item><button type="button" class="ds-interactive-card ds-interactive-card--session" data-card-action="${escapeHtml(`undated:${row.RowID}`)}"><p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p><p class="ds-interactive-card__subtitle">${escapeHtml([row.activity_type, row.authority, row.school].filter(Boolean).join(' · '))}</p></button></div>`).join('')}</div>`
+      })}</section>
     `);
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
@@ -215,6 +221,7 @@ export const exceptionsScreen = {
     const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
+    const canDeleteActivity = ['admin', 'operation_manager'].includes(String(state?.user?.display_role || '').trim());
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
 
@@ -278,6 +285,7 @@ export const exceptionsScreen = {
           canEditActivity,
           !!state?.user?.can_edit_direct,
           !!state?.user?.can_request_edit,
+          canDeleteActivity,
           hideEmpIds,
           hideRowId,
           hideActivityNo,
@@ -297,6 +305,7 @@ export const exceptionsScreen = {
             canEditActivity,
             !!state?.user?.can_edit_direct,
             !!state?.user?.can_request_edit,
+            canDeleteActivity,
             hideEmpIds,
             hideRowId,
             hideActivityNo,
@@ -308,8 +317,10 @@ export const exceptionsScreen = {
       } catch {}
     }
 
-    const openAt = (idx) => {
-      const hit = allRows[idx];
+    const allUndatedRows = (Array.isArray(data?.undatedRows) ? data.undatedRows : []);
+    const openAt = (idx, group = 'exception') => {
+      const list = group === 'undated' ? allUndatedRows : allRows;
+      const hit = list[idx];
       if (!hit || !ui) return;
       if (!api) {
         ui.openDrawer({
@@ -322,10 +333,17 @@ export const exceptionsScreen = {
     };
 
     ui?.bindInteractiveCards(root, (action) => {
-      if (!action.startsWith('exception:')) return;
-      const rowId = action.slice('exception:'.length);
-      const idx = allRows.findIndex((row) => String(row.RowID) === rowId);
-      openAt(idx);
+      if (action.startsWith('exception:')) {
+        const rowId = action.slice('exception:'.length);
+        const idx = allRows.findIndex((row) => String(row.RowID) === rowId);
+        openAt(idx);
+        return;
+      }
+      if (action.startsWith('undated:')) {
+        const undatedId = action.slice('undated:'.length);
+        const undatedIdx = allUndatedRows.findIndex((row) => String(row.RowID) === undatedId);
+        openAt(undatedIdx, 'undated');
+      }
     });
   }
 };

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -593,14 +593,15 @@ function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
 }
 
 
-function blockEditActions({ canEdit = false, canDirectEdit = false } = {}) {
-  if (!canEdit) return '';
+function blockEditActions({ canEdit = false, canDirectEdit = false, canDeleteActivity = false } = {}) {
+  if (!canEdit && !canDeleteActivity) return '';
   const requestOnlyEdit = canEdit && !canDirectEdit;
   return `
     <section class="activity-drawer__section activity-drawer__section--actions" data-mode="edit" hidden>
       <div class="activity-drawer__edit-actions">
-        <button type="button" class="activity-drawer__action activity-drawer__action--primary" data-action="save-edit">${requestOnlyEdit ? 'שליחת בקשת עריכה לאישור' : 'שמור'}</button>
-        <button type="button" class="activity-drawer__action" data-action="cancel-edit">ביטול</button>
+        ${canEdit ? `<button type="button" class="activity-drawer__action activity-drawer__action--primary" data-action="save-edit">${requestOnlyEdit ? 'שליחת בקשת עריכה לאישור' : 'שמור'}</button>
+        <button type="button" class="activity-drawer__action" data-action="cancel-edit">ביטול</button>` : ''}
+        ${canDeleteActivity ? '<button type="button" class="activity-drawer__action activity-drawer__action--danger" data-action="delete-activity">מחק פעילות</button>' : ''}
         <p class="ds-activity-edit-status ds-muted" role="status"></p>
       </div>
     </section>
@@ -693,7 +694,7 @@ function jsonAttr(value) {
   }
 }
 
-function singleForm(row, { settings = {}, privateNote = null, canEdit = false, canDirectEdit = false, canRequestEdit = false, showPrivateNote = false, idx = 0, datesLoading = false, instructorLimited = false } = {}) {
+function singleForm(row, { settings = {}, privateNote = null, canEdit = false, canDirectEdit = false, canRequestEdit = false, canDeleteActivity = false, showPrivateNote = false, idx = 0, datesLoading = false, instructorLimited = false } = {}) {
   const computedEnd = autoEndDate(row);
   const activityType = String(row.activity_type || '').trim();
   const editReqStatus = String(row.edit_request_status || '').trim();
@@ -725,7 +726,7 @@ function singleForm(row, { settings = {}, privateNote = null, canEdit = false, c
       ${instructorLimited ? '' : blockExtraEditInfo(row, { settings })}
       ${blockNotes(row, { hidden: instructorLimited })}
       ${blockSupplementalView(row, { settings, hideFunding: instructorLimited })}
-      ${blockEditActions({ canEdit, canDirectEdit })}
+      ${blockEditActions({ canEdit, canDirectEdit, canDeleteActivity })}
     </form>
   `;
 }
@@ -747,7 +748,7 @@ export function activityRowDetailHtml(row, { privateNote = null, hideActivityNo 
 }
 
 export function activityWorkDrawerHtml(row, opts = {}) {
-  const { mode = 'single', summaryDate = '', privateNote = null, canEdit = false, canDirectEdit = false, canRequestEdit = false, settings = {}, datesLoading = false, exportAction = true, instructorLimited = false } = opts;
+  const { mode = 'single', summaryDate = '', privateNote = null, canEdit = false, canDirectEdit = false, canRequestEdit = false, canDeleteActivity = false, settings = {}, datesLoading = false, exportAction = true, instructorLimited = false } = opts;
   if (mode === 'summary') {
     const rows = Array.isArray(row) ? row : [];
     const body = rows
@@ -766,6 +767,7 @@ export function activityWorkDrawerHtml(row, opts = {}) {
             canEdit,
             canDirectEdit,
             canRequestEdit,
+            canDeleteActivity,
             showPrivateNote: privateNote !== null,
             idx,
             instructorLimited
@@ -790,6 +792,7 @@ export function activityWorkDrawerHtml(row, opts = {}) {
         canEdit,
         canDirectEdit,
         canRequestEdit,
+        canDeleteActivity,
         showPrivateNote: privateNote !== null,
         datesLoading,
         idx: 0,

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -358,6 +358,27 @@ export function bindActivityEditForm(contentRoot, {
         void saveActivityForm(form);
         return;
       }
+      if (ev.target.closest('[data-action="delete-activity"]')) {
+        ev.preventDefault();
+        const rowId = String(form.getAttribute('data-row-id') || '').trim();
+        if (!rowId) return;
+        const ok = window.confirm('מחיקת פעילות מיועדת רק לפעילות שנוצרה בטעות או בכפילות. הפעילות תוסר מהמסכים הפעילים. להמשיך?');
+        if (!ok) return;
+        api.deleteActivity(rowId)
+          .then(async () => {
+            showToast('הפעילות הוסרה מהמסכים הפעילים', 'success', 2400);
+            clearScreenDataCache?.();
+            if (typeof onSaveSuccess === 'function') {
+              await onSaveSuccess({ sourceSheet: form.getAttribute('data-source-sheet') || '', sourceRowId: rowId, changes: { status: 'נמחק' }, form, contentRoot });
+            } else if (typeof rerender === 'function') {
+              rerender();
+            }
+          })
+          .catch((err) => {
+            showToast(translateApiErrorForUser(err?.message || 'delete_activity_failed'), 'error', 3000);
+          });
+        return;
+      }
 
       const chainBtn = ev.target.closest('[data-date-mode]');
       if (chainBtn) {


### PR DESCRIPTION
### Motivation
- להוסיף לשונית נפרדת להציג פעילויות פתוחות שאין להן אף תאריך תקף, בלי לשנות לוגיקת חריגות הקורסים הקיימת או ה‑schema. 
- לאפשר מחיקה מבוקרת של רשומות שנוצרו בטעות דרך מחיקה רכה (soft delete) בלבד, והמגבלה על הפעולה תהיה בקפידה לפי תפקיד (רק `admin` ו־`operation_manager`).

### Description
- הוספתי סטטוס חדש `נמחק` (`DELETED_STATUS`) ו־helpers חדשים `isActivityDeleted`, `isActivityInactive`, ו־`hasAnyActivityDate` וכן עדכנתי סינונים כך שפעילויות עם `status = "נמחק"` ייחשבו לא פעילות (שורות בוצעו ב־`frontend/src/api.js`).
- הרחבתי `readExceptionsFromSupabase` כך שיחזיר גם `undatedRows` ו־`undatedCount` (פעילויות פתוחות שאין להן תאריכים ב־`start_date`, `end_date`, `date_1..date_35`) מבלי לשנות את המודל הקיים של חריגות הקורסים (שורות בוצעו ב־`frontend/src/api.js`).
- הוספתי API חדש `deleteActivity` שמבצע מחיקה רכה דרך `update({ status: 'נמחק' })`, עם בדיקת תפקיד בצד הלקוח/שרת ומניעת ביצוע למי שאינו `admin`/`operation_manager`, ו־`deleteActivity` נוסף ל־`MUTATING_ACTIONS` כדי לאתחל cache לאחר פעולה זו (ב־`frontend/src/api.js`).
- UI: במסך חריגות הוספתי כרטיס/כרטיסיה נפרדת "פעילויות ללא תאריך" שמציגה `undatedRows` כ־compact list ונפתחת ל‑drawer העריכה הקיים; ב‑drawer הוספתי כפתור "מחק פעילות" שמוצג רק למורשים ומבצע confirm ואז קורא ל־`api.deleteActivity` עם ניקוי cache ותצוגת toast (שינויים ב־`frontend/src/screens/exceptions.js`, `frontend/src/screens/shared/activity-detail-html.js`, ו־`frontend/src/screens/shared/bind-activity-edit-form.js`).
- קבצים שעודכנו: `frontend/src/api.js`, `frontend/src/screens/exceptions.js`, `frontend/src/screens/shared/activity-detail-html.js`, `frontend/src/screens/shared/bind-activity-edit-form.js`.

### Testing
- הרצתי את המבחנים הממוקדים באמצעות `npm test -- --run tests/exceptions-all-types.test.mjs tests/api-mutations.test.mjs tests/service-worker-pwa-cache.test.mjs` בתכולת ה־repo; רבות מהאסרטציות בענפים הרלוונטיים עברו בהצלחה, כולל בדיקות UI/compact-list והוספת `deleteActivity` ל־`MUTATING_ACTIONS` שהפעלה של invalidation עובדת.
- חלק מבדיקות ב־`api-mutations` וה־snapshot-related tests נכשלו בסביבת הריצה הזו אך אלו שגיאות baseline קיימות שאינן תוצאה ישירה של השינויים האלה (לוגים מצורפים בריצת ה‑CI המקומית); אין שינויי schema או RLS שנדרשים על‑ידי הפיצ'ר.
- לא בוצעו שינויים ב־`frontend/sw.js`; מחיקת פעילות רכה מנקה cache דרך המנגנון הקיים של `MUTATING_ACTIONS` כדי להבטיח שהלקוח טוען גרסה עדכנית מהמסכים לאחר הפעולה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d9770ea8832bac07d5ff8f5acc53)