### PR TITLE
Refine invitation A5 fit, alignment, participants typography, logos and footer styling

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -95,11 +95,11 @@ function ensureStyles() {
 .invitation-screen-root .cbg{position:absolute;inset:0;z-index:0;background-size:cover;background-position:center}
 .invitation-screen-root .cframe{position:absolute;inset:5mm;border-radius:10px;border:1.5px solid rgba(255,255,255,.55);pointer-events:none;z-index:3}
 .invitation-screen-root .cwrap{position:relative;z-index:2;flex:1;display:flex;flex-direction:column}
-.invitation-screen-root .c-logos{display:flex;align-items:center;justify-content:center;gap:1mm;padding:7mm 10mm 1mm;background:rgba(255,255,255,.42);border-bottom:1px solid rgba(255,255,255,.45)}
+.invitation-screen-root .c-logos{display:flex;align-items:center;justify-content:center;gap:1mm;padding:7mm 10mm 1mm;background:transparent;border-bottom:none}
 .invitation-screen-root .c-logo-item{width:32mm;height:14mm;display:flex;align-items:center;justify-content:center;gap:4px;font-size:10px;font-weight:800;color:#1a3a5c;line-height:1.2}
 .invitation-screen-root .c-logo-sep{width:1px;height:26px;background:rgba(26,58,92,.2);flex-shrink:0}
 .invitation-screen-root .c-logo-item img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain}
-.invitation-screen-root .c-main{padding:2mm 6.5mm 2.5mm;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center}
+.invitation-screen-root .c-main{padding:2.6mm 6.5mm 2.8mm;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center}
 .invitation-screen-root .c-title{font-weight:900;line-height:1;margin-bottom:0;font-size:12.5mm}
 .invitation-screen-root .c-sub-event{font-weight:700;line-height:1.08;margin-bottom:1mm;font-size:6.2mm}
 .invitation-screen-root .c-course{font-weight:500;line-height:1.08;margin-bottom:1mm;font-size:6.8mm}
@@ -113,7 +113,7 @@ function ensureStyles() {
 .invitation-screen-root .c-opening{font-size:3.85mm;color:#333;line-height:1.28;margin:1mm auto;max-width:none;width:82%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.2mm;box-sizing:border-box}
 .invitation-screen-root .c-opening strong{font-weight:700;color:var(--accent-color,#1a8c6e)}
 .invitation-screen-root .c-para{font-size:3.85mm;color:#333;line-height:1.28;margin:.5mm auto;text-align:right;max-width:none;width:82%;align-self:center;margin-inline:auto;padding-inline:4.2mm;box-sizing:border-box}
-.invitation-screen-root .c-section-title{font-size:3.3mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1.2mm auto .5mm;max-width:none;width:82%;text-align:right;align-self:center;margin-inline:auto;padding-inline:4.2mm;box-sizing:border-box}
+.invitation-screen-root .c-section-title{font-size:3.3mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1.2mm auto .5mm;max-width:none;width:82%;text-align:right;align-self:center;margin-inline:auto;padding-inline:0;box-sizing:border-box}
 .invitation-screen-root .c-box{background:rgba(255,255,255,.5);border:1px solid rgba(26,140,110,.22);border-radius:8px;padding:1.6mm 4mm;margin:1.2mm 0;width:100%;text-align:right}
 .invitation-screen-root .c-participants-box{width:80%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1.2mm 3.5mm}
 .invitation-screen-root .c-details-box{width:76%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.9mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.4mm 3.5mm}
@@ -122,12 +122,13 @@ function ensureStyles() {
 .invitation-screen-root .c-details-box .c-info-row{justify-content:center;text-align:center}
 .invitation-screen-root .c-info-row{display:flex;align-items:center;gap:4px;font-size:4.3mm;color:#333;line-height:1.4}
 .invitation-screen-root .c-info-row strong{font-weight:700}
-.invitation-screen-root .c-part-title{font-size:3.05mm;font-weight:700;margin-bottom:1px;line-height:1.35}
-.invitation-screen-root .c-part-line{font-size:3.05mm;color:#333;line-height:1.35}
-.invitation-screen-root .c-part-line strong{font-weight:700;color:#333}
+.invitation-screen-root .c-part-title{font-size:3mm;font-weight:700;margin-bottom:1px;line-height:1.32}
+.invitation-screen-root .c-part-line{font-size:3mm;color:#333;line-height:1.32}
+.invitation-screen-root .c-part-line strong{font-size:3mm;font-weight:700;color:#333;line-height:1.32}
+.invitation-screen-root .c-part-line span{font-size:3mm;font-weight:400;line-height:1.32}
 .invitation-screen-root .c-closing{font-size:5.7mm;font-weight:900;margin-top:2mm;padding-top:1.2mm;text-align:center;line-height:1.05}
 .invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:1mm 6mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:5mm;position:relative;z-index:4;width:100%}
-.invitation-screen-root .c-footer-sentence{font-size:2.45mm;font-weight:600;line-height:1.28;letter-spacing:.02em;text-shadow:none;display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:1.1mm}
+.invitation-screen-root .c-footer-sentence{font-size:2.45mm;font-weight:600;line-height:1.3;letter-spacing:.006em;text-shadow:none;display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:1.5mm}
 .invitation-screen-root #card.fit-a5-relaxed .c-main{padding-top:2.8mm;padding-bottom:3.2mm}
 .invitation-screen-root #card.fit-a5-relaxed .c-opening{margin:1.3mm auto}
 .invitation-screen-root #card.fit-a5-relaxed .c-para{margin:.9mm auto}
@@ -138,10 +139,10 @@ function ensureStyles() {
 .invitation-screen-root #card.fit-a5-compact .c-course .course-sub{font-size:5.35mm}
 .invitation-screen-root #card.fit-a5-compact .c-course .course-company{font-size:3.9mm}
 .invitation-screen-root #card.fit-a5-compact .c-opening,.invitation-screen-root #card.fit-a5-compact .c-para{font-size:3.72mm;line-height:1.26}
-.invitation-screen-root #card.fit-a5-compact .c-main{padding:1.9mm 6.2mm 2.2mm}
+.invitation-screen-root #card.fit-a5-compact .c-main{padding:2.35mm 6.3mm 2.5mm}
 .invitation-screen-root #card.fit-a5-compact .c-box{padding:1.4mm 3.6mm;margin:1.1mm 0}
 .invitation-screen-root #card.fit-a5-compact .c-info-row{font-size:4.1mm;line-height:1.34}
-.invitation-screen-root #card.fit-a5-compact .c-part-title,.invitation-screen-root #card.fit-a5-compact .c-part-line{font-size:3mm;line-height:1.3}
+.invitation-screen-root #card.fit-a5-compact .c-part-title,.invitation-screen-root #card.fit-a5-compact .c-part-line,.invitation-screen-root #card.fit-a5-compact .c-part-line strong,.invitation-screen-root #card.fit-a5-compact .c-part-line span{font-size:2.95mm;line-height:1.3}
 .invitation-screen-root #card.fit-a5-compact .c-closing{font-size:5.45mm;margin-top:2mm}
 .invitation-screen-root #card.fit-a5-tight .c-title{font-size:8.8mm}
 .invitation-screen-root #card.fit-a5-tight .c-sub-event{font-size:4.6mm}
@@ -151,11 +152,11 @@ function ensureStyles() {
 .invitation-screen-root #card.fit-a5-tight .c-opening,.invitation-screen-root #card.fit-a5-tight .c-para{font-size:3mm;line-height:1.14;width:86%}
 .invitation-screen-root #card.fit-a5-tight .c-section-title{font-size:2.9mm;margin:.7mm auto .3mm}
 .invitation-screen-root #card.fit-a5-tight .c-info-row{font-size:3.5mm;line-height:1.22}
-.invitation-screen-root #card.fit-a5-tight .c-part-title,.invitation-screen-root #card.fit-a5-tight .c-part-line{font-size:2.65mm;line-height:1.18}
+.invitation-screen-root #card.fit-a5-tight .c-part-title,.invitation-screen-root #card.fit-a5-tight .c-part-line,.invitation-screen-root #card.fit-a5-tight .c-part-line strong,.invitation-screen-root #card.fit-a5-tight .c-part-line span{font-size:2.65mm;line-height:1.2}
 .invitation-screen-root #card.fit-a5-tight .c-closing{font-size:4.2mm;padding-top:.5mm}
 .invitation-screen-root #card.fit-a5-tight .c-logos{padding:5mm 8mm .5mm}
 .invitation-screen-root #card.fit-a5-tight .c-logo-item{width:28mm;height:11mm}
-.invitation-screen-root .c-footer-sentence span{-webkit-text-stroke:.25px rgba(30,38,46,.35);text-shadow:none}
+.invitation-screen-root .c-footer-sentence span{-webkit-text-stroke:.25px rgba(30,38,46,.35);text-shadow:-0.25px 0 rgba(30,38,46,.35),0.25px 0 rgba(30,38,46,.35),0 -0.25px rgba(30,38,46,.35),0 0.25px rgba(30,38,46,.35)}
 @media (max-width:1200px){.invitation-screen-root .app{grid-template-columns:300px minmax(0,1fr)}}
 `;
   document.head.appendChild(style);
@@ -841,10 +842,10 @@ export const invitationsScreen = {
       card.classList.remove('fit-a5-relaxed', 'fit-a5-compact', 'fit-a5-tight');
 
       const OVERFLOW_EPSILON_PX = 20;
-      const COMPACT_TRIGGER_PX = 28;
-      const TIGHT_TRIGGER_PX = 56;
-      const UNDERFLOW_EPSILON_PX = 44;
-      const RELAXED_UNDERFLOW_PX = 52;
+      const COMPACT_TRIGGER_PX = 36;
+      const TIGHT_TRIGGER_PX = 72;
+      const UNDERFLOW_EPSILON_PX = 56;
+      const RELAXED_UNDERFLOW_PX = 62;
       const overflowAmount = () => cwrap.scrollHeight - card.clientHeight;
 
       return new Promise((resolve) => {
@@ -948,10 +949,10 @@ function fitInvitationToA5(card){
   if(!cwrap) return Promise.resolve();
   card.classList.remove('fit-a5-relaxed','fit-a5-compact','fit-a5-tight');
   var OVERFLOW_EPSILON_PX=20;
-  var COMPACT_TRIGGER_PX=28;
-  var TIGHT_TRIGGER_PX=56;
-  var UNDERFLOW_EPSILON_PX=44;
-  var RELAXED_UNDERFLOW_PX=52;
+  var COMPACT_TRIGGER_PX=36;
+  var TIGHT_TRIGGER_PX=72;
+  var UNDERFLOW_EPSILON_PX=56;
+  var RELAXED_UNDERFLOW_PX=62;
   function overflowAmount(){return cwrap.scrollHeight-card.clientHeight}
   return new Promise(function(resolve){
     requestAnimationFrame(function(){


### PR DESCRIPTION
### Motivation
- Reduce excessive empty space on A5 invitations so short/normal invitations look balanced without unnecessary downscaling.
- Only apply `compact`/`tight` reductions for real overflow by raising the trigger thresholds so mild underflow/overflow doesn't shrink content.
- Align the "מה מצפה לנו" heading with body text and make the participants area visually consistent by unifying font sizes.
- Improve footer readability by removing blur/glow and using a thin sharp outline, and remove the translucent logos strip so logos sit cleanly on the card.

### Description
- Tuned `fitInvitationToA5` thresholds in both runtime and print flows by changing `COMPACT_TRIGGER_PX` from `28`→`36`, `TIGHT_TRIGGER_PX` from `56`→`72`, and increasing underflow/relaxed underflow values in `frontend/src/screens/invitations.js`.
- Increased `c-main` padding slightly to reduce vertical leftover space and avoid premature shrinking, and adjusted compact/tight compact-mode paddings accordingly.
- Removed the translucent bar behind logos by setting `.c-logos { background: transparent; border-bottom: none; }` so logos appear directly on the card.
- Aligned the section heading by removing the extra `padding-inline` from `.c-section-title` so it starts on the same visual line as `.c-opening`/`.c-para`.
- Unified participants typography by normalizing `font-size`/`line-height` for `.c-part-title`, `.c-part-line`, `.c-part-line strong`, and added `.c-part-line span` rule; applied the same baseline in `fit-a5-compact` and `fit-a5-tight` variants while preserving weight for hierarchy.
- Refined footer visuals by reducing `letter-spacing`, increasing `gap`, and replacing blur with a thin outline via `-webkit-text-stroke` plus a sharp `text-shadow` fallback in `.c-footer-sentence span`.
- All changes are limited to `frontend/src/screens/invitations.js` and the embedded print JS; no changes to `@page`, form logic, logo/upload mechanisms, or other screens.

### Testing
- Ran repository checks and status with `git status --short` and confirmed only `frontend/src/screens/invitations.js` changed, and the change was committed successfully.
- Searched for service worker / cache hooks with `rg` to verify existing SW cache update logic remains present and compatible, and the check succeeded.
- Created the PR metadata via the repository `make_pr` flow and confirmed the PR description was generated; all automated steps executed without errors.
- No unit/UI test suite was modified; visual verification (CSS/template review and print-inlined JS changes) was performed against the requested selectors and constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1305798eb4832bb0f5da0bc083105c)