### PR TITLE
Proposals: remove activity picker, combined form sections, A4 CSS, cl…

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 450;
+const CACHE_VERSION = 451;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 450;
+const CACHE_VERSION = 451;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -345,7 +345,47 @@ function itemRowHtml(item = {}, idx = 0, pricingOptions = []) {
   </article>`;
 }
 
-function itemsEditorHtml(items = [], pricingOptions = []) {
+const SUMMER_GROUP_KEYS = new Set(['summer', 'קיץ', 'קיץ תשפ״ו', 'פעילויות קיץ']);
+const NEXT_YEAR_GROUP_KEYS = new Set(['next_year', 'תשפ״ז', 'שנה הבאה', 'תוכניות תשפ״ז']);
+
+function isSummerItem(item) {
+  const g = text(item.proposal_group);
+  return SUMMER_GROUP_KEYS.has(g) || SUMMER_GROUP_KEYS.has(LEGACY_GROUP_MAP[g]);
+}
+function isNextYearItem(item) {
+  const g = text(item.proposal_group);
+  return NEXT_YEAR_GROUP_KEYS.has(g) || NEXT_YEAR_GROUP_KEYS.has(LEGACY_GROUP_MAP[g]);
+}
+
+function combinedItemsSectionHtml(label, groupKey, items, pricingOptions, idxOffset) {
+  const startItems = items.length ? items : [{ proposal_group: groupKey }];
+  const rowsHtml = startItems.map((item, i) => itemRowHtml({ ...item, proposal_group: item.proposal_group || groupKey }, idxOffset + i, pricingOptions)).join('');
+  return `<div class="ds-pa-items-section ds-pa-items-section--group" data-pa-items-group="${escapeHtml(groupKey)}">
+    <div class="ds-pa-items-header">
+      <span class="ds-pa-items-section-label">${escapeHtml(label)}</span>
+      <button type="button" class="ds-btn ds-btn--xs" data-pa-add-item data-pa-add-item-group="${escapeHtml(groupKey)}">+ הוסף שורה</button>
+    </div>
+    <div class="ds-pa-items-list" data-pa-items-body data-pa-items-group-body="${escapeHtml(groupKey)}">${rowsHtml}</div>
+  </div>`;
+}
+
+function itemsEditorHtml(items = [], pricingOptions = [], activityTypeGroup = '') {
+  const isCombined = activityTypeGroup === 'קיץ תשפ״ו + תשפ״ז';
+  const footer = `<datalist id="pa-item-type-list">${ITEM_TYPE_OPTIONS.map((v) => `<option value="${escapeHtml(v)}">`).join('')}</datalist>
+    <div class="ds-pa-items-total-row">סה״כ כללי: <strong data-pa-grand-total></strong></div>`;
+
+  if (isCombined) {
+    const summerItems = items.filter(isSummerItem);
+    const nextYearItems = items.filter(isNextYearItem);
+    const unassigned = items.filter((i) => !isSummerItem(i) && !isNextYearItem(i));
+    const allSummer = [...summerItems, ...unassigned];
+    return `<div class="ds-pa-items-section ds-pa-items-combined">
+      ${combinedItemsSectionHtml('שורות הצעה – קיץ תשפ״ו', 'קיץ תשפ״ו', allSummer, pricingOptions, 0)}
+      ${combinedItemsSectionHtml('שורות הצעה – תוכניות תשפ״ז', 'תוכניות תשפ״ז', nextYearItems, pricingOptions, allSummer.length || 1)}
+      ${footer}
+    </div>`;
+  }
+
   const startItems = items.length ? items : [{}];
   const rowsHtml = startItems.map((item, idx) => itemRowHtml(item, idx, pricingOptions)).join('');
   return `<div class="ds-pa-items-section">
@@ -354,8 +394,7 @@ function itemsEditorHtml(items = [], pricingOptions = []) {
       <button type="button" class="ds-btn ds-btn--xs" data-pa-add-item>+ הוסף שורה</button>
     </div>
     <div class="ds-pa-items-list" data-pa-items-body>${rowsHtml}</div>
-    <datalist id="pa-item-type-list">${ITEM_TYPE_OPTIONS.map((v) => `<option value="${escapeHtml(v)}">`).join('')}</datalist>
-    <div class="ds-pa-items-total-row">סה״כ כללי: <strong data-pa-grand-total></strong></div>
+    ${footer}
   </div>`;
 }
 
@@ -513,13 +552,16 @@ function resolveDocumentSections(row, templateSections = []) {
   return custom.length ? custom : fallback;
 }
 
-function documentSectionsEditorHtml(sections = []) {
+function documentSectionsEditorHtml(sections = [], isCustom = false) {
+  const indicator = isCustom
+    ? `<p class="ds-pa-doc-indicator ds-pa-doc-indicator--custom">✎ עריכה מותאמת אישית — שימוש באיפוס לתבנית המקור ימחק שינויים אלו</p>`
+    : `<p class="ds-pa-doc-indicator ds-pa-doc-indicator--template">⊞ תבנית מקור — כל שינוי ייצור גרסה מותאמת אישית</p>`;
   const rows = (Array.isArray(sections) ? sections : []).map((section, idx) => `
     <label class="ds-pa-form-field ds-pa-form-field--wide">
       <span>${escapeHtml(text(section.section_title) || text(section.section_key) || `סעיף ${idx + 1}`)}</span>
       <textarea class="ds-input ds-input--sm" rows="4" data-pa-doc-body="${escapeHtml(text(section.section_key))}">${escapeHtml(String(section.section_body || ''))}</textarea>
     </label>`).join('');
-  return `<div class="ds-pa-doc-editor" data-pa-doc-editor>${rows}</div>`;
+  return `<div class="ds-pa-doc-editor" data-pa-doc-editor>${indicator}${rows}</div>`;
 }
 
 const STRUCTURED_SECTION_DEFAULTS = {
@@ -645,6 +687,33 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
 
 // ─── Form ─────────────────────────────────────────────────────────────────────
 
+// ─── Client dedup helpers ─────────────────────────────────────────────────────
+
+function normalizeForDedup(str) {
+  return text(str).toLowerCase()
+    .replace(/['"׳״']/g, '')
+    .replace(/[-–—]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function findSimilarClients(contactOptions, authority, school) {
+  const normAuth = normalizeForDedup(authority);
+  if (!normAuth) return [];
+  return (Array.isArray(contactOptions) ? contactOptions : []).reduce((acc, c) => {
+    const cAuth = normalizeForDedup(c.authority);
+    if (!cAuth) return acc;
+    const authMatch = cAuth === normAuth || cAuth.includes(normAuth) || normAuth.includes(cAuth);
+    if (!authMatch) return acc;
+    const normSchool = normalizeForDedup(school);
+    const cSchool = normalizeForDedup(c.school);
+    if (normSchool && cSchool && cSchool !== normSchool) return acc;
+    const key = `${text(c.authority)}||${text(c.school)}`;
+    if (!acc._seen.has(key)) { acc._seen.add(key); acc.push(c); }
+    return acc;
+  }, Object.assign([], { _seen: new Set() }));
+}
+
 function filterPricingByProposalType(pricingOptions, activityTypeGroup) {
   const groupFilters = PROPOSAL_GROUP_FOR_TYPE[activityTypeGroup];
   if (!groupFilters) return pricingOptions;
@@ -658,7 +727,6 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const title = mode === 'edit' ? 'עריכת הצעת מחיר' : 'יצירת הצעת מחיר';
   const normalizedActivityGroup = LEGACY_GROUP_MAP[text(row.activity_type_group)] || text(row.activity_type_group);
   const filteredPricing = filterPricingByProposalType(pricingOptions, normalizedActivityGroup);
-  const rowActivity = Array.isArray(row.activity_names) ? row.activity_names : [];
   const currentStatus = STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft';
   const initAuth = text(row.client_authority);
   const initSchool = text(row.school_framework);
@@ -691,11 +759,9 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
       ${textField('email', FIELD_LABELS.email, row.email, false)}
     </div>
 
-    ${activityPickerHtml(rowActivity, activityNameOptions)}
-
     <label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(FIELD_LABELS.notes)}</span><textarea class="ds-input ds-input--sm" name="notes" rows="2">${escapeHtml(text(row.notes))}</textarea></label>
 
-    ${itemsEditorHtml(items, filteredPricing)}
+    <div data-pa-items-host>${itemsEditorHtml(items, filteredPricing, normalizedActivityGroup)}</div>
 
     <input type="hidden" name="status" data-pa-status-input value="${escapeHtml(currentStatus)}">
     <p class="ds-pa-form-error" data-pa-form-error role="alert"></p>
@@ -755,13 +821,18 @@ function drawerHtml(row, activityNameOptions = [], state = null) {
       <span class="ds-pa-detail-value"><strong>₪${formatCurrency(row.total_amount)}</strong></span>
     </div>` : '';
 
+  const hasCustomSections = Array.isArray(row.custom_document_sections) && row.custom_document_sections.length > 0;
+  const customBadge = hasCustomSections
+    ? `<span class="ds-pa-badge" title="המסמך הזה כולל עריכה מותאמת אישית" style="display:inline-block;padding:1px 7px;border-radius:10px;font-size:0.75rem;background:#6366f1;color:#fff;margin-right:4px">מסמך מותאם</span>`
+    : '';
+
   return `<aside class="ds-pa-drawer" data-pa-drawer data-pa-drawer-id="${escapeHtml(row.id)}" aria-live="polite" dir="rtl">
     <div class="ds-pa-drawer-panel">
       <header class="ds-pa-drawer-head">
         <div><p class="ds-muted">פרטי רשומה</p><h3>${escapeHtml(row.client_authority || '—')}</h3></div>
         <button type="button" class="ds-btn ds-btn--sm" data-pa-close-drawer aria-label="סגירת פרטי רשומה">✕</button>
       </header>
-      <div class="ds-pa-drawer-status" style="margin-bottom:8px">${statusBadgeHtml(row.status)}</div>
+      <div class="ds-pa-drawer-status" style="margin-bottom:8px">${statusBadgeHtml(row.status)}${customBadge}</div>
       <div class="ds-pa-detail-grid">${detailRowsHtml(row)}</div>
       ${totalHtml}
       ${approvalNoteHtml}
@@ -849,6 +920,11 @@ function validatePayload(payload, statusOverride) {
     const invalidItem = items.find((i) => !text(i.item_name));
     if (invalidItem) errors.push('שם פעילות בכל שורה');
     if (!payload.total_amount) errors.push('סה״כ כללי');
+    const grp = LEGACY_GROUP_MAP[text(payload.activity_type_group)] || text(payload.activity_type_group);
+    if (grp === 'קיץ תשפ״ו + תשפ״ז') {
+      const missingGroup = items.find((i) => !text(i.proposal_group));
+      if (missingGroup) errors.push('שייוך לקיץ/תשפ״ז בכל שורה (הצעה משולבת)');
+    }
   }
 
   return errors.length ? `חובה למלא: ${errors.join(', ')}` : '';
@@ -919,42 +995,21 @@ export const proposalsAgreementsScreen = {
 
     const formHost = root.querySelector('[data-pa-form-host]');
 
-    // ── Activity picker setup ─────────────────────────────────────────────────
-    const closeAllActivityDropdowns = () => {
-      root.querySelectorAll('[data-pa-activity-picker]').forEach((picker) => {
-        const dropdown = picker.querySelector('[data-pa-activity-dropdown]');
-        const trigger = picker.querySelector('[data-pa-activity-toggle]');
-        if (dropdown) dropdown.hidden = true;
-        if (trigger) trigger.setAttribute('aria-expanded', 'false');
-      });
-    };
-
-    const setupActivityPickers = (container) => {
-      container?.querySelectorAll?.('[data-pa-activity-picker]')?.forEach((picker) => {
-        const trigger = picker.querySelector('[data-pa-activity-toggle]');
-        const chipsHost = picker.querySelector('[data-pa-activity-chips]');
-        const dropdown = picker.querySelector('[data-pa-activity-dropdown]');
-        const search = picker.querySelector('[data-pa-activity-search]');
-        const optionsHost = picker.querySelector('[data-pa-activity-options]');
-        const hiddenInputsHost = picker.querySelector('[data-pa-activity-hidden-inputs]');
-        const checkboxes = Array.from(picker.querySelectorAll('.ds-pa-activity-option input[type="checkbox"]'));
-        const sync = () => {
-          const selected = checkboxes.filter((cb) => cb.checked).map((cb) => text(cb.value)).filter(Boolean);
-          chipsHost.innerHTML = selected.length
-            ? selected.map((item) => `<button type="button" class="ds-pa-chip" data-pa-chip-remove="${escapeHtml(item)}">${escapeHtml(item)} <span aria-hidden="true">×</span></button>`).join('')
-            : '<span class="ds-muted">לא נבחרו פעילויות</span>';
-          trigger.textContent = selected.length ? `נבחרו ${selected.length} פעילויות` : 'בחרו פעילויות';
-          hiddenInputsHost.innerHTML = selected.map((item) => `<input type="hidden" name="activity_names" value="${escapeHtml(item)}">`).join('');
-        };
-        sync();
-        checkboxes.forEach((cb) => cb.addEventListener('change', sync, { signal }));
-        search?.addEventListener('input', () => {
-          const q = normalizeSearch(search.value);
-          optionsHost.querySelectorAll('.ds-pa-activity-option').forEach((option) => {
-            option.hidden = q ? !normalizeSearch(option.textContent).includes(q) : false;
-          });
-        }, { signal });
-      });
+    // ── Type change → re-render items section ────────────────────────────────
+    const setupTypeChangeHandler = (container) => {
+      const form = container?.closest?.('[data-pa-form]') || container?.querySelector?.('[data-pa-form]') || container;
+      if (!form) return;
+      const typeSelect = form.querySelector('[name="activity_type_group"]');
+      if (!typeSelect) return;
+      typeSelect.addEventListener('change', () => {
+        const newType = text(typeSelect.value);
+        const currentItems = extractItemsFromForm(form);
+        const itemsHost = form.querySelector('[data-pa-items-host]');
+        if (!itemsHost) return;
+        const filteredPricing = filterPricingByProposalType(proposalActivityPricing, newType);
+        itemsHost.innerHTML = itemsEditorHtml(currentItems, filteredPricing, newType);
+        setupItemCalc(form);
+      }, { signal });
     };
 
     // ── Contact / client setup ────────────────────────────────────────────────
@@ -1064,7 +1119,7 @@ export const proposalsAgreementsScreen = {
       }
       formHost.hidden = false;
       formHost.innerHTML = formHtml(mode, row, activityNameOptions, contactOptions, items, proposalActivityPricing);
-      setupActivityPickers(formHost);
+      setupTypeChangeHandler(formHost);
       setupClientSelector(formHost);
       setupItemCalc(formHost);
       const pickerHost = formHost.querySelector('[data-pa-contact-picker-host]');
@@ -1114,6 +1169,22 @@ export const proposalsAgreementsScreen = {
       const payload = payloadFromForm(form);
       payload.is_new_client = form.dataset.paNewClient === 'yes';
       if (statusOverride) payload.status = statusOverride;
+
+      // Client dedup — warn if a similar client already exists
+      if (payload.is_new_client && text(payload.client_authority)) {
+        const similar = findSimilarClients(contactOptions, payload.client_authority, payload.school_framework);
+        if (similar.length) {
+          const names = similar.slice(0, 3).map((c) => `${text(c.authority)}${text(c.school) ? ' — ' + text(c.school) : ''}`).join('\n');
+          const useExisting = window.confirm(`נמצאו לקוחות דומים:\n${names}\n\nהאם להשתמש בלקוח הקיים?`);
+          if (useExisting) {
+            const match = similar[0];
+            payload.client_authority = text(match.authority);
+            payload.school_framework = text(match.school);
+            payload.is_new_client = false;
+          }
+        }
+      }
+
       const validationError = validatePayload(payload, statusOverride);
       if (validationError) {
         if (errorEl) errorEl.textContent = validationError;
@@ -1197,7 +1268,6 @@ export const proposalsAgreementsScreen = {
     root.addEventListener('click', async (event) => {
       const rowEl = event.target.closest?.('[data-pa-row-id]');
       if (rowEl) {
-        closeAllActivityDropdowns();
         const row = data.rows.find((item) => text(item.id) === text(rowEl.dataset.paRowId));
         const drawer = root.querySelector('[data-pa-drawer]');
         if (drawer && row) {
@@ -1237,7 +1307,7 @@ export const proposalsAgreementsScreen = {
           } catch { items = []; }
           host.innerHTML = formHtml('edit', row, activityNameOptions, contactOptions, items, proposalActivityPricing);
           setDocumentEditMode(root, false);
-          setupActivityPickers(host);
+          setupTypeChangeHandler(host);
           setupClientSelector(host);
           setupItemCalc(host);
           const pickerHost = host.querySelector('[data-pa-contact-picker-host]');
@@ -1263,8 +1333,9 @@ export const proposalsAgreementsScreen = {
         }));
         const host = root.querySelector('[data-pa-inline-form]');
         if (!host) return;
+        const isCustom = Array.isArray(row.custom_document_sections) && row.custom_document_sections.length > 0;
         host.innerHTML = `<div class="ds-pa-form ds-pa-doc-edit-form" data-pa-doc-edit-wrap>
-          <h4>עריכת מסמך</h4>${documentSectionsEditorHtml(workingSections)}
+          <h4>עריכת מסמך</h4>${documentSectionsEditorHtml(workingSections, isCustom)}
           <div class="ds-pa-form-actions">
             <button type="button" class="ds-btn ds-btn--sm ds-btn--primary" data-pa-doc-save="${escapeHtml(id)}">שמירת עריכת מסמך</button>
             <button type="button" class="ds-btn ds-btn--sm" data-pa-doc-reset="${escapeHtml(id)}">איפוס לתבנית מקור</button>
@@ -1378,44 +1449,17 @@ export const proposalsAgreementsScreen = {
         return;
       }
 
-      const toggleBtn = event.target.closest?.('[data-pa-activity-toggle]');
-      if (toggleBtn) {
-        const picker = toggleBtn.closest('[data-pa-activity-picker]');
-        const dropdown = picker?.querySelector('[data-pa-activity-dropdown]');
-        const isOpen = dropdown && !dropdown.hidden;
-        closeAllActivityDropdowns();
-        if (dropdown && !isOpen) {
-          dropdown.hidden = false;
-          toggleBtn.setAttribute('aria-expanded', 'true');
-          picker.querySelector('[data-pa-activity-search]')?.focus();
-        }
-        return;
-      }
-
-      const chipRemoveBtn = event.target.closest?.('[data-pa-chip-remove]');
-      if (chipRemoveBtn) {
-        const picker = chipRemoveBtn.closest('[data-pa-activity-picker]');
-        const targetValue = text(chipRemoveBtn.dataset.paChipRemove);
-        const checkbox = Array.from(picker?.querySelectorAll('.ds-pa-activity-option input[type="checkbox"]') || [])
-          .find((cb) => text(cb.value) === targetValue);
-        if (checkbox) {
-          checkbox.checked = false;
-          checkbox.dispatchEvent(new Event('change', { bubbles: true }));
-        }
-        return;
-      }
-
-      if (!event.target.closest?.('[data-pa-activity-picker]')) closeAllActivityDropdowns();
-
       // Items: add row
       const addItemBtn = event.target.closest?.('[data-pa-add-item]');
       if (addItemBtn) {
         const form = addItemBtn.closest('[data-pa-form]');
-        const tbody = form?.querySelector('[data-pa-items-body]');
+        const groupKey = text(addItemBtn.dataset.paAddItemGroup);
+        const groupSection = groupKey ? form?.querySelector(`[data-pa-items-group="${groupKey}"]`) : null;
+        const tbody = groupSection?.querySelector('[data-pa-items-body]') || form?.querySelector('[data-pa-items-body]');
         if (!tbody) return;
-        const idx = tbody.querySelectorAll('[data-pa-item-row]').length;
-        const tmp = document.createElement('tbody');
-        tmp.innerHTML = itemRowHtml({}, idx, proposalActivityPricing);
+        const idx = form ? form.querySelectorAll('[data-pa-item-row]').length : 0;
+        const tmp = document.createElement('div');
+        tmp.innerHTML = itemRowHtml({ proposal_group: groupKey }, idx, proposalActivityPricing);
         tbody.appendChild(tmp.firstElementChild);
         if (form) calcGrandTotal(form);
         tbody.querySelector(`[data-pa-item-idx="${idx}"] [name="item_name"]`)?.focus();

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10561,6 +10561,28 @@ select.ds-input {
   font-size: 0.72rem; color: var(--ds-color-text-muted, #64748b); font-weight: 600;
 }
 
+/* Combined items sections */
+.ds-pa-items-combined { display: flex; flex-direction: column; gap: 10px; }
+.ds-pa-items-section--group {
+  border: 1px solid var(--ds-color-border-subtle, #e2e8f0);
+  border-radius: 6px; padding: 8px 10px;
+}
+.ds-pa-items-section-label {
+  font-size: 0.78rem; color: var(--ds-color-text-muted, #64748b); font-weight: 700;
+}
+
+/* Document sections custom/template indicator */
+.ds-pa-doc-indicator {
+  font-size: 0.78rem; padding: 4px 8px; border-radius: 4px;
+  margin: 0 0 8px; display: flex; align-items: center; gap: 4px;
+}
+.ds-pa-doc-indicator--custom {
+  background: #ede9fe; color: #5b21b6; border: 1px solid #c4b5fd;
+}
+.ds-pa-doc-indicator--template {
+  background: #f0fdf4; color: #166534; border: 1px solid #86efac;
+}
+
 /* ═══════════════════════════════════════════════════════════════════
    Proposals – Preview overlay
    ═══════════════════════════════════════════════════════════════════ */
@@ -10579,16 +10601,16 @@ select.ds-input {
   direction: rtl;
   width: 794px;
   max-width: 100%;
-  min-height: 297mm;
+  min-height: 1123px; /* ~297mm at 96dpi */
   margin: 24px auto 48px;
-  padding: 36px 58px 18mm;
-  font-family: Arial, "Noto Sans Hebrew", sans-serif;
+  padding: 54px 72px 68px;
+  font-family: Arial, "Noto Sans Hebrew", "David", sans-serif;
   font-size: 10pt;
-  line-height: 1.5;
-  letter-spacing: 0.15px;
-  box-shadow: none;
+  line-height: 1.6;
+  letter-spacing: 0.1px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.13), 0 1px 4px rgba(0,0,0,0.07);
   border: none;
-  border-radius: 0;
+  border-radius: 2px;
   display: flex;
   flex-direction: column;
 }
@@ -10596,22 +10618,22 @@ select.ds-input {
   margin-bottom: 8px;
 }
 .pa-doc-topline {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  align-items: start;
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  align-items: flex-start;
   margin-top: 4pt;
-  margin-bottom: 8pt;
+  margin-bottom: 10pt;
 }
 .pa-doc-header-brand {
   text-align: right;
-  justify-self: end;
 }
 .pa-doc-logo {
   display: block; max-width: 100%; height: auto;
 }
 .pa-doc-logo--header {
-  width: 155px;
-  max-width: 32%;
+  width: 160px;
+  max-width: 38%;
   margin-inline: 0;
 }
 .pa-doc-logo--footer {
@@ -10623,43 +10645,43 @@ select.ds-input {
   transform: none;
 }
 .pa-doc-date {
-  justify-self: start;
-  color: #111827;
-  font-size: 9pt;
+  color: #374151;
+  font-size: 9.5pt;
   line-height: 1.5;
   text-align: left;
   direction: ltr;
   margin-bottom: 4pt;
+  align-self: flex-start;
 }
 .pa-doc-address {
-  margin: 0;
+  margin: 0 0 6pt;
   font-size: 10pt;
-  line-height: 1.5;
+  line-height: 1.7;
   text-align: right;
-  margin-bottom: 4pt;
 }
-.pa-doc-address p { margin: 0 0 2px; }
+.pa-doc-address p { margin: 0; }
 .pa-doc-divider {
   border: none;
-  border-top: 1px solid #444;
-  margin: 10px 0 14px;
+  border-top: 1.5px solid #1f4e79;
+  margin: 10pt 0 12pt;
 }
 .pa-doc-subject {
-  margin: 10pt 0 8pt;
+  margin: 12pt 0 10pt;
   color: #1f4e79;
-  font-size: 11pt;
+  font-size: 12pt;
   font-weight: 700;
   text-decoration: underline;
   line-height: 1.5;
   text-align: center;
+  letter-spacing: 0.2px;
 }
 .pa-section {
-  margin: 8pt 0;
+  margin: 10pt 0 6pt;
   break-inside: avoid;
   page-break-inside: avoid;
 }
 .pa-section h3 {
-  font-size: 10pt;
+  font-size: 10.5pt;
   break-after: avoid;
   page-break-after: avoid;
   font-weight: 700;
@@ -10744,14 +10766,14 @@ select.ds-input {
     width: calc(100vw - 16px);
     min-height: auto;
     margin: 12px auto 28px;
-    padding: 34px 28px;
+    padding: 34px 22px 44px;
   }
 
   .pa-doc-header {
     margin-bottom: 6px;
   }
   .pa-doc-topline {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     gap: 8px;
   }
 }
@@ -10761,8 +10783,8 @@ select.ds-input {
    ═══════════════════════════════════════════════════════════════════ */
 @media print {
   @page {
-    size: A4;
-    margin: 18mm 16mm;
+    size: A4 portrait;
+    margin: 20mm 18mm 22mm;
   }
 
   html,
@@ -10770,21 +10792,33 @@ select.ds-input {
     background: #fff !important;
     margin: 0 !important;
     padding: 0 !important;
+    font-size: 10pt !important;
   }
 
+  /* Hide everything except the preview overlay */
+  body > *:not(#pa-preview-overlay) {
+    display: none !important;
+  }
   body * {
     visibility: hidden !important;
   }
-
   #pa-preview-overlay,
   #pa-preview-overlay * {
     visibility: visible !important;
   }
 
+  .no-print,
+  #pa-preview-overlay .ds-pa-preview-toolbar,
+  #pa-preview-overlay button,
+  #pa-preview-overlay .ds-btn {
+    display: none !important;
+    visibility: hidden !important;
+  }
+
   #pa-preview-overlay {
     position: static !important;
     inset: auto !important;
-    width: auto !important;
+    width: 100% !important;
     height: auto !important;
     overflow: visible !important;
     background: #fff !important;
@@ -10794,43 +10828,90 @@ select.ds-input {
     box-shadow: none !important;
   }
 
-  #pa-preview-overlay .pa-preview-toolbar,
-  #pa-preview-overlay .ds-pa-preview-toolbar,
-  #pa-preview-overlay button,
-  #pa-preview-overlay .ds-btn,
-  #pa-preview-overlay [data-pa-print],
-  #pa-preview-overlay [data-pa-preview-close] {
-    display: none !important;
-  }
-
   .ds-pa-preview-doc {
     position: static !important;
-    width: auto !important;
+    width: 100% !important;
     max-width: none !important;
-    min-height: 297mm !important;
+    min-height: 0 !important;
     margin: 0 !important;
-    padding: 0 0 14mm !important;
-    display: flex !important;
-    flex-direction: column !important;
+    padding: 0 !important;
+    display: block !important;
     box-shadow: none !important;
     border: none !important;
-    background: #fff !important;
-    color: #111827 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    color: #000 !important;
     direction: rtl !important;
-    font-family: Arial, "Noto Sans Hebrew", sans-serif !important;
+    font-family: Arial, "Noto Sans Hebrew", "David", sans-serif !important;
     font-size: 10pt !important;
+    line-height: 1.55 !important;
+    letter-spacing: 0.1px !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .pa-doc-header {
+    margin-bottom: 6pt !important;
+  }
+
+  .pa-doc-topline {
+    display: flex !important;
+    flex-direction: row-reverse !important;
+    justify-content: space-between !important;
+    align-items: flex-start !important;
+    margin-top: 0 !important;
+    margin-bottom: 8pt !important;
+  }
+
+  .pa-doc-logo--header {
+    width: 140px !important;
+    max-width: 35% !important;
+    height: auto !important;
+    display: block !important;
+  }
+
+  .pa-doc-date {
+    font-size: 9pt !important;
+    text-align: left !important;
+    direction: ltr !important;
     line-height: 1.5 !important;
-    letter-spacing: 0.15px !important;
+    color: #374151 !important;
+    align-self: flex-start !important;
+  }
+
+  .pa-doc-address {
+    text-align: right !important;
+    direction: rtl !important;
+    font-size: 10pt !important;
+    line-height: 1.65 !important;
+    margin-bottom: 4pt !important;
+  }
+  .pa-doc-address p { margin: 0 !important; }
+
+  .pa-doc-divider {
+    border: none !important;
+    border-top: 1.5px solid #1f4e79 !important;
+    margin: 8pt 0 10pt !important;
+  }
+
+  .pa-doc-subject {
+    text-align: center !important;
+    font-size: 11.5pt !important;
+    font-weight: 700 !important;
+    color: #1f4e79 !important;
+    text-decoration: underline !important;
+    margin: 10pt 0 8pt !important;
+    line-height: 1.5 !important;
   }
 
   .pa-section {
-    margin: 8pt 0 !important;
+    margin: 8pt 0 4pt !important;
     break-inside: avoid !important;
     page-break-inside: avoid !important;
   }
 
   .pa-section h3 {
-    font-size: 10pt !important;
+    font-size: 10.5pt !important;
     break-after: avoid !important;
     page-break-after: avoid !important;
     font-weight: 700 !important;
@@ -10840,20 +10921,25 @@ select.ds-input {
     line-height: 1.5 !important;
   }
 
+  .pa-doc-intro,
   .pa-section-body,
   .pa-section-line,
-  .pa-doc-intro,
   .pa-proposal-lines {
     font-size: 10pt !important;
-    line-height: 1.5 !important;
+    line-height: 1.55 !important;
+    color: #000 !important;
   }
 
   .pa-section-line {
-    margin: 0 0 4pt !important;
+    display: block !important;
+    margin: 0 0 3pt !important;
+  }
+
+  .pa-section-line--empty {
+    margin: 0 0 2pt !important;
   }
 
   .pa-section-line--bullet {
-    margin: 0 0 3pt !important;
     padding-right: 14pt !important;
     text-indent: -10pt !important;
     word-break: break-word !important;
@@ -10861,57 +10947,31 @@ select.ds-input {
     page-break-inside: avoid !important;
   }
 
-  .pa-doc-date {
-    font-size: 9pt !important;
-    text-align: left !important;
-    direction: ltr !important;
-    line-height: 1.5 !important;
-  }
-
-  .pa-doc-address {
-    text-align: right !important;
-    direction: rtl !important;
-    font-size: 10pt !important;
-  }
-
-  .pa-doc-subject {
-    text-align: center !important;
-    font-size: 11pt !important;
-    font-weight: 700 !important;
-    color: #1f4e79 !important;
-    text-decoration: underline !important;
-    margin: 10pt 0 8pt !important;
-  }
-
-  .pa-doc-logo--header {
-    width: 155px !important;
-    max-width: 32% !important;
-    height: auto !important;
-    display: block !important;
-  }
-
-  .pa-doc-footer {
-    margin-top: auto !important;
-    width: 100% !important;
-    padding-top: 10mm !important;
-    display: flex !important;
-    justify-content: center !important;
-    align-items: center !important;
-  }
-
-  .pa-doc-logo--footer {
-    width: auto !important;
-    max-width: 48mm !important;
-    height: auto !important;
-    opacity: 0.95 !important;
-    display: block !important;
-    transform: none !important;
-  }
-
   .pa-doc-signature-simple {
     text-align: left !important;
     font-size: 9pt !important;
     line-height: 1.5 !important;
-    margin-top: 8pt !important;
+    margin-top: 10pt !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+  }
+
+  .pa-doc-footer {
+    margin-top: 16pt !important;
+    width: 100% !important;
+    padding-top: 8pt !important;
+    border-top: 0.5px solid #e2e8f0 !important;
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+    break-inside: avoid !important;
+  }
+
+  .pa-doc-logo--footer {
+    width: auto !important;
+    max-width: 44mm !important;
+    height: auto !important;
+    display: block !important;
+    opacity: 0.9 !important;
   }
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 450;
+const CACHE_VERSION = 451;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 446;
+const SW_ENTRY_VERSION = 451;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
…ient dedup, indicators

- Remove the checkbox-based activity picker from the proposal form; item rows are now the sole source of activity names
- Two-section combined form: when type is "קיץ תשפ״ו + תשפ״ז" the items editor renders separate summer and next-year sections; adding items in each section auto-assigns proposal_group; switching type re-renders the items host in place
- Client dedup: normalizeForDedup + findSimilarClients check for similar authority/school on save and prompt the user before creating a duplicate
- Custom document sections badge in the drawer (purple "מסמך מותאם")
- documentSectionsEditorHtml shows template-vs-custom indicator with a reset-to-template note
- Combined proposal validation: warns when items are missing proposal_group before sending for approval
- A4 CSS rebuild: proper flex header layout (logo right, date left), 1123px min-height, better padding and shadows in preview, improved @media print with correct @page margins, section spacing, footer border
- Bump CACHE_VERSION 450→451, SW_ENTRY_VERSION 446→451

https://claude.ai/code/session_01P5SFTUfKLXXX8aMQKXPCtM