### PR TITLE
שיפור עמוד חריגות — כרטיסים וחיווי מספרי בהידר

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 486;
+const CACHE_VERSION = 487;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-TNapkck_.js",
+  "./assets/index-DIOMbAJI.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-T5bw0io7.css",
+  "./assets/style-BOhxJUAw.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-TNapkck_.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-T5bw0io7.css">
+  <script type="module" crossorigin src="./assets/index-DIOMbAJI.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BOhxJUAw.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 486;
+const CACHE_VERSION = 487;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-TNapkck_.js",
+  "./assets/index-DIOMbAJI.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-T5bw0io7.css",
+  "./assets/style-BOhxJUAw.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,6 +6,7 @@ import { escapeHtml } from './screens/shared/html.js';
 import { hebrewRole, translateApiErrorForUser } from './screens/shared/ui-hebrew.js';
 import { createSharedInteractionLayer } from './screens/shared/interactions.js';
 import { headerNavGridHtml } from './screens/shared/act-nav-grid.js';
+import { exceptionDisplayGroupCount } from './screens/shared/exceptions-metrics.js';
 import { loginScreen } from './screens/login.js';
 import { clearFinancePrefsIfUserChanged } from './screens/shared/finance-prefs-storage.js';
 import { applyGlobalAccent, accentNameFromStorage, bindAccentPickerOnce as bindAccentPickerListenerOnce } from './accent-picker.js';
@@ -714,6 +715,32 @@ function shellUserDisplayName() {
   return escapeHtml(fn || 'משתמש');
 }
 
+
+function exceptionsNavCount() {
+  const entry = state.screenDataCache?.exceptions;
+  const rows = Array.isArray(entry?.data?.rows) ? entry.data.rows : [];
+  return exceptionDisplayGroupCount(rows);
+}
+
+function navLabelHtmlForRoute(route) {
+  const label = escapeHtml(navLabelForRoute(route));
+  if (route !== 'exceptions') return label;
+  const count = exceptionsNavCount();
+  if (!Number.isFinite(count) || count <= 0) return label;
+  const safeCount = escapeHtml(String(count));
+  return `${label} <span class="ds-nav-count-badge" aria-label="${safeCount} חריגות">(${safeCount})</span>`;
+}
+
+function updateExceptionNavCount() {
+  if (typeof document === 'undefined') return;
+  document.querySelectorAll('[data-route="exceptions"] .ds-act-nav-item__label').forEach((node) => {
+    node.innerHTML = navLabelHtmlForRoute('exceptions');
+  });
+  document.querySelectorAll('.shell-nav__btn[data-route="exceptions"]').forEach((node) => {
+    node.innerHTML = navLabelHtmlForRoute('exceptions');
+  });
+}
+
 function shellUserRoleLine() {
   const r2 = repairHebrewMojibake(state.user?.display_role2).trim();
   if (r2) return escapeHtml(r2);
@@ -747,7 +774,7 @@ function shell(content) {
     )
     .map(
       (route) =>
-        `<button type="button" class="shell-nav__btn ${route === state.route ? 'is-active' : ''}" data-route="${route}">${navLabelForRoute(route)}</button>`
+        `<button type="button" class="shell-nav__btn ${route === state.route ? 'is-active' : ''}" data-route="${route}">${navLabelHtmlForRoute(route)}</button>`
     )
     .join('');
 
@@ -764,7 +791,7 @@ function shell(content) {
   const headerNavHtml = headerNavGridHtml({
     route: state.route,
     routes: effectiveRoutes().filter((r) => !adminHeaderExclude.has(r) && !HEADER_ALWAYS_EXCLUDE.has(r))
-  });
+  }, { exceptions: exceptionsNavCount() });
   const headerTechHtml = '';
 
   return `
@@ -1011,6 +1038,7 @@ async function loadScreenDataWithCache(screen) {
       const entry = { data, t: Date.now() };
       state.screenDataCache[key] = entry;
       maybePersistScreenCacheEntry(key, entry);
+      if (key === 'exceptions') updateExceptionNavCount();
       inflightRequests.delete(key);
       return data;
     })
@@ -1045,6 +1073,7 @@ async function backgroundRefreshScreen(screen, cacheKey) {
     const entry = { data, t: Date.now() };
     state.screenDataCache[cacheKey] = entry;
     maybePersistScreenCacheEntry(cacheKey, entry);
+    if (cacheKey === 'exceptions') updateExceptionNavCount();
     if (
       activeNavigationToken === guardedToken &&
       state.route === guardedRoute &&
@@ -1174,6 +1203,7 @@ function updateNavActiveClasses() {
   document.querySelectorAll('[data-route]').forEach((btn) => {
     btn.classList.toggle('is-active', btn.dataset.route === state.route);
   });
+  updateExceptionNavCount();
   const mobileBrand = document.querySelector('.shell-top__mobile-brand');
   if (mobileBrand) {
     mobileBrand.textContent = screenLabels[state.route] || systemNameDisplay();

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -4,7 +4,6 @@ import { hebrewExceptionType, hebrewColumn } from './shared/ui-hebrew.js';
 import { activityWorkDrawerHtml } from './shared/activity-detail-html.js';
 import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bind-activity-edit-form.js';
 import {
-  dsCard,
   dsScreenStack,
   dsEmptyState,
   dsStatusChip
@@ -45,28 +44,47 @@ function fieldRow(label, value) {
   return `<p><strong>${escapeHtml(label)}:</strong> ${display}</p>`;
 }
 
-function exceptionCardSubtitle(row) {
-  const meta = [String(row?.authority || '').trim(), String(row?.school || '').trim()].filter(Boolean);
-  return meta.length ? meta.join(' · ') : 'ללא רשות / בית ספר';
+function exceptionCardTone(row, fallbackTone = 'other') {
+  const type = normalizedExceptionTypes(row)[0] || fallbackTone;
+  if (type === 'missing_start_date') return 'waiting-date';
+  if (type === 'end_date_passed') return 'ended-open';
+  if (type === 'late_end_date') return 'late-end';
+  if (type === 'missing_instructor') return 'missing-instructor';
+  return 'other';
 }
 
-function exceptionCardMeta(row) {
-  const instructors = [row?.instructor_name, row?.instructor_name_2]
-    .map((value) => String(value || '').trim())
-    .filter(Boolean);
-  const instructorText = instructors.length ? instructors.join(' / ') : 'ללא מדריך';
-  const exceptionText = normalizedExceptionTypes(row)
-    .map((type) => hebrewExceptionType(String(type || '').trim()))
-    .filter(Boolean)
-    .join(' · ');
-  return `מדריך: ${instructorText}${exceptionText ? ` · חריגה: ${exceptionText}` : ''}`;
+function exceptionCardHtml(row, groupKey) {
+  const activityName = String(row?.activity_name || '').trim() || '—';
+  const school = String(row?.school || '').trim() || 'ללא בית ספר';
+  const authority = String(row?.authority || '').trim() || 'ללא רשות';
+  const tone = groupKey || exceptionCardTone(row);
+  return `<div data-list-item class="ds-exception-list-item">
+    <button
+      type="button"
+      class="ds-interactive-card ds-interactive-card--session ds-exception-card"
+      data-exception-tone="${escapeHtml(tone)}"
+      data-card-action="${escapeHtml(`exception:${row.RowID}`)}"
+      aria-label="פתיחת פרטי חריגה עבור ${escapeHtml(activityName)}"
+    >
+      <span class="ds-exception-card__accent" aria-hidden="true"></span>
+      <span class="ds-exception-card__content">
+        <span class="ds-exception-card__activity">${escapeHtml(activityName)}</span>
+        <span class="ds-exception-card__school">${escapeHtml(school)}</span>
+        <span class="ds-exception-card__authority">${escapeHtml(authority)}</span>
+      </span>
+    </button>
+  </div>`;
 }
 
-function exceptionGroupCard(title, rows) {
-  const body = `<div class="ds-compact-list ds-exceptions-grid">${rows.map((row) =>
-    `<div data-list-item class="ds-exception-list-item"><button type="button" class="ds-interactive-card ds-interactive-card--session ds-exception-card" data-card-action="${escapeHtml(`exception:${row.RowID}`)}"><p class="ds-interactive-card__title">${escapeHtml(row.activity_name || '—')}</p><p class="ds-interactive-card__subtitle">${escapeHtml(exceptionCardSubtitle(row))}</p><p class="ds-interactive-card__meta">${escapeHtml(exceptionCardMeta(row))}</p></button></div>`
-  ).join('')}</div>`;
-  return dsCard({ title: `${title} · ${rows.length}`, body, padded: false });
+function exceptionGroupCard({ title, rows, key }) {
+  const body = `<div class="ds-exceptions-grid">${rows.map((row) => exceptionCardHtml(row, key)).join('')}</div>`;
+  return `<section class="ds-exception-group" data-exception-group="${escapeHtml(key || 'other')}">
+    <header class="ds-exception-group__head">
+      <h3 class="ds-exception-group__title">${escapeHtml(title)}</h3>
+      <span class="ds-exception-group__count" aria-label="${escapeHtml(String(rows.length))} חריגות בקבוצה">${escapeHtml(String(rows.length))}</span>
+    </header>
+    <div class="ds-exception-group__body">${body}</div>
+  </section>`;
 }
 
 function activityDrawerContent(row, canSeePrivateNotes, canEdit, canDirectEdit, canRequestEdit, canDeleteActivity, hideEmpIds, hideRowId, hideActivityNo, settings) {
@@ -151,18 +169,18 @@ export const exceptionsScreen = {
     const otherExceptionRows = filteredRows.filter((row) => normalizedExceptionTypes(row).some((type) => !mainTypes.has(type)));
     const hasAnyRows = filteredRows.length > 0;
     const groups = [
-      { title: 'פעילויות ממתינות לתיאום תאריך', rows: waitingDateRows },
-      { title: 'פעילויות פתוחות שהסתיימו', rows: endDatePassedRows },
-      { title: 'פעילויות עם תאריך סיום מאוחר', rows: lateEndDateRows },
-      { title: 'פעילויות ללא מדריך', rows: noInstructorRows },
-      ...(otherExceptionRows.length ? [{ title: 'חריגות נוספות', rows: otherExceptionRows }] : [])
+      { key: 'waiting-date', title: 'פעילויות ממתינות לתיאום תאריך', rows: waitingDateRows },
+      { key: 'ended-open', title: 'פעילויות פתוחות שהסתיימו', rows: endDatePassedRows },
+      { key: 'late-end', title: 'פעילויות עם תאריך סיום מאוחר', rows: lateEndDateRows },
+      { key: 'missing-instructor', title: 'פעילויות ללא מדריך', rows: noInstructorRows },
+      ...(otherExceptionRows.length ? [{ key: 'other', title: 'חריגות נוספות', rows: otherExceptionRows }] : [])
     ].filter((group) => group.rows.length > 0);
 
     return dsScreenStack(`
       <div class="ds-exceptions-screen">
       ${toolbarHtml}
       <section class="ds-exceptions-screen__section"><h2 class="ds-section-title ds-exceptions-screen__title">חריגות${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}</h2></section>
-      ${!hasAnyRows ? `<section class="ds-exceptions-screen__section">${dsEmptyState('אין חריגות פעילות להצגה.')}</section>` : groups.map((group) => `<section class="ds-exceptions-screen__section">${exceptionGroupCard(group.title, group.rows)}</section>`).join('')}
+      ${!hasAnyRows ? `<section class="ds-exceptions-screen__section">${dsEmptyState('אין חריגות פעילות להצגה.')}</section>` : groups.map((group) => `<section class="ds-exceptions-screen__section">${exceptionGroupCard(group)}</section>`).join('')}
       </div>
     `);
   },

--- a/frontend/src/screens/shared/act-nav-grid.js
+++ b/frontend/src/screens/shared/act-nav-grid.js
@@ -1,5 +1,12 @@
 import { escapeHtml } from './html.js';
 
+function itemLabelHtml(item, counts = {}) {
+  const label = escapeHtml(item.label);
+  const count = item.route === 'exceptions' ? Number(counts.exceptions || 0) : 0;
+  if (!Number.isFinite(count) || count <= 0) return label;
+  return `${label} <span class="ds-nav-count-badge" aria-label="${escapeHtml(String(count))} חריגות">(${escapeHtml(String(count))})</span>`;
+}
+
 export const ACT_SUBNAV_ITEMS = [
   { route: 'dashboard',           label: 'לוח בקרה',             icon: '📊' },
   { route: 'activities',          label: 'פעילויות',             icon: '📋' },
@@ -20,7 +27,7 @@ export const ACT_SUBNAV_ITEMS = [
  * @param {object} state - state.routes, state.route
  * @returns {string}
  */
-export function actNavGridHtml(state) {
+export function actNavGridHtml(state, counts = {}) {
   const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
   const currentRoute = state?.route || '';
   const items = ACT_SUBNAV_ITEMS.filter((item) => availableRoutes.has(item.route));
@@ -35,7 +42,7 @@ export function actNavGridHtml(state) {
         dir="rtl"
       >
         <span class="ds-act-nav-item__icon" aria-hidden="true">${item.icon}</span>
-        <span class="ds-act-nav-item__label">${escapeHtml(item.label)}</span>
+        <span class="ds-act-nav-item__label">${itemLabelHtml(item, counts)}</span>
       </button>`
     )
     .join('');
@@ -47,7 +54,7 @@ export function actNavGridHtml(state) {
  * @param {object} state - state.routes, state.route
  * @returns {string}
  */
-export function headerNavGridHtml(state) {
+export function headerNavGridHtml(state, counts = {}) {
   const availableRoutes = new Set(Array.isArray(state?.routes) ? state.routes : []);
   const currentRoute = state?.route || '';
   const items = ACT_SUBNAV_ITEMS.filter((item) => availableRoutes.has(item.route));
@@ -61,7 +68,7 @@ export function headerNavGridHtml(state) {
         data-route="${escapeHtml(item.route)}"
         dir="rtl"
       >
-        <span class="ds-act-nav-item__label">${escapeHtml(item.label)}</span>
+        <span class="ds-act-nav-item__label">${itemLabelHtml(item, counts)}</span>
       </button>`
     )
     .join('');

--- a/frontend/src/screens/shared/exceptions-metrics.js
+++ b/frontend/src/screens/shared/exceptions-metrics.js
@@ -9,6 +9,27 @@ export function normalizedExceptionTypes(row) {
   return [row?.exception_type].map((type) => String(type || '').trim()).filter(Boolean);
 }
 
+
+const EXCEPTION_DISPLAY_GROUP_TYPES = ['missing_start_date', 'end_date_passed', 'late_end_date', 'missing_instructor'];
+
+export function exceptionDisplayGroupCount(rows) {
+  let total = 0;
+  const mainTypes = new Set(EXCEPTION_DISPLAY_GROUP_TYPES);
+  for (const row of asList(rows)) {
+    const types = normalizedExceptionTypes(row);
+    if (!types.length) {
+      total += 1;
+      continue;
+    }
+    const uniqueTypes = new Set(types);
+    for (const type of EXCEPTION_DISPLAY_GROUP_TYPES) {
+      if (uniqueTypes.has(type)) total += 1;
+    }
+    if ([...uniqueTypes].some((type) => !mainTypes.has(type))) total += 1;
+  }
+  return total;
+}
+
 function exceptionActivityKey(row) {
   const explicitId = [row?.RowID, row?.row_id, row?.source_row_id]
     .map((value) => String(value ?? '').trim())

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11359,3 +11359,261 @@ select.ds-input {
     color: #1f4e79 !important;
   }
 }
+
+/* ===== Exceptions UX refresh: grouped cards, balanced grid, and header count badge ===== */
+.ds-nav-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-inline-start: 4px;
+  padding: 1px 5px;
+  border-radius: var(--ds-radius-full);
+  background: color-mix(in srgb, var(--ds-danger-soft) 82%, #fff);
+  border: 1px solid color-mix(in srgb, var(--ds-danger) 22%, var(--ds-danger-border));
+  color: var(--ds-danger);
+  font-size: 0.72em;
+  font-weight: 800;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.shell-header-nav.ds-act-nav-grid--header .ds-nav-count-badge {
+  margin-inline-start: 3px;
+  padding: 0 4px;
+  font-size: 0.9em;
+}
+
+.shell-nav__btn .ds-nav-count-badge {
+  font-size: 0.72rem;
+}
+
+.ds-exceptions-screen {
+  gap: 14px;
+}
+
+.ds-exceptions-screen__section {
+  overflow: visible;
+}
+
+.ds-exceptions-screen__title {
+  color: var(--ds-accent);
+  font-weight: 850;
+}
+
+.ds-exception-group {
+  --exception-group-color: var(--ds-accent);
+  --exception-group-bg: color-mix(in srgb, var(--ds-accent-soft) 36%, #fff);
+  position: relative;
+  overflow: visible;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--exception-group-color) 18%, var(--ds-border));
+  border-radius: 18px;
+  background: linear-gradient(180deg, var(--exception-group-bg), #fff 72%);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.05);
+}
+
+.ds-exception-group[data-exception-group="waiting-date"] {
+  --exception-group-color: #b45309;
+  --exception-group-bg: #fff7ed;
+}
+
+.ds-exception-group[data-exception-group="ended-open"] {
+  --exception-group-color: #dc2626;
+  --exception-group-bg: #fff1f2;
+}
+
+.ds-exception-group[data-exception-group="late-end"] {
+  --exception-group-color: #7c3aed;
+  --exception-group-bg: #f5f3ff;
+}
+
+.ds-exception-group[data-exception-group="missing-instructor"] {
+  --exception-group-color: #2563eb;
+  --exception-group-bg: #eff6ff;
+}
+
+.ds-exception-group__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 14px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--exception-group-color) 16%, transparent);
+}
+
+.ds-exception-group__title {
+  margin: 0;
+  color: var(--ds-text);
+  font-size: 1rem;
+  font-weight: 850;
+  line-height: 1.25;
+}
+
+.ds-exception-group__count {
+  min-width: 30px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  border-radius: var(--ds-radius-full);
+  background: color-mix(in srgb, var(--exception-group-color) 12%, #fff);
+  border: 1px solid color-mix(in srgb, var(--exception-group-color) 24%, var(--ds-border));
+  color: var(--exception-group-color);
+  font-size: 0.78rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.ds-exception-group__body {
+  overflow: visible;
+}
+
+.ds-exceptions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 260px));
+  justify-content: start;
+  align-items: stretch;
+  gap: 14px;
+  overflow: visible;
+}
+
+.ds-exception-list-item {
+  display: flex;
+  min-width: 0;
+  width: 100%;
+  max-width: 260px;
+}
+
+.ds-exception-card {
+  --exception-card-color: var(--ds-accent);
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  height: 124px;
+  min-height: 124px;
+  padding: 0;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: right;
+  border: 1px solid color-mix(in srgb, var(--exception-card-color) 18%, var(--ds-border));
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--exception-card-color) 9%, #fff), #fff 58%),
+    var(--ds-surface);
+  box-shadow: 0 7px 18px rgba(15, 23, 42, 0.09), 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+}
+
+.ds-exception-card[data-exception-tone="waiting-date"] { --exception-card-color: #b45309; }
+.ds-exception-card[data-exception-tone="ended-open"] { --exception-card-color: #dc2626; }
+.ds-exception-card[data-exception-tone="late-end"] { --exception-card-color: #7c3aed; }
+.ds-exception-card[data-exception-tone="missing-instructor"] { --exception-card-color: #2563eb; }
+.ds-exception-card[data-exception-tone="other"] { --exception-card-color: #475569; }
+
+.ds-exception-card:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--exception-card-color) 36%, var(--ds-border-strong));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--exception-card-color) 13%, #fff), #fff 55%);
+  box-shadow: 0 11px 24px rgba(15, 23, 42, 0.12), 0 2px 5px rgba(15, 23, 42, 0.07);
+  transform: translateY(-2px);
+}
+
+.ds-exception-card:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--exception-card-color) 22%, transparent), 0 11px 24px rgba(15, 23, 42, 0.12);
+}
+
+.ds-exception-card__accent {
+  flex: 0 0 6px;
+  background: linear-gradient(180deg, var(--exception-card-color), color-mix(in srgb, var(--exception-card-color) 55%, #fff));
+}
+
+.ds-exception-card__content {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  align-content: stretch;
+  gap: 7px;
+  padding: 13px 14px 12px 12px;
+}
+
+.ds-exception-card__activity,
+.ds-exception-card__school {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
+}
+
+.ds-exception-card__activity {
+  -webkit-line-clamp: 2;
+  color: var(--ds-text);
+  font-size: 0.92rem;
+  font-weight: 850;
+  line-height: 1.28;
+}
+
+.ds-exception-card__school {
+  -webkit-line-clamp: 1;
+  color: var(--ds-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.ds-exception-card__authority {
+  justify-self: start;
+  max-width: 100%;
+  padding: 3px 9px;
+  overflow: hidden;
+  border-radius: var(--ds-radius-full);
+  background: color-mix(in srgb, var(--exception-card-color) 10%, #fff);
+  border: 1px solid color-mix(in srgb, var(--exception-card-color) 18%, var(--ds-border));
+  color: color-mix(in srgb, var(--exception-card-color) 78%, #111827);
+  font-size: 0.72rem;
+  font-weight: 750;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 1180px) {
+  .ds-exceptions-grid {
+    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  }
+  .ds-exception-list-item {
+    max-width: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .ds-exception-group {
+    padding: 12px;
+    border-radius: 16px;
+  }
+  .ds-exception-group__head {
+    align-items: flex-start;
+  }
+  .ds-exceptions-grid {
+    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+    gap: 12px;
+  }
+  .ds-exception-card {
+    height: 118px;
+    min-height: 118px;
+  }
+}
+
+@media (max-width: 520px) {
+  .ds-exceptions-grid {
+    grid-template-columns: 1fr;
+  }
+  .ds-exception-card {
+    height: 116px;
+    min-height: 116px;
+  }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 486;
+const CACHE_VERSION = 487;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- להפוך את עמוד החריגות לקריא, ברור וסריקתי באמצעות כרטיסים חיצוניים נקיים שמציגים רק שדות זיהוי מרכזיים. 
- להוסיף חיווי מספרי דינמי בכפתור/טאב "חריגות" בהידר שמציג את סך כל החריגות בפועל ומתגה אדומה כשהמספר גדול מ‑0. 
- לשפר מראה ותחושת הממשק (צבעים לפי סוג, עומק עדין, hover/focus, רספונסיביות) ולוודא שה‑Service Worker לא מחזיק גרסאות ישנות.

### Description
- הוספת פונקציית עזר `exceptionDisplayGroupCount` ב־`frontend/src/screens/shared/exceptions-metrics.js` לחישוב מדויק של סך החריגות שמוצגות בקבוצות. 
- חיבור החיווי להידר: עדכון `frontend/src/screens/shared/act-nav-grid.js` ו־`frontend/src/main.js` להצגת תגית מספרית דינמית (`ds-nav-count-badge`) עבור הראוטה `exceptions` ועדכון התצוגה אחרי טעינה/refresh של נתוני החריגות. 
- שינוי מבנה ותצוגת הכרטיסים ב־`frontend/src/screens/exceptions.js` כדי שהכרטיס החיצוני יציג רק `שם הפעילות`, `בית הספר` ו־`רשות`, עם חלוקת רשומות לקבוצות ברורות שהרחבות/פירוט מופיעים ב‑drawer. 
- מיזוג עיצובים חדשים ב־`frontend/src/styles/main.css` (כרטיסים צבעוניים לפי סוג, grid מאוזן, line-clamp, shadow, border, hover/focus) וגם עדכון `frontend/sw.js` (bump `CACHE_VERSION`) ויצירת build עדכני (`dist`) שמצביע על הקבצים המגוונים החדשים.

### Testing
- הרצת `npm run build` והפקת `dist` בוצעה בהצלחה. 
- בדיקות תפקודיות קצרות ב‑node הושלמו בהצלחה, כולל בדיקת `exceptionDisplayGroupCount` ו‑`exceptionsScreen.render` עם סימולציה של `localStorage/sessionStorage`. 
- הרצת `git diff --check` בוצעה בהצלחה ללא סימני שגיאה קריטיים. 
- הרצת `npm test` בוצעה אך חלק מהמבחנים הקיימים כשלו במבחנים ישנים/לא קשורים (Apps Script / API tests); אלה לא נגרמו משינויים חבילתיים אלו.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae27601c0832b917fbeea660e5a03)