### PR TITLE
Load catalog and proposal activity options from Supabase `lists`/details and wire pricing by `activity_no`

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1577,6 +1577,20 @@ async function upsertProposalClientContactIfNeeded(payload = {}, options = {}) {
 }
 
 async function readProposalActivityNamesFromSupabase() {
+  try {
+    const { data, error } = await supabase
+      .from('lists')
+      .select('activity_name,label_he,label')
+      .eq('category', 'activity_names')
+      .eq('active', true)
+      .order('sort_order', { ascending: true });
+    if (!error && Array.isArray(data)) {
+      return Array.from(new Set(data.map((row) => cleanProposalAgreementText(row?.activity_name || row?.label_he || row?.label)).filter(Boolean)))
+        .sort((a, b) => a.localeCompare(b, 'he'));
+    }
+  } catch {
+    // fallback below
+  }
   const pricingRows = await readProposalActivityPricingFromSupabase();
   return Array.from(new Set(
     pricingRows
@@ -1589,11 +1603,12 @@ async function readProposalActivityPricingFromSupabase() {
   try {
     const { data, error } = await supabase
       .from('proposal_activity_pricing')
-      .select('activity_name,proposal_group,item_type,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order')
+      .select('activity_no,activity_name,proposal_group,item_type,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order')
       .eq('is_active_for_proposals', true)
       .order('sort_order', { ascending: true });
     if (error) return [];
     return (Array.isArray(data) ? data : []).map((row) => ({
+      activity_no: cleanProposalAgreementText(row?.activity_no),
       activity_name: cleanProposalAgreementText(row?.activity_name),
       proposal_group: cleanProposalAgreementText(row?.proposal_group),
       item_type: cleanProposalAgreementText(row?.item_type),
@@ -1669,9 +1684,7 @@ async function readProposalsAgreementsFromSupabase() {
     readProposalTemplateSectionsFromSupabase()
   ]);
   if (paResult.error) throw new Error(paResult.error.message || 'proposals_agreements_read_failed');
-  const activityNameOptions = Array.from(new Set((Array.isArray(proposalActivityPricing) ? proposalActivityPricing : [])
-    .map((row) => cleanProposalAgreementText(row?.activity_name))
-    .filter(Boolean))).sort((a, b) => a.localeCompare(b, 'he'));
+  const activityNameOptions = await readProposalActivityNamesFromSupabase();
   return {
     rows: (Array.isArray(paResult.data) ? paResult.data : []).map(normalizeProposalAgreementRow),
     activityNameOptions,

--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -88,6 +88,12 @@ function normalizeAudienceLevel(value) {
 
 function normalizeProductType(value) {
   const raw = String(value || '').trim();
+  const normalized = raw.toLowerCase();
+  if (normalized === 'course') return 'תוכנית';
+  if (normalized === 'after_school') return 'חוג';
+  if (normalized === 'workshop') return 'סדנה';
+  if (normalized === 'tour') return 'סיור';
+  if (normalized === 'escape_room') return 'סדנה';
   if (raw === 'חוגים') return 'חוג';
   if (raw === 'סיורים') return 'סיור';
   if (raw === 'סדנאות') return 'סדנה';
@@ -116,8 +122,8 @@ function normalizeProgram(item, idx) {
   const syllabus = Array.isArray(p.syllabus) ? p.syllabus : [];
   const firstSyllabusDescription = syllabus.find((x) => x && typeof x === 'object' && x.description)?.description || '';
   return {
-    id: String(p.id || p.programId || p.slug || `program-${idx + 1}`),
-    name: String(pickFirstNonEmpty(p.activity_name, p.name, p.title, p.program_name, p.programName) || 'ללא שם'),
+    id: String(pickFirstNonEmpty(p.activity_no, p.id, p.programId, p.slug) || `program-${idx + 1}`),
+    name: String(pickFirstNonEmpty(p.catalog_title, p.activity_name, p.label_he, p.label, p.name, p.title, p.program_name, p.programName) || 'ללא שם'),
     audienceLevel: normalizeAudienceLevel(p.audience_level || p.audienceLevel || 'לא צוין'),
     productType: normalizeProductType(p.item_type || p.productType || 'תוכנית'),
     grades: String(pickFirstNonEmpty(p.grades, p.targetGrades) || 'לא צוין'),
@@ -185,25 +191,33 @@ function renderCatalogGroup(title, programs) {
 export const catalogScreen = {
   load: async () => {
     if (!supabase) throw new Error('חיבור Supabase אינו זמין');
-    let query = supabase
-      .from('proposal_activity_pricing')
-      .select('*')
-      .eq('is_active_for_catalog', true)
-      .order('sort_order', { ascending: true });
-
-    const withProposals = await query.eq('is_active_for_proposals', true);
-    let rows = [];
-    if (!withProposals.error) rows = Array.isArray(withProposals.data) ? withProposals.data : [];
-    else {
-      const fallback = await supabase
+    const [listsRes, detailsRes, pricingRes] = await Promise.all([
+      supabase
+        .from('lists')
+        .select('activity_no,activity_name,label_he,label,type,activity_type,audience_level,target_grades,gefen_number,sort_order')
+        .eq('category', 'activity_names')
+        .eq('active', true)
+        .order('sort_order', { ascending: true }),
+      supabase
+        .from('catalog_program_details')
+        .select('activity_no,catalog_title,catalog_subtitle,audience_level,target_grades,domain,scope,session_duration,gefen_number,opening_line,core_idea,program_flow,student_develops,school_value,final_outcome,syllabus,page_template')
+        .eq('is_active_for_catalog', true),
+      supabase
         .from('proposal_activity_pricing')
-        .select('*')
-        .eq('is_active_for_catalog', true)
-        .order('sort_order', { ascending: true });
-      if (fallback.error) throw new Error('טעינת הקטלוג נכשלה');
-      rows = Array.isArray(fallback.data) ? fallback.data : [];
-    }
-    const programs = rows.map(normalizeProgram);
+        .select('activity_no,activity_name,item_type,meetings_count,hours_count,unit_price,hourly_price')
+    ]);
+    if (listsRes.error) throw new Error('טעינת הקטלוג נכשלה');
+    const listRows = Array.isArray(listsRes.data) ? listsRes.data : [];
+    const detailRows = Array.isArray(detailsRes.data) ? detailsRes.data : [];
+    const pricingRows = Array.isArray(pricingRes.data) ? pricingRes.data : [];
+    const detailsByNo = new Map(detailRows.map((r) => [String(r.activity_no || '').trim(), r]));
+    const pricingByNo = new Map(pricingRows.map((r) => [String(r.activity_no || '').trim(), r]));
+    const programs = listRows.map((row) => {
+      const key = String(row.activity_no || '').trim();
+      const details = detailsByNo.get(key) || {};
+      const pricing = pricingByNo.get(key) || {};
+      return normalizeProgram({ ...row, ...pricing, ...details });
+    });
     return { programs, selectedId: '', audience: 'הכול', type: 'הכול' };
   },
 

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -310,8 +310,11 @@ function itemRowHtml(item = {}, idx = 0, pricingOptions = []) {
   const calcTotal = (Number(item.quantity) || 0) && (Number(item.unit_price) || 0)
     ? String(((Number(item.quantity) || 0) * (Number(item.unit_price) || 0)).toFixed(2))
     : n(item.total_price);
-  const selectedPricingName = text(item.pricing_activity_name || item.item_name);
-  const pricingSelectOptions = ['<option value="">— בחירה מהירה —</option>', ...pricingOptions.map((row) => optionHtml(row.activity_name, selectedPricingName))].join('');
+  const selectedPricingKey = text(item.pricing_activity_no || item.pricing_activity_name || item.item_name);
+  const pricingSelectOptions = ['<option value="">— בחירה מהירה —</option>', ...pricingOptions.map((row) => {
+    const value = text(row.activity_no || row.activity_name);
+    return optionHtml(value, selectedPricingKey, row.activity_name);
+  })].join('');
   return `<article class="ds-pa-item-card ds-pa-item-row" data-pa-item-row data-pa-item-idx="${idx}">
     <label class="ds-pa-item-field ds-pa-item-field--full"><span>בחירה מהירה</span><select class="ds-input ds-input--sm" name="pricing_activity_name" data-pa-pricing-select>${pricingSelectOptions}</select></label>
     <div class="ds-pa-item-grid">
@@ -979,6 +982,28 @@ export const proposalsAgreementsScreen = {
 
     const setupItemCalc = (container) => { calcGrandTotal(container); };
     const pricingByName = new Map(proposalActivityPricing.map((row) => [text(row.activity_name), row]));
+    const pricingByNo = new Map(proposalActivityPricing.map((row) => [text(row.activity_no), row]).filter(([k]) => k));
+    const pricingFallbackByName = {
+      workshop_space: proposalActivityPricing.find((row) => text(row.activity_name) === 'סדנת חלל') || null,
+      workshop_makers: proposalActivityPricing.find((row) => text(row.activity_name) === 'סדנת מייקרים') || null,
+      escape_room: proposalActivityPricing.find((row) => text(row.activity_name) === 'חדר בריחה דיגיטלי') || null
+    };
+    const workshopSpaceCodes = new Set(['001', '002', '013']);
+
+    const resolvePricingRow = ({ activityNo, activityName, itemType }) => {
+      const no = text(activityNo);
+      const name = text(activityName);
+      const type = text(itemType).toLowerCase();
+      if (no && pricingByNo.has(no)) return pricingByNo.get(no);
+      if (name && pricingByName.has(name)) return pricingByName.get(name);
+      if (type === 'tour') return no ? pricingByNo.get(no) || null : null;
+      if (type === 'escape_room') return pricingFallbackByName.escape_room;
+      if (type === 'workshop') {
+        if (workshopSpaceCodes.has(no)) return pricingFallbackByName.workshop_space || pricingFallbackByName.workshop_makers;
+        return pricingFallbackByName.workshop_makers || pricingFallbackByName.workshop_space;
+      }
+      return null;
+    };
 
     // ── Form open/close ───────────────────────────────────────────────────────
     const openForm = async (mode, row = {}, preloadedItems = []) => {
@@ -1096,7 +1121,13 @@ export const proposalsAgreementsScreen = {
       if (!pricingSelect) return;
       const itemRow = pricingSelect.closest('[data-pa-item-row]');
       const form = pricingSelect.closest('[data-pa-form]');
-      const picked = pricingByName.get(text(pricingSelect.value));
+      const selectedKey = text(pricingSelect.value);
+      const itemTypeInput = itemRow?.querySelector?.('[name="item_type"]');
+      const picked = resolvePricingRow({
+        activityNo: selectedKey,
+        activityName: selectedKey,
+        itemType: itemTypeInput?.value
+      });
       if (!itemRow || !picked) return;
       const setValue = (name, value) => {
         const input = itemRow.querySelector(`[name="${name}"]`);
@@ -1109,6 +1140,7 @@ export const proposalsAgreementsScreen = {
       setValue('meetings_count', picked.meetings_count);
       setValue('unit_price', picked.unit_price);
       setValue('description', picked.description_for_proposal || '');
+      if (picked.activity_no) setValue('pricing_activity_no', picked.activity_no);
       calcItemRow(itemRow);
       if (form) calcGrandTotal(form);
     }, { signal });

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 438;
+const CACHE_VERSION = 439;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 438;
+const SW_ENTRY_VERSION = 439;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להחליף את מקור הנתונים הישן שמבוסס על JSON/מיון מחירים בלבד בחיבור ישיר ל־Supabase כדי שהקטלוג ומחירון ההצעות ישתמשו בנתונים רשמיים מ־`public.lists` ו־`public.catalog_program_details`.
- להבטיח שהבחירה בפורם הצעת המחיר תגיע מ־`lists` ותשלים נתוני מחיר בצורה תקנית לפי `activity_no` עם fallback לחוקי תמחור ל־workshop/escape_room.
- למנוע הצגה של קטלוג ישן מה־cache על ידי עדכון גרסת ה־Service Worker כך שפריסה חדשה תטען נתונים טריים.

### Description
- החלפתי את טעינת הקטלוג ב־`frontend/src/screens/catalog.js` כדי לקרוא בו־זמנית את `lists` (עם `category='activity_names'` ו־`active=true`), `catalog_program_details` (`is_active_for_catalog=true`) ו־`proposal_activity_pricing` ולמזג שורות לפי `activity_no` לפני נירמול לתצוגה.
- שיפרתי את `normalizeProgram` כדי להשתמש ב־`activity_no` כ־`id` ולבחור שם מצטבר עם עדיפות ל־`catalog_title`, אחר כך `activity_name` / `label_he` / `label` כ־fallback.
- הוספתי נירמול סוגי מוצר (מחרוזות אנגליות כמו `course`, `workshop`, `tour`, `escape_room`) ל־מילים בעברית כדי שהתצוגה והסינון יתאימו לקטלוג.
- בעדכונים ל־`frontend/src/api.js` קריאה ל־`readProposalActivityNamesFromSupabase` מסתמכת על `lists` (וקיימת נפילה חזרה לקריאת תמחור אם נכשלה), והוספתי `activity_no` לתוצאת `proposal_activity_pricing`.
- ב־`frontend/src/screens/proposals-agreements.js` הרחבתי את ה־quick-select כך שיוכל לבחור לפי `activity_no` או `activity_name`, והוספתי `resolvePricingRow` שמעדיפה התאמה לפי `activity_no` ותומכת ב־fallbackים: קודי סדנה `001/002/013` → "סדנת חלל", סדנאות אחרות → "סדנת מייקרים", `escape_room` → "חדר בריחה דיגיטלי"; כאשר יש התאמה לפי `activity_no` היא משמשת לעדכון שדות המחיר וה־`pricing_activity_no`.
- עדכנתי את גרסת ה־Service Worker ב־`frontend/sw.js` ו־`sw.js` (`CACHE_VERSION` / `SW_ENTRY_VERSION`) כדי לגרום לפריסה לרענן cache ולהמנע מהצגת קטלוג ישן.

### Testing
- הרצתי את יחידת המבחנים עם `npm run -s test -- --runInBand` והסקריפט הורץ עד סיומו; תצוגות ופעולות רבות עוברות, אך הריצה הצביעה על מספר כשלונות כלליים בריפו שאינם קשורים ישירות לשינויים אלה (הופיעו מספר בדיקות כושלות בקטגוריות activity-save ו־backend-simulation).
- במהלך הריצה נצפו בדיקות עוברות עבור חלק מההיבטים של הקטלוג ופעילויות (למשל שמירה על שדות `activity_names` וטעינת activity options), ולא נצפו קריסות ישירות שנובעות משגיאות סינטקס בקבצים ששונו.
- לא בוצעו שינויים ב־SQL או במבנה טבלאות, וחוקי השמירה של הצעות המחיר לא שונו, כך שהבדיקות לשמירה רצות כנגד הלוגיקה הקיימת כפי שנשמרה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1325748cd8832bbbf1afb19b1ca953)