### PR TITLE
Adjust invitation closing section spacing and remove logos bar

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -125,7 +125,7 @@ function ensureStyles() {
 .invitation-screen-root .c-part-title{font-size:2.9mm;font-weight:700;margin-bottom:1px;line-height:1.3}
 .invitation-screen-root .c-part-line{font-size:2.9mm;color:#333;line-height:1.3}
 .invitation-screen-root .c-part-line strong{font-weight:700;color:#333}
-.invitation-screen-root .c-closing{font-size:5.2mm;font-weight:900;margin-top:auto;padding-top:1mm;text-align:center;line-height:1.05}
+.invitation-screen-root .c-closing{font-size:5.2mm;font-weight:900;margin-top:1.4mm;padding-top:.6mm;text-align:center;line-height:1.05}
 .invitation-screen-root .c-footer{display:flex;align-items:center;justify-content:center;text-align:center;padding:.8mm 6mm;background:#fff;border-top:.25mm solid #fff;margin-top:0;margin-bottom:0;backdrop-filter:none;min-height:4.5mm;position:relative;z-index:4;width:100%}
 .invitation-screen-root .c-footer-sentence{font-size:2.65mm;font-weight:600;line-height:1.1;letter-spacing:.035em;text-shadow:-.3px -.3px 0 rgba(30,38,46,.25),.3px -.3px 0 rgba(30,38,46,.25),-.3px .3px 0 rgba(30,38,46,.25),.3px .3px 0 rgba(30,38,46,.25),0 1px 1.5px rgba(0,0,0,.08);display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:.35mm}
 .invitation-screen-root #card.fit-a5-compact .c-title{font-size:9.5mm}
@@ -802,8 +802,7 @@ export const invitationsScreen = {
           ${b2 ? `<div class="c-section-title">מה מצפה לנו:</div><div class="c-para">${esc(b2)}</div>` : ''}
           <div class="c-box c-participants-box">${participantsHTML}</div>
           <div class="c-closing" style="color:${c3}">${esc(closing)}</div>
-        </div>
-        ${logosBarHTML(true)}`;
+        </div>`;
     }
 
     function up() {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 441;
+const CACHE_VERSION = 442;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 440;
+const SW_ENTRY_VERSION = 441;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR refines the visual layout of the invitation screen by adjusting the spacing of the closing section and removing the logos bar from the invitation template.

## Key Changes
- **Spacing adjustments**: Modified `.c-closing` CSS styling to use fixed margins (`margin-top: 1.4mm` and `padding-top: 0.6mm`) instead of `margin-top: auto`, providing more consistent vertical positioning
- **Removed logos bar**: Eliminated the `logosBarHTML(true)` call from the invitation template, simplifying the footer layout
- **Cache version bumps**: Updated service worker cache versions to ensure clients pick up the new layout changes

## Implementation Details
The closing section previously used `margin-top: auto` to push content to the bottom of its container. This has been replaced with explicit pixel measurements (1.4mm and 0.6mm) for more predictable spacing. The removal of the logos bar streamlines the invitation card design by eliminating the decorative element that was previously rendered below the closing section.

https://claude.ai/code/session_01VMjLUNuR9qryGfuVeaWV2f