### PR TITLE
הקטלוג: מעבר ל־API יחיד (api.getCatalogPrograms) ותיקון cache ב‑SW

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2329,6 +2329,63 @@ async function readSettingsRowsFromSupabase() {
   }));
 }
 
+
+
+async function readCatalogProgramsFromSupabase() {
+  if (!supabase) throw new Error('no_supabase_client');
+  const [listsRes, detailsRes, pricingRes] = await Promise.all([
+    supabase
+      .from('lists')
+      .select('activity_no,activity_name,label_he,label,type,activity_type,audience_level,target_grades,gefen_number,sort_order,category,active')
+      .eq('category', 'activity_names')
+      .eq('active', true)
+      .order('sort_order', { ascending: true }),
+    supabase
+      .from('catalog_program_details')
+      .select('activity_no,catalog_title,catalog_subtitle,audience_level,target_grades,domain,scope,session_duration,gefen_number,opening_line,core_idea,program_flow,student_develops,school_value,final_outcome,syllabus,page_template,is_active_for_catalog')
+      .eq('is_active_for_catalog', true),
+    supabase
+      .from('proposal_activity_pricing')
+      .select('activity_no,activity_name,item_type,meetings_count,hours_count,unit_price,hourly_price')
+  ]);
+
+  const logReadError = (source, table, error) => {
+    if (!error) return;
+    console.error('[catalog-load-error]', {
+      source,
+      table,
+      operation: 'select',
+      message: String(error?.message || error || 'unknown_error')
+    });
+  };
+
+  logReadError('catalog', 'lists', listsRes?.error);
+  logReadError('catalog', 'catalog_program_details', detailsRes?.error);
+  logReadError('catalog', 'proposal_activity_pricing', pricingRes?.error);
+
+  if (listsRes?.error) {
+    return {
+      programs: [],
+      error: 'לא ניתן לטעון את נתוני הקטלוג. בדקו חיבור והרשאות.'
+    };
+  }
+
+  const listRows = Array.isArray(listsRes?.data) ? listsRes.data : [];
+  const detailRows = Array.isArray(detailsRes?.data) ? detailsRes.data : [];
+  const pricingRows = Array.isArray(pricingRes?.data) ? pricingRes.data : [];
+  const detailsByNo = new Map(detailRows.map((row) => [String(row?.activity_no || '').trim(), row]));
+  const pricingByNo = new Map(pricingRows.map((row) => [String(row?.activity_no || '').trim(), row]));
+
+  const programs = listRows.map((row) => {
+    const key = String(row?.activity_no || '').trim();
+    return { ...row, ...(pricingByNo.get(key) || {}), ...(detailsByNo.get(key) || {}) };
+  });
+
+  return {
+    programs,
+    error: (detailsRes?.error || pricingRes?.error) ? 'לא ניתן לטעון את נתוני הקטלוג. בדקו חיבור והרשאות.' : ''
+  };
+}
 export const api = {
   login: async (user_id, entry_code) => {
     const [user, listsData, settingsRows] = await Promise.all([
@@ -2451,6 +2508,7 @@ export const api = {
     return buildSupabaseErrorPayload({ instructor_rows: [], school_rows: [], can_view_instructors: true, can_view_schools: true }, 'contacts_supabase_failed');
   },
   endDates: () => readEndDatesFromSupabase(),
+  getCatalogPrograms: () => readCatalogProgramsFromSupabase(),
   myData: async () => {
     const allRows = await readAllActivitiesRowsSupabase();
     const idsSet = getInstructorIdentitySet();

--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -1,4 +1,4 @@
-import { supabase } from '../supabase-client.js';
+import { api } from '../api.js';
 import { escapeHtml } from './shared/html.js';
 const AUDIENCE_OPTIONS = ['הכול', 'יסודי', 'חטיבה'];
 const TYPE_OPTIONS = ['הכול', 'תוכנית', 'סדנה', 'סיור', 'חוג'];
@@ -196,35 +196,18 @@ function renderCatalogGroup(title, programs) {
 
 export const catalogScreen = {
   load: async () => {
-    if (!supabase) throw new Error('חיבור Supabase אינו זמין');
-    const [listsRes, detailsRes, pricingRes] = await Promise.all([
-      supabase
-        .from('lists')
-        .select('activity_no,activity_name,label_he,label,type,activity_type,audience_level,target_grades,gefen_number,sort_order')
-        .eq('category', 'activity_names')
-        .eq('active', true)
-        .order('sort_order', { ascending: true }),
-      supabase
-        .from('catalog_program_details')
-        .select('activity_no,catalog_title,catalog_subtitle,audience_level,target_grades,domain,scope,session_duration,gefen_number,opening_line,core_idea,program_flow,student_develops,school_value,final_outcome,syllabus,page_template')
-        .eq('is_active_for_catalog', true),
-      supabase
-        .from('proposal_activity_pricing')
-        .select('activity_no,activity_name,item_type,meetings_count,hours_count,unit_price,hourly_price')
-    ]);
-    if (listsRes.error) throw new Error('טעינת הקטלוג נכשלה');
-    const listRows = Array.isArray(listsRes.data) ? listsRes.data : [];
-    const detailRows = Array.isArray(detailsRes.data) ? detailsRes.data : [];
-    const pricingRows = Array.isArray(pricingRes.data) ? pricingRes.data : [];
-    const detailsByNo = new Map(detailRows.map((r) => [String(r.activity_no || '').trim(), r]));
-    const pricingByNo = new Map(pricingRows.map((r) => [String(r.activity_no || '').trim(), r]));
-    const programs = listRows.map((row) => {
-      const key = String(row.activity_no || '').trim();
-      const details = detailsByNo.get(key) || {};
-      const pricing = pricingByNo.get(key) || {};
-      return normalizeProgram({ ...row, ...pricing, ...details });
-    });
-    return { programs, selectedId: '', audience: 'הכול', type: 'הכול', groupMode: '' };
+    const payload = await api.getCatalogPrograms();
+    const programs = Array.isArray(payload?.programs)
+      ? payload.programs.map((row, idx) => normalizeProgram(row, idx))
+      : [];
+    return {
+      programs,
+      selectedId: '',
+      audience: 'הכול',
+      type: 'הכול',
+      groupMode: '',
+      loadError: payload?.error ? 'לא ניתן לטעון את נתוני הקטלוג. בדקו חיבור והרשאות.' : ''
+    };
   },
 
   render: (data) => {
@@ -245,6 +228,7 @@ export const catalogScreen = {
           <label class="catalog-filter">שכבת גיל <select data-catalog-filter="audience">${AUDIENCE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === audience ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
           <label class="catalog-filter">סוג פעילות <select data-catalog-filter="type">${TYPE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === type ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
         </div>
+        ${data.loadError ? `<p class="catalog-empty">${escapeHtml(data.loadError)}</p>` : ''}
         <div class="catalog-detail-actions">
           <button class="catalog-btn" data-catalog-back>חזרה לקטלוג</button>
         </div>
@@ -263,6 +247,7 @@ export const catalogScreen = {
           <label class="catalog-filter">שכבת גיל <select data-catalog-filter="audience">${AUDIENCE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === audience ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
           <label class="catalog-filter">סוג פעילות <select data-catalog-filter="type">${TYPE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === type ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
         </div>
+        ${data.loadError ? `<p class="catalog-empty">${escapeHtml(data.loadError)}</p>` : ''}
         <div class="catalog-groups">
           ${renderCatalogGroup('יסודי', elementaryPrograms)}
           ${renderCatalogGroup('חטיבה', middlePrograms)}

--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -115,7 +115,7 @@ function ensureStyles() {
 .invitation-screen-root .c-para{font-size:3.95mm;color:#333;line-height:1.35;margin:.5mm auto;text-align:right;max-width:none;width:70%;align-self:center;margin-inline:auto;padding-inline:5mm;box-sizing:border-box}
 .invitation-screen-root .c-section-title{font-size:3.95mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.35;margin:1mm auto .4mm;max-width:none;width:70%;text-align:right;align-self:center;margin-inline:auto;padding-inline:5mm;box-sizing:border-box}
 .invitation-screen-root .c-box{background:rgba(255,255,255,.5);border:1px solid rgba(26,140,110,.22);border-radius:8px;padding:1.3mm 3.5mm;margin:1mm 0;width:100%;text-align:right}
-.invitation-screen-root .c-participants-box{width:70%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1.2mm 5.15mm}
+.invitation-screen-root .c-participants-box{width:60%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;background:rgba(255,255,255,.38);border-color:rgba(26,140,110,.12);padding:1.2mm 5.15mm}
 .invitation-screen-root .c-details-box{width:60%;max-width:none;margin-left:auto;margin-right:auto;align-self:center;display:flex;flex-direction:column;align-items:center;gap:.7mm;background:transparent;border-color:rgba(26,140,110,.18);text-align:center;padding:1.2mm 3mm}
 .invitation-screen-root .c-details-top{display:flex;align-items:center;justify-content:center;gap:4mm;width:100%;flex-wrap:wrap}
 .invitation-screen-root .c-details-location{justify-content:center;text-align:center;width:100%;font-size:4.4mm;line-height:1.5}
@@ -758,7 +758,7 @@ export const invitationsScreen = {
       let opening = '';
 
       if (type === 'end') {
-        opening = `<div class="c-opening">אנו שמחים להזמינכם למפגש הסיום של קורס <strong>${esc(getCourseOpeningText(course))}</strong>, שהתקיים בבית הספר במסגרת התוכניות החינוכיות של עמותת תעשיידע.</div>`;
+        opening = `<div class="c-opening">אנו שמחים להזמינכם למפגש הסיום של קורס <strong>${esc(getCourseOpeningText(course))}</strong>, שהתקיים בבית הספר במסגרת התוכניות החינוכיות של תעשיידע.</div>`;
       } else if (type === 'lecture') {
         const lecturer = $('lec-name')?.value || '';
         const topic = $('lec-topic')?.value || '';

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 447;
+const CACHE_VERSION = 448;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 446;
+const CACHE_VERSION = 447;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 444;
+const SW_ENTRY_VERSION = 445;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- הקטלוג היה טוען נתונים ישירות מתוך `catalog.js` מול Supabase והדבר הוביל לטעינות חלקיות/בעיות RLS בשל קריאות ישירות מה‑client; יש לאחד את קריאות הנתונים דרך שכבת API של האפליקציה.
- הקובץ הישן `frontend/public/catalog.html` הוא legacy ואינו ישמש כמקור נתונים או fallback סטטי.

### Description
- הוספתי את הפונקציה `readCatalogProgramsFromSupabase()` ב־`frontend/src/api.js` וחשפתי אותה כ־`api.getCatalogPrograms()`, שמאחדת נתונים מ־`lists`, `catalog_program_details` ו־`proposal_activity_pricing` לפי `activity_no` לאחר `trim` והמרה ל־string. (קובץ: `frontend/src/api.js`)
- עדכנתי את `frontend/src/screens/catalog.js` להסיר קריאות ישירות ל־`supabase` ולהשתמש ב־`api.getCatalogPrograms()`, כולל הוספת שדה `loadError` להצגת הודעת שגיאה ידידותית למשתמש כאשר יש כשל בקריאה. (קובץ: `frontend/src/screens/catalog.js`)
- שיפרתי טיפול בשגיאות עם לוג טכני מובנה לקונסול לכל מקור נתונים וביצעתי fallback חלקי כך שאם `lists` נטען אך `details`/`pricing` נכשלו הכרטיסים עדיין מוצגים עם ערכי fallback.
- עדכנתי את `frontend/sw.js` והגבתי את `CACHE_VERSION` מ־`446` ל־`447` כדי לאלץ ריענון של קבצים מטמון ישנים לאחר ההעלאה; לא בוצעו שינויים במדיניות RLS או חשיפת `service_role`, ולא שוחזר/הופעל `frontend/public/catalog.html`.

### Testing
- ריצה אוטומטית: ביצעתי `git add` ו־`git commit` של הקבצים (`frontend/src/api.js`, `frontend/src/screens/catalog.js`, `frontend/sw.js`) בהצלחה.
- ניסיון להריץ build אוטומטי עם `npm --prefix frontend run build` נכשל בסביבה זו כי אין `frontend/package.json`, לכן לא בוצע build מלא כאן.
- לא הורצו בדיקות יחידה או E2E אוטומטיות בסשן זה; יש להריץ build ובדיקות בסביבת CI/הדפליי כדי לאמת שהקבצים החדשים נטענים על לקוחות לאחר עדכון ה‑SW.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a85de094832b9b25f89fedaa69c2)