### PR TITLE
Hide current view button in activities view-switcher; bump SW/CACHE versions

### DIFF
--- a/frontend/src/screens/shared/view-switcher.js
+++ b/frontend/src/screens/shared/view-switcher.js
@@ -9,7 +9,7 @@ const VIEW_SWITCH_ROUTES = [
 export function renderActivitiesViewSwitcher(state, activeRoute) {
   const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
   const buttons = VIEW_SWITCH_ROUTES
-    .filter(({ route }) => availableRoutes.has(route))
+    .filter(({ route }) => availableRoutes.has(route) && route !== activeRoute)
     .map(({ route, label }) => {
       const isActive = route === activeRoute;
       return `<button type="button" class="ds-btn ds-btn--sm ds-btn--accent ds-activities-view-btn${isActive ? ' is-active' : ''}" data-route-switch="${escapeHtml(route)}" ${isActive ? 'aria-current="page"' : ''}>${escapeHtml(label)}</button>`;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 462;
+const CACHE_VERSION = 463;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 462;
+const SW_ENTRY_VERSION = 463;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Remove the redundant "פעילויות" button when the user is already on the Activities screen and ensure frontend cache invalidation for the deployed change.

### Description
- Stop rendering the active route button by changing the filter in `frontend/src/screens/shared/view-switcher.js` to exclude `activeRoute`, and bump `SW_ENTRY_VERSION` in `sw.js` and `CACHE_VERSION` in `frontend/sw.js` to `463` for service worker / cache refresh.

### Testing
- Ran `node --test tests/service-worker-pwa-cache.test.mjs`, `node --test tests/activities-screen.test.mjs`, and `node --test tests/calendar-navigation.test.mjs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e0afb058832b880e13bba736f259)