### PR TITLE
fix: filter activity names by type using parent_value in public.lists

### DIFF
--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -166,11 +166,21 @@ function resolveActivityNameOptions(settings, activityType) {
     'activity_names', 'activity_name',
     'program_names', 'workshop_names', 'tour_names', 'escape_room_names'
   ];
+  let all = [];
   for (let i = 0; i < keys.length; i++) {
     const arr = opts[keys[i]];
-    if (Array.isArray(arr) && arr.length > 0) return normalizeActivityNameOptions(arr);
+    if (Array.isArray(arr) && arr.length > 0) { all = normalizeActivityNameOptions(arr); break; }
   }
-  return [];
+  if (!all.length) return [];
+  const type = String(activityType || '').trim().toLowerCase();
+  if (!type) return all;
+  const filtered = all.filter((o) => {
+    const parent = String(o?.parent_value || o?.activity_type || '').trim().toLowerCase();
+    return !parent || parent === type;
+  });
+  // Fall back to full list only when nothing is tagged — avoids empty dropdown for legacy data.
+  const hasTagged = all.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
+  return (filtered.length || hasTagged) ? filtered : all;
 }
 
 function buildActivityNameOpts(options, safeValue, activityType) {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 479;
+const CACHE_VERSION = 480;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260529_lists_add_parent_value_activity_names.sql
+++ b/supabase/migrations/20260529_lists_add_parent_value_activity_names.sql
@@ -1,0 +1,96 @@
+-- Add parent_value column to public.lists to enable per-type filtering of activity names.
+alter table public.lists
+  add column if not exists parent_value text;
+
+-- Populate parent_value for all existing activity_names rows based on the canonical mapping.
+-- Rows that already have a non-null parent_value are left untouched.
+
+update public.lists
+set parent_value = 'workshop'
+where category = 'activity_names'
+  and parent_value is null
+  and value in (
+    'אסטרונאוט על חוטים',
+    'מעבורת חלל תלת-ממדית',
+    'רוטוקופטר',
+    'פרפרטוס',
+    'צמידי שמש',
+    'קלידוסקופ',
+    'ג׳וני השלד',
+    'נשכן מפרקים',
+    'פרוגי המקפצת',
+    'מכונית מגנטית',
+    'ציפור שיווי משקל',
+    'גלגל הקסם',
+    'חללית בראשית',
+    'מערכת השמש בתלת-ממד',
+    'טלסקופ קפלר',
+    'כדור מולקולה',
+    'משקפת מתקפלת',
+    'מצפן',
+    'מכונית תנע',
+    'גשר לאונרדו',
+    'קטפולטה',
+    'כדורי ברנולי',
+    'ספינר',
+    'קופת קסם (ד''-ו'')',
+    'גיטרה - מנגנים פיזיקה',
+    'יוסי התוכי',
+    'קסם האנימציה',
+    'מאזניים',
+    'קופת קסם – מדע או אשליה?',
+    'הגיטרה הראשונה שלי',
+    'שעון רובוט – הזמן שלנו',
+    'הנדסת זמן – שעון רובוט',
+    'פריסקופ'
+  );
+
+update public.lists
+set parent_value = 'escape_room'
+where category = 'activity_names'
+  and parent_value is null
+  and value in (
+    'תמיר - חדר בריחה קווסט',
+    'תמיר - איפה דדי?'
+  );
+
+update public.lists
+set parent_value = 'tour'
+where category = 'activity_names'
+  and parent_value is null
+  and value in (
+    'התנסות בתעשייה'
+  );
+
+update public.lists
+set parent_value = 'after_school'
+where category = 'activity_names'
+  and parent_value is null
+  and value in (
+    'חוג מייקרים'
+  );
+
+update public.lists
+set parent_value = 'course'
+where category = 'activity_names'
+  and parent_value is null
+  and value in (
+    'ביומימיקרי',
+    'טכנולוגיות החלל',
+    'מנהיגות ירוקה',
+    'משחקי קופסה',
+    'מייקרים',
+    'ביומימיקרי לחטיבה',
+    'בינה מלאכותית',
+    'השמיים אינם הגבול',
+    'יישומי AI',
+    'פורצות דרך',
+    'פרימיום',
+    'רוקחים עולם',
+    'אופק לתעשייה',
+    'תלמידים להייטק'
+  );
+
+-- Index to speed up category + parent_value lookups.
+create index if not exists lists_category_parent_value_idx
+  on public.lists(category, parent_value);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 479;
+const SW_ENTRY_VERSION = 480;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
- Add migration to add parent_value column to public.lists and populate it for all activity_names rows based on the canonical type mapping (workshop / escape_room / tour / after_school / course)
- Fix resolveActivityNameOptions to filter by activityType; falls back to full list only when no rows are tagged (legacy-safe)
- Bump service worker cache version to 480 to force fresh load after deploy

https://claude.ai/code/session_0197o4UZGKR5FuMSRy7rULCN