### PR TITLE
Center invitation opening paragraph and bump service worker versions

### DIFF
--- a/frontend/src/screens/invitations.js
+++ b/frontend/src/screens/invitations.js
@@ -110,7 +110,7 @@ function ensureStyles() {
 .invitation-screen-root .c-school{font-size:4mm;color:#333;margin:1.5mm 0}
 .invitation-screen-root .c-school strong{font-weight:700}
 .invitation-screen-root .c-divider{width:100%;height:1px;background:rgba(26,58,92,.1);margin:1.5mm 0}
-.invitation-screen-root .c-opening{font-size:3.95mm;color:#333;line-height:1.35;margin:1mm auto;max-width:none;width:70%;text-align:right;align-self:center;margin-inline:auto;padding-inline:5mm;box-sizing:border-box}
+.invitation-screen-root .c-opening{font-size:3.95mm;color:#333;line-height:1.35;margin:1mm auto;max-width:none;width:70%;text-align:center;align-self:center;margin-inline:auto;padding-inline:5mm;box-sizing:border-box}
 .invitation-screen-root .c-opening strong{font-weight:700;color:var(--accent-color,#1a8c6e)}
 .invitation-screen-root .c-para{font-size:3.95mm;color:#333;line-height:1.35;margin:.5mm auto;text-align:right;max-width:none;width:70%;align-self:center;margin-inline:auto;padding-inline:5mm;box-sizing:border-box}
 .invitation-screen-root .c-section-title{font-size:3.95mm;font-weight:800;color:var(--accent-color,#1a8c6e);line-height:1.35;margin:1mm auto .4mm;max-width:none;width:70%;text-align:right;align-self:center;margin-inline:auto;padding-inline:5mm;box-sizing:border-box}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 448;
+const CACHE_VERSION = 449;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 445;
+const SW_ENTRY_VERSION = 446;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Center the opening invitation paragraph (class `.c-opening`) to improve visual alignment while ensuring service worker caches are invalidated so the change is deployed.

### Description
- Updated `.c-opening` in `frontend/src/screens/invitations.js` from `text-align:right` to `text-align:center`, and incremented `CACHE_VERSION` in `frontend/sw.js` from `448` to `449` and `SW_ENTRY_VERSION` in `sw.js` from `445` to `446`; no other changes were made.

### Testing
- Executed `git diff -- frontend/src/screens/invitations.js`, `git diff -- frontend/sw.js`, and `git diff -- sw.js` to verify the diffs are limited to the alignment change and the two SW version bumps, and performed `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13acda6874832b8be4b75097ad114e)