### PR TITLE
תקן זיהוי סוג פעילות במסך הקטלוג

### DIFF
--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -125,7 +125,13 @@ function normalizeProgram(item, idx) {
     id: String(pickFirstNonEmpty(p.activity_no, p.id, p.programId, p.slug) || `program-${idx + 1}`),
     name: String(pickFirstNonEmpty(p.catalog_title, p.activity_name, p.label_he, p.label, p.name, p.title, p.program_name, p.programName) || 'ללא שם'),
     audienceLevel: normalizeAudienceLevel(p.audience_level || p.audienceLevel || 'לא צוין'),
-    productType: normalizeProductType(p.item_type || p.productType || 'תוכנית'),
+    productType: normalizeProductType(
+      p.item_type ||
+      p.productType ||
+      p.activity_type ||
+      p.type ||
+      'תוכנית'
+    ),
     grades: String(pickFirstNonEmpty(p.grades, p.targetGrades) || 'לא צוין'),
     scope: String(pickFirstNonEmpty(p.meetings_count, p.scope, p.meetings) || inferScope(p)),
     sessionDuration: String(pickFirstNonEmpty(p.unit_duration, p.sessionDuration, p.duration) || 'לא צוין'),


### PR DESCRIPTION
### Motivation
- לתקן זיהוי סוג הפעילות כך שפריטים שמגיעים מטבלת `lists` עם שדות `activity_type` או `type` יזוהו כ־`workshop`/`סדנה` ולא יפלו לברירת המחדל `תוכנית`.

### Description
- בעדכון ב־`frontend/src/screens/catalog.js` הוספתי ב־`normalizeProgram` שורת fallback ל־`productType` שמכלילה את `p.activity_type` ו־`p.type` לפני ברירת המחדל, כלומר `productType: normalizeProductType(p.item_type || p.productType || p.activity_type || p.type || 'תוכנית')`.

### Testing
- ביצעתי בדיקות סטטיות והנהלות קוד: `git diff -- frontend/src/screens/catalog.js` ו־`git commit -m "Fix catalog activity type normalization fallback"` הצליחו; שינוי הקובץ חופץ בהצלחה.
- בדיקות ה־UI והבדיקות המפורטות ברשימת הדרישות (פתיחת מסך הקטלוג, אימות 001–033, אימות 60025–60027, פילטר "סדנה", ווידוא כרטיס אחד במסך הראשי ו־Service Worker/cache) דורשות ריצה ידנית בדפדפן ולא רוצו אוטומטית here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137c007180832bb379cec073ca0293)