### PR TITLE
Fix instructor popup to include all active monthly activities

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -665,7 +665,7 @@ async function readInstructorsFromSupabase() {
     }));
 
     rows.sort((a, b) => String(a.full_name || '').localeCompare(String(b.full_name || ''), 'he'));
-    return { rows, activities_loaded: true, _source: 'supabase' };
+    return { rows, detail_rows: activeRows, activities_loaded: true, _source: 'supabase' };
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('[supabase] Unexpected instructors fetch error:', error);

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -145,7 +145,8 @@ export function buildInstructorActivityDetailsForMonth(allRows, { empId, instrNa
   const items = [];
   const seenRowIds = new Set();
   (Array.isArray(allRows) ? allRows : []).forEach((r) => {
-    if (String(r.status || '').trim() === 'סגור') return;
+    const status = String(r.status || '').trim();
+    if (status === 'סגור' || status === 'נמחק') return;
     if (!instructorMatchesActivity(r, empId, instrName)) return;
     if (!activityInDetailsMonth(r, targetYm)) return;
 
@@ -478,8 +479,9 @@ export const instructorsScreen = {
         openPopup(instrName, null, openActivityFromPopup);
 
         try {
+          const detailRows = Array.isArray(data?.detail_rows) ? data.detail_rows : null;
           const cachedActivities = state?.screenDataCache?.['activities:all']?.data;
-          const res = cachedActivities || await api.activities({ activity_type: 'all' });
+          const res = detailRows ? { rows: detailRows } : (cachedActivities || await api.activities({ activity_type: 'all' }));
           const allRows = Array.isArray(res?.rows) ? res.rows : [];
           const items = buildInstructorActivityDetailsForMonth(allRows, { empId, instrName, targetYm });
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 468;
+const CACHE_VERSION = 469;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- The instructor popup showed only course-type activities for a selected month instead of all activity types assigned to the instructor. 
- The popup lacked a full active activity list and relied on filtered sources, causing missing workshops/tours/afterschool/etc. in the UI. 
- The change aims to show every active (not closed/not deleted) activity for the instructor in the selected month while keeping existing instructor summary counts intact.

### Description
- Return the active rows payload from `readInstructorsFromSupabase` as `detail_rows` so the instructors API can provide a full active activity list (`api.instructors()` now returns `detail_rows: activeRows`).
- In `buildInstructorActivityDetailsForMonth` strengthen filtering to exclude both `סגור` and `נמחק` statuses so only active activities are shown in the popup.
- When opening the instructor popup prefer `data.detail_rows` when present, otherwise fall back to the cached `activities:all` screen data or `api.activities({ activity_type: 'all' })`, and then pass the full rows to `buildInstructorActivityDetailsForMonth` (no type restriction to `course`).
- Bumped service worker `CACHE_VERSION` from `468` to `469` to ensure clients refresh cached frontend assets after deployment.

### Testing
- Ran the project's automated tests with `npm test`; the test run started and completed but the suite contains unrelated baseline failures (for example `activities-snapshot.gs` and some mutation/perf tests); these failures were present in the baseline and are not introduced by this change.
- Verified that instructor popup path uses `detail_rows` when available and falls back to existing activity-loading logic, and that `buildInstructorActivityDetailsForMonth` now excludes closed/deleted rows; no automated test failures specific to the instructor-popup behavior were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16baa21c64832baf046e05a1c1e8fc)