### PR TITLE
Remove internal "activities" switch button; add edit-mode soft-delete and bump SW cache

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -521,13 +521,14 @@ function applyActivitiesLocalFilters(rows, state, settings) {
   return applyLocalFilters(gapRows, filters, { filterFields: ACTIVITY_FILTER_FIELDS }).sort(compareActivityDefaultOrder);
 }
 
-function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, canRequestEdit, hideEmpIds, hideRowId, hideActivityNo, settings, { datesLoading = false } = {}) {
+function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, canRequestEdit, canDeleteActivity, hideEmpIds, hideRowId, hideActivityNo, settings, { datesLoading = false } = {}) {
   const privateNote = canSeePrivateNotes ? row.private_note || '—' : null;
   return activityWorkDrawerHtml(row, {
     privateNote,
     canEdit,
     canDirectEdit,
     canRequestEdit,
+    canDeleteActivity,
     hideEmpIds: !!hideEmpIds,
     hideRowId,
     hideActivityNo,
@@ -724,6 +725,7 @@ export const activitiesScreen = {
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    const canDeleteActivity = ['admin', 'operation_manager'].includes(role);
     const canAddActivity = !!state?.user?.can_add_activity || role === 'operation_manager' || role === 'admin';
     const isAdmin = isAdminUser(state);
 
@@ -894,6 +896,9 @@ export const activitiesScreen = {
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
     const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    const canDeleteActivity = ['admin', 'operation_manager'].includes(
+      String(state?.user?.display_role || state?.user?.role || '').trim()
+    );
     const canAddActivity = !!state?.user?.can_add_activity || role === 'operation_manager' || role === 'admin';
     const isAdmin = isAdminUser(state);
 
@@ -958,6 +963,7 @@ export const activitiesScreen = {
               putCachedActivityDetail({ RowID: sourceRowId, source_sheet: sourceSheet || 'activities' }, freshRow, state);
               contentRoot.innerHTML = activityDrawerContent(
                 freshRow, canSeePrivateNotes, canEditActivity, !!state?.user?.can_edit_direct, !!state?.user?.can_request_edit,
+                canDeleteActivity,
                 hideEmpIds, hideRowId, hideActivityNo,
                 mergeSettingsWithFallback(state?.clientSettings || {}, buildFallbackOptionsFromRows(activitiesRows)),
                 { datesLoading: false }
@@ -1019,6 +1025,7 @@ export const activitiesScreen = {
           title: '',
           content: activityDrawerContent(
             cachedDetail, canSeePrivateNotes, canEditActivity, canDirectEdit, canRequestEdit,
+            canDeleteActivity,
             hideEmpIds, hideRowId, hideActivityNo, settings, { datesLoading: false }
           ),
           onOpen: makeOnOpen,
@@ -1035,6 +1042,7 @@ export const activitiesScreen = {
         title: '',
         content: activityDrawerContent(
           summaryRow, canSeePrivateNotes, canEditActivity, canDirectEdit, canRequestEdit,
+          canDeleteActivity,
           hideEmpIds, hideRowId, hideActivityNo, settings, { datesLoading: needDates }
         ),
         onOpen: makeOnOpen,

--- a/frontend/src/screens/shared/view-switcher.js
+++ b/frontend/src/screens/shared/view-switcher.js
@@ -8,13 +8,18 @@ const VIEW_SWITCH_ROUTES = [
 
 export function renderActivitiesViewSwitcher(state, activeRoute) {
   const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
+  const allowedRoutes = activeRoute === 'activities'
+    ? new Set(['week', 'month'])
+    : (activeRoute === 'week'
+        ? new Set(['month'])
+        : (activeRoute === 'month' ? new Set(['week']) : new Set()));
   const buttons = VIEW_SWITCH_ROUTES
-    .filter(({ route }) => availableRoutes.has(route) && route !== activeRoute)
+    .filter(({ route }) => availableRoutes.has(route) && route !== activeRoute && allowedRoutes.has(route))
     .map(({ route, label }) => {
       const isActive = route === activeRoute;
       return `<button type="button" class="ds-btn ds-btn--sm ds-btn--accent ds-activities-view-btn${isActive ? ' is-active' : ''}" data-route-switch="${escapeHtml(route)}" ${isActive ? 'aria-current="page"' : ''}>${escapeHtml(label)}</button>`;
     });
-  if (buttons.length <= 1) return '';
+  if (!buttons.length) return '';
   return `<div class="ds-activities-view-switcher" dir="rtl" aria-label="מעבר בין תצוגות פעילות">${buttons.join('')}</div>`;
 }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 465;
+const CACHE_VERSION = 466;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 465;
+const SW_ENTRY_VERSION = 466;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להסיר את כפתור "פעילויות" המיותר באזור המעבר הפנימי בין תצוגות כדי למנוע כפילויות מול ההידר העליון. 
- לאפשר מחיקה רכה של פעילות מתוך מצב עריכה בלבד, עם בקרה לפי תפקידים (רק `admin` / `operation_manager`).
- לעדכן גרסת Service Worker / cache כדי לוודא שדרוג ה־frontend מתגלגל ללקוחות ומנקה caches ישנים.

### Description
- שונתה הלוגיקה של ה־view switcher ב־`frontend/src/screens/shared/view-switcher.js` כך שבכל מסך יוצגו רק הכפתורים ההקשריים המבוקשים (activities → only `week`/`month`, `week` → only `month`, `month` → only `week`) וכפוף ל־`state.routes` ללא הצגת כפתור "פעילויות" פנימי. 
- הוספתי העברת פרמטר `canDeleteActivity` ל־drawer של פעילות והחלפתי בדיקת הרשאת מחיקה במסך ה־activities כך שכפתור "מחיקת פעילות" יופיע רק במצב עריכה ולמשתמשים בעלי role `admin` או `operation_manager` בלבד. 
- לא שונתה לוגיקת המחיקה עצמה — נעשה שימוש ב־API הקיים `api.deleteActivity(rowId)` כמחיקה רכה (status = `נמחק`) והותרו אישור משתמש, טיפול בכשל וסגירת ה־drawer/ניקוי cache לפי הזרימה המקורית. 
- הוקפצו גרסאות SW/cache: `SW_ENTRY_VERSION` ב־`sw.js` ו־`CACHE_VERSION` ב־`frontend/sw.js` ל־`466`, וקבצים ששונו הם `frontend/src/screens/shared/view-switcher.js`, `frontend/src/screens/activities.js`, `sw.js`, ו־`frontend/sw.js`.

### Testing
- הורצו בדיקות השירות של ה־SW עם `node --test tests/service-worker-pwa-cache.test.mjs` והכל עבר בהצלחה (all tests passed). 
- הורצו בדיקות מסך פעילויות עם `node --test tests/activities-screen.test.mjs` והכל עבר בהצלחה (all tests passed). 
- שתי הסדרות הושלמו ללא כשל, מה שמאשר את שדרוג גרסת ה־SW ואת ההתנהגות המעודכנת במסך ה־activities.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1626082320832b813bebcbf6b8bec1)