### PR TITLE
Catalog: display short program names and split standalone category into four cards

### DIFF
--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -2,6 +2,22 @@ import { api } from '../api.js';
 import { escapeHtml } from './shared/html.js';
 const AUDIENCE_OPTIONS = ['הכול', 'יסודי', 'חטיבה'];
 const TYPE_OPTIONS = ['הכול', 'תוכנית', 'סדנה', 'סיור', 'חוג'];
+const STANDALONE_CATEGORIES = [
+  ['workshops', 'סדנאות'],
+  ['tours', 'סיורים'],
+  ['classes', 'חוגים'],
+  ['escape', 'חדרי בריחה']
+];
+const STANDALONE_LABELS = Object.fromEntries(STANDALONE_CATEGORIES);
+const CATALOG_SHORT_TITLE_OVERRIDES = new Map([
+  ['המצאות בהשראה מן הטבע', 'ביומימיקרי'],
+  ['טכנולוגיות חלל', 'טכנולוגיות החלל'],
+  ['טכנולוגיות החלל', 'טכנולוגיות החלל'],
+  ['פורצות דרך', 'פורצות דרך'],
+  ['סודות ויסודות הבינה המלאכותית', 'בינה מלאכותית'],
+  ['רוקחים עולם', 'רוקחים עולם'],
+  ['אופק לתעשייה', 'אופק לתעשייה']
+]);
 const SCHOOL_VALUE_COLUMNS = ['למה לבחור בזה?', 'איך זה נראה בכיתה?', 'מה התלמידים לוקחים איתם?'];
 
 function ensureCatalogStyles() {
@@ -141,14 +157,43 @@ function pickFirstNonEmpty(...values) {
   return '';
 }
 
+
+function textBeforeMarketingDash(value) {
+  return String(value || '')
+    .split(/\s+[–—-]\s+/)[0]
+    .trim();
+}
+
+function catalogCardTitleFromFields(p, fullName) {
+  const explicitShortName = pickFirstNonEmpty(
+    p.catalog_short_title,
+    p.catalog_short_name,
+    p.short_title,
+    p.short_name,
+    p.display_short_name,
+    p.display_name_short,
+    p.catalog_display_name
+  );
+  if (explicitShortName) return String(explicitShortName).trim();
+
+  const sourceName = String(fullName || '').trim();
+  for (const [needle, shortTitle] of CATALOG_SHORT_TITLE_OVERRIDES) {
+    if (sourceName.includes(needle)) return shortTitle;
+  }
+
+  const compactTitle = textBeforeMarketingDash(sourceName);
+  return compactTitle || sourceName || 'ללא שם';
+}
+
 function normalizeProgram(item, idx) {
   const p = item && typeof item === 'object' ? item : {};
   const syllabus = Array.isArray(p.syllabus) ? p.syllabus : [];
   const firstSyllabusDescription = syllabus.find((x) => x && typeof x === 'object' && x.description)?.description || '';
+  const fullName = String(pickFirstNonEmpty(p.catalog_title, p.activity_name, p.label_he, p.label, p.name, p.title, p.program_name, p.programName) || 'ללא שם');
   return {
     id: String(pickFirstNonEmpty(p.activity_no, p.id, p.programId, p.slug) || `program-${idx + 1}`),
-    name: String(pickFirstNonEmpty(p.catalog_title, p.activity_name, p.label_he, p.label, p.name, p.title, p.program_name, p.programName) || 'ללא שם'),
-    shortName: String(pickFirstNonEmpty(p.activity_name, p.label_he, p.label, p.catalog_title, p.name, p.title) || ''),
+    name: fullName,
+    catalogCardTitle: catalogCardTitleFromFields(p, fullName),
     audienceLevel: normalizeAudienceLevel(p.audience_level || p.audienceLevel || 'לא צוין'),
     productType: normalizeProductType(
       p.item_type ||
@@ -233,7 +278,7 @@ function isTamirWorkshop(program) {
 
 function renderCatalogCard(program) {
   return `<article class="catalog-card ${toneClassForProgram(program, 'catalog-card')}" data-audience-level="${escapeHtml(program.audienceLevel)}" data-page-template="${escapeHtml(program.pageTemplate)}" data-catalog-open="${escapeHtml(program.id)}">
-    <h3>${escapeHtml(program.shortName || program.name)}</h3>
+    <h3>${escapeHtml(program.catalogCardTitle || program.name)}</h3>
   </article>`;
 }
 
@@ -280,7 +325,7 @@ export const catalogScreen = {
       audience: 'הכול',
       type: 'הכול',
       groupMode: '',
-      standaloneCategory: 'escape',
+      standaloneCategory: 'workshops',
       loadError: payload?.error ? 'לא ניתן לטעון את נתוני הקטלוג. בדקו חיבור והרשאות.' : ''
     };
   },
@@ -297,18 +342,17 @@ export const catalogScreen = {
     const workshopAndTours = filtered.filter((p) => isStandaloneActivity(p));
 
     const standaloneByCategory = {
-      escape: workshopAndTours.filter((p) => isEscapeRoomProgram(p)),
-      makers: workshopAndTours.filter((p) => p.productType === 'סדנה' && !isEscapeRoomProgram(p) && !isTamirWorkshop(p)),
+      workshops: workshopAndTours.filter((p) => p.productType === 'סדנה' && !isEscapeRoomProgram(p)),
       tours: workshopAndTours.filter((p) => p.productType === 'סיור'),
-      classes: workshopAndTours.filter((p) => p.productType === 'חוג' || isAfterSchoolProgram(p))
+      classes: workshopAndTours.filter((p) => p.productType === 'חוג' || isAfterSchoolProgram(p)),
+      escape: workshopAndTours.filter((p) => isEscapeRoomProgram(p))
     };
-    const standaloneLabels = { escape: 'חדרי בריחה', makers: 'מייקרים', tours: 'סיורים', classes: 'חוגים' };
-    const selectedStandaloneCategory = standaloneByCategory[data.standaloneCategory] ? data.standaloneCategory : 'escape';
+    const selectedStandaloneCategory = standaloneByCategory[data.standaloneCategory] ? data.standaloneCategory : 'workshops';
 
     if (!selected && data.groupMode === 'standalone') {
       const selectedStandalonePrograms = standaloneByCategory[selectedStandaloneCategory] || [];
       return `<section class="catalog-screen">
-        <header class="catalog-header"><h2>סיורים, סדנאות</h2><p class="ds-muted">בחירה ממוקדת לפי 4 קבוצות פעילות</p></header>
+        <header class="catalog-header"><h2>סדנאות, סיורים וחוגים</h2><p class="ds-muted">בחירה ממוקדת לפי 4 קבוצות פעילות</p></header>
         <div class="catalog-toolbar">
           <label class="catalog-filter">שכבת גיל <select data-catalog-filter="audience">${AUDIENCE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === audience ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
           <label class="catalog-filter">סוג פעילות <select data-catalog-filter="type">${TYPE_OPTIONS.map((o) => `<option value="${escapeHtml(o)}" ${o === type ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('')}</select></label>
@@ -319,11 +363,11 @@ export const catalogScreen = {
         </div>
         <section class="catalog-group">
           <div class="catalog-subgroup-grid">
-            ${Object.entries(standaloneLabels).map(([key, label]) => `<button class="catalog-subgroup-card ${selectedStandaloneCategory === key ? 'is-active' : ''}" data-catalog-subgroup="${escapeHtml(key)}">${escapeHtml(label)}</button>`).join('')}
+            ${STANDALONE_CATEGORIES.map(([key, label]) => `<button class="catalog-subgroup-card ${selectedStandaloneCategory === key ? 'is-active' : ''}" data-catalog-subgroup="${escapeHtml(key)}">${escapeHtml(label)}</button>`).join('')}
           </div>
         </section>
         <section class="catalog-group">
-          <h3 class="catalog-group-title">${escapeHtml(standaloneLabels[selectedStandaloneCategory])}</h3>
+          <h3 class="catalog-group-title">${escapeHtml(STANDALONE_LABELS[selectedStandaloneCategory])}</h3>
           <div class="catalog-group-grid">
             ${selectedStandalonePrograms.length ? selectedStandalonePrograms.map(renderCatalogCard).join('') : '<p class="catalog-empty">אין פריטים להצגה</p>'}
           </div>
@@ -345,9 +389,7 @@ export const catalogScreen = {
           <section class="catalog-group">
             <h3 class="catalog-group-title">סדנאות, סיורים וחוגים</h3>
             <div class="catalog-group-grid">
-              <article class="catalog-card catalog-card--neutral" data-catalog-group-open="standalone">
-                <h3>סדנאות, סיורים וחוגים</h3>
-              </article>
+              ${STANDALONE_CATEGORIES.map(([key, label]) => `<article class="catalog-card catalog-card--neutral" data-catalog-subgroup="${escapeHtml(key)}"><h3>${escapeHtml(label)}</h3></article>`).join('')}
             </div>
           </section>
         </div>
@@ -414,7 +456,7 @@ export const catalogScreen = {
       }
       if (ev.target.closest('[data-catalog-group-open="standalone"]')) {
         data.groupMode = 'standalone';
-        data.standaloneCategory = 'escape';
+        data.standaloneCategory = 'workshops';
         data.selectedId = '';
         rerender();
         return;
@@ -422,7 +464,7 @@ export const catalogScreen = {
       const subgroupButton = ev.target.closest('[data-catalog-subgroup]');
       if (subgroupButton) {
         data.groupMode = 'standalone';
-        data.standaloneCategory = subgroupButton.dataset.catalogSubgroup || 'escape';
+        data.standaloneCategory = subgroupButton.dataset.catalogSubgroup || 'workshops';
         data.selectedId = '';
         rerender();
         return;

--- a/tests/catalog-screen-display.test.mjs
+++ b/tests/catalog-screen-display.test.mjs
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const CATALOG_JS = new URL('../frontend/src/screens/catalog.js', import.meta.url);
+
+async function readCatalogSource() {
+  return readFile(CATALOG_JS, 'utf8');
+}
+
+test('catalog card titles prefer short display-only names', async () => {
+  const src = await readCatalogSource();
+
+  assert.match(src, /function catalogCardTitleFromFields\(p, fullName\)/);
+  assert.match(src, /p\.catalog_short_title/);
+  assert.match(src, /p\.short_name/);
+  assert.match(src, /\['המצאות בהשראה מן הטבע', 'ביומימיקרי'\]/);
+  assert.match(src, /\['טכנולוגיות חלל', 'טכנולוגיות החלל'\]/);
+  assert.match(src, /\['סודות ויסודות הבינה המלאכותית', 'בינה מלאכותית'\]/);
+  assert.match(src, /<h3>\$\{escapeHtml\(program\.catalogCardTitle \|\| program\.name\)\}<\/h3>/);
+  assert.match(src, /<h1>\$\{escapeHtml\(selected\.name\)\}<\/h1>/);
+});
+
+test('standalone catalog group renders four short category cards, not one aggregate card', async () => {
+  const src = await readCatalogSource();
+
+  assert.match(src, /\['workshops', 'סדנאות'\]/);
+  assert.match(src, /\['tours', 'סיורים'\]/);
+  assert.match(src, /\['classes', 'חוגים'\]/);
+  assert.match(src, /\['escape', 'חדרי בריחה'\]/);
+  assert.match(src, /data-catalog-subgroup="\$\{escapeHtml\(key\)\}"/);
+  assert.doesNotMatch(src, /<h3>סדנאות, סיורים וחוגים<\/h3>\s*<\/article>/);
+});


### PR DESCRIPTION
### Motivation
- Make the catalog list view use short, compact titles instead of long marketing/full names so cards stay readable. 
- Replace the single aggregate card for “סדנאות, סיורים וחוגים” with four distinct selectable cards for the user to open focused subcategories. 
- Keep all internal data, identifiers, pricing and export fields unchanged; this is a display-only change.

### Description
- Added a short-title resolution flow (`catalogCardTitleFromFields`, `textBeforeMarketingDash` and `CATALOG_SHORT_TITLE_OVERRIDES`) and set `catalogCardTitle` in `normalizeProgram` while preserving the full `name` field. 
- Updated `renderCatalogCard` to show `program.catalogCardTitle || program.name` so cards use the short display name only. 
- Replaced the single aggregate standalone card with `STANDALONE_CATEGORIES` (workshops, tours, classes, escape rooms), adjusted `standaloneByCategory` and subgroup rendering/selection, and set the default standalone category to `workshops`. 
- Added regression tests in `tests/catalog-screen-display.test.mjs` that assert short-title logic and that the standalone group renders four short category cards (and kept the program full name used in the detail view unchanged).

### Testing
- Ran `node -c frontend/src/screens/catalog.js && node --test tests/catalog-screen-display.test.mjs` and the new catalog tests passed. 
- Verified `node --test tests/catalog-screen-display.test.mjs` (source-level assertions) passed and confirms the new rendering strings are present. 
- Attempted a full build with `npm run build` where the change applied, but the build failed due to an existing unrelated syntax error in `frontend/src/screens/proposals-agreements.js:628`. 
- Ran the wider test suite (`npm test` / `timeout 25s npm test`) which exercised unrelated areas and timed out / surfaced preexisting unrelated failures; the catalog-related tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aa460dacc832ba8c38fe961a8681f)