### PR TITLE
Fix bullet point handling for indented lines in proposals

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -585,7 +585,17 @@ function parseSectionBodyStructure(value, options = {}) {
   };
 
   const isPlaceholderLine = (s) => /^שורה\s+חדשה\s*:?\s*$/i.test(s);
-  const expandedLines = raw.split('\n').flatMap(splitInlineBullets).map((line) => line.trim()).filter((line) => Boolean(line) && !isPlaceholderLine(line.replace(/^[·•▫▪◦‣–\-]\s*/, '')));
+  const bulletStartRe = new RegExp(`^[${BULLET_CHARS}]\s`);
+  const expandedLines = raw.split('\n').flatMap((rawLine) => {
+    const hasLeadingSpace = /^[ \t]+\S/.test(rawLine);
+    return splitInlineBullets(rawLine).map((item, i) => {
+      if (hasLeadingSpace && i === 0) {
+        const t = item.trim();
+        if (!bulletStartRe.test(t)) return `• ${t}`;
+      }
+      return item;
+    });
+  }).map((line) => line.trim()).filter((line) => Boolean(line) && !isPlaceholderLine(line.replace(/^[·•▫▪◦‣–\-]\s*/, '')));
   if (!expandedLines.length) return [];
 
   const bulletRegex = new RegExp(`^[${BULLET_CHARS}]\\s*(.+)$`);


### PR DESCRIPTION
## Summary
Improved the parsing logic for section body structures to properly handle indented lines that should be treated as bullet points, even when they don't explicitly start with a bullet character.

## Key Changes
- Added `bulletStartRe` regex pattern to detect lines that already start with bullet characters
- Enhanced the line expansion logic to detect leading whitespace on raw lines
- Automatically prepend a bullet character (`•`) to trimmed indented lines that don't already have one
- Preserves the existing behavior for lines that already have bullet characters or are not indented

## Implementation Details
The fix addresses a specific case where indented text lines (those starting with spaces/tabs) should be treated as bullet points. The logic now:
1. Detects if a raw line has leading whitespace before non-whitespace content
2. For the first item from `splitInlineBullets`, checks if it needs a bullet prefix
3. Only adds the bullet prefix if the trimmed line doesn't already start with a bullet character
4. Maintains backward compatibility with existing bullet point detection and filtering

https://claude.ai/code/session_01VJz58ghrGfJ4CT9jaoiRh5