### PR TITLE
תיקון רינדור סעיפי הצעת מחיר — שורות ורשימות נפרדות

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 460;
+const CACHE_VERSION = 470;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CelL_sHn.js",
+  "./assets/index-Bs8hIda7.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DRNU7Icn.css",
+  "./assets/style-BY8pJlYX.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CelL_sHn.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DRNU7Icn.css">
+  <script type="module" crossorigin src="./assets/index-Bs8hIda7.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BY8pJlYX.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 460;
+const CACHE_VERSION = 470;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CelL_sHn.js",
+  "./assets/index-Bs8hIda7.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DRNU7Icn.css",
+  "./assets/style-BY8pJlYX.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -470,7 +470,7 @@ function proposalTitle(row) {
 }
 
 function sectionBodyHtml(value) {
-  return sectionLinesHtml(value);
+  return renderSectionBodyHtml(value);
 }
 
 function sectionHeadingText(rawTitle, fallback = '') {
@@ -509,22 +509,74 @@ function sectionHtml(title, body, className = '') {
   return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body)}</section>`;
 }
 
-function sectionLinesHtml(value, options = {}) {
-  const { alwaysBullet = false, className = '' } = options;
-  const raw = String(value == null ? '' : value).replace(/\r\n?/g, '\n');
-  const lines = raw.split('\n');
-  const rendered = lines.map((line) => {
-    const original = String(line || '');
-    const trimmed = original.trim();
-    if (!trimmed) return '<span class="pa-section-line pa-section-line--empty">&nbsp;</span>';
-    const bulletMatch = trimmed.match(/^[·•-]\s*(.+)$/);
-    const isBullet = alwaysBullet || Boolean(bulletMatch);
-    const body = isBullet ? (bulletMatch ? bulletMatch[1].trim() : trimmed) : trimmed;
-    const marker = isBullet ? '<span class="pa-section-bullet-marker">·</span>' : '';
-    return `<span class="pa-section-line${isBullet ? ' pa-section-line--bullet' : ''}">${marker}${escapeHtml(body)}</span>`;
+function parseSectionBodyStructure(value, options = {}) {
+  const { alwaysBullet = false } = options;
+  const raw = String(value == null ? '' : value).replace(/\r\n?/g, '\n').trim();
+  if (!raw) return [];
+
+  const splitInlineBullets = (line) => {
+    const t = String(line || '').trim();
+    if (!t) return [];
+    if (!/[•·]/.test(t) || /^[•·]/.test(t)) return [t];
+    return t.split(/[•·]/).map((part) => part.trim()).filter(Boolean);
+  };
+
+  const expandedLines = raw.split('\n').flatMap(splitInlineBullets).map((line) => line.trim()).filter(Boolean);
+  if (!expandedLines.length) return [];
+
+  const bulletRegex = /^[·•-]\s*(.+)$/;
+  const orderedRegex = /^(\d+)[.)]\s*(.+)$/;
+  if (alwaysBullet) {
+    return [{ type: 'ul', items: expandedLines.map((line) => line.replace(bulletRegex, '$1').trim()).filter(Boolean) }];
+  }
+
+  const groups = [];
+  let currentType = null;
+  let currentItems = [];
+  const flush = () => {
+    if (!currentItems.length) return;
+    groups.push({ type: currentType, items: currentItems });
+    currentType = null;
+    currentItems = [];
+  };
+
+  expandedLines.forEach((line) => {
+    const bulletMatch = line.match(bulletRegex);
+    const orderedMatch = line.match(orderedRegex);
+    let type = 'p';
+    let body = line;
+    if (bulletMatch) {
+      type = 'ul';
+      body = bulletMatch[1];
+    } else if (orderedMatch) {
+      type = 'ol';
+      body = orderedMatch[2];
+    }
+    const cleaned = body.trim();
+    if (!cleaned) return;
+    if (currentType && currentType !== type) flush();
+    currentType = type;
+    currentItems.push(cleaned);
+  });
+  flush();
+  return groups;
+}
+
+function renderSectionBodyHtml(value, options = {}) {
+  const { className = '' } = options;
+  const groups = parseSectionBodyStructure(value, options);
+  if (!groups.length) return '';
+  const rendered = groups.map((group) => {
+    if (group.type === 'ul' || group.type === 'ol') {
+      return `<${group.type}>${group.items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</${group.type}>`;
+    }
+    return group.items.map((item) => `<p>${escapeHtml(item)}</p>`).join('');
   }).join('');
-  if (!rendered.trim()) return '';
   return `<div class="pa-section-body${className ? ` ${className}` : ''}">${rendered}</div>`;
+}
+
+function sectionLinesHtml(value, options = {}) {
+  return renderSectionBodyHtml(value, options);
 }
 
 function signatureSectionHtml(signatureText) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10910,26 +10910,25 @@ select.ds-input {
 .pa-section-body {
   margin: 0;
 }
-.pa-section-line {
-  display: block;
-  margin: 0 0 4pt;
+.ds-pa-preview-doc .pa-section-body p,
+.ds-pa-preview-doc .pa-doc-intro p {
+  margin: 0 0 6px;
 }
-.pa-section-line--bullet {
-  margin: 0 0 3pt;
-  padding-right: 14pt;
-  text-indent: -10pt;
+.ds-pa-preview-doc .pa-section-body ul,
+.ds-pa-preview-doc .pa-section-body ol,
+.ds-pa-preview-doc .pa-doc-intro ul,
+.ds-pa-preview-doc .pa-doc-intro ol {
+  margin: 4px 0 8px;
+  padding-inline-start: 22px;
+}
+.ds-pa-preview-doc .pa-section-body li,
+.ds-pa-preview-doc .pa-doc-intro li {
+  margin: 2px 0;
+  line-height: 1.45;
   white-space: normal;
   word-break: break-word;
   break-inside: avoid;
   page-break-inside: avoid;
-}
-.pa-section-line--empty {
-  margin: 0 0 3pt;
-}
-.pa-section-bullet-marker {
-  display: inline-block;
-  width: 10pt;
-  margin-left: 2pt;
 }
 .pa-proposal-lines {
   margin-top: 2pt;
@@ -11129,25 +11128,29 @@ select.ds-input {
 
   .pa-doc-intro,
   .pa-section-body,
-  .pa-section-line,
   .pa-proposal-lines {
     font-size: 10pt !important;
     line-height: 1.55 !important;
     color: #000 !important;
   }
 
-  .pa-section-line {
-    display: block !important;
-    margin: 0 0 3pt !important;
+  .ds-pa-preview-doc .pa-section-body p,
+  .ds-pa-preview-doc .pa-doc-intro p {
+    margin: 0 0 4pt !important;
   }
 
-  .pa-section-line--empty {
-    margin: 0 0 2pt !important;
+  .ds-pa-preview-doc .pa-section-body ul,
+  .ds-pa-preview-doc .pa-section-body ol,
+  .ds-pa-preview-doc .pa-doc-intro ul,
+  .ds-pa-preview-doc .pa-doc-intro ol {
+    margin: 3pt 0 6pt !important;
+    padding-inline-start: 18pt !important;
   }
 
-  .pa-section-line--bullet {
-    padding-right: 14pt !important;
-    text-indent: -10pt !important;
+  .ds-pa-preview-doc .pa-section-body li,
+  .ds-pa-preview-doc .pa-doc-intro li {
+    margin: 1.5pt 0 !important;
+    line-height: 1.5 !important;
     word-break: break-word !important;
     break-inside: avoid !important;
     page-break-inside: avoid !important;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 469;
+const CACHE_VERSION = 470;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- לתקן בעיה שבה סעיפי תבנית שהכילו כמה שורות או נקודות הוצגו כפסקה אחת במקום כרשימה או שורות נפרדות בתצוגה המקדימה ובהדפסה.
- לשמור על פסקאות רגילות ללא פיצול, ובאותו הזמן לתמוך ב־bullets (`-`, `•`, `·`), ברשימות ממוספרות (`1.` / `1)`), ובנקודות המופיעות באותה שורה (inline bullets).
- להבטיח שהשינויים נטענים נכון על ידי עדכון גרסת ה־Service Worker כך שגרסה חדשה תטען אחרי פריסה.

### Description
- הוספתי פרסינג וסדרת רנדרינג חדשים בקובץ `frontend/src/screens/proposals-agreements.js`: `parseSectionBodyStructure` ו־`renderSectionBodyHtml`, והחלפתי את `sectionBodyHtml`/`sectionLinesHtml` לשימוש ב־helper החדש כדי לייצר HTML סמנטי (`<p>`, `<ul>`, `<ol>`, `<li>`).
- התמיכה הורחבה כדי לזהות שורות המתחילות ב־`-`, `•`, `·` (עם או בלי רווח), רשימות ממוספרות לפי `1.`/`1)`, ופיצול של bullets המופיעים באותה שורה (למשל `• a • b • c`).
- עדכנתי את ה־CSS ב־`frontend/src/styles/main.css` עבור המחלקה של תצוגת ההצעה (`.ds-pa-preview-doc`) כדי לתת מרווחים ונראות נכונה ל־`p`, `ul`, `ol`, ו־`li` גם בתצוגה המוקדמת וגם בסגנונות הדפסה.
- שיניתי את `CACHE_VERSION` ל־`470` ב־`frontend/sw.js` כדי לזרז רענון של ה־cache בצד הלקוח לאחר הפריסה.

### Testing
- הרצת `npm run build` בראוטוט הפרויקט הסתיימה בהצלחה והבנייה נוצרה ללא שגיאות (Vite build succeeded).
- ניסיון להריץ `npm --prefix frontend run build` נכשל בגלל שאין `frontend/package.json` בסביבה וכרגע לא דרוש במבנה הפרויקט, והתקבל שגיאת `ENOENT` כפי שדווח; זה אינו משפיע על הבנייה הכללית שנעשתה בעזרת `npm run build` בשורש.
- ווידאתי שה־`CACHE_VERSION` ב־`frontend/sw.js` עודכן ל־`470` כדי לאלץ עדכון cache בלקוח לאחר פריסה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16e74d7588832b9a2ee74bd17751e8)