### PR TITLE
מחיקה רק במצב עריכה, כרטיסי חריגות מקוצצים וניווט אחיד (פעילויות/שבוע/חודש)

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -37,6 +37,7 @@ import {
 } from './shared/activity-options.js';
 import { readActivitiesGapFromQuery, syncActivitiesGapQuery, isActivitiesGapQueryValue } from './shared/route-query.js';
 import { rowMatchesActivityGapFilter } from './shared/activity-gap-filter.js';
+import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shared/view-switcher.js';
 
 const inflightActivityDetailRequests = new Map();
 
@@ -818,11 +819,7 @@ export const activitiesScreen = {
 
     const isNavLoading = !!state.activitiesNavLoading;
     const navLoadingChip = isNavLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : '';
-    const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
-    const viewSwitcher = (availableRoutes.has('week') || availableRoutes.has('month')) ? `<div class="ds-activities-view-switcher" dir="rtl">
-      ${availableRoutes.has('week') ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--accent ds-activities-view-btn" data-activities-go-route="week" title="מעבר לתצוגת שבוע">שבוע</button>` : ''}
-      ${availableRoutes.has('month') ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--accent ds-activities-view-btn" data-activities-go-route="month" title="מעבר לתצוגת חודש">חודש</button>` : ''}
-    </div>` : '';
+    const viewSwitcher = renderActivitiesViewSwitcher(state, 'activities');
     const mainToolbar = `<div class="ds-activities-main-toolbar" dir="rtl" data-local-filters="${ACTIVITIES_SCOPE}">
       <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="חיפוש" aria-label="חיפוש פעילויות" title="חיפוש לפי פעילות / מדריך / רשות / בית ספר" />
       ${bareFilters}
@@ -905,12 +902,7 @@ export const activitiesScreen = {
       else rerender();
     };
 
-    root.querySelectorAll('[data-activities-go-route]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const route = btn.dataset.activitiesGoRoute;
-        if (route) { state.route = route; rerender?.(); }
-      });
-    });
+    bindActivitiesViewSwitcher(root, state, rerender);
 
     const upsertLocalRow = (rowId, patch) => {
       const hit = activitiesRows.find((row) => String(row?.RowID || '') === String(rowId || ''));

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -87,14 +87,16 @@ function exceptionsOperationalSummaryHtml(data, rows) {
   });
 }
 
-function exceptionGroupCard(title, rows, { canDelete = false } = {}) {
-  const body = rows.length === 0
-    ? dsEmptyState('אין פריטים בקבוצה זו')
-    : `<div class="ds-compact-list">${rows.map((row) => {
-      const chips = normalizedExceptionTypes(row).map((type) => dsStatusChip(hebrewExceptionType(type), 'neutral')).join(' ');
-      return `<div data-list-item class="ds-exception-list-item"><button type="button" class="ds-interactive-card ds-interactive-card--session" data-card-action="${escapeHtml(`exception:${row.RowID}`)}"><p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p><p class="ds-interactive-card__subtitle">${escapeHtml([row.activity_type, row.authority, row.school].filter(Boolean).join(' · '))}</p><p class="ds-interactive-card__subtitle">${escapeHtml(`מנהל פעילות: ${activityManagerDisplayName(row.activity_manager) || '—'}`)}</p><p class="ds-interactive-card__subtitle">${escapeHtml(`מדריך: ${row.instructor_name || row.instructor_name_2 || '—'}`)}</p><p class="ds-interactive-card__subtitle">${escapeHtml(`התחלה: ${formatDateHe(row.start_date) || row.start_date || '—'} | סיום: ${formatDateHe(row.end_date) || row.end_date || '—'}`)}</p><p class="ds-interactive-card__subtitle">${escapeHtml(`סטטוס: ${row.status || '—'}`)}</p>${chips ? `<div class="ds-row" style="gap:6px;flex-wrap:wrap">${chips}</div>` : ''}</button>${canDelete ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-exception-delete="${escapeHtml(String(row.RowID || ''))}" title="מחיקה רכה">מחיקה</button>` : ''}</div>`;
-    }).join('')}</div>`;
-  return dsCard({ title: `${title} · ${rows.length}`, body, padded: rows.length === 0 });
+function exceptionCardSubtitle(row) {
+  const meta = [String(row?.authority || '').trim(), String(row?.school || '').trim()].filter(Boolean);
+  return meta.length ? meta.join(' · ') : 'ללא רשות / בית ספר';
+}
+
+function exceptionGroupCard(title, rows) {
+  const body = `<div class="ds-compact-list">${rows.map((row) =>
+    `<div data-list-item class="ds-exception-list-item"><button type="button" class="ds-interactive-card ds-interactive-card--session" data-card-action="${escapeHtml(`exception:${row.RowID}`)}"><p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p><p class="ds-interactive-card__subtitle">${escapeHtml(exceptionCardSubtitle(row))}</p></button></div>`
+  ).join('')}</div>`;
+  return dsCard({ title: `${title} · ${rows.length}`, body, padded: false });
 }
 
 function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, canRequestEdit, canDeleteActivity, hideEmpIds, hideRowId, hideActivityNo, settings) {
@@ -184,17 +186,19 @@ export const exceptionsScreen = {
     const noInstructorRows = allRows.filter((row) => normalizedExceptionTypes(row).includes('missing_instructor'));
     const mainTypes = new Set(['missing_start_date', 'late_end_date', 'end_date_passed', 'missing_instructor']);
     const otherExceptionRows = allRows.filter((row) => normalizedExceptionTypes(row).some((type) => !mainTypes.has(type)));
-    const compact = visibleRows.length === 0 ? dsEmptyState('לא נמצאו חריגות') : '';
-    const canDeleteActivity = ['admin', 'operation_manager'].includes(String(state?.user?.display_role || state?.user?.role || '').trim());
+    const hasAnyRows = allRows.length > 0;
+    const groups = [
+      { title: 'פעילויות ממתינות לתיאום תאריך', rows: waitingDateRows },
+      { title: 'פעילויות עם חריגת תאריך סיום', rows: endDateExceptionRows },
+      { title: 'פעילויות ללא מדריך', rows: noInstructorRows },
+      ...(otherExceptionRows.length ? [{ title: 'חריגות נוספות', rows: otherExceptionRows }] : [])
+    ].filter((group) => group.rows.length > 0);
 
     return dsScreenStack(`
       ${toolbarHtml}
       <section>${exceptionsOperationalSummaryHtml(data, allRows)}</section>
-      <section>${dsCard({ title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''} · סה״כ פעילויות חריגות: ${escapeHtml(String(data?.totalExceptionRows ?? total))}`, body: compact || loadMoreHtml, padded: visibleRows.length === 0 })}</section>
-      <section>${exceptionGroupCard('פעילויות ממתינות לתיאום תאריך', waitingDateRows, { canDelete: canDeleteActivity })}</section>
-      <section>${exceptionGroupCard('פעילויות עם חריגת תאריך סיום', endDateExceptionRows, { canDelete: canDeleteActivity })}</section>
-      <section>${exceptionGroupCard('פעילויות ללא מדריך', noInstructorRows, { canDelete: canDeleteActivity })}</section>
-      ${otherExceptionRows.length ? `<section>${exceptionGroupCard('חריגות נוספות', otherExceptionRows, { canDelete: canDeleteActivity })}</section>` : ''}
+      ${hasAnyRows ? `<section>${dsCard({ title: `חריגות קורסים${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}`, body: loadMoreHtml, padded: false })}</section>` : ''}
+      ${!hasAnyRows ? `<section>${dsEmptyState('אין חריגות פעילות להצגה.')}</section>` : groups.map((group) => `<section>${exceptionGroupCard(group.title, group.rows)}</section>`).join('')}
     `);
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
@@ -326,25 +330,5 @@ export const exceptionsScreen = {
       }
     });
 
-    root.querySelectorAll('[data-exception-delete]').forEach((btn) => {
-      btn.addEventListener('click', async (ev) => {
-        ev.preventDefault();
-        ev.stopPropagation();
-        const rowId = String(btn.getAttribute('data-exception-delete') || '').trim();
-        if (!rowId) return;
-        const ok = window.confirm('האם למחוק את הפעילות? הפעילות תוסתר מהמסכים ולא תימחק פיזית מהמערכת.');
-        if (!ok) return;
-        btn.disabled = true;
-        try {
-          await api.deleteActivity(rowId);
-          clearScreenDataCache?.();
-          rerender();
-        } catch (_err) {
-          window.alert('הפעילות לא נמחקה. ייתכן שאין הרשאה או שהפעילות לא נמצאה.');
-        } finally {
-          btn.disabled = false;
-        }
-      });
-    });
   }
 };

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -13,6 +13,7 @@ import {
 } from './shared/activity-list-filters.js';
 import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { calendarMonthStorageKey } from '../state.js';
+import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shared/view-switcher.js';
 
 const inflightActivityDetailRequests = new Map();
 const inflightMonthRequests = new Map();
@@ -294,7 +295,9 @@ export const monthScreen = {
         ? `<div class="ds-empty" role="status" dir="rtl"><p class="ds-empty__msg">לא נמצאו פעילויות התואמות לסינון</p></div>`
         : '';
 
+    const viewSwitcher = renderActivitiesViewSwitcher(state, 'month');
     const html = dsScreenStack(`
+      ${viewSwitcher}
       <nav class="ds-cal-nav${navLoading ? ' is-nav-loading' : ''}" role="navigation" aria-label="ניווט חודשי" dir="rtl">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-month-prev aria-label="חודש קודם" title="חודש קודם" ${navLoading ? 'disabled' : ''}>▶</button>
         <span class="ds-cal-nav__label">${escapeHtml(monthTitle)} ${navLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>
@@ -311,6 +314,7 @@ export const monthScreen = {
     return html;
   },
   bind({ root, ui, data, state, rerender, clearScreenDataCache, api }) {
+    bindActivitiesViewSwitcher(root, state, rerender);
     root.classList.remove('is-month-loading');
     root.setAttribute('aria-busy', 'false');
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -363,7 +363,7 @@ export function bindActivityEditForm(contentRoot, {
         ev.preventDefault();
         const rowId = String(form.getAttribute('data-row-id') || '').trim();
         if (!rowId) return;
-        const ok = window.confirm('מחיקת פעילות מיועדת רק לפעילות שנוצרה בטעות או בכפילות. הפעילות תוסר מהמסכים הפעילים. להמשיך?');
+        const ok = window.confirm('האם למחוק את הפעילות? הפעילות תוסתר מהמסכים ולא תימחק פיזית מהמערכת.\n\nניתן יהיה לשחזר אותה רק דרך ניהול נתונים/הרשאות מתאימות.');
         if (!ok) return;
         api.deleteActivity(rowId)
           .then(async () => {
@@ -377,7 +377,7 @@ export function bindActivityEditForm(contentRoot, {
             }
           })
           .catch((err) => {
-            showToast(translateApiErrorForUser(err?.message || 'delete_activity_failed'), 'error', 3000);
+            showToast('הפעילות לא נמחקה. ייתכן שאין הרשאה או שהפעילות לא נמצאה.', 'error', 3000);
           });
         return;
       }

--- a/frontend/src/screens/shared/view-switcher.js
+++ b/frontend/src/screens/shared/view-switcher.js
@@ -1,0 +1,32 @@
+import { escapeHtml } from './html.js';
+
+const VIEW_SWITCH_ROUTES = [
+  { route: 'activities', label: 'פעילויות' },
+  { route: 'week', label: 'שבוע' },
+  { route: 'month', label: 'חודש' }
+];
+
+export function renderActivitiesViewSwitcher(state, activeRoute) {
+  const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
+  const buttons = VIEW_SWITCH_ROUTES
+    .filter(({ route }) => availableRoutes.has(route))
+    .map(({ route, label }) => {
+      const isActive = route === activeRoute;
+      return `<button type="button" class="ds-btn ds-btn--sm ds-btn--accent ds-activities-view-btn${isActive ? ' is-active' : ''}" data-route-switch="${escapeHtml(route)}" ${isActive ? 'aria-current="page"' : ''}>${escapeHtml(label)}</button>`;
+    });
+  if (buttons.length <= 1) return '';
+  return `<div class="ds-activities-view-switcher" dir="rtl" aria-label="מעבר בין תצוגות פעילות">${buttons.join('')}</div>`;
+}
+
+export function bindActivitiesViewSwitcher(root, state, rerender) {
+  root.querySelectorAll('[data-route-switch]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const route = String(btn.getAttribute('data-route-switch') || '').trim();
+      if (!route) return;
+      const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
+      if (!availableRoutes.has(route) || state.route === route) return;
+      state.route = route;
+      rerender();
+    });
+  });
+}

--- a/frontend/src/screens/week.js
+++ b/frontend/src/screens/week.js
@@ -13,6 +13,7 @@ import {
 } from './shared/activity-list-filters.js';
 import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { bindActNavGrid } from './shared/act-nav-grid.js';
+import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shared/view-switcher.js';
 
 const inflightActivityDetailRequests = new Map();
 const inflightWeekRequests = new Map();
@@ -269,7 +270,9 @@ export const weekScreen = {
 
     const navLoading = !!state.weekNavLoading;
     const navDirection = state.weekNavDirection === 'prev' ? ' week-transition is-entering-prev' : state.weekNavDirection === 'next' ? ' week-transition is-entering-next' : '';
+    const viewSwitcher = renderActivitiesViewSwitcher(state, 'week');
     const html = dsScreenStack(`
+      ${viewSwitcher}
       <nav class="ds-cal-nav${navLoading ? ' is-nav-loading' : ''}" role="navigation" aria-label="ניווט שבועי" dir="rtl">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-week-prev aria-label="שבוע קודם" title="שבוע קודם" ${navLoading ? 'disabled' : ''}>▶</button>
         <span class="ds-cal-nav__label">${escapeHtml(navLabel)} ${navLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : ''}</span>
@@ -299,6 +302,7 @@ export const weekScreen = {
     if (typeof bindActNavGrid === 'function') {
       bindActNavGrid(root, { state, rerender });
     }
+    bindActivitiesViewSwitcher(root, state, rerender);
     root.classList.remove('is-week-loading');
     root.setAttribute('aria-busy', 'false');
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 460;
+const CACHE_VERSION = 461;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 460;
+const SW_ENTRY_VERSION = 461;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- לתקן את הופעת כפתור המחיקה כך שיוצג רק בתוך מצב עריכה של פרטי הפעילות ולשמור על מנגנון המחיקה הקיים כ־soft-delete דרך `api.deleteActivity(rowId)`;\
- לשפר את UX של מסך החריגות על ידי הסרת כרטיסים ריקים וכפילויות מידע;\
- לאפשר ניווט ישיר ואחיד בין המסכים `activities` / `week` / `month` עם בדיקת הרשאות קיימת ובלי לשנות לוגיקת טעינת נתונים. 

### Description
- הוספת רכיב שיתוף ל־view switcher ב־`frontend/src/screens/shared/view-switcher.js` ושימוש בו ב־`activities.js`, `week.js` ו־`month.js` כדי לאפשר מעבר ישיר בין התצוגות באמצעות `state.route` ו־`rerender()` בלבד.\
- עדכון מסך החריגות (`frontend/src/screens/exceptions.js`) כך שכרטיס חיצוני יהיה קומפקטי ומכיל רק `שם פעילות` ו־`רשות · בית ספר`, קבוצות ריקות לא יוצגו, ובהיעדר חריגות מוצג מסר יחיד `אין חריגות פעילות להצגה.`; כפתורי מחיקה חיצוניים הוסרו מהכרטיסים.\
- ריכוז וחיזוק מיקום המחיקה בתוך טופס העריכה (drawer): בשיתוף `frontend/src/screens/shared/bind-activity-edit-form.js` נשמר השימוש ב־`api.deleteActivity(rowId)`, הותקן טקסט אישור/שגיאה מעודכן וההליך סוגר drawer, מנקה cache רלוונטי וגורם לרענון תצוגה לאחר מחיקה מוצלחת.\
- הוקפצו גרסאות ה־Service Worker / Cache (`SW_ENTRY_VERSION` ו־`CACHE_VERSION`) ב־`sw.js` ו־`frontend/sw.js` כדי לבטל מטמוני frontend אחרי הפריסה.\
- שינויים נקודתיים ושמירה על הלוגיקה ומנגנוני הטעינה הקיימים ללא ריפקטור רחב; קבצים בולטים: `frontend/src/screens/shared/view-switcher.js`, `frontend/src/screens/activities.js`, `frontend/src/screens/week.js`, `frontend/src/screens/month.js`, `frontend/src/screens/exceptions.js`, `frontend/src/screens/shared/bind-activity-edit-form.js`, `sw.js`, `frontend/sw.js`.

### Testing
- רץ: `node --test tests/service-worker-pwa-cache.test.mjs` — עבר בהצלחה.\
- רץ: `node --test tests/activities-screen.test.mjs` — עבר בהצלחה.\
- רץ: `node --test tests/exceptions-all-types.test.mjs` — עבר בהצלחה (התאים לדרישות ספירת חריגות ייחודיות והסבר הסיכום).\
- רץ: `node --test tests/archive-local-search.test.mjs` ו־`node --test tests/calendar-navigation.test.mjs` — עברו בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a157dc02430832b9fd0c67bc34fe8ce)