### PR TITLE
Preserve proposal section multiline formatting

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 485;
+const CACHE_VERSION = 486;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CG6q1FJ6.js",
+  "./assets/index-TNapkck_.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CG6q1FJ6.js"></script>
+  <script type="module" crossorigin src="./assets/index-TNapkck_.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-T5bw0io7.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 485;
+const CACHE_VERSION = 486;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CG6q1FJ6.js",
+  "./assets/index-TNapkck_.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -69,6 +69,21 @@ function text(value) {
   return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
 }
 
+function normalizeMultilineText(value) {
+  return String(value == null ? '' : value)
+    .replace(/\r\n?/g, '\n')
+    .trim();
+}
+
+function normalizeDocumentSection(section = {}) {
+  return {
+    ...section,
+    section_key: text(section.section_key),
+    section_title: text(section.section_title),
+    section_body: normalizeMultilineText(section.section_body)
+  };
+}
+
 function normalizeSearch(value) {
   return text(value).toLowerCase();
 }
@@ -105,7 +120,7 @@ export function normalizeProposalAgreementRow(row = {}) {
     status:              STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft',
     approval_note:       text(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
-    custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections : [],
+    custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections.map(normalizeDocumentSection) : [],
     created_at:          text(row.created_at),
     updated_at:          text(row.updated_at)
   };
@@ -536,9 +551,7 @@ const TEMPLATE_KEY_BY_GROUP = {
 };
 
 function templateBodyText(section) {
-  return String(section?.section_body == null ? '' : section.section_body)
-    .replace(/\r\n?/g, '\n')
-    .trim();
+  return normalizeMultilineText(section?.section_body);
 }
 
 function proposalTitle(row) {
@@ -591,103 +604,89 @@ function sectionHtml(title, body, className = '', options = {}) {
 
 function parseSectionBodyStructure(value, options = {}) {
   const { alwaysBullet = false } = options;
-  const raw = String(value == null ? '' : value).replace(/\r\n?/g, '\n').trim();
+  const raw = normalizeMultilineText(value).replace(/[ \t]*שורה\s+חדשה\s*:?\s*/gi, '\n');
   if (!raw) return [];
 
-  const BULLET_CHARS = '·•▫▪◦‣–\\-';
-  const splitInlineBullets = (line) => {
-    const t = String(line || '').trim();
-    if (!t) return [];
-    // שורה שמתחילה בנקודה — החזר כמות שהיא
-    if (new RegExp(`^[${BULLET_CHARS}]\\s`).test(t)) return [t];
-    // אין נקודות כלל — החזר כמות שהיא
-    if (!new RegExp(`[${BULLET_CHARS}]`).test(t) && !/\s-\s/.test(t)) return [t];
-    // נקודות באמצע — פצל וסמן כל חלק
-    const parts = t.split(new RegExp(`\\s*[${BULLET_CHARS}]\\s*`)).map((p) => p.trim()).filter(Boolean);
-    return parts.map((p, i) => i === 0 ? p : ` ${p}`);
-  };
+  const stripBulletMarker = (line) => String(line || '')
+    .replace(/^\s*(?:|-|·|•|▫|▪|◦|‣|–)\s+/, '')
+    .replace(/^\s*\d+[.)]\s+/, '')
+    .trim();
 
-  const isPlaceholderLine = (s) => /^שורה\s+חדשה\s*:?\s*$/i.test(s);
-  const bulletStartRe = new RegExp(`^[${BULLET_CHARS}]\\s`);
-  const inlineNewlineMarkerRe = /\s*שורה\s+חדשה\s*:?\s*/i;
-  const expandedLines = raw.split('\n').flatMap((rawLine) => {
-    const hasLeadingSpace = /^[ \t]+\S/.test(rawLine);
-    const subParts = rawLine.split(inlineNewlineMarkerRe);
-    return subParts.flatMap((sub, subIdx) => {
-      if (!sub.trim()) return [];
-      const lineForBullet = subIdx === 0 ? sub : ` ${sub.trim()}`;
-      const effectiveLeadingSpace = subIdx === 0 ? hasLeadingSpace : true;
-      return splitInlineBullets(lineForBullet).map((item, i) => {
-        if (effectiveLeadingSpace && i === 0) {
-          const t = item.trim();
-          if (!bulletStartRe.test(t)) return `• ${t}`;
-        }
-        return item;
-      });
-    });
-  }).map((line) => line.trim()).filter((line) => Boolean(line) && !isPlaceholderLine(line.replace(/^[·•▫▪◦‣–\-]\s*/, '')));
-  if (!expandedLines.length) return [];
+  const normalizedLines = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => !/^שורה\s+חדשה\s*:?$/i.test(line));
 
-  const bulletRegex = new RegExp(`^[${BULLET_CHARS}]\\s*(.+)$`);
-  const orderedRegex = /^(\d+)[.)]\s*(.+)$/;
   if (alwaysBullet) {
-    return [{ type: 'ul', items: expandedLines.map((line) => line.replace(bulletRegex, '$1').trim()).filter(Boolean) }];
+    const items = normalizedLines.map(stripBulletMarker).filter(Boolean);
+    return items.length ? [{ type: 'ul', items }] : [];
   }
 
   const groups = [];
-  let currentType = null;
-  let currentItems = [];
-  const flush = () => {
-    if (!currentItems.length) return;
-    groups.push({ type: currentType, items: currentItems });
-    currentType = null;
-    currentItems = [];
+  let paragraphLines = [];
+  let bulletItems = [];
+
+  const flushParagraph = () => {
+    if (!paragraphLines.length) return;
+    groups.push({ type: 'p', items: [paragraphLines] });
+    paragraphLines = [];
+  };
+  const flushBullets = () => {
+    if (!bulletItems.length) return;
+    groups.push({ type: 'ul', items: bulletItems });
+    bulletItems = [];
   };
 
-  expandedLines.forEach((line) => {
-    const bulletMatch = line.match(bulletRegex);
-    const orderedMatch = line.match(orderedRegex);
-    let type = 'p';
-    let body = line;
-    if (bulletMatch) {
-      type = 'ul';
-      body = bulletMatch[1];
-    } else if (orderedMatch) {
-      type = 'ol';
-      body = orderedMatch[2];
+  for (const line of normalizedLines) {
+    if (!line) {
+      flushParagraph();
+      flushBullets();
+      continue;
     }
-    const cleaned = body.trim();
-    if (!cleaned) return;
-    if (currentType && currentType !== type) flush();
-    currentType = type;
-    currentItems.push(cleaned);
-  });
-  flush();
+
+    const bulletMatch = line.match(/^\s*(?:-|)\s+(.+)$/);
+    if (bulletMatch) {
+      flushParagraph();
+      const item = bulletMatch[1].trim();
+      if (item) bulletItems.push(item);
+      continue;
+    }
+
+    flushBullets();
+    paragraphLines.push(line);
+  }
+
+  flushParagraph();
+  flushBullets();
   return groups;
 }
 
-function renderSectionBodyHtml(value, options = {}) {
+function renderProposalSectionBody(body, options = {}) {
   const { className = '' } = options;
-  const groups = parseSectionBodyStructure(value, options);
+  const groups = parseSectionBodyStructure(body, options);
   if (!groups.length) return '';
   const rendered = groups.map((group) => {
-    if (group.type === 'ul' || group.type === 'ol') {
-      return `<${group.type}>${group.items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</${group.type}>`;
+    if (group.type === 'ul') {
+      return `<ul>${group.items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
     }
-    return group.items.map((item) => `<p>${escapeHtml(item)}</p>`).join('');
+    return group.items.map((lines) => `<p>${lines.map((line) => escapeHtml(line)).join('<br>')}</p>`).join('');
   }).join('');
   return `<div class="pa-section-body${className ? ` ${className}` : ''}">${rendered}</div>`;
 }
 
+function renderSectionBodyHtml(value, options = {}) {
+  return renderProposalSectionBody(value, options);
+}
+
 function sectionLinesHtml(value, options = {}) {
-  return renderSectionBodyHtml(value, options);
+  return renderProposalSectionBody(value, options);
 }
 
 function signatureSectionHtml(signatureText) {
   const fallback = 'בברכה,\n\nעידן נחום, סמנכ״ל כספים ותפעול.';
-  const raw = text(signatureText) ? signatureText : fallback;
-  const lines = String(raw || '')
-    .split(/\r?\n/)
+  const raw = normalizeMultilineText(signatureText) ? normalizeMultilineText(signatureText) : fallback;
+  const lines = raw
+    .split('\n')
     .map((line) => String(line || '').trim())
     .filter(Boolean);
   if (!lines.length) return '';
@@ -1831,7 +1830,7 @@ export const proposalsAgreementsScreen = {
         const workingSections = resolveDocumentSections(row, templateSections).map((section) => ({
           section_key: text(section.section_key),
           section_title: text(section.section_title),
-          section_body: String(section.section_body || '')
+          section_body: normalizeMultilineText(section.section_body)
         }));
         const host = root.querySelector('[data-pa-inline-form]');
         if (!host) return;
@@ -1859,7 +1858,7 @@ export const proposalsAgreementsScreen = {
         const sections = templateSections.map((section) => ({
           section_key: text(section.section_key),
           section_title: text(section.section_title),
-          section_body: String((Array.from(wrap.querySelectorAll('[data-pa-doc-body]')).find((el) => text(el.dataset.paDocBody) === text(section.section_key))?.value) || '')
+          section_body: normalizeMultilineText(Array.from(wrap.querySelectorAll('[data-pa-doc-body]')).find((el) => text(el.dataset.paDocBody) === text(section.section_key))?.value)
         }));
         const result = typeof api.saveProposalAgreementCustomDocumentSections === 'function'
           ? await api.saveProposalAgreementCustomDocumentSections(id, sections)

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 485;
+const CACHE_VERSION = 486;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 485;
+const SW_ENTRY_VERSION = 486;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -857,6 +857,40 @@ test('preview prefers custom_document_sections when present', async () => {
   });
 });
 
+
+test('proposal preview preserves multiline section paragraphs and dash bullets', async () => {
+  const row = {
+    ...sampleRows[0],
+    custom_document_sections: [{
+      section_key: 'intro',
+      section_title: 'פתיח',
+      section_body: 'פסקת פתיחה להצעה.\r\nשורת המשך נשמרת.\n\n- ההצעה מיועדת לקבוצה של עד 20 משתתפים.\n בכל סדנת מייקרים יכין כל משתתף תוצר אישי.\nשורה חדשה'
+    }]
+  };
+
+  await withJSDOM(proposalsAgreementsScreen.render({ rows: [row] }, { state: stateFor('admin') }), async (root, dom) => {
+    proposalsAgreementsScreen.bind({
+      root,
+      data: { rows: [row], proposalTemplateSections: [{ template_key: 'summer', section_key: 'intro', section_title: 'פתיח', section_body: 'טקסט תבנית' }] },
+      state: stateFor('admin'),
+      api: { readProposalAgreementItems: async () => [] }
+    });
+    root.querySelector(`[data-pa-row-id="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+    root.querySelector(`[data-pa-preview="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+
+    const intro = dom.window.document.querySelector('.pa-doc-intro');
+    assert.ok(intro, 'intro section body should render');
+    assert.equal(intro.querySelectorAll('p').length, 1, 'opening text should render as one paragraph');
+    assert.equal(intro.querySelectorAll('br').length, 1, 'opening paragraph line break should be preserved');
+    assert.equal(intro.querySelectorAll('li').length, 2, 'dash and square bullets should render as separate list items');
+    assert.equal(intro.querySelectorAll('li')[0]?.textContent, 'ההצעה מיועדת לקבוצה של עד 20 משתתפים.');
+    assert.equal(intro.querySelectorAll('li')[1]?.textContent, 'בכל סדנת מייקרים יכין כל משתתף תוצר אישי.');
+    assert.doesNotMatch(intro.textContent, /שורה חדשה/);
+  });
+});
+
 test('approved proposal has no edit document button', async () => {
   const row = { ...sampleRows[0], status: 'approved' };
   await withJSDOM(proposalsAgreementsScreen.render({ rows: [row] }, { state: stateFor('admin') }), async (root, dom) => {


### PR DESCRIPTION
### Motivation
- Fix loss of line breaks and collapsed bullets in proposal document bodies caused by the generic `text()` normalization that replaces all whitespace (including CR/LF) with spaces, while keeping DB, templates and SQL unchanged.

### Description
- Add `normalizeMultilineText()` to normalize CRLF to LF and trim without collapsing line breaks and apply it to document section bodies and editor save/load flows.
- Introduce `normalizeDocumentSection()` and ensure `custom_document_sections` are normalized with preserved newlines when rows are loaded and when edited/saved.
- Replace the section renderer with `parseSectionBodyStructure()` + `renderProposalSectionBody()` (used via `renderSectionBodyHtml`/`sectionLinesHtml`) so paragraphs are preserved, inline newlines are rendered as `<br>`, lines starting with `- ` or `` become separate bullet items, and placeholder lines like `שורה חדשה` are removed.
- Bump service-worker/cache version to `486` and update built assets so preview/print/PDF use the new rendering logic consistently.
- Add a regression test ensuring multiline paragraphs, preserved `<br>`, dash/`` bullets and removal of `שורה חדשה` are rendered in the preview.

### Testing
- `node --check frontend/src/screens/proposals-agreements.js` succeeded without syntax errors.
- Focused tests `node --test --test-name-pattern='proposal preview preserves multiline|preview prefers custom' tests/proposals-agreements-screen.test.mjs` passed (2 tests).
- Full test run `node --test tests/proposals-agreements-screen.test.mjs` completed but reported 5 pre-existing failures unrelated to this change (table/header and some form-field expectations); the new multiline tests passed in isolation.
- Production build via `npm run build` completed successfully and updated the `dist` service-worker assets to the new cache version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae027e6a4832baa2856602a4b46b7)