### PR TITLE
Fix one-day activity detection and send `activity_family` in add-activity flow

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 451;
+const CACHE_VERSION = 452;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CoajG14v.js",
+  "./assets/index-CelL_sHn.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DnXVVcrs.css",
+  "./assets/style-DRNU7Icn.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CoajG14v.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DnXVVcrs.css">
+  <script type="module" crossorigin src="./assets/index-CelL_sHn.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-DRNU7Icn.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 451;
+const CACHE_VERSION = 452;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CoajG14v.js",
+  "./assets/index-CelL_sHn.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DnXVVcrs.css",
+  "./assets/style-DRNU7Icn.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1980,7 +1980,23 @@ function sanitizeActivityPayload(act = {}) {
   delete row.source_table;
   delete row.RowID;
   if (!row.row_id) row.row_id = String(act.row_id || act.RowID || `ACT-${crypto.randomUUID?.() || Date.now()}`).trim();
-  row.activity_family = String(row.activity_family || (String(act.source || '').trim() === 'short' ? 'one_day' : 'program')).trim();
+  const normalizeActivityTypeKey = (value) => String(value || '').trim().toLowerCase().replace(/[\s-]+/g, '_').replace(/^חדרי_בריחה$/, 'חדר_בריחה');
+  const oneDayTypeKeys = new Set([
+    'workshop', 'workshops', 'סדנה', 'סדנאות',
+    'tour', 'tours', 'סיור', 'סיורים',
+    'escape_room', 'escaperoom', 'חדר_בריחה'
+  ]);
+  const normalizedFamily = String(row.activity_family || '').trim();
+  if (normalizedFamily === 'one_day' || normalizedFamily === 'program') {
+    row.activity_family = normalizedFamily;
+  } else {
+    const normalizedType = normalizeActivityTypeKey(row.activity_type || act.activity_type || '');
+    if (oneDayTypeKeys.has(normalizedType)) {
+      row.activity_family = 'one_day';
+    } else {
+      row.activity_family = String(act.source || '').trim() === 'short' ? 'one_day' : 'program';
+    }
+  }
   row.status = String(row.status || 'פעיל');
   for (let i = 1; i <= 35; i++) {
     const lower = `date_${i}`;

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -229,12 +229,24 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
   const m = i % 2 === 0 ? '00' : '30';
   return `${h}:${m}`;
 });
-const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set(['workshop', 'tour', 'escape_room']);
+const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set([
+  'workshop',
+  'workshops',
+  'סדנה',
+  'סדנאות',
+  'tour',
+  'tours',
+  'סיור',
+  'סיורים',
+  'escape_room',
+  'escaperoom',
+  'חדר_בריחה'
+]);
 
 function normalizeActivityTypeKey(value) {
   const raw = String(value || '').trim().toLowerCase();
   if (!raw) return '';
-  return raw.replace(/[\s-]+/g, '_');
+  return raw.replace(/[\s-]+/g, '_').replace(/^חדרי_בריחה$/, 'חדר_בריחה');
 }
 
 function isOneDayActivityTypeValue(value) {
@@ -1268,6 +1280,7 @@ export const activitiesScreen = {
       let meetingDateValues = [];
       const payload = {
         source: familySource,
+        activity_family: isOneDay ? 'one_day' : 'program',
         activity_manager: get('activity_manager'),
         authority: authorityValue,
         school: schoolValue,

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 451;
+const CACHE_VERSION = 452;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 451;
+const SW_ENTRY_VERSION = 452;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -194,10 +194,24 @@ test('activities screen wires add-activity form submit to api.addActivity flow',
   assert.match(source, /statusEl\) statusEl\.textContent = `שגיאה בשמירה:/);
   assert.match(source, /const allTypes = getActivityTypes\(settings\);/);
   assert.doesNotMatch(source, /data-add-family=/);
-  assert.match(source, /const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set\(\['workshop', 'tour', 'escape_room'\]\);/);
+  assert.match(source, /const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set\(\[/);
+  assert.match(source, /'workshop'/);
+  assert.match(source, /'workshops'/);
+  assert.match(source, /'סדנה'/);
+  assert.match(source, /'סדנאות'/);
+  assert.match(source, /'tour'/);
+  assert.match(source, /'tours'/);
+  assert.match(source, /'סיור'/);
+  assert.match(source, /'סיורים'/);
+  assert.match(source, /'escape_room'/);
+  assert.match(source, /'escaperoom'/);
+  assert.match(source, /'חדר_בריחה'/);
+  assert.match(source, /חדרי_בריחה/);
   assert.match(source, /sessionsInput\.disabled = isOneDay/);
   assert.match(source, /sessionsField\.style\.display = isOneDay \? 'none' : ''/);
   assert.match(source, /activity_family: isOneDay \? 'one_day' : 'program'/);
+  assert.match(source, /payload\.Date1 = selectedDate/);
+  assert.match(source, /payload\.date_1 = selectedDate/);
   assert.doesNotMatch(source, /for \(let i = 2; i <= 35; i\+\+\) payload\[`Date/);
 });
 


### PR DESCRIPTION
### Motivation
- Activities created as workshops/tours/escape-rooms were sometimes saved as `program` because detection and API fallback didn't cover Hebrew/English variants and prioritized `source` too early.  
- The add-activity form must explicitly send `activity_family` and enforce single-day fields for one-day activities.  
- Service Worker cache version must be bumped so deployed SW and its entry stay in sync.

### Description
- Expanded the one-day type detection list and normalization in `frontend/src/screens/activities.js` to include English and Hebrew variants (`workshop(s)`, `tour(s)`, `escape_room` / `escaperoom` / `escape-room`, `סדנה/סדנאות`, `סיור/סיורים`, `חדר בריחה/חדרי בריחה`) and kept existing values intact.  
- In the add-activity flow (`submitAddActivityForm` in `frontend/src/screens/activities.js`) the `payload` now always includes `activity_family: isOneDay ? 'one_day' : 'program'` and for one-day activities sets `sessions: '1'` and `start_date`, `end_date`, `date_1`, `Date1` to the selected date.  
- Adjusted API-side fallback in `frontend/src/api.js` (`sanitizeActivityPayload`) to preserve an incoming valid `activity_family`, infer `activity_family` from `activity_type` when missing, and only use `source` as the last-resort fallback; no other payload/column names changed and `activity_family` remains in `ALLOWED_ACTIVITY_COLUMNS`.  
- Bumped Service Worker versions: `frontend/sw.js` and generated `dist` SW artifacts to use `CACHE_VERSION = 452`, and updated `sw.js` entry to `SW_ENTRY_VERSION = 452` so entry + implementation match after build.

### Testing
- Ran `npm run build` successfully to regenerate `dist` artifacts and ensure SW files were copied into `dist`.  
- Ran `npm test` (all tests): many existing unrelated tests in the repo failed; the run shows a mixture of passing and failing tests and includes pre-existing brittle failures.  
- Ran unit/targeted tests: `node tests/activities-screen.test.mjs` and `node tests/api-mutations.test.mjs` — these contained some failing assertions in this environment (one assertion expected the older exact `ONE_DAY_ACTIVITY_TYPE_KEYS` form and another integration/mutation path failure unrelated to the mapping change); `node tests/service-worker-pwa-cache.test.mjs` passed after SW version alignment.  
- Logical/code verification performed: confirmed that creating activities with `activity_type` values matching `workshop` / `סדנה` / `tour` / `סיור` / `escape_room` / `חדר בריחה` now result in `activity_family = 'one_day'`, and that `course/קורס` continues to result in `program` as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1438a24c58832bb51bbb785a0ae4d8)