### PR TITLE
Fix exceptions grouping semantics and SW cache bump

### DIFF
--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -14,8 +14,7 @@ import {
   prepareRowsForSearch,
   applyLocalFilters,
   filtersToolbarHtml,
-  bindLocalFilters,
-  splitVisibleRows
+  bindLocalFilters
 } from './shared/activity-list-filters.js';
 import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { isEmptyValue } from '../utils/empty-value.js';
@@ -126,29 +125,23 @@ export const exceptionsScreen = {
     const filterState = ensureActivityListFilters(state, EXCEPTIONS_SCOPE);
     prepareRowsForSearch(allRows, ['RowID', 'activity_name', 'activity_manager', 'authority', 'school', 'funding', 'exception_type', 'exception_types']);
     const filteredRows = applyLocalFilters(allRows, filterState, { filterFields: EXCEPTION_FILTER_FIELDS });
-    const { visible: visibleRows, hasMore, nextCount, total } = splitVisibleRows(filteredRows, filterState);
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const toolbarHtml = filtersToolbarHtml(EXCEPTIONS_SCOPE, allRows, state, {
       filterFields: EXCEPTION_FILTER_FIELDS,
       searchPlaceholder: 'חיפוש חריגות קורסים…',
       optionsOverrides: getFilterOptionOverrides(state?.clientSettings || {})
     });
-    const loadMoreHtml = hasMore
-      ? `<div style="display:flex;justify-content:center;padding:12px 0"><button type="button" class="ds-btn ds-btn--sm" data-list-show-more="${EXCEPTIONS_SCOPE}" data-next-count="${nextCount}">הצג עוד</button></div>`
-      : '';
-
-    const waitingDateRows = allRows.filter((row) => normalizedExceptionTypes(row).includes('missing_start_date'));
-    const endDateExceptionRows = allRows.filter((row) => {
-      const types = normalizedExceptionTypes(row);
-      return types.includes('late_end_date') || types.includes('end_date_passed');
-    });
-    const noInstructorRows = allRows.filter((row) => normalizedExceptionTypes(row).includes('missing_instructor'));
+    const waitingDateRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('missing_start_date'));
+    const endDatePassedRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('end_date_passed'));
+    const lateEndDateRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('late_end_date'));
+    const noInstructorRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('missing_instructor'));
     const mainTypes = new Set(['missing_start_date', 'late_end_date', 'end_date_passed', 'missing_instructor']);
-    const otherExceptionRows = allRows.filter((row) => normalizedExceptionTypes(row).some((type) => !mainTypes.has(type)));
-    const hasAnyRows = allRows.length > 0;
+    const otherExceptionRows = filteredRows.filter((row) => normalizedExceptionTypes(row).some((type) => !mainTypes.has(type)));
+    const hasAnyRows = filteredRows.length > 0;
     const groups = [
       { title: 'פעילויות ממתינות לתיאום תאריך', rows: waitingDateRows },
-      { title: 'פעילויות עם חריגת תאריך סיום', rows: endDateExceptionRows },
+      { title: 'פעילויות פעילות שתאריך הסיום שלהן חלף', rows: endDatePassedRows },
+      { title: 'פעילויות עם מפגש לאחר תאריך הסיום', rows: lateEndDateRows },
       { title: 'פעילויות ללא מדריך', rows: noInstructorRows },
       ...(otherExceptionRows.length ? [{ title: 'חריגות נוספות', rows: otherExceptionRows }] : [])
     ].filter((group) => group.rows.length > 0);
@@ -158,17 +151,12 @@ export const exceptionsScreen = {
       ${toolbarHtml}
       <section class="ds-exceptions-screen__section"><h2 class="ds-section-title ds-exceptions-screen__title">חריגות${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}</h2></section>
       ${!hasAnyRows ? `<section class="ds-exceptions-screen__section">${dsEmptyState('אין חריגות פעילות להצגה.')}</section>` : groups.map((group) => `<section class="ds-exceptions-screen__section">${exceptionGroupCard(group.title, group.rows)}</section>`).join('')}
-      ${hasAnyRows ? loadMoreHtml : ''}
       </div>
     `);
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
     const allRows   = (Array.isArray(data?.rows) ? data.rows : []);
     bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 150 });
-    root.querySelector(`[data-list-show-more="${EXCEPTIONS_SCOPE}"]`)?.addEventListener('click', (ev) => {
-      ensureActivityListFilters(state, EXCEPTIONS_SCOPE).visibleCount = Number(ev.currentTarget?.dataset?.nextCount || 200);
-      rerender();
-    });
     const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 464;
+const CACHE_VERSION = 465;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 464;
+const SW_ENTRY_VERSION = 465;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -12,6 +12,27 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
+if (!globalThis.sessionStorage) {
+  const sessionStore = new Map();
+  globalThis.sessionStorage = {
+    getItem: (key) => sessionStore.has(key) ? sessionStore.get(key) : null,
+    setItem: (key, value) => sessionStore.set(key, String(value)),
+    removeItem: (key) => sessionStore.delete(key),
+    clear: () => sessionStore.clear()
+  };
+}
+if (!globalThis.localStorage) {
+  const localStore = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => localStore.has(key) ? localStore.get(key) : null,
+    setItem: (key, value) => localStore.set(key, String(value)),
+    removeItem: (key) => localStore.delete(key),
+    clear: () => localStore.clear()
+  };
+}
+
+const { exceptionsScreen } = await import('../frontend/src/screens/exceptions.js');
+
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), 'utf8');
 
 // ─── Lightweight JS re-implementations of backend helpers ────────────────────
@@ -366,6 +387,31 @@ test('frontend exception Hebrew labels describe the exception details clearly', 
   assert.match(src, /missing_instructor:\s+'חסר מדריך'/);
   assert.match(src, /missing_start_date:\s+'חסר תאריך התחלה'/);
   assert.match(src, /late_end_date:\s+'תאריך סיום מאוחר'/);
+});
+
+test('exceptions screen separates end_date_passed and late_end_date into distinct group titles', async () => {
+  const src = await read('frontend/src/screens/exceptions.js');
+  assert.match(src, /פעילויות פעילות שתאריך הסיום שלהן חלף/);
+  assert.match(src, /פעילויות עם מפגש לאחר תאריך הסיום/);
+  assert.doesNotMatch(src, /פעילויות עם חריגת תאריך סיום/);
+});
+
+test('exceptions screen group count matches rendered clickable cards', () => {
+  const state = { exceptionsListFilters: {}, activityListFilters: {}, clientSettings: {} };
+  const data = {
+    month: '2026-05',
+    rows: [
+      { RowID: '1', activity_name: 'א', authority: 'ר1', school: 'ב1', exception_types: ['end_date_passed'] },
+      { RowID: '2', activity_name: 'ב', authority: 'ר1', school: 'ב1', exception_types: ['late_end_date'] },
+      { RowID: '3', activity_name: 'ג', authority: 'ר1', school: 'ב1', exception_types: ['late_end_date', 'missing_instructor'] }
+    ]
+  };
+  const html = exceptionsScreen.render(data, { state });
+  assert.match(html, /פעילויות פעילות שתאריך הסיום שלהן חלף · 1/);
+  assert.match(html, /פעילויות עם מפגש לאחר תאריך הסיום · 2/);
+  const clickableCards = (html.match(/data-card-action="exception:/g) || []).length;
+  assert.equal(clickableCards, 4, 'each grouped appearance must be rendered as a clickable card');
+  assert.doesNotMatch(html, /data-action="delete"/);
 });
 
 test('frontend drawer shows exception type chip when opening activity detail', async () => {


### PR DESCRIPTION
### Motivation
- The exceptions screen was mixing different date-related exception types under one ambiguous heading and counting groups from unfiltered source rows, causing mismatched titles/counts and confusing users.
- `late_end_date` was being conflated with `end_date_passed` in the UI despite having distinct conditions in the data model.
- Group visibility needed to respect client-side filters/month context so the displayed counts match the clickable cards.
- Service worker cache/version must be bumped when frontend changes are deployed to avoid serving stale assets.

### Description
- Updated `frontend/src/screens/exceptions.js` to build groups from `filteredRows` instead of raw `allRows`, so groups reflect active filters and month context.
- Split the combined date group into two explicit groups and titles: `end_date_passed` → `פעילויות פעילות שתאריך הסיום שלהן חלף` and `late_end_date` → `פעילויות עם מפגש לאחר תאריך הסיום` and removed the ambiguous `פעילויות עם חריגת תאריך סיום` title.
- Kept minimal external card presentation (activity name and `רשות · בית ספר`) and preserved clickable `data-card-action="exception:RowID"` behavior to open full details with exact exception type chips.
- Removed stale load-more wiring in the exceptions bind/render path and adjusted imports accordingly.
- Added/updated tests in `tests/exceptions-all-types.test.mjs` to assert separate group titles, correct group counts vs rendered clickable cards, and absence of external delete actions; added a small `sessionStorage`/`localStorage` shim for test runtime.
- Bumped service worker versions: `SW_ENTRY_VERSION` in `sw.js` and `CACHE_VERSION` in `frontend/sw.js` (both to `465`).

### Testing
- Ran `node --test tests/service-worker-pwa-cache.test.mjs` and it passed (service worker entry and cache version checks succeeded). 
- Ran `node --test tests/exceptions-all-types.test.mjs` and it passed (new grouping and count expectations validated). 
- Ran `node --test tests/activities-screen.test.mjs` and it passed (activities screen regressions check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a162232de44832b9242c490c9de75b1)