### PR TITLE
Stabilize A5 invitation layout and disable dynamic fit modes

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -1,4 +1,4 @@
-const STORAGE_KEY = 'taasiyeda_invitation_builder_state_v4';
+const STORAGE_KEY = 'taasiyeda_invitation_builder_state_v5';
 const ASSET_BASE = './assets/invitations/';
 
 const LOGOS = {
@@ -95,67 +95,40 @@ function ensureStyles() {
 .invitation-screen-root .cbg{position:absolute;inset:0;z-index:0;background-size:cover;background-position:center}
 .invitation-screen-root .cframe{position:absolute;inset:5mm;border-radius:10px;border:1.5px solid rgba(255,255,255,.55);pointer-events:none;z-index:3}
 .invitation-screen-root .cwrap{position:relative;z-index:2;flex:1;display:flex;flex-direction:column}
-.invitation-screen-root .c-logos{display:flex;align-items:center;justify-content:center;gap:1mm;padding:5mm 10mm .5mm;background:transparent;border-bottom:none}
+.invitation-screen-root .c-logos{display:flex;align-items:center;justify-content:center;gap:1mm;padding:5mm 10mm 1mm;background:transparent;border-bottom:none}
 .invitation-screen-root .c-logo-item{width:32mm;height:14mm;display:flex;align-items:center;justify-content:center;gap:4px;font-size:10px;font-weight:800;color:#1a3a5c;line-height:1.2}
 .invitation-screen-root .c-logo-sep{width:1px;height:26px;background:rgba(26,58,92,.2);flex-shrink:0}
 .invitation-screen-root .c-logo-item img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain}
-.invitation-screen-root .c-main{padding:2.1mm 6mm 2.4mm;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center}
-.invitation-screen-root .c-title{font-weight:900;line-height:.95;margin-bottom:0;font-size:10.8mm}
-.invitation-screen-root .c-sub-event{font-weight:700;line-height:1.08;margin-bottom:.9mm;font-size:5.6mm}
-.invitation-screen-root .c-course{font-weight:500;line-height:1.04;margin-bottom:.9mm;font-size:6.1mm}
-.invitation-screen-root .c-course .course-main{display:block;font-size:6.1mm;line-height:1.04;font-weight:500}
-.invitation-screen-root .c-course .course-sub{display:block;font-size:5.6mm;line-height:1.06;font-weight:500}
+.invitation-screen-root .c-main{padding:2mm 6.5mm 2.5mm;flex:1;display:flex;flex-direction:column;align-items:center;text-align:center}
+.invitation-screen-root .c-title{font-weight:900;line-height:.95;margin-bottom:.2mm;font-size:10.8mm}
+.invitation-screen-root .c-sub-event{font-weight:700;line-height:1.08;margin-bottom:.8mm;font-size:5.6mm}
+.invitation-screen-root .c-course{font-weight:500;line-height:1.05;margin-bottom:.8mm;font-size:6.1mm}
+.invitation-screen-root .c-course .course-main{display:block;font-size:6.1mm;line-height:1.05;font-weight:500}
+.invitation-screen-root .c-course .course-sub{display:block;font-size:5.4mm;line-height:1.05;font-weight:500}
 .invitation-screen-root .c-course .course-company{display:block;font-size:4mm;line-height:1.1;font-weight:500;margin-top:.8mm}
 .invitation-screen-root .c-year{font-size:4.8mm;font-weight:700;margin-bottom:2mm}
-.invitation-screen-root .c-school{font-size:3.7mm;color:#333;margin:1.4mm 0}
+.invitation-screen-root .c-school{font-size:3.7mm;color:#333;margin:1.2mm 0}
 .invitation-screen-root .c-school strong{font-weight:700}
-.invitation-screen-root .c-divider{width:100%;height:1px;background:rgba(26,58,92,.1);margin:1.4mm 0}
-.invitation-screen-root .c-opening{font-size:3.65mm;color:#333;line-height:1.26;margin:1mm auto;max-width:none;width:88%;text-align:right;align-self:center;margin-inline:auto;padding-inline:2mm;box-sizing:border-box}
+.invitation-screen-root .c-divider{width:100%;height:1px;background:rgba(26,58,92,.1);margin:1.2mm 0}
+.invitation-screen-root .c-opening{font-size:3.6mm;color:#333;line-height:1.24;margin:.85mm auto;max-width:none;width:88%;text-align:right;align-self:center;margin-inline:auto;padding-inline:2mm;box-sizing:border-box}
 .invitation-screen-root .c-opening strong{font-weight:700;color:var(--accent-color,#1a8c6e)}
-.invitation-screen-root .c-para{font-size:3.65mm;color:#333;line-height:1.26;margin:1mm auto;text-align:right;max-width:none;width:88%;align-self:center;margin-inline:auto;padding-inline:2mm;box-sizing:border-box}
-.invitation-screen-root .c-section-title{font-size:3.1mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1.1mm auto .45mm;max-width:none;width:88%;text-align:right;align-self:center;margin-inline:auto;padding-inline:0;box-sizing:border-box}
+.invitation-screen-root .c-para{font-size:3.6mm;color:#333;line-height:1.24;margin:.85mm auto;text-align:right;max-width:none;width:88%;align-self:center;margin-inline:auto;padding-inline:2mm;box-sizing:border-box}
+.invitation-screen-root .c-section-title{font-size:3.1mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.15;margin:1mm auto .35mm;max-width:none;width:88%;text-align:right;align-self:center;margin-inline:auto;padding-inline:0;box-sizing:border-box}
 .invitation-screen-root .c-box{background:rgba(255,255,255,.5);border:1px solid rgba(26,140,110,.22);border-radius:8px;padding:1.6mm 4mm;margin:1.2mm 0;width:100%;text-align:right}
-.invitation-screen-root .c-participants-box{width:82%;max-width:none;margin:1.1mm auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1.1mm 3.2mm}
-.invitation-screen-root .c-details-box{width:82%;max-width:none;margin:1.1mm auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.7mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.35mm 3.4mm}
+.invitation-screen-root .c-participants-box{width:82%;max-width:none;margin:1mm auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1mm 3.2mm}
+.invitation-screen-root .c-details-box{width:82%;max-width:none;margin:1mm auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.55mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.2mm 3.2mm}
 .invitation-screen-root .c-details-top{display:flex;align-items:center;justify-content:center;gap:4mm;width:100%;flex-wrap:wrap}
-.invitation-screen-root .c-details-location{justify-content:center;text-align:center;width:100%;font-size:4.05mm;line-height:1.32}
+.invitation-screen-root .c-details-location{justify-content:center;text-align:center;width:100%;font-size:4mm;line-height:1.28}
 .invitation-screen-root .c-details-box .c-info-row{justify-content:center;text-align:center}
-.invitation-screen-root .c-info-row{display:flex;align-items:center;gap:4px;font-size:4mm;color:#333;line-height:1.32}
+.invitation-screen-root .c-info-row{display:flex;align-items:center;gap:4px;font-size:4mm;color:#333;line-height:1.28}
 .invitation-screen-root .c-info-row strong{font-weight:700}
-.invitation-screen-root .c-part-title{font-size:2.95mm;font-weight:700;margin-bottom:1px;line-height:1.28}
-.invitation-screen-root .c-part-line{font-size:2.95mm;color:#333;line-height:1.28}
-.invitation-screen-root .c-part-line strong{font-size:2.95mm;font-weight:700;color:#333;line-height:1.28}
-.invitation-screen-root .c-part-line span{font-size:2.95mm;font-weight:400;line-height:1.28}
-.invitation-screen-root .c-closing{font-size:5.25mm;font-weight:900;margin-top:1.7mm;padding-top:.8mm;text-align:center;line-height:1.05}
-.invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:.7mm 5mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:4.2mm;position:relative;z-index:4;width:100%}
-.invitation-screen-root .c-footer-sentence{font-size:2.2mm;font-weight:600;line-height:1.3;letter-spacing:.006em;text-shadow:none;display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:1.5mm}
-.invitation-screen-root #card.fit-a5-relaxed .c-main{padding-top:1.8mm;padding-bottom:2.2mm}
-.invitation-screen-root #card.fit-a5-relaxed .c-opening{margin:.85mm auto}
-.invitation-screen-root #card.fit-a5-relaxed .c-para{margin:.55mm auto}
-.invitation-screen-root #card.fit-a5-relaxed .c-closing{margin-top:1.2mm}
-.invitation-screen-root #card.fit-a5-compact .c-title{font-size:11.9mm}
-.invitation-screen-root #card.fit-a5-compact .c-sub-event{font-size:6mm}
-.invitation-screen-root #card.fit-a5-compact .c-course,.invitation-screen-root #card.fit-a5-compact .c-course .course-main{font-size:6.45mm}
-.invitation-screen-root #card.fit-a5-compact .c-course .course-sub{font-size:5.35mm}
-.invitation-screen-root #card.fit-a5-compact .c-course .course-company{font-size:3.9mm}
-.invitation-screen-root #card.fit-a5-compact .c-opening,.invitation-screen-root #card.fit-a5-compact .c-para{font-size:3.72mm;line-height:1.26}
-.invitation-screen-root #card.fit-a5-compact .c-main{padding:2.35mm 6.3mm 2.5mm}
-.invitation-screen-root #card.fit-a5-compact .c-box{padding:1.4mm 3.6mm;margin:1.1mm 0}
-.invitation-screen-root #card.fit-a5-compact .c-info-row{font-size:4.1mm;line-height:1.34}
-.invitation-screen-root #card.fit-a5-compact .c-part-title,.invitation-screen-root #card.fit-a5-compact .c-part-line,.invitation-screen-root #card.fit-a5-compact .c-part-line strong,.invitation-screen-root #card.fit-a5-compact .c-part-line span{font-size:2.95mm;line-height:1.3}
-.invitation-screen-root #card.fit-a5-compact .c-closing{font-size:5.45mm;margin-top:2mm}
-.invitation-screen-root #card.fit-a5-tight .c-title{font-size:8.8mm}
-.invitation-screen-root #card.fit-a5-tight .c-sub-event{font-size:4.6mm}
-.invitation-screen-root #card.fit-a5-tight .c-course,.invitation-screen-root #card.fit-a5-tight .c-course .course-main{font-size:5mm}
-.invitation-screen-root #card.fit-a5-tight .c-course .course-sub{font-size:4.4mm}
-.invitation-screen-root #card.fit-a5-tight .c-course .course-company{font-size:3.2mm}
-.invitation-screen-root #card.fit-a5-tight .c-opening,.invitation-screen-root #card.fit-a5-tight .c-para{font-size:3mm;line-height:1.14;width:86%}
-.invitation-screen-root #card.fit-a5-tight .c-section-title{font-size:2.9mm;margin:.7mm auto .3mm}
-.invitation-screen-root #card.fit-a5-tight .c-info-row{font-size:3.5mm;line-height:1.22}
-.invitation-screen-root #card.fit-a5-tight .c-part-title,.invitation-screen-root #card.fit-a5-tight .c-part-line,.invitation-screen-root #card.fit-a5-tight .c-part-line strong,.invitation-screen-root #card.fit-a5-tight .c-part-line span{font-size:2.65mm;line-height:1.2}
-.invitation-screen-root #card.fit-a5-tight .c-closing{font-size:4.2mm;padding-top:.5mm}
-.invitation-screen-root #card.fit-a5-tight .c-logos{padding:5mm 8mm .5mm}
-.invitation-screen-root #card.fit-a5-tight .c-logo-item{width:28mm;height:11mm}
+.invitation-screen-root .c-part-title{font-size:2.9mm;font-weight:700;margin-bottom:1px;line-height:1.25}
+.invitation-screen-root .c-part-line{font-size:2.9mm;color:#333;line-height:1.25}
+.invitation-screen-root .c-part-line strong{font-size:2.9mm;font-weight:700;color:#333;line-height:1.25}
+.invitation-screen-root .c-part-line span{font-size:2.9mm;font-weight:400;line-height:1.25}
+.invitation-screen-root .c-closing{font-size:5.2mm;font-weight:900;margin-top:1.4mm;padding-top:.6mm;text-align:center;line-height:1.05}
+.invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:.8mm 5mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:4.4mm;position:relative;z-index:4;width:100%}
+.invitation-screen-root .c-footer-sentence{font-size:2.2mm;font-weight:600;line-height:1.25;letter-spacing:.006em;text-shadow:none;display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:1.5mm}
 .invitation-screen-root .c-footer-sentence span{-webkit-text-stroke:.25px rgba(30,38,46,.35);text-shadow:-0.25px 0 rgba(30,38,46,.35),0.25px 0 rgba(30,38,46,.35),0 -0.25px rgba(30,38,46,.35),0 0.25px rgba(30,38,46,.35)}
 @media (max-width:1200px){.invitation-screen-root .app{grid-template-columns:300px minmax(0,1fr)}}
 `;
@@ -836,68 +809,8 @@ export const invitationsScreen = {
 
     function fitInvitationToA5(card) {
       if (!card) return Promise.resolve();
-      const cwrap = card.querySelector('.cwrap');
-      if (!cwrap) return Promise.resolve();
-
       card.classList.remove('fit-a5-relaxed', 'fit-a5-compact', 'fit-a5-tight');
-
-      const OVERFLOW_EPSILON_PX = 20;
-      const COMPACT_TRIGGER_PX = 36;
-      const TIGHT_TRIGGER_PX = 72;
-      const UNDERFLOW_EPSILON_PX = 56;
-      const RELAXED_UNDERFLOW_PX = 120;
-      const overflowAmount = () => cwrap.scrollHeight - card.clientHeight;
-
-      return new Promise((resolve) => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const baseOverflow = overflowAmount();
-            if (baseOverflow <= OVERFLOW_EPSILON_PX) {
-              if (baseOverflow < -RELAXED_UNDERFLOW_PX) card.classList.add('fit-a5-relaxed');
-              resolve();
-              return;
-            }
-
-            if (baseOverflow <= COMPACT_TRIGGER_PX) {
-              resolve();
-              return;
-            }
-
-            card.classList.add('fit-a5-compact');
-            requestAnimationFrame(() => {
-              const compactOverflow = overflowAmount();
-
-              if (compactOverflow <= OVERFLOW_EPSILON_PX) {
-                if (compactOverflow < -UNDERFLOW_EPSILON_PX) {
-                  card.classList.remove('fit-a5-compact');
-                }
-                resolve();
-                return;
-              }
-
-              if (compactOverflow <= TIGHT_TRIGGER_PX) {
-                resolve();
-                return;
-              }
-
-              card.classList.add('fit-a5-tight');
-              requestAnimationFrame(() => {
-                const tightOverflow = overflowAmount();
-                if (tightOverflow <= OVERFLOW_EPSILON_PX && tightOverflow < -UNDERFLOW_EPSILON_PX) {
-                  card.classList.remove('fit-a5-tight', 'fit-a5-compact');
-                } else if (tightOverflow > OVERFLOW_EPSILON_PX) {
-                  console.warn('[invitations] A5 content still overflows after tight fit', {
-                    cardHeight: card.clientHeight,
-                    contentHeight: cwrap.scrollHeight,
-                    overflowPx: tightOverflow
-                  });
-                }
-                resolve();
-              });
-            });
-          });
-        });
-      });
+      return Promise.resolve();
     }
 
     function getPrintCSS(bg) {
@@ -945,46 +858,8 @@ body{font-family:'Heebo',sans-serif;background:#ccc;display:flex;flex-direction:
 <script>
 function fitInvitationToA5(card){
   if(!card) return Promise.resolve();
-  var cwrap=card.querySelector('.cwrap');
-  if(!cwrap) return Promise.resolve();
   card.classList.remove('fit-a5-relaxed','fit-a5-compact','fit-a5-tight');
-  var OVERFLOW_EPSILON_PX=20;
-  var COMPACT_TRIGGER_PX=36;
-  var TIGHT_TRIGGER_PX=72;
-  var UNDERFLOW_EPSILON_PX=56;
-  var RELAXED_UNDERFLOW_PX=120;
-  function overflowAmount(){return cwrap.scrollHeight-card.clientHeight}
-  return new Promise(function(resolve){
-    requestAnimationFrame(function(){
-      requestAnimationFrame(function(){
-        var baseOverflow=overflowAmount();
-        if(baseOverflow<=OVERFLOW_EPSILON_PX){
-          if(baseOverflow<-RELAXED_UNDERFLOW_PX){card.classList.add('fit-a5-relaxed');}
-          resolve();return;
-        }
-        if(baseOverflow<=COMPACT_TRIGGER_PX){resolve();return;}
-        card.classList.add('fit-a5-compact');
-        requestAnimationFrame(function(){
-          var compactOverflow=overflowAmount();
-          if(compactOverflow<=OVERFLOW_EPSILON_PX){
-            if(compactOverflow<-UNDERFLOW_EPSILON_PX){card.classList.remove('fit-a5-compact');}
-            resolve();return;
-          }
-          if(compactOverflow<=TIGHT_TRIGGER_PX){resolve();return;}
-          card.classList.add('fit-a5-tight');
-          requestAnimationFrame(function(){
-            var tightOverflow=overflowAmount();
-            if(tightOverflow<=OVERFLOW_EPSILON_PX && tightOverflow<-UNDERFLOW_EPSILON_PX){
-              card.classList.remove('fit-a5-tight','fit-a5-compact');
-            }else if(tightOverflow>OVERFLOW_EPSILON_PX){
-              console.warn('[invitations] A5 content still overflows after tight fit',{cardHeight:card.clientHeight,contentHeight:cwrap.scrollHeight,overflowPx:tightOverflow});
-            }
-            resolve();
-          });
-        });
-      });
-    });
-  });
+  return Promise.resolve();
 }
 window.addEventListener('load',function(){
   fitInvitationToA5(document.getElementById('card')).then(function(){window.print();});


### PR DESCRIPTION
### Motivation

- להפחית את התנהגות ה-layout הבלתי יציבה שנגרמת מהמנגנון שמשנה מחלקות `fit-a5-relaxed` / `fit-a5-compact` / `fit-a5-tight` בהתאם ל-overflow. 
- להבטיח פריסת פוסטר A5 קבועה, מאוזנת וללא קפיצות בעת הקלדה או שינויים קטנים בתוכן. 
- למנוע אפקטים של סטייט/קאש ישן שמשפיע על המראה על-ידי עדכון מפתח השמירה המקומית כשנדרש.

### Description

- בוצעה פישוט של הפונקציה `fitInvitationToA5` כך שבשני המקומות (תצוגה חיה וחלון ההדפסה) היא רק מסירה את המחלקות `fit-a5-relaxed`, `fit-a5-compact`, `fit-a5-tight` ומחזירה `Promise.resolve()` ללא חישובי overflow או שינוי מצבים דינמי. 
- הוסרו/נוטרלו כל בלוקי ה-CSS התלויים ב־`#card.fit-a5-relaxed`, `#card.fit-a5-compact` ו־`#card.fit-a5-tight` כדי למנוע השפעות עיצוביות תלויות-מצב. 
- נוספו/מוינו ערכי ה-base CSS של הפוסטר A5 לכדי ערכים יציבים ומאוזנים עבור אלמנטים עיקריים כגון `.c-logos`, `.c-main`, `.c-title`, `.c-sub-event`, `.c-course`, `.c-opening`/`.c-para`, `.c-details-box`, `.c-participants-box`, `.c-closing` ו־`.c-footer`. 
- שונתה המפתח להחזרת מצב מקומי מ־`taasiyeda_invitation_builder_state_v4` ל־`taasiyeda_invitation_builder_state_v5` כדי לצמצם השפעות של גרסאות קאש ישנות.

### Testing

- ביצעתי בדיקת תחביר עם `node --check frontend/src/screens/invitations.js`, הבדיקה הסתיימה בהצלחה. 
- בדקתי את התוצר על-ידי בדיקת ה-diff/הסתכלות בקובץ `frontend/src/screens/invitations.js` כדי לוודא שרק השינויים המיועדים בוצעו, ובדיקת התוכן עלתה כפי שמצופה. 
- לא בוצעו בדיקות אוטומטיות של ממשק/הדפסת PDF ב-ci; שינויים אלה מיועדים לייצב התנהגות לפני בדיקות ויזואליות ידניות נוספות.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137d3cb724832bb49fd2fb84c7b2a6)