### PR TITLE
Separate catalog display from proposal pricing

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 482;
+const CACHE_VERSION = 483;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BOs3yzit.js",
+  "./assets/index-CaFWTeYI.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-Dych4ZX-.css",
+  "./assets/style-T5bw0io7.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BOs3yzit.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-Dych4ZX-.css">
+  <script type="module" crossorigin src="./assets/index-CaFWTeYI.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-T5bw0io7.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 482;
+const CACHE_VERSION = 483;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BOs3yzit.js",
+  "./assets/index-CaFWTeYI.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-Dych4ZX-.css",
+  "./assets/style-T5bw0io7.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2375,11 +2375,11 @@ async function readCatalogProgramsFromSupabase() {
       .order('sort_order', { ascending: true }),
     supabase
       .from('catalog_program_details')
-      .select('activity_no,catalog_title,catalog_subtitle,audience_level,target_grades,domain,scope,session_duration,gefen_number,opening_line,core_idea,program_flow,student_develops,school_value,final_outcome,syllabus,page_template,is_active_for_catalog')
+      .select('activity_no,catalog_title,catalog_subtitle,short_description,audience_level,target_grades,domain,scope,session_duration,gefen_number,opening_line,core_idea,program_flow,student_develops,participants_receive,school_value,final_outcome,closing_box,syllabus,page_template,is_active_for_catalog')
       .eq('is_active_for_catalog', true),
     supabase
       .from('proposal_activity_pricing')
-      .select('activity_no,activity_name,proposal_group,item_type,gefen_number,meetings_count,hours_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order,is_active_for_proposals')
+      .select('activity_no,activity_name,proposal_group,item_type,catalog_group,gefen_number,meetings_count,hours_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order,is_active_for_proposals,is_active_for_catalog')
       .eq('is_active_for_proposals', true)
       .order('sort_order', { ascending: true })
   ]);
@@ -2418,6 +2418,47 @@ async function readCatalogProgramsFromSupabase() {
     return acc;
   }, new Map());
 
+  const cleanCatalogText = (value) => String(value ?? '').trim();
+  const normalizeCatalogGroup = (value) => {
+    const raw = cleanCatalogText(value);
+    const normalized = raw.toLowerCase().replace(/[\s-]+/g, '_');
+    if (!raw) return '';
+    if (['after_school', 'afterschool', 'classes', 'class', 'club', 'clubs'].includes(normalized) || raw.includes('אפטרסקול') || raw.includes('חוג')) return 'after_school';
+    if (['makers', 'maker', 'workshop_makers'].includes(normalized) || raw.includes('מייקרים')) return 'makers';
+    if (['space', 'workshop_space'].includes(normalized) || raw.includes('חלל')) return 'space';
+    if (['escape', 'escape_room', 'digital_escape_room'].includes(normalized) || raw.includes('חדר בריחה')) return 'escape';
+    if (['tour', 'tours'].includes(normalized) || raw.includes('סיור')) return 'tours';
+    if (['program', 'programs', 'course', 'courses'].includes(normalized) || raw.includes('תוכנית')) return 'programs';
+    return normalized;
+  };
+  const hasExplicitCatalogGroup = (row) => Boolean(cleanCatalogText(row?.catalog_group));
+  const isTamirCatalogPricingRow = (row) => [row?.activity_name, row?.item_type, row?.description_for_proposal]
+    .map((value) => cleanCatalogText(value).toLowerCase())
+    .join(' ')
+    .includes('תמיר');
+  const catalogPricingGroup = (row) => {
+    if (row?.is_active_for_catalog !== true) return '';
+    const explicitGroup = normalizeCatalogGroup(row?.catalog_group);
+    if (explicitGroup) return explicitGroup;
+    if (isTamirCatalogPricingRow(row)) return '';
+    const itemTypeGroup = normalizeCatalogGroup(row?.item_type);
+    if (itemTypeGroup && itemTypeGroup !== 'programs') return itemTypeGroup;
+    const name = cleanCatalogText(row?.activity_name);
+    if (name === 'תלמידים להייטק' || name === 'חוג מייקרים') return 'after_school';
+    if (name === 'סדנת מייקרים') return 'makers';
+    if (name === 'סדנת חלל') return 'space';
+    if (name === 'חדר בריחה דיגיטלי') return 'escape';
+    return '';
+  };
+  const catalogGroupToProductType = (group, row = {}) => {
+    const itemType = cleanCatalogText(row?.item_type);
+    if (itemType === 'חוג אפטרסקול') return 'חוג';
+    if (group === 'after_school') return 'חוג';
+    if (group === 'tours') return 'סיור';
+    if (group === 'makers' || group === 'space' || group === 'escape') return 'סדנה';
+    return itemType || 'תוכנית';
+  };
+
   const toCatalogSyllabus = (value) => {
     if (Array.isArray(value)) return value;
     if (value && typeof value === 'object') return [value];
@@ -2437,13 +2478,9 @@ async function readCatalogProgramsFromSupabase() {
     }
   };
 
-  const programKeys = Array.from(new Set([
-    ...listByNo.keys(),
-    ...detailsByNo.keys(),
-    ...pricingByNo.keys()
-  ])).filter(Boolean);
+  const detailKeys = Array.from(detailsByNo.keys()).filter(Boolean);
 
-  const programs = programKeys.map((key) => {
+  const detailPrograms = detailKeys.map((key) => {
     const row = listByNo.get(key) || {};
     const pricingRowsForProgram = pricingByNo.get(key) || [];
     const primaryPricing = pricingRowsForProgram[0] || {};
@@ -2452,6 +2489,9 @@ async function readCatalogProgramsFromSupabase() {
     const sessionDuration = details.session_duration || primaryPricing.unit_duration || '';
     const scope = details.scope || primaryPricing.meetings_count || primaryPricing.hours_count || '';
     const gefenNumber = details.gefen_number || row.gefen_number || primaryPricing.gefen_number || '';
+    const shortDescription = details.opening_line || details.catalog_subtitle || details.short_description || primaryPricing.description_for_proposal || '';
+    const participantsReceive = details.student_develops || details.participants_receive || '';
+    const closingBox = details.final_outcome || details.closing_box || '';
     return {
       ...row,
       ...primaryPricing,
@@ -2459,8 +2499,10 @@ async function readCatalogProgramsFromSupabase() {
       activity_no: key,
       pricing_options: pricingRowsForProgram,
       proposal_pricing_rows: pricingRowsForProgram,
+      catalog_source: 'catalog_program_details',
+      catalog_group: 'programs',
       // Normalize detail fields to the naming contract expected by catalog screen.
-      catalog_title: details.catalog_title || primaryPricing.activity_name || row.activity_name || row.label_he || row.label || '',
+      catalog_title: details.catalog_title || row.activity_name || row.label_he || row.label || primaryPricing.activity_name || '',
       catalog_subtitle: details.catalog_subtitle || '',
       audience_level: details.audience_level || row.audience_level || '',
       target_grades: targetGrades,
@@ -2475,22 +2517,87 @@ async function readCatalogProgramsFromSupabase() {
       gefen_number: gefenNumber,
       gefenNumber,
       opening_line: details.opening_line || '',
+      short_description: details.short_description || '',
       core_idea: details.core_idea || '',
       program_flow: details.program_flow || '',
       student_develops: details.student_develops || '',
+      participants_receive: details.participants_receive || '',
       school_value: details.school_value || '',
       final_outcome: details.final_outcome || '',
+      closing_box: details.closing_box || '',
       page_template: details.page_template || '',
-      catalog_short_description: details.opening_line || details.catalog_subtitle || primaryPricing.description_for_proposal || '',
-      catalog_core_idea: details.core_idea || primaryPricing.description_for_proposal || '',
+      catalog_short_description: shortDescription,
+      catalog_core_idea: details.core_idea || '',
       catalog_goals: details.program_flow || '',
-      catalog_participants_receive: details.student_develops || '',
+      catalog_program_flow: details.program_flow || '',
+      catalog_participants_receive: participantsReceive,
       catalog_school_value: details.school_value || '',
       catalog_syllabus: toCatalogSyllabus(details.syllabus),
-      catalog_closing_box: details.final_outcome || '',
+      catalog_closing_box: closingBox,
       catalog_page_template: details.page_template || ''
     };
   });
+
+  const explicitCatalogPricingRows = pricingRows
+    .map((row, idx) => ({ row, idx, catalogGroup: catalogPricingGroup(row) }))
+    .filter(({ row, catalogGroup }) => catalogGroup && (!cleanCatalogText(row?.activity_no) || !detailsByNo.has(cleanCatalogText(row?.activity_no))));
+
+  const pricingPrograms = explicitCatalogPricingRows.map(({ row, idx, catalogGroup }) => {
+    const key = cleanCatalogText(row.activity_no) || `pricing-${idx + 1}`;
+    const listRow = listByNo.get(key) || {};
+    const targetGrades = listRow.target_grades || '';
+    const scopeParts = [];
+    if (row.meetings_count != null) scopeParts.push(`${row.meetings_count} מפגשים`);
+    if (row.hours_count != null) scopeParts.push(`${row.hours_count} שעות`);
+    const scope = scopeParts.join(' / ');
+    const title = row.activity_name || listRow.activity_name || listRow.label_he || listRow.label || '';
+    return {
+      ...listRow,
+      ...row,
+      id: `pricing-${key}-${idx + 1}`,
+      activity_no: key,
+      pricing_options: [row],
+      proposal_pricing_rows: [row],
+      catalog_source: 'proposal_activity_pricing',
+      catalog_group: catalogGroup,
+      catalog_group_explicit: hasExplicitCatalogGroup(row),
+      catalog_title: title,
+      catalog_subtitle: row.item_type || '',
+      audience_level: listRow.audience_level || '',
+      target_grades: targetGrades,
+      grades: targetGrades,
+      targetGrades,
+      domain: catalogGroup === 'after_school' ? 'חוגי אפטרסקול' : '',
+      scope,
+      session_duration: row.unit_duration || '',
+      meetings_count: row.meetings_count,
+      hours_count: row.hours_count,
+      unit_duration: row.unit_duration || '',
+      gefen_number: row.gefen_number || listRow.gefen_number || '',
+      gefenNumber: row.gefen_number || listRow.gefen_number || '',
+      item_type: catalogGroupToProductType(catalogGroup, row),
+      opening_line: row.description_for_proposal || '',
+      core_idea: row.description_for_proposal || '',
+      program_flow: '',
+      student_develops: '',
+      participants_receive: '',
+      school_value: '',
+      final_outcome: '',
+      closing_box: '',
+      page_template: catalogGroup,
+      catalog_short_description: row.description_for_proposal || '',
+      catalog_core_idea: row.description_for_proposal || '',
+      catalog_goals: '',
+      catalog_program_flow: '',
+      catalog_participants_receive: '',
+      catalog_school_value: '',
+      catalog_syllabus: [],
+      catalog_closing_box: '',
+      catalog_page_template: catalogGroup
+    };
+  });
+
+  const programs = [...detailPrograms, ...pricingPrograms];
 
   return {
     programs,

--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -2,6 +2,7 @@ import { api } from '../api.js';
 import { escapeHtml } from './shared/html.js';
 const AUDIENCE_OPTIONS = ['הכול', 'יסודי', 'חטיבה'];
 const TYPE_OPTIONS = ['הכול', 'תוכנית', 'סדנה', 'סיור', 'חוג'];
+const STANDALONE_GROUP_LABELS = { escape: 'חדרי בריחה', makers: 'מייקרים', space: 'חלל', tours: 'סיורים', classes: 'חוגים / אפטרסקול' };
 const SCHOOL_VALUE_COLUMNS = ['למה לבחור בזה?', 'איך זה נראה בכיתה?', 'מה התלמידים לוקחים איתם?'];
 
 function ensureCatalogStyles() {
@@ -114,7 +115,7 @@ function normalizeProductType(value) {
   const raw = String(value || '').trim();
   const normalized = raw.toLowerCase();
   if (normalized === 'course') return 'תוכנית';
-  if (normalized === 'after_school') return 'חוג';
+  if (normalized === 'after_school' || normalized === 'חוג אפטרסקול') return 'חוג';
   if (normalized === 'workshop') return 'סדנה';
   if (normalized === 'tour') return 'סיור';
   if (normalized === 'escape_room') return 'סדנה';
@@ -122,6 +123,18 @@ function normalizeProductType(value) {
   if (raw === 'סיורים') return 'סיור';
   if (raw === 'סדנאות') return 'סדנה';
   return raw || 'תוכנית';
+}
+
+function normalizeCatalogGroup(value) {
+  const raw = String(value || '').trim();
+  const normalized = raw.toLowerCase().replace(/[\s-]+/g, '_');
+  if (!raw) return '';
+  if (['after_school', 'afterschool', 'classes', 'club', 'clubs'].includes(normalized) || raw.includes('אפטרסקול') || raw.includes('חוג')) return 'classes';
+  if (['makers', 'maker', 'workshop_makers'].includes(normalized) || raw.includes('מייקרים')) return 'makers';
+  if (['space', 'workshop_space'].includes(normalized) || raw.includes('חלל')) return 'space';
+  if (['escape', 'escape_room', 'digital_escape_room'].includes(normalized) || raw.includes('חדר בריחה')) return 'escape';
+  if (['tour', 'tours'].includes(normalized) || raw.includes('סיור')) return 'tours';
+  return '';
 }
 
 function inferScope(p) {
@@ -164,17 +177,21 @@ function normalizeProgram(item, idx) {
     sessionDuration: String(pickFirstNonEmpty(p.session_duration, p.unit_duration, p.sessionDuration, p.duration) || 'לא צוין'),
     gefenNumber: String(pickFirstNonEmpty(p.gefen_number, p.gefenNumber, p.gefen) || ''),
     subtitle: String(pickFirstNonEmpty(p.catalog_subtitle, p.subtitle) || ''),
-    shortDescription: String(pickFirstNonEmpty(p.catalog_subtitle, p.catalog_short_description, p.opening_line, p.description_short, p.shortDescription, p.openingLine, p.subtitle, p.sections?.openingStatement, firstSyllabusDescription) || ''),
-    coreIdea: String(pickFirstNonEmpty(p.catalog_core_idea, p.core_idea, p.description_for_proposal, p.coreIdea, p.description, p.sections?.mainIdea, firstSyllabusDescription) || ''),
-    goals: String(pickFirstNonEmpty(p.catalog_goals, p.program_flow, p.goals, p.sections?.programFlow) || ''),
-    studentDevelops: pickFirstNonEmpty(p.catalog_participants_receive, p.student_develops, p.studentDevelops, p.participantsReceive) || '',
+    shortDescription: String(pickFirstNonEmpty(p.catalog_short_description, p.opening_line, p.catalog_subtitle, p.short_description, p.description_short, p.shortDescription, p.openingLine, p.subtitle, p.sections?.openingStatement, firstSyllabusDescription) || ''),
+    coreIdea: String(pickFirstNonEmpty(p.catalog_core_idea, p.core_idea, p.coreIdea, p.sections?.mainIdea, firstSyllabusDescription) || ''),
+    goals: String(pickFirstNonEmpty(p.catalog_program_flow, p.catalog_goals, p.program_flow, p.goals, p.sections?.programFlow) || ''),
+    programFlow: String(pickFirstNonEmpty(p.catalog_program_flow, p.program_flow, p.catalog_goals, p.goals, p.sections?.programFlow) || ''),
+    studentDevelops: pickFirstNonEmpty(p.catalog_participants_receive, p.student_develops, p.participants_receive, p.studentDevelops, p.participantsReceive) || '',
     schoolValue: String(pickFirstNonEmpty(p.catalog_school_value, p.school_value, p.schoolValue, p.sections?.schoolValue) || ''),
     syllabus: Array.isArray(p.catalog_syllabus) && p.catalog_syllabus.length ? p.catalog_syllabus : syllabus,
     stations: Array.isArray(p.stations) ? p.stations : [],
-    participantsReceive: pickFirstNonEmpty(p.catalog_participants_receive, p.student_develops, p.studentDevelops, p.participantsReceive) || [],
-    closingBox: String(pickFirstNonEmpty(p.catalog_closing_box, p.final_outcome, p.closingBox, p.sections?.finalOutcome) || ''),
-    footer: String(pickFirstNonEmpty(p.catalog_footer, p.footer, p.final_outcome) || ''),
+    participantsReceive: pickFirstNonEmpty(p.catalog_participants_receive, p.student_develops, p.participants_receive, p.studentDevelops, p.participantsReceive) || [],
+    closingBox: String(pickFirstNonEmpty(p.catalog_closing_box, p.final_outcome, p.closing_box, p.closingBox, p.sections?.finalOutcome) || ''),
+    finalOutcome: String(pickFirstNonEmpty(p.final_outcome, p.catalog_closing_box, p.closing_box, p.closingBox, p.sections?.finalOutcome) || ''),
+    footer: String(pickFirstNonEmpty(p.catalog_footer, p.footer, p.final_outcome, p.closing_box) || ''),
     pageTemplate: String(pickFirstNonEmpty(p.catalog_page_template, p.page_template, p.pageTemplate) || 'default'),
+    catalogGroup: normalizeCatalogGroup(p.catalog_group || p.catalogGroup),
+    catalogSource: String(pickFirstNonEmpty(p.catalog_source, p.catalogSource) || ''),
     pricingOptions: Array.isArray(p.pricing_options) ? p.pricing_options : []
   };
 }
@@ -210,6 +227,7 @@ function isStandaloneActivity(program) {
 }
 
 function isAfterSchoolProgram(program) {
+  if (program.catalogGroup === 'classes') return true;
   const haystack = [program.productType, program.name, program.coreIdea, program.shortDescription]
     .map((v) => String(v || '').toLowerCase())
     .join(' ');
@@ -217,14 +235,24 @@ function isAfterSchoolProgram(program) {
 }
 
 function isEscapeRoomProgram(program) {
+  if (program.catalogGroup === 'escape') return true;
   const haystack = [program.name, program.coreIdea, program.shortDescription]
     .map((v) => String(v || '').toLowerCase())
     .join(' ');
   return haystack.includes('חדר בריחה') || haystack.includes('escape room') || haystack.includes('escape_room');
 }
 
+function isSpaceWorkshop(program) {
+  if (program.catalogGroup === 'space') return true;
+  const haystack = [program.name, program.coreIdea, program.shortDescription]
+    .map((v) => String(v || '').toLowerCase())
+    .join(' ');
+  return haystack.includes('חלל');
+}
+
 function isTamirWorkshop(program) {
   if (program.productType !== 'סדנה') return false;
+  if (program.catalogSource === 'proposal_activity_pricing' && !program.catalogGroup) return true;
   const haystack = [program.name, program.coreIdea, program.shortDescription]
     .map((v) => String(v || '').toLowerCase())
     .join(' ');
@@ -297,12 +325,13 @@ export const catalogScreen = {
     const workshopAndTours = filtered.filter((p) => isStandaloneActivity(p));
 
     const standaloneByCategory = {
-      escape: workshopAndTours.filter((p) => isEscapeRoomProgram(p)),
-      makers: workshopAndTours.filter((p) => p.productType === 'סדנה' && !isEscapeRoomProgram(p) && !isTamirWorkshop(p)),
-      tours: workshopAndTours.filter((p) => p.productType === 'סיור'),
-      classes: workshopAndTours.filter((p) => p.productType === 'חוג' || isAfterSchoolProgram(p))
+      escape: workshopAndTours.filter((p) => p.catalogGroup === 'escape' || isEscapeRoomProgram(p)),
+      makers: workshopAndTours.filter((p) => p.catalogGroup === 'makers' || (p.productType === 'סדנה' && !isEscapeRoomProgram(p) && !isSpaceWorkshop(p) && !isTamirWorkshop(p))),
+      space: workshopAndTours.filter((p) => p.catalogGroup === 'space' || isSpaceWorkshop(p)),
+      tours: workshopAndTours.filter((p) => p.catalogGroup === 'tours' || p.productType === 'סיור'),
+      classes: workshopAndTours.filter((p) => p.catalogGroup === 'classes' || p.productType === 'חוג' || isAfterSchoolProgram(p))
     };
-    const standaloneLabels = { escape: 'חדרי בריחה', makers: 'מייקרים', tours: 'סיורים', classes: 'חוגים' };
+    const standaloneLabels = STANDALONE_GROUP_LABELS;
     const selectedStandaloneCategory = standaloneByCategory[data.standaloneCategory] ? data.standaloneCategory : 'escape';
 
     if (!selected && data.groupMode === 'standalone') {
@@ -355,9 +384,10 @@ export const catalogScreen = {
     }
 
     const labels = productTypeLabels(selected.productType);
-    const programFlowList = splitToList(selected.goals);
+    const programFlowList = splitToList(selected.programFlow || selected.goals);
     const studentDevList = splitToList(selected.studentDevelops || selected.participantsReceive);
     const participants = splitToList(selected.participantsReceive || selected.studentDevelops).slice(0, 4);
+    const outcomeText = fallbackText(selected.finalOutcome || selected.closingBox || selected.footer, 'למידה פעילה, משמעותית ומחוברת לעולם האמיתי.');
     const schoolValueParts = splitToList(selected.schoolValue).slice(0, 3);
     while (schoolValueParts.length < 3) schoolValueParts.push('—');
     const syllabusSource = selected.productType === 'סיור' && selected.stations.length ? selected.stations : selected.syllabus;
@@ -380,15 +410,15 @@ export const catalogScreen = {
         </header>
         <section class="catalog-frame-grid"><div class="catalog-box"><strong>כיתות</strong><p>${escapeHtml(fallbackText(selected.grades))}</p></div><div class="catalog-box"><strong>היקף</strong><p>${escapeHtml(fallbackText(selected.scope))}</p></div><div class="catalog-box"><strong>משך מפגש</strong><p>${escapeHtml(fallbackText(selected.sessionDuration))}</p></div><div class="catalog-box"><strong>מספר גפ״ן</strong><p>${escapeHtml(fallbackText(selected.gefenNumber))}</p></div></section>
         <section class="catalog-content-grid">
-          <div class="catalog-box"><h3>${escapeHtml(labels.happening)}</h3><p>${escapeHtml(fallbackText(selected.shortDescription || selected.goals))}</p></div>
+          <div class="catalog-box"><h3>${escapeHtml(labels.happening)}</h3><p>${escapeHtml(fallbackText(selected.shortDescription || selected.programFlow || selected.goals))}</p>${programFlowList.length ? `<ul>${programFlowList.map((i) => `<li>${escapeHtml(i)}</li>`).join('')}</ul>` : ''}</div>
           <div class="catalog-box"><h3>הרעיון המרכזי</h3><p>${escapeHtml(fallbackText(selected.coreIdea))}</p></div>
-          <div class="catalog-box"><h3>מה התלמידים מפתחים</h3><ul>${programFlowList.length ? programFlowList.map((i) => `<li>${escapeHtml(i)}</li>`).join('') : '<li>—</li>'}</ul></div>
-          <div class="catalog-box"><h3>${escapeHtml(labels.outcome)}</h3><ul>${studentDevList.length ? studentDevList.map((i) => `<li>${escapeHtml(i)}</li>`).join('') : '<li>—</li>'}</ul></div>
+          <div class="catalog-box"><h3>מה מקבלים המשתתפים / מה התלמידים מפתחים</h3><ul>${studentDevList.length ? studentDevList.map((i) => `<li>${escapeHtml(i)}</li>`).join('') : '<li>—</li>'}</ul></div>
+          <div class="catalog-box"><h3>${escapeHtml(labels.outcome)}</h3><p>${escapeHtml(outcomeText)}</p></div>
         </section>
         <section class="catalog-strip"><h3>הערך לבית הספר</h3><div class="catalog-strip-grid">${SCHOOL_VALUE_COLUMNS.map((label, i) => `<div class="catalog-box"><strong>${label}</strong><p>${escapeHtml(schoolValueParts[i] || '—')}</p></div>`).join('')}</div></section>
         ${hasSyllabus ? `<section class="catalog-box"><h3>${escapeHtml(labels.syllabus)}</h3><table><thead><tr><th>מפגש / תחנה</th><th>נושא</th><th>מה עושים</th></tr></thead><tbody>${syllabusRows}</tbody></table></section>` : ''}
         <section><h3>מה מקבלים המשתתפים</h3><div class="catalog-mini-card-grid">${(participants.length ? participants : ['—']).map((item) => `<div class="catalog-mini-card">${escapeHtml(item)}</div>`).join('')}</div></section>
-        <section class="catalog-box catalog-close"><h3>${escapeHtml(labels.closing)}</h3><p>✓ ${escapeHtml(fallbackText(selected.footer || selected.closingBox, 'למידה פעילה, משמעותית ומחוברת לעולם האמיתי.'))}</p></section>
+        <section class="catalog-box catalog-close"><h3>${escapeHtml(labels.closing)}</h3><p>✓ ${escapeHtml(outcomeText)}</p></section>
         <footer class="catalog-footer"><span>עמותת תעשיידע — חינוך טכנולוגי, חדשנות ויזמות</span><span>קטלוג תוכניות תשפ״ז</span></footer>
       </article></div>
     </section>`;

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -608,7 +608,7 @@ function parseSectionBodyStructure(value, options = {}) {
   };
 
   const isPlaceholderLine = (s) => /^שורה\s+חדשה\s*:?\s*$/i.test(s);
-  const bulletStartRe = new RegExp(`^[${BULLET_CHARS}]\s`);
+  const bulletStartRe = new RegExp(`^[${BULLET_CHARS}]\\s`);
   const inlineNewlineMarkerRe = /\s*שורה\s+חדשה\s*:?\s*/i;
   const expandedLines = raw.split('\n').flatMap((rawLine) => {
     const hasLeadingSpace = /^[ \t]+\S/.test(rawLine);
@@ -625,7 +625,7 @@ function parseSectionBodyStructure(value, options = {}) {
         return item;
       });
     });
-  })).map((line) => line.trim()).filter((line) => Boolean(line) && !isPlaceholderLine(line.replace(/^[·•▫▪◦‣–\-]\s*/, '')));
+  }).map((line) => line.trim()).filter((line) => Boolean(line) && !isPlaceholderLine(line.replace(/^[·•▫▪◦‣–\-]\s*/, '')));
   if (!expandedLines.length) return [];
 
   const bulletRegex = new RegExp(`^[${BULLET_CHARS}]\\s*(.+)$`);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 482;
+const CACHE_VERSION = 483;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 482;
+const SW_ENTRY_VERSION = 483;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להפריד בבירור בין נתוני הקטלוג הציבורי לנתוני תמחור/הצעות כדי שלא כל שורה ב־`proposal_activity_pricing` תוצג בקטלוג הציבורי ולהימנע מחשיפת פריטי "תמיר" או שמות כלליים לא מיועדים להצגה. 
- להשתמש בשדות מפורשים (`catalog_group` / `item_type` / `is_active_for_catalog`) כקריטריון ראשון ולבצע זיהוי טקסטואלי רק כ־fallback. 
- לשמור על פועליות מלאה של זרימות הצעות המחיר ולמנוע שינויים במחירים/שעות/גפ"ן שלא נדרשים. 
- להבטיח שה־Service Worker יקפיץ גרסה כדי לרוקן cache ישן אחרי פריסה.

### Description
- `frontend/src/api.js`: שיניתי את `readCatalogProgramsFromSupabase` כך ש־`catalog_program_details` הוא המקור הראשי לכרטיסי תוכניות, ושהשורות מתוך `proposal_activity_pricing` יוכנסו לקטלוג רק אם מסומנות למופע בקטלוג (`is_active_for_catalog`) ויש להן קיבוץ/סיווג תקף; הוספתי פונקציות `cleanCatalogText`, `normalizeCatalogGroup`, `catalogPricingGroup` ו־`catalogGroupToProductType` כדי לקבוע קטגוריות (after_school / makers / space / escape / tours) ולחרוג מפריטי Tamir אם אין הגדרה מפורשת. 
- מיפוי שדות: עדכנתי את מיפוי השדות כך ש־`target_grades/grades` מועדף עבור "כיתות", `session_duration` -> "משך מפגש", `scope` -> "היקף", `gefen_number` -> "מספר גפ״ן", `opening_line/catalog_subtitle/short_description` -> תיאור קצר, `core_idea` -> רעיון מרכזי, `program_flow` -> מה עושים/מהלך התוכנית, `student_develops/participants_receive` -> מה מקבלים המשתתפים, `school_value` -> ערך לבית הספר, `final_outcome/closing_box` -> תוצר/סגירה, ו־`syllabus` נכנס כסילבוס כאשר קיים. 
- `frontend/src/screens/catalog.js`: עדכנתי `normalizeProgram` כדי להשתמש בשדות החדשים (`catalog_short_description`, `catalog_program_flow`, `catalog_participants_receive`, `catalogGroup`, `catalogSource`), הוספתי זיהוי וסינון קבוצות standalone (חוגים/אפטרסקול, מייקרים, חלל, חדרי בריחה, סיורים) שמעדיף שדה קטלוג מפורש ומוריד הסתמכות על זיהוי טקסטואלי בלבד, ושיפרתי את תצוגת הכרטיסים/A4 כדי להציג את השדות החדשים נכון. 
- `frontend/src/screens/proposals-agreements.js`: תיקנתי בעיית תחביר/רגקס בפיצול שורות (bullet parsing) שגרמה לכשל ב־`node --check`, שימרתי את סינון "שעות בדיקות"/פריטי בדיקה (לא נכללים בתצוגת בחירה מהירה) ושמרתי את כל זרימת הצעות המחיר ללא שינוי פונקציונלי (רק תיקוני parsing/ייצוב). 
- Service Worker: קיפצתי גרסת cache בשני המקומות `frontend/sw.js` ו־`sw.js` ל־483 כדי להכריח רענון קאש אחרי פריסה; בוצעו עדכוני build ו־dist מתאימים. 

### Testing
- הרצת בדיקות תחביר: `node --check frontend/src/api.js && node --check frontend/src/screens/catalog.js && node --check frontend/src/screens/proposals-agreements.js` — עברו בהצלחה לאחר התיקונים. 
- בנייה לפרודקשן: `npm run build` — ביצוע מוצלח ויצירת `dist`. 
- ריצה מלאה של המבחנים: `npm test` — הסוויטה החלה אך נתקלו בכשלות קיימות ואי־קשורות במבחני snapshot/activities (ולבסוף הושבתה); השינויים בקיטלוג ובתיקון ה־syntax לא קשורים לכשלים אלו.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aa56fccec832b9f32cfea114cd33c)