### PR TITLE
שיפור מסך חריגות: ריווח, כרטיסים קומפקטיים והעברת מחיקה לעריכת פעילות

### DIFF
--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -52,8 +52,8 @@ function exceptionCardSubtitle(row) {
 }
 
 function exceptionGroupCard(title, rows) {
-  const body = `<div class="ds-compact-list">${rows.map((row) =>
-    `<div data-list-item class="ds-exception-list-item"><button type="button" class="ds-interactive-card ds-interactive-card--session" data-card-action="${escapeHtml(`exception:${row.RowID}`)}"><p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p><p class="ds-interactive-card__subtitle">${escapeHtml(exceptionCardSubtitle(row))}</p></button></div>`
+  const body = `<div class="ds-compact-list ds-exceptions-grid">${rows.map((row) =>
+    `<div data-list-item class="ds-exception-list-item"><button type="button" class="ds-interactive-card ds-interactive-card--session ds-exception-card" data-card-action="${escapeHtml(`exception:${row.RowID}`)}"><p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p><p class="ds-interactive-card__subtitle">${escapeHtml(exceptionCardSubtitle(row))}</p></button></div>`
   ).join('')}</div>`;
   return dsCard({ title: `${title} · ${rows.length}`, body, padded: false });
 }
@@ -154,10 +154,12 @@ export const exceptionsScreen = {
     ].filter((group) => group.rows.length > 0);
 
     return dsScreenStack(`
+      <div class="ds-exceptions-screen">
       ${toolbarHtml}
-      <section><h2 class="ds-section-title">חריגות${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}</h2></section>
+      <section class="ds-exceptions-screen__section"><h2 class="ds-section-title ds-exceptions-screen__title">חריגות${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}</h2></section>
+      ${!hasAnyRows ? `<section class="ds-exceptions-screen__section">${dsEmptyState('אין חריגות פעילות להצגה.')}</section>` : groups.map((group) => `<section class="ds-exceptions-screen__section">${exceptionGroupCard(group.title, group.rows)}</section>`).join('')}
       ${hasAnyRows ? loadMoreHtml : ''}
-      ${!hasAnyRows ? `<section>${dsEmptyState('אין חריגות פעילות להצגה.')}</section>` : groups.map((group) => `<section>${exceptionGroupCard(group.title, group.rows)}</section>`).join('')}
+      </div>
     `);
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1604,6 +1604,42 @@ span.ds-chip {
   font-size: 0.65rem;
 }
 
+/* Exceptions screen only: tighter vertical rhythm and compact clickable cards. */
+.ds-exceptions-screen {
+  display: grid;
+  gap: 8px;
+}
+
+.ds-exceptions-screen .ds-activities-main-toolbar {
+  margin-bottom: 2px;
+}
+
+.ds-exceptions-screen__section {
+  margin: 0;
+  padding: 0;
+}
+
+.ds-exceptions-screen__title {
+  margin: 0;
+}
+
+.ds-exceptions-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+@media (max-width: 960px) {
+  .ds-exceptions-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 640px) {
+  .ds-exceptions-grid { grid-template-columns: minmax(0, 1fr); }
+}
+
+.ds-exception-card {
+  cursor: pointer;
+}
+
 .ds-compact-row {
   border: 1px solid var(--ds-border);
   border-radius: var(--ds-radius-md);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 463;
+const CACHE_VERSION = 464;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 463;
+const SW_ENTRY_VERSION = 464;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- לצמצם ריווח עודף ולהפוך את מסך החריגות לקומפקטי ונקי מבלי לשנות מבני נתונים או לבצע ריפקטור רחב.
- להסיר כפתורי מחיקה חיצוניים על כרטיסי/רשומות ולשמור את פעולת המחיקה בתוך מצב העריכה בלבד לפי הרשאות.
- לוודא ש־Service Worker / cache מיועכנים אחרי משתנים ב־frontend.

### Description
- עטפתי את תצוגת החריגות ב־`<div class="ds-exceptions-screen">` והעברתי את ה־DOM למבנה מסודר: סינון → כותרת חודש → קבוצות חריגות (כותרת עם כמות) → כרטיסים → "הצג עוד", כדי לצמצם ריפוד אנכי רק למסך זה (`frontend/src/screens/exceptions.js`).
- הממשק של כרטיסי החריגות הופך לקומפקטי ולחיץ בלבד (שם פעילות + רשות·בית ספר) ושומר על `data-card-action="exception:${row.RowID}"` בלי כפתור מחיקה חיצוני (`frontend/src/screens/exceptions.js`, `frontend/src/styles/main.css`).
- הוספתי סגנונות ייעודיים שמטרתם רק למסך החריגות (grid 3/2/1 עמודות, מרווחים קטנים, cursor:pointer) כדי לא לשנות ריווח גלובלי (`frontend/src/styles/main.css`).
- שמרתי את מנגנון המחיקה הקיים בתוך טופס העריכה בדרואור: הכפתור `מחיקת פעילות` נותר ברכיב העריכה המשותף ומפעיל `api.deleteActivity(rowId)` (מחיקה רכה) עם אישור למשתמש, והרשאות מוגבלות ל־`admin`/`operation_manager` (שינויים לא נדרשו בקוד המחיקה הקיים, רק וידאתי שלא נוספו כפתורי מחיקה חיצוניים).
- הקפצתי את גרסאות ה־Service Worker / cache ל־`SW_ENTRY_VERSION = 464` ו־`CACHE_VERSION = 464` כדי לוודא ש־SW מתעדכן (`sw.js`, `frontend/sw.js`).
- קבצים ששונו: `frontend/src/screens/exceptions.js`, `frontend/src/styles/main.css`, `sw.js`, `frontend/sw.js`.

### Testing
- ריצתי את `node --test tests/service-worker-pwa-cache.test.mjs` והבדיקה עברה בהצלחה; ה־SW וה־cache versions תואמים ונקיים. (pass)
- ריצתי את `node --test tests/exceptions-all-types.test.mjs` והבדיקות הקשורות למסך החריגות עברו בהצלחה. (pass)
- ריצתי את `node --test tests/activities-screen.test.mjs` והבדיקות הקשורות למסכי פעילויות עברו בהצלחה. (pass)
- ריצתי את `node --test tests/ui-fixes-regression.test.mjs` והתקבלו כשלי רגרסיה לא קשורים ישירות לשינויים אלה (מחרוזות/regex בהגדרות טקסט של dashboard/instructors); אלה נראים קיימים ברמת בדיקות ולא שונו במודיפיקציות אלו. (some tests failed)

Commit: `9504f84`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e57bc7b8832b82c97f4930ffe841)