### PR TITLE
Update document styling and add proposal lines formatting

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 472;
+const CACHE_VERSION = 473;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 472;
+const CACHE_VERSION = 473;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10838,16 +10838,16 @@ select.ds-input {
   display: block; max-width: 100%; height: auto;
 }
 .pa-doc-logo--header {
-  width: 160px;
-  max-width: 38%;
+  width: 240px;
+  max-width: 44%;
   margin-inline: 0;
 }
 .pa-doc-logo--footer {
   width: auto;
   height: auto;
-  max-width: 48mm;
+  max-width: 100mm;
   margin-inline: auto;
-  opacity: 0.95;
+  opacity: 1;
   transform: none;
 }
 .pa-doc-date {
@@ -10956,14 +10956,40 @@ select.ds-input {
 .pa-doc-footer {
   margin-top: auto;
   width: 100%;
-  padding-top: 10mm;
-  border: 0;
+  padding-top: 8mm;
+  border-top: 0.5px solid #e2e8f0;
   break-inside: avoid;
   page-break-inside: avoid;
   text-align: center;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+/* שורות פעילות — נקודה מפורשת לפני כל שורה */
+.pa-proposal-lines ul {
+  list-style: none;
+  padding-inline-start: 0;
+  margin: 2pt 0 6pt;
+}
+
+.pa-proposal-lines ul li {
+  position: relative;
+  padding-inline-start: 14pt;
+  margin: 3pt 0;
+  line-height: 1.55;
+  font-size: 10pt;
+  color: #111827;
+}
+
+.pa-proposal-lines ul li::before {
+  content: '·';
+  position: absolute;
+  inset-inline-start: 0;
+  font-weight: 900;
+  font-size: 12pt;
+  line-height: 1.3;
+  color: #1f4e79;
 }
 
 @media (max-width: 720px) {
@@ -11182,5 +11208,30 @@ select.ds-input {
     height: auto !important;
     display: block !important;
     opacity: 0.9 !important;
+  }
+
+  /* שורות פעילות בהדפסה */
+  .pa-proposal-lines ul {
+    list-style: none !important;
+    padding-inline-start: 0 !important;
+    margin: 2pt 0 6pt !important;
+  }
+
+  .pa-proposal-lines ul li {
+    position: relative !important;
+    padding-inline-start: 14pt !important;
+    margin: 3pt 0 !important;
+    line-height: 1.55 !important;
+    font-size: 10pt !important;
+    color: #000 !important;
+  }
+
+  .pa-proposal-lines ul li::before {
+    content: '·' !important;
+    position: absolute !important;
+    inset-inline-start: 0 !important;
+    font-weight: 900 !important;
+    font-size: 12pt !important;
+    color: #1f4e79 !important;
   }
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 472;
+const CACHE_VERSION = 473;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 468;
+const SW_ENTRY_VERSION = 473;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR updates the document styling for headers, footers, and introduces new styling for proposal lines with custom bullet points. The changes improve the visual presentation of documents and add support for formatted list items with Hebrew comments.

## Key Changes
- **Header logo**: Increased width from 160px to 240px and max-width from 38% to 44%
- **Footer logo**: Increased max-width from 48mm to 100mm and changed opacity from 0.95 to 1 (fully opaque)
- **Footer styling**: Reduced padding-top from 10mm to 8mm and added a subtle top border (0.5px solid #e2e8f0)
- **Proposal lines**: Added new `.pa-proposal-lines` styles with custom bullet point formatting:
  - Custom centered dot (·) bullets in dark blue (#1f4e79)
  - Proper spacing and typography for list items (10pt font, 1.55 line-height)
  - RTL-aware padding using `padding-inline-start`
- **Print media**: Added corresponding print-specific styles with `!important` flags to ensure consistent rendering when printing, including black text color override for accessibility

## Implementation Details
- The proposal lines styling uses CSS `::before` pseudo-elements to create custom bullet points
- All new styles include print media query variants to maintain consistency across screen and print layouts
- Hebrew comments indicate RTL (right-to-left) language support considerations
- The implementation uses logical properties (`inset-inline-start`, `padding-inline-start`) for better internationalization support

https://claude.ai/code/session_01XniZDuuVgB2ChxSAe2ybX4