### PR TITLE
A5 layout: add relaxed fit, align section title, and improve footer spacing

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -113,7 +113,7 @@ function ensureStyles() {
 .invitation-screen-root .c-opening{font-size:3.85mm;color:#333;line-height:1.28;margin:1mm auto;max-width:none;width:82%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
 .invitation-screen-root .c-opening strong{font-weight:700;color:var(--accent-color,#1a8c6e)}
 .invitation-screen-root .c-para{font-size:3.85mm;color:#333;line-height:1.28;margin:.5mm auto;text-align:right;max-width:none;width:82%;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
-.invitation-screen-root .c-section-title{font-size:3.3mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1.2mm auto .5mm;max-width:none;width:80%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
+.invitation-screen-root .c-section-title{font-size:3.3mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1.2mm auto .5mm;max-width:none;width:82%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.5mm;box-sizing:border-box}
 .invitation-screen-root .c-box{background:rgba(255,255,255,.5);border:1px solid rgba(26,140,110,.22);border-radius:8px;padding:1.6mm 4mm;margin:1.2mm 0;width:100%;text-align:right}
 .invitation-screen-root .c-participants-box{width:80%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1.2mm 3.5mm}
 .invitation-screen-root .c-details-box{width:76%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.9mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.4mm 3.5mm}
@@ -127,7 +127,11 @@ function ensureStyles() {
 .invitation-screen-root .c-part-line strong{font-weight:700;color:#333}
 .invitation-screen-root .c-closing{font-size:5.7mm;font-weight:900;margin-top:2mm;padding-top:1.4mm;text-align:center;line-height:1.05}
 .invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:1mm 6mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:5mm;position:relative;z-index:4;width:100%}
-.invitation-screen-root .c-footer-sentence{font-size:2.8mm;font-weight:600;line-height:1.12;letter-spacing:.035em;text-shadow:-.3px -.3px 0 rgba(30,38,46,.25),.3px -.3px 0 rgba(30,38,46,.25),-.3px .3px 0 rgba(30,38,46,.25),.3px .3px 0 rgba(30,38,46,.25),0 1px 1.5px rgba(0,0,0,.08);display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:.35mm}
+.invitation-screen-root .c-footer-sentence{font-size:2.45mm;font-weight:600;line-height:1.25;letter-spacing:.05em;text-shadow:-.3px -.3px 0 rgba(30,38,46,.25),.3px -.3px 0 rgba(30,38,46,.25),-.3px .3px 0 rgba(30,38,46,.25),.3px .3px 0 rgba(30,38,46,.25),0 1px 1.5px rgba(0,0,0,.08);display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:.9mm}
+.invitation-screen-root #card.fit-a5-relaxed .c-main{padding-top:2.8mm;padding-bottom:3.2mm}
+.invitation-screen-root #card.fit-a5-relaxed .c-opening{margin:1.3mm auto}
+.invitation-screen-root #card.fit-a5-relaxed .c-para{margin:.9mm auto}
+.invitation-screen-root #card.fit-a5-relaxed .c-closing{margin-top:2.3mm}
 .invitation-screen-root #card.fit-a5-compact .c-title{font-size:11.3mm}
 .invitation-screen-root #card.fit-a5-compact .c-sub-event{font-size:5.8mm}
 .invitation-screen-root #card.fit-a5-compact .c-course,.invitation-screen-root #card.fit-a5-compact .c-course .course-main{font-size:6.2mm}
@@ -836,11 +840,12 @@ export const invitationsScreen = {
       const cwrap = card.querySelector('.cwrap');
       if (!cwrap) return Promise.resolve();
 
-      card.classList.remove('fit-a5-compact', 'fit-a5-tight');
+      card.classList.remove('fit-a5-relaxed', 'fit-a5-compact', 'fit-a5-tight');
 
       const OVERFLOW_EPSILON_PX = 12;
       const TIGHT_OVERFLOW_EPSILON_PX = 10;
       const UNDERFLOW_EPSILON_PX = 36;
+      const RELAXED_UNDERFLOW_PX = 42;
       const overflowAmount = () => cwrap.scrollHeight - card.clientHeight;
 
       return new Promise((resolve) => {
@@ -848,6 +853,7 @@ export const invitationsScreen = {
           requestAnimationFrame(() => {
             const baseOverflow = overflowAmount();
             if (baseOverflow <= OVERFLOW_EPSILON_PX) {
+              if (baseOverflow < -RELAXED_UNDERFLOW_PX) card.classList.add('fit-a5-relaxed');
               resolve();
               return;
             }
@@ -936,16 +942,20 @@ function fitInvitationToA5(card){
   if(!card) return Promise.resolve();
   var cwrap=card.querySelector('.cwrap');
   if(!cwrap) return Promise.resolve();
-  card.classList.remove('fit-a5-compact','fit-a5-tight');
+  card.classList.remove('fit-a5-relaxed','fit-a5-compact','fit-a5-tight');
   var OVERFLOW_EPSILON_PX=12;
   var TIGHT_OVERFLOW_EPSILON_PX=10;
   var UNDERFLOW_EPSILON_PX=36;
+  var RELAXED_UNDERFLOW_PX=42;
   function overflowAmount(){return cwrap.scrollHeight-card.clientHeight}
   return new Promise(function(resolve){
     requestAnimationFrame(function(){
       requestAnimationFrame(function(){
         var baseOverflow=overflowAmount();
-        if(baseOverflow<=OVERFLOW_EPSILON_PX){resolve();return;}
+        if(baseOverflow<=OVERFLOW_EPSILON_PX){
+          if(baseOverflow<-RELAXED_UNDERFLOW_PX){card.classList.add('fit-a5-relaxed');}
+          resolve();return;
+        }
         card.classList.add('fit-a5-compact');
         requestAnimationFrame(function(){
           var compactOverflow=overflowAmount();


### PR DESCRIPTION
### Motivation

- Reduce large empty space on short invitations without aggressively shrinking content or changing A5 page size. 
- Ensure the section title `מה מצפה לנו` aligns with the paragraph body instead of appearing indented. 
- Make the footer sentence more readable and less cramped while keeping its content unchanged.

### Description

- Added a new gentle layout mode `fit-a5-relaxed` (CSS + behavior) and a `RELAXED_UNDERFLOW_PX` threshold so short content can be spaced more pleasantly instead of forcing `fit-a5-compact` or `fit-a5-tight`. Changes are in `fitInvitationToA5` in both preview and print window scripts. 
- Aligned the `מה מצפה לנו` section title by changing `.c-section-title` width to `82%` to match `.c-opening` and `.c-para`. 
- Improved footer sentence styling by reducing `.c-footer-sentence` font-size from `2.8mm` to `2.45mm`, increasing `line-height`, `letter-spacing`, and `gap` to produce a more airy, readable footer. 
- Added small relaxed-mode CSS rules targeting `#card.fit-a5-relaxed` to slightly increase top/bottom padding and adjust margins for `.c-opening`, `.c-para`, and `.c-closing` so content is distributed more evenly on A5.

### Testing

- No automated test suite exists for this UI/PDF flow, so no automated tests were run.
- Changes were limited to `frontend/src/screens/invitations.js` and the preview/print fit logic was updated symmetrically to keep PDF output consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12efc83108832ba797ef5d22f8667f)