### PR TITLE
Fix activity delete UX flow and cache invalidation

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1318,6 +1318,7 @@ function invalidateScreenDataByAction(action) {
   const targetedMutations = {
     saveActivity: ['activities:', 'activityDetail:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     addActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
+    deleteActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'archive', 'end-dates', 'exceptions:'],
     submitEditRequest: ['activities:', 'edit-requests', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'end-dates'],
     reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:', 'exceptions:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:'],
     addUser: ['permissions', 'dashboard:'],

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -894,6 +894,17 @@ export const activitiesScreen = {
       return true;
     };
     const patchLocalRowFromSave = ({ sourceRowId, changes }) => {
+      const normalizedStatus = String(changes?.status || '').trim();
+      if (normalizedStatus === 'נמחק') {
+        const rowId = String(sourceRowId || '');
+        const removeByRowId = (arr) => {
+          const idx = arr.findIndex((row) => String(row?.RowID || '') === rowId);
+          if (idx >= 0) arr.splice(idx, 1);
+        };
+        removeByRowId(activitiesRows);
+        removeByRowId(filteredRows);
+        return;
+      }
       if (!upsertLocalRow(sourceRowId, changes || {})) return;
       const summaryHit = filteredRows.find((row) => String(row?.RowID || '') === String(sourceRowId || ''));
       if (summaryHit) Object.assign(summaryHit, changes || {});

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -175,6 +175,7 @@ function hasMeetingDatesChanged(form, initialValues = {}) {
 
 export function bindActivityEditForm(contentRoot, {
   api,
+  ui,
   clearScreenDataCache,
   rerender,
   onRowSaved,
@@ -368,6 +369,7 @@ export function bindActivityEditForm(contentRoot, {
           .then(async () => {
             showToast('הפעילות הוסרה מהמסכים הפעילים', 'success', 2400);
             clearScreenDataCache?.();
+            ui?.closeDrawer?.();
             if (typeof onSaveSuccess === 'function') {
               await onSaveSuccess({ sourceSheet: form.getAttribute('data-source-sheet') || '', sourceRowId: rowId, changes: { status: 'נמחק' }, form, contentRoot });
             } else if (typeof rerender === 'function') {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 452;
+const CACHE_VERSION = 453;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- לשפר את חוויית המשתמש אחרי מחיקת פעילות כך שה-drawer נסגר מיד והפעילות תיעלם מהממשק מבלי לרענון ידני, מבלי לשנות את סוג המחיקה ב-DB (להישאר soft-delete).
- לוודא שה-cache הרלוונטי מתנקה אחרי המחיקה כדי שמסכים אחרים יתעדכנו במהירות.

### Description
- הוספת פרמטר `ui` ל-`bindActivityEditForm` וקריאה ל-`ui.closeDrawer()` מיד לאחר הצלחת `api.deleteActivity` כדי לסגור את drawer מיד לאחר מחיקה (`frontend/src/screens/shared/bind-activity-edit-form.js`).
- עדכון ה-logics בצד הלקוח כדי להסיר רשומה מהערכים המקומיים `activitiesRows` ו-`filteredRows` כאשר השדה `status` הופך ל-`נמחק`, כך שהשורה נעלמת מהממשק ללא רענון (`frontend/src/screens/activities.js`).
- הוספת כניסת `deleteActivity` למפת invalidation ב-`invalidateScreenDataByAction` עם prefixes של המפתחות המבוקשים כדי לנקות cache רלוונטי אחרי פעולה זו (`frontend/src/api.js`).
- העלאת `CACHE_VERSION` ב-service worker כדי לאלץ לקוחות לקבל את השינויים מיד אחרי הפריסה (`frontend/sw.js`).

### Testing
- רצתה את הסדרה האוטומטית עם `npm test --silent`.
- נכשלו הטסטים הבאים (שם הטסט — שגיאה):
  - `activities render: operation_manager sees add activity button` — `test failed`
  - `load activities-snapshot.gs source` — `test failed`
  - `safeCellValue_ function is defined in activities-snapshot.gs` — `test failed`
  - `safeJsonArrayCell_ function is defined in activities-snapshot.gs` — `test failed`
  - `safeCellValue_: caps at 45000 chars` — `test failed`
  - `safeCellValue_: appends TRUNCATED marker on overflow` — `test failed`
  - `safeCellValue_: calls Logger.log on truncation` — `test failed`
  - `safeJsonArrayCell_: uses binary search (lo/hi/mid pattern)` — `test failed`
  - `safeJsonArrayCell_: calls Logger.log on truncation` — `test failed`
  - `safeJsonArrayCell_: returns [] for empty input` — `test failed`
  - `refreshActivitiesSnapshot_: uses safeCellValue_ for activity_type_counts` — `test failed`
  - `refreshActivitiesSnapshot_: uses safeJsonArrayCell_ for rows` — `test failed`
  - `refreshActivitiesSnapshot_: does NOT use raw JSON.stringify for rows` — `test failed`
  - `addActivity supports object payload (short)` — `save_failed`
  - `addActivity supports (target, data) signature for long source` — `save_failed`
  - `saveActivity sends source_sheet, source_row_id and changes in direct-edit flow` — `save_failed`
  - `submitEditRequest and reviewEditRequest send correct payloads` — `submit_edit_request_failed`
  - `read-model rollout excludes finance from normal paths and keeps end-dates` — `activities_date_range_read_failed`
  - `perf request marks slow=true for API calls longer than 3000ms` — `test failed`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1471172dd8832b978e1c104009703a)