### PR TITLE
Bump SW cache version to 440 and disable legacy catalog JSON loader

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 432;
+const CACHE_VERSION = 440;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Bw1JAQ1L.js",
+  "./assets/index-BxX-E_Sk.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Bw1JAQ1L.js"></script>
+  <script type="module" crossorigin src="./assets/index-BxX-E_Sk.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DnXVVcrs.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 432;
+const CACHE_VERSION = 440;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Bw1JAQ1L.js",
+  "./assets/index-BxX-E_Sk.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/public/catalog.html
+++ b/frontend/public/catalog.html
@@ -114,13 +114,9 @@ document.getElementById('printBtn').onclick=()=>{
 
 (async function init(){
   try{
-    const res=await fetch('./catalog_programs_tashpaz.json?v=2026-05-23-1',{cache:'no-store'});
-    const data=await res.json();
-    programs=Array.isArray(data.programs)?data.programs:[];
-    renderCatalog();
-    const qp=new URLSearchParams(location.search).get('program');
-    if(qp) openProgram(qp);
-    statusEl.textContent=`נטענו ${programs.length} תוכניות`;
+    console.warn('catalog.html legacy page is disabled: catalog data is now loaded from Supabase via app route only.');
+    statusEl.textContent='דף ישן הושבת. יש לפתוח את הקטלוג מתוך המערכת הראשית (Supabase).';
+    catalogView.innerHTML = '<p class="muted">הקטלוג הועבר למערכת הראשית ומוטען מ-Supabase בלבד.</p>';
   }catch(e){
     console.error(e); statusEl.textContent='שגיאה בטעינת הקטלוג';
   }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 439;
+const CACHE_VERSION = 440;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 439;
+const SW_ENTRY_VERSION = 440;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- למנוע מצב שבו Service Worker/קאש ישן עדיין טוען את הקטלוג מקובץ JSON מקומי ולהכריח לקוחות לקבל גרסת SW ו-cache חדשה אחרי הפריסה.
- להסיר את נקודת הטעינה הישנה (`catalog_programs_tashpaz.json`) שיכולה לטעון קטלוג ישן במקום הנתונים החדשים ב‑Supabase.
- לשמר את לוגיקת המסכים הקיימת ללא שינויים ב‑SQL או ברינדור מעבר למה שנדרש לתיקון ה‑cache/SW.

### Description
- עדכון `SW_ENTRY_VERSION` ו‑`CACHE_VERSION` ל־`440` ב־`sw.js` וב־`frontend/sw.js` כדי לאלץ ניקוי ובניית קאש חדש. (שינוי גרסת SW/Cache ל־440).
- הסרת הקריאה הישירה ל־`./catalog_programs_tashpaz.json` מתוך `frontend/public/catalog.html` והחלפתה בהודעת legacy שמציינת שהקטלוג נטען מ‑Supabase בלבד.
- שמירה על מדיניות ה‑SW: API-like routes נשארים `network-only` והאפליקציה ממשיכה להשתמש ב׳network-first׳ עבור HTML/JS/CSS, כך שרענון רגיל או חזק יביא גרסה חדשה.
- שונו גם ארטיפקטים שנוצרו בבנייה (`dist/sw.js`, `dist/frontend/sw.js`, `dist/index.html`) כדי לשקף את עדכוני ה‑assets והגרסה במבנה שנבנה.

### Testing
- הרצה של `npm run build` הושלמה בהצלחה וה־dist נבנו עם הקבצים המעודכנים. (הצלחה).
- הרצה של `npm test` בוצעה אך קיימות בדיקות שנכשלו שאינן קשורות לשינויים ב‑SW/cache; הכשלים הם בדיקות קיימות ברפרטואר ולא תוצאה של התיקון (נכשלות חלקית).
- חיפוש מקוד המקור (`rg`) לא מצא עוד הפניות פעילות ל־`catalog_programs_tashpaz.json` לאחר השינוי; הקובץ הוסר כמקור טעינה מה־HTML הישן (עברת בדיקה: לא נמצאו הפניות).
- בדיקות נוספות שנעשו: בניית הפרויקט והרצת חיפוש קבצים כדי לוודא שטבלאות Supabase הנדרשות (`from('lists')`, `from('catalog_program_details')`, `from('proposal_activity_pricing')`) נשארו כמקורות הנתונים למסך הקטלוג (נמצאו בקוד).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1327504b60832b9531cc3babd0715c)