### PR TITLE
קטלוג: כרטיס יחיד ל'סדנאות, סיורים וחוגים' והוספת מסך פנימי

### DIFF
--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -218,7 +218,7 @@ export const catalogScreen = {
       const pricing = pricingByNo.get(key) || {};
       return normalizeProgram({ ...row, ...pricing, ...details });
     });
-    return { programs, selectedId: '', audience: 'הכול', type: 'הכול' };
+    return { programs, selectedId: '', audience: 'הכול', type: 'הכול', groupMode: '' };
   },
 
   render: (data) => {
@@ -227,12 +227,30 @@ export const catalogScreen = {
     const type = data.type || 'הכול';
     const selected = data.programs.find((p) => p.id === data.selectedId) || null;
 
-    if (!selected) {
-      const filtered = data.programs.filter((p) => (audience === 'הכול' || p.audienceLevel === audience) && (type === 'הכול' || p.productType === type));
-      const elementaryPrograms = filtered.filter((p) => p.audienceLevel === 'יסודי' && p.productType === 'תוכנית');
-      const middlePrograms = filtered.filter((p) => p.audienceLevel === 'חטיבה' && p.productType === 'תוכנית');
-      const workshopAndTours = filtered.filter((p) => isStandaloneActivity(p));
+    const filtered = data.programs.filter((p) => (audience === 'הכול' || p.audienceLevel === audience) && (type === 'הכול' || p.productType === type));
+    const elementaryPrograms = filtered.filter((p) => p.audienceLevel === 'יסודי' && p.productType === 'תוכנית');
+    const middlePrograms = filtered.filter((p) => p.audienceLevel === 'חטיבה' && p.productType === 'תוכנית');
+    const workshopAndTours = filtered.filter((p) => isStandaloneActivity(p));
 
+    if (!selected && data.groupMode === 'standalone') {
+      return `<section class="catalog-screen">
+        <header class="catalog-header"><h2>סדנאות, סיורים וחוגים</h2><p class="ds-muted">כל הסדנאות, הסיורים והחוגים במקום אחד</p></header>
+        <div class="catalog-toolbar">
+          <label class="catalog-filter">שכבת גיל <select data-catalog-filter="audience">${AUDIENCE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === audience ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
+          <label class="catalog-filter">סוג פעילות <select data-catalog-filter="type">${TYPE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === type ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
+        </div>
+        <div class="catalog-detail-actions">
+          <button class="catalog-btn" data-catalog-back>חזרה לקטלוג</button>
+        </div>
+        <section class="catalog-group">
+          <div class="catalog-group-grid">
+            ${workshopAndTours.length ? workshopAndTours.map(renderCatalogCard).join('') : '<p class="catalog-empty">אין פריטים להצגה</p>'}
+          </div>
+        </section>
+      </section>`;
+    }
+
+    if (!selected) {
       return `<section class="catalog-screen">
         <header class="catalog-header"><h2>קטלוג תוכניות תלמידים תשפ״ז</h2><p class="ds-muted">בחירת תוכנית לפי שכבת גיל וסוג פעילות</p></header>
         <div class="catalog-toolbar">
@@ -242,7 +260,14 @@ export const catalogScreen = {
         <div class="catalog-groups">
           ${renderCatalogGroup('יסודי', elementaryPrograms)}
           ${renderCatalogGroup('חטיבה', middlePrograms)}
-          ${renderCatalogGroup('סדנאות, סיורים וחוגים', workshopAndTours)}
+          <section class="catalog-group">
+            <h3 class="catalog-group-title">סדנאות, סיורים וחוגים</h3>
+            <div class="catalog-group-grid">
+              <article class="catalog-card catalog-card--neutral" data-catalog-group-open="standalone">
+                <h3>סדנאות, סיורים וחוגים</h3>
+              </article>
+            </div>
+          </section>
         </div>
       </section>`;
     }
@@ -279,14 +304,27 @@ export const catalogScreen = {
     });
 
     root.addEventListener('click', (ev) => {
+      const selected = data.programs.find((p) => p.id === data.selectedId) || null;
       const openCard = ev.target.closest('[data-catalog-open]');
       if (openCard) {
         data.selectedId = openCard.dataset.catalogOpen;
         rerender();
         return;
       }
-      if (ev.target.closest('[data-catalog-back]')) {
+      if (ev.target.closest('[data-catalog-group-open="standalone"]')) {
+        data.groupMode = 'standalone';
         data.selectedId = '';
+        rerender();
+        return;
+      }
+      if (ev.target.closest('[data-catalog-back]')) {
+        if (selected && isStandaloneActivity(selected)) {
+          data.selectedId = '';
+          data.groupMode = 'standalone';
+        } else {
+          data.selectedId = '';
+          data.groupMode = '';
+        }
         rerender();
         return;
       }


### PR DESCRIPTION
### Motivation
- למנוע רינדור של כל סדנה/סיור/חוג ככרטיס נפרד במסך הראשי ולהציג במקום כרטיס אחד שפותח מסך פנימי עם כל הפריטים. 
- לשמור את כל הנתונים והלוגיקה הקיימת כמו `normalizeProgram`, `isStandaloneActivity` ו־`renderCatalogCard` כפי שהם, ולבצע שינוי נקודתי לרינדור וניווט בלבד ב־`frontend/src/screens/catalog.js`.

### Description
- הוספתי שדה state חדש `groupMode` (ערכים: `''`/`main` ו־`'standalone'`) ל־data בחזרת ה־`load` כדי לתמוך במצב תצוגה פנימי ליחידות סטנדאלון. 
- שיניתי את לוגיקת ה־`render` כך שבמסך הראשי יציגו רק שתי קבוצות רגילות (`יסודי`, `חטיבה`) ועוד כרטיס יחיד עבור `סדנאות, סיורים וחוגים` במקום רינדור של כל הפריטים; בעת `data.groupMode === 'standalone'` נציג מסך פנימי עם כותרת, כפתור חזרה וגריד של כל ה־workshop/tour/club הממויינים דרך `renderCatalogCard`. 
- עדכנתי את ה־`bind` כדי: לפתוח את המסך הפנימי על לחיצה על הכרטיס הייעודי (`[data-catalog-group-open=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1379f89fe0832ba0d698129234a7fb)