### PR TITLE
Exceptions screen: compact cards and bump SW/CACHE versions

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1624,7 +1624,8 @@ span.ds-chip {
 }
 
 .ds-exceptions-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 260px));
+  justify-content: start;
   gap: 8px;
 }
 
@@ -1638,6 +1639,10 @@ span.ds-chip {
 
 .ds-exception-card {
   cursor: pointer;
+  min-height: 40px;
+  padding: var(--ds-space-2);
+  width: min(100%, 260px);
+  overflow-wrap: anywhere;
 }
 
 .ds-compact-row {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 466;
+const CACHE_VERSION = 467;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 466;
+const SW_ENTRY_VERSION = 467;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- לשפר את הדיוק בתצוגת החריגות על ידי שימוש בניסוח ברור לקבוצת החריגה ולצמצם את רוחב כרטיסי החריגה כדי שיהיו קומפקטיים וקריאים. 
- להפחית את שטח הכרטיסים במסך החריגות בלבד כדי לשפר צפיפות תצוגה ללא שינוי לוגיקת חריגות או נתונים. 
- לוודא שהלקוחות מקבלים את עדכוני ה-Frontend על ידי invalidation של cache/Service Worker.

### Description
- הותאמה ה-CSS עבור מסך החריגות: `.ds-exceptions-grid` עבר ל-`grid-template-columns: repeat(auto-fit, minmax(220px, 260px))` עם `justify-content: start` והוגדרו סגנונות קומפקטיים ל-`.ds-exception-card` (מינימום גובה, padding, רוחב מקסימלי ו-`overflow-wrap`).
- הוקפצו גרסאות ה-Service Worker ו-cache: `SW_ENTRY_VERSION` ו-`CACHE_VERSION` הועלו ל-`467` בקבצים `sw.js` ו-`frontend/sw.js` כדי לאלץ invalidation של המטמון לאחר הפריסה. 
- לא שונתה לוגיקה, מודלים או מבני נתונים במסד, וכל התוכן המוצג בכרטיס נשאר רק שם הפעילות ו-רשות/בית ספר כפי שקבוע במרקאפ הקיים.

### Testing
- רוצו בדיקות ה-Service Worker עם `node --test tests/service-worker-pwa-cache.test.mjs` והן עברו בהצלחה.
- רוצו בדיקות המסך והלוגיקה של חריגות עם `node --test tests/exceptions-all-types.test.mjs` והן עברו בהצלחה.
- אין בדיקות אוטומטיות ששונו; שינויים הוגבלו ל-CSS וגרסאות SW בלבד.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1628ef274c832b88c9d32c4a713b9c)