### PR TITLE
Fix proposal preview bullets for responsibility/payment/cancellation sections

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -469,8 +469,8 @@ function proposalTitle(row) {
   return 'הצעת מחיר לפעילויות תעשיידע | קיץ תשפ״ו + תשפ״ז';
 }
 
-function sectionBodyHtml(value) {
-  return renderSectionBodyHtml(value);
+function sectionBodyHtml(value, options = {}) {
+  return renderSectionBodyHtml(value, options);
 }
 
 function sectionHeadingText(rawTitle, fallback = '') {
@@ -505,8 +505,8 @@ function proposalItemsListHtml(items = []) {
   return lines ? sectionLinesHtml(lines, { alwaysBullet: true, className: 'pa-proposal-lines' }) : '';
 }
 
-function sectionHtml(title, body, className = '') {
-  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body)}</section>`;
+function sectionHtml(title, body, className = '', options = {}) {
+  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body, options)}</section>`;
 }
 
 function parseSectionBodyStructure(value, options = {}) {
@@ -517,14 +517,15 @@ function parseSectionBodyStructure(value, options = {}) {
   const splitInlineBullets = (line) => {
     const t = String(line || '').trim();
     if (!t) return [];
-    if (!/[•·]/.test(t) || /^[•·]/.test(t)) return [t];
-    return t.split(/[•·]/).map((part) => part.trim()).filter(Boolean);
+    if (/^[•·\-]\s+/.test(t)) return [t];
+    if (!/[•·]/.test(t) && !/\s-\s/.test(t)) return [t];
+    return t.split(/[•·]|(?<=\S)\s-\s(?=\S)/).map((part) => part.trim()).filter(Boolean);
   };
 
   const expandedLines = raw.split('\n').flatMap(splitInlineBullets).map((line) => line.trim()).filter(Boolean);
   if (!expandedLines.length) return [];
 
-  const bulletRegex = /^[·•-]\s*(.+)$/;
+  const bulletRegex = /^[·•\-]\s*(.+)$/;
   const orderedRegex = /^(\d+)[.)]\s*(.+)$/;
   if (alwaysBullet) {
     return [{ type: 'ul', items: expandedLines.map((line) => line.replace(bulletRegex, '$1').trim()).filter(Boolean) }];
@@ -720,10 +721,10 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
     <h1 class="pa-doc-subject">${escapeHtml(proposalTitle(row))}</h1>
     ${introText ? sectionLinesHtml(introText, { className: 'pa-doc-intro' }) : ''}
     ${sections.join('')}
-    ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility) : ''}
-    ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility) : ''}
-    ${paymentTerms ? sectionHtml(sectionTitle('payment_terms', 'עלויות ותנאי תשלום'), paymentTerms) : ''}
-    ${changesCancellation ? sectionHtml(sectionTitle('cancellation_terms', 'שינויים, ביטולים והתאמות'), changesCancellation) : ''}
+    ${orgResponsibility ? sectionHtml(sectionTitle('taasiyeda_responsibility', 'אחריות תעשיידע'), orgResponsibility, '', { alwaysBullet: true }) : ''}
+    ${schoolResponsibility ? sectionHtml(sectionTitle('school_responsibility', 'אחריות בית הספר'), schoolResponsibility, '', { alwaysBullet: true }) : ''}
+    ${paymentTerms ? sectionHtml(sectionTitle('payment_terms', 'עלויות ותנאי תשלום'), paymentTerms, '', { alwaysBullet: true }) : ''}
+    ${changesCancellation ? sectionHtml(sectionTitle('cancellation_terms', 'שינויים, ביטולים והתאמות'), changesCancellation, '', { alwaysBullet: true }) : ''}
     ${remarks ? sectionHtml(sectionTitle('notes', 'הערות'), remarks) : ''}
     ${signatureSectionHtml(signatureText)}
     <footer class="pa-doc-footer">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10918,12 +10918,12 @@ select.ds-input {
 .ds-pa-preview-doc .pa-section-body ol,
 .ds-pa-preview-doc .pa-doc-intro ul,
 .ds-pa-preview-doc .pa-doc-intro ol {
-  margin: 4px 0 8px;
+  margin: 4px 0 10px;
   padding-inline-start: 22px;
 }
 .ds-pa-preview-doc .pa-section-body li,
 .ds-pa-preview-doc .pa-doc-intro li {
-  margin: 2px 0;
+  margin: 3px 0;
   line-height: 1.45;
   white-space: normal;
   word-break: break-word;
@@ -11143,14 +11143,14 @@ select.ds-input {
   .ds-pa-preview-doc .pa-section-body ol,
   .ds-pa-preview-doc .pa-doc-intro ul,
   .ds-pa-preview-doc .pa-doc-intro ol {
-    margin: 3pt 0 6pt !important;
-    padding-inline-start: 18pt !important;
+    margin: 4px 0 10px !important;
+    padding-inline-start: 22px !important;
   }
 
   .ds-pa-preview-doc .pa-section-body li,
   .ds-pa-preview-doc .pa-doc-intro li {
-    margin: 1.5pt 0 !important;
-    line-height: 1.5 !important;
+    margin: 3px 0 !important;
+    line-height: 1.45 !important;
     word-break: break-word !important;
     break-inside: avoid !important;
     page-break-inside: avoid !important;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 470;
+const CACHE_VERSION = 471;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- The proposal preview rendered several structured sections as a single paragraph when their content contained bullets or inline separators, which must be displayed as distinct list items under a section heading. 
- Certain sections (`taasiyeda_responsibility`, `school_responsibility`, `payment_terms`, `cancellation_terms`) must always render as bullet lists per the display requirements and not as plain paragraphs.

### Description
- Updated `proposalPreviewBodyHtml` rendering to force `alwaysBullet: true` for the structured sections so `taasiyeda_responsibility`, `school_responsibility`, `payment_terms`, and `cancellation_terms` are always rendered as `<ul><li>…</li></ul>` (file: `frontend/src/screens/proposals-agreements.js`).
- Extended parsing in `parseSectionBodyStructure` to split inline bullets and dash-delimited items and to correctly treat leading `-` as a bullet token; exposed options through `sectionBodyHtml` and `sectionHtml` so `alwaysBullet` can be passed down (file: `frontend/src/screens/proposals-agreements.js`).
- Adjusted preview/print CSS for cleaner list spacing and indentation to match the requested visual rules (file: `frontend/src/styles/main.css`).
- Bumped the service worker cache version to `471` to ensure clients fetch the updated assets (file: `frontend/sw.js`).

### Testing
- Ran the project test suite with `npm test`; the suite executed but there are pre-existing unrelated failures (some `activities-snapshot.gs` and API/perf-related tests) and those failures are not caused by these UI/preview changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f7baff84832bbd4e9f1d62a0fcc4)