### PR TITLE
Fix canonical exception logic and counts

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 487;
+const CACHE_VERSION = 489;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DIOMbAJI.js",
+  "./assets/index-BfP01lWo.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BOhxJUAw.css",
+  "./assets/style-0I1OTkMW.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DIOMbAJI.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BOhxJUAw.css">
+  <script type="module" crossorigin src="./assets/index-BfP01lWo.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-0I1OTkMW.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 487;
+const CACHE_VERSION = 489;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DIOMbAJI.js",
+  "./assets/index-BfP01lWo.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BOhxJUAw.css",
+  "./assets/style-0I1OTkMW.css",
   "./index.html",
   "./manifest.json"
 ];

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -244,6 +244,24 @@ function getActivityDateColumns(row = {}) {
   }
   return dates;
 }
+
+function calculatedEndDateFromActivityDates(row = {}) {
+  const dates = getActivityDateColumns(row);
+  return dates.length ? dates.reduce((max, dateKey) => (dateKey > max ? dateKey : max), '') : '';
+}
+
+function todayLocalIsoDate() {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+}
+
+function isOpenStatus(row = {}) {
+  return String(row?.status || '').trim() === 'פתוח';
+}
+
+function districtDisplayKey(row = {}) {
+  return String(row?.district || '').trim() || 'ללא מחוז';
+}
 function hasAnyActivityDate(row = {}) {
   if (normalizeSupabaseDate(row?.start_date ?? row?.date_start)) return true;
   if (normalizeSupabaseDate(row?.end_date ?? row?.date_end)) return true;
@@ -911,7 +929,7 @@ async function dashboardReadModelFromSupabase(month) {
       throw new Error('dashboard_exceptions_model_failed');
     }
     const exceptionCounts = exceptionSummary.counts || {};
-    const exceptionsByManager = exceptionSummary.byManager || {};
+    const exceptionsByDistrict = exceptionSummary.byDistrict || exceptionSummary.byManager || {};
 
     // Active (open-only) summary data
     const instructorIds = new Set();
@@ -920,7 +938,7 @@ async function dashboardReadModelFromSupabase(month) {
     const byManagerMap = new Map();
 
     function managerStats(manager) {
-      const key = cleanActivityManagerName(manager) || NO_ACTIVITY_MANAGER_LABEL;
+      const key = String(manager || '').trim() || 'ללא מחוז';
       if (!byManagerMap.has(key)) {
         byManagerMap.set(key, {
           activity_manager: key,
@@ -948,7 +966,7 @@ async function dashboardReadModelFromSupabase(month) {
       if (instructor1 || emp1) instructorNames.add(instructor1 || emp1);
       if (instructor2 || emp2) instructorNames.add(instructor2 || emp2);
 
-      const stats = managerStats(row?.activity_manager);
+      const stats = managerStats(row?.district);
       stats.total_activities += 1;
       if (isProgramActivity(row)) stats.total_long += 1;
       if (isOneDayActivity(row)) stats.total_short += 1;
@@ -958,10 +976,10 @@ async function dashboardReadModelFromSupabase(month) {
     }
 
     for (const row of endingRows) {
-      managerStats(row?.activity_manager).course_endings += 1;
+      managerStats(row?.district).course_endings += 1;
     }
-    for (const [manager, count] of Object.entries(exceptionsByManager)) {
-      managerStats(manager).exceptions = Number(count || 0);
+    for (const [district, count] of Object.entries(exceptionsByDistrict)) {
+      managerStats(district).exceptions = Number(count || 0);
     }
 
     const by_activity_manager = [...byManagerMap.values()].map((stats) => {
@@ -969,7 +987,7 @@ async function dashboardReadModelFromSupabase(month) {
       delete stats._instructors;
       return stats;
     });
-    const exceptionsCount = Number(exceptionSummary.totalExceptionRows || 0);
+    const exceptionsCount = Number(exceptionSummary.totalExceptionInstances || 0);
     const totals = {
       total_short_activities: allMonthRows.filter(isOneDayActivity).length,
       total_long_activities: allMonthRows.filter(isProgramActivity).length,
@@ -986,15 +1004,15 @@ async function dashboardReadModelFromSupabase(month) {
       missing_instructor_count: Number(exceptionCounts.missing_instructor || 0),
       missing_start_date_count: Number(exceptionCounts.missing_start_date || 0),
       missing_date_count: Number(exceptionCounts.missing_start_date || 0),
-      late_end_date_count: Number(exceptionCounts.late_end_date || 0),
+      end_date_out_of_sync_count: Number(exceptionCounts.end_date_out_of_sync || 0),
       end_date_passed_count: Number(exceptionCounts.end_date_passed || 0),
-      operational_gaps_count: Number(exceptionSummary.operationalUniqueCount || 0),
-      operational_gaps_unique_count: Number(exceptionSummary.operationalUniqueCount || 0),
-      operationalTotal: Number(exceptionSummary.operationalUniqueCount || 0),
+      operational_gaps_count: exceptionsCount,
+      operational_gaps_unique_count: Number(exceptionSummary.uniqueExceptionActivities || exceptionSummary.totalExceptionRows || 0),
+      operationalTotal: exceptionsCount,
       exceptions_count: exceptionsCount,
-      totalExceptionRows: exceptionsCount,
-      total_exception_rows: exceptionsCount,
-      totalExceptionInstances: Number(exceptionSummary.totalExceptionInstances || 0),
+      totalExceptionRows: Number(exceptionSummary.totalExceptionRows || 0),
+      total_exception_rows: Number(exceptionSummary.totalExceptionRows || 0),
+      totalExceptionInstances: exceptionsCount,
       counts: exceptionCounts
     };
     // KPI cards use totalTypeCounts (all month rows including closed)
@@ -1037,62 +1055,51 @@ async function readEndDatesFromSupabase() {
 
 
 function activityOverlapsMonthForExceptions(row, month) {
-  if (!/^\d{4}-\d{2}$/.test(String(month || ''))) return true;
-
-  const range = monthDateRange(month);
-  const dates = getActivityDateColumns(row);
-  if (dates.length > 0) {
-    return dates.some((dateKey) => dateKey >= range.startDate && dateKey <= range.endDate);
-  }
-
-  const start = firstNormalizedDate(row?.start_date, row?.date_start);
-  // Missing start_date is itself an exception and must stay visible under a
-  // month filter because there is no reliable date from which to exclude it.
-  if (!start) return true;
-  const end = firstNormalizedDate(row?.end_date, row?.date_end) || start;
-  return start <= range.endDate && end >= range.startDate;
+  void row;
+  void month;
+  // Exceptions are intentionally computed from the current activity record, not
+  // from the selected dashboard month. This keeps end-date-passed and data-sync
+  // anomalies visible until they are fixed or the activity is closed/deleted.
+  return true;
 }
 
 function rowExceptionTypesFromActivity(row, opts = {}) {
   const types = [];
   const knownIds    = opts.knownInstructorIds; // Set<string> | undefined
-  const lateEndThreshold = normalizeSupabaseDate(opts.lateEndDateThreshold);
   const emp1        = nullStr(row?.emp_id);
   const emp2        = nullStr(row?.emp_id_2);
   const instructorName = resolveActivityInstructorName(row);
   const start       = firstNormalizedDate(row?.start_date, row?.date_start);
   const end         = firstNormalizedDate(row?.end_date, row?.date_end);
-  const now = new Date();
-  const todayLocalIso = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const todayLocalIso = todayLocalIsoDate();
+  const inactive = isActivityInactive(row);
 
   // Instructor check uses the same normalized name source used by the UI.
   // A valid displayed instructor name is sufficient even when guideId/emp_id is
   // missing or not present in the contacts table. Technical ids are a fallback.
   const isValidId = (id) => !!id && (!knownIds || knownIds.has(id));
   const hasValidInstructor = !!instructorName || isValidId(emp1) || isValidId(emp2);
-  if (!hasValidInstructor) types.push('missing_instructor');
+  if (!inactive && !hasValidInstructor) types.push('missing_instructor');
 
-  // Start-date check: date_1 is a real scheduling date too, so either a
-  // valid start_date or a valid first meeting date resolves this exception.
-  const date1 = normalizeSupabaseDate(row?.date_1 ?? row?.Date1);
-  if (!start && !date1) types.push('missing_start_date');
+  // Missing start date is based only on start_date; meeting dates do not replace
+  // the dedicated start date field for this exception.
+  if (!inactive && !start) types.push('missing_start_date');
 
-  const meetingDates = getActivityDateColumns(row);
-  const lateMeetingDates = lateEndThreshold
-    ? meetingDates.filter((dateKey) => dateKey > lateEndThreshold)
-    : [];
-  if (end && end < todayLocalIso) {
+  // Ended but not closed: only status "פתוח", real end_date, and the end date is
+  // before today. It is not based on month-end or on meeting dates.
+  if (isOpenStatus(row) && end && end < todayLocalIso) {
     types.push('end_date_passed');
   }
 
-  if (lateMeetingDates.length > 0) {
-    types.push('late_end_date');
-    row._late_end_date_threshold = lateEndThreshold;
-    row._late_end_date_hits = lateMeetingDates;
-  } else {
-    row._late_end_date_threshold = lateEndThreshold || '';
-    row._late_end_date_hits = [];
+  // Data synchronization gap: end_date must exactly match the latest meeting date.
+  // This replaces the old late_end_date / meeting-after-end labels.
+  const calculatedEndDate = calculatedEndDateFromActivityDates(row);
+  row._calculated_end_date = calculatedEndDate || '';
+  if (end && calculatedEndDate && end !== calculatedEndDate) {
+    types.push('end_date_out_of_sync');
   }
+  row._late_end_date_threshold = '';
+  row._late_end_date_hits = [];
   return types;
 }
 
@@ -1100,37 +1107,42 @@ function buildExceptionsModelFromRows(activityRows = [], month = '', opts = {}) 
   const includeRows = opts.include_rows !== false;
   const knownInstructorIds = opts.knownInstructorIds; // Set<string> | undefined
   const rows = [];
-  const counts = { missing_instructor: 0, missing_start_date: 0, late_end_date: 0, end_date_passed: 0 };
-  const byManager = {};
-  let operationalUniqueCount = 0;
+  const counts = { missing_instructor: 0, missing_start_date: 0, end_date_out_of_sync: 0, end_date_passed: 0 };
+  const byDistrict = {};
+  const uniqueActivityIds = new Set();
   for (const row of activityRows) {
     if (isActivityInactive(row)) continue;
-    if (rowActivityType(row) !== 'course') continue;
     if (!activityOverlapsMonthForExceptions(row, month)) continue;
-    const types = rowExceptionTypesFromActivity(row, {
-      knownInstructorIds,
-      lateEndDateThreshold: opts.lateEndDateThreshold
-    });
+    const types = rowExceptionTypesFromActivity(row, { knownInstructorIds });
     if (!types.length) continue;
-    const manager = cleanActivityManagerName(row?.activity_manager) || NO_ACTIVITY_MANAGER_LABEL;
-    byManager[manager] = (byManager[manager] || 0) + 1;
-    for (const type of types) counts[type] = (counts[type] || 0) + 1;
-    if (types.includes('missing_instructor') || types.includes('missing_start_date')) {
-      operationalUniqueCount += 1;
-    }
+    const uniqueTypes = [...new Set(types)];
+    const district = districtDisplayKey(row);
+    byDistrict[district] = (byDistrict[district] || 0) + uniqueTypes.length;
+    for (const type of uniqueTypes) counts[type] = (counts[type] || 0) + 1;
+    const activityKey = String(row?.RowID || row?.row_id || '').trim() || [row?.activity_name, row?.school, row?.authority].map((v) => String(v || '').trim()).join('|');
+    if (activityKey) uniqueActivityIds.add(activityKey);
     if (includeRows) {
       rows.push({
         ...row,
-        exception_type: types[0],
-        exception_types: [...new Set(types)],
-        exception_count: types.length,
-        has_multiple_exceptions: types.length > 1 ? 'yes' : 'no'
+        exception_type: uniqueTypes[0],
+        exception_types: uniqueTypes,
+        exception_count: uniqueTypes.length,
+        has_multiple_exceptions: uniqueTypes.length > 1 ? 'yes' : 'no'
       });
     }
   }
-  const totalExceptionRows = Object.values(byManager).reduce((sum, value) => sum + Number(value || 0), 0);
+  const totalExceptionRows = uniqueActivityIds.size;
   const totalExceptionInstances = Object.values(counts).reduce((sum, value) => sum + Number(value || 0), 0);
-  return { rows, totalExceptionRows, totalExceptionInstances, operationalUniqueCount, counts, byManager };
+  return {
+    rows,
+    totalExceptionRows,
+    totalExceptionInstances,
+    uniqueExceptionActivities: totalExceptionRows,
+    operationalUniqueCount: totalExceptionRows,
+    counts,
+    byManager: byDistrict,
+    byDistrict
+  };
 }
 
 function buildExceptionsFromRows(activityRows = [], month = '') {
@@ -1138,123 +1150,40 @@ function buildExceptionsFromRows(activityRows = [], month = '') {
 }
 
 async function readExceptionsFromSupabase(params = {}) {
-  if (!supabase) return buildSupabaseErrorPayload({ rows: [], totalExceptionRows: 0 }, 'no_supabase_client');
+  if (!supabase) return buildSupabaseErrorPayload({ rows: [], totalExceptionRows: 0, totalExceptionInstances: 0 }, 'no_supabase_client');
   const candidate = String(params?.month || params?.ym || '').trim();
   const now = new Date();
   const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
   const month = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
-  const COURSE_TYPE_VALUES = ['course', 'קורס', 'קורסים'];
   try {
-    const range = monthDateRange(month);
-    const settingsPromise = supabase
-      .from('settings')
-      .select('key,value')
-      .eq('key', 'late_end_date_threshold')
-      .maybeSingle();
+    const [activitiesResult, instrListResult] = await Promise.all([
+      supabase.from('activities').select('*'),
+      supabase.from('contacts_instructors').select('emp_id')
+    ]);
+    if (activitiesResult.error) throw new Error(activitiesResult.error.message || 'activities_read_failed');
 
-    // Query 1: courses active in the chosen month (date-range based)
-    const dateRangeRowsRaw = await selectActivitiesByDateRangeFromSupabase({
-      startDate: range.startDate,
-      endDate: range.endDate,
-      activityType: 'course',
-      includeEndDate: true
-    });
-    const dateRangeRows = dateRangeRowsRaw.filter((row) => {
-      if (rowActivityType(row) !== 'course') return false;
-      return activityHasDateInMonth(row, month)
-        || String(row?.end_date || '').startsWith(month);
-    });
-
-    // Fetch known instructor IDs from contacts list (for cross-reference validation)
-    const instrListResult = await supabase.from('contacts_instructors').select('emp_id');
     const knownInstructorIds = new Set(
       (Array.isArray(instrListResult.data) ? instrListResult.data : [])
         .map((r) => nullStr(r?.emp_id))
         .filter(Boolean)
     );
-
-    // Query 2 + 3 + 4 (parallel):
-    // 2 — broad open-course candidates for missing_start_date
-    // 3 — open courses where all instructor fields are empty
-    // 4 — open courses where emp_id is set but NOT in the known instructors list
-    const queryBase = () =>
-      supabase.from('activities').select('*').in('activity_type', COURSE_TYPE_VALUES).not('status', 'in', '("סגור","נמחק")');
-
-    const knownIdsList = [...knownInstructorIds];
-
-    const [missingStartResult, missingInstructorResult, invalidInstructorResult, lateEndDateResult, lateEndThresholdResult] = await Promise.all([
-      // 2: broad missing-start candidates. This query is intentionally
-      // not constrained by month: undated courses must stay visible as
-      // missing_start_date exceptions even while a month filter is active.
-      // Keep this broad instead of relying on Supabase .or() null/blank
-      // filters so textual markers like "NULL", "null", "undefined" and
-      // whitespace-only values are normalized and classified in code by
-      // rowExceptionTypesFromActivity/buildExceptionsModelFromRows.
-      queryBase(),
-      // 3: all instructor fields are empty
-      queryBase()
-        .or('emp_id.is.null,emp_id.eq.')
-        .or('emp_id_2.is.null,emp_id_2.eq.')
-        .or('instructor_name.is.null,instructor_name.eq.')
-        .or('instructor_name_2.is.null,instructor_name_2.eq.'),
-      // 4: emp_id is present but not in the official instructors list
-      knownIdsList.length > 0
-        ? queryBase()
-            .not('emp_id', 'is', null)
-            .neq('emp_id', '')
-            .not('emp_id', 'in', `(${knownIdsList.join(',')})`)
-        : Promise.resolve({ data: [] }),
-      // 5: broad open-course candidates for late_end_date. The exact exception
-      // is recomputed below from fresh normalized meeting dates and the
-      // configurable late_end_date_threshold.
-      queryBase(),
-      settingsPromise
-    ]);
-    const lateEndDateThresholdRaw = lateEndThresholdResult?.data?.value;
-    const lateEndDateThreshold = normalizeSupabaseDate(lateEndDateThresholdRaw);
-    if (!lateEndDateThreshold) {
-      console.warn('[exceptions] late_end_date_threshold missing/invalid in settings; late_end_date exceptions disabled until key is fixed.', {
-        key: 'late_end_date_threshold',
-        raw: lateEndDateThresholdRaw ?? null
-      });
-    }
-
-    const missingStartRows      = (Array.isArray(missingStartResult.data)      ? missingStartResult.data      : []).map(normalizeActivityRow);
-    const missingInstructorRows = (Array.isArray(missingInstructorResult.data) ? missingInstructorResult.data : []).map(normalizeActivityRow);
-    const invalidInstructorRows = (Array.isArray(invalidInstructorResult.data) ? invalidInstructorResult.data : []).map(normalizeActivityRow);
-    const lateEndDateRows       = (Array.isArray(lateEndDateResult.data)       ? lateEndDateResult.data       : []).map(normalizeActivityRow);
-
-    // Deduplicate by RowID across all result sets
-    const seenIds = new Set();
-    const allRows = [];
-    for (const row of [...dateRangeRows, ...missingStartRows, ...missingInstructorRows, ...invalidInstructorRows, ...lateEndDateRows]) {
-      const id = row?.RowID;
-      if (id != null && seenIds.has(id)) continue;
-      if (id != null) seenIds.add(id);
-      allRows.push(row);
-    }
-
+    const allRows = (Array.isArray(activitiesResult.data) ? activitiesResult.data : []).map(normalizeActivityRow);
     const exceptionSummary = buildExceptionsModelFromRows(allRows, month, {
       include_rows: true,
-      knownInstructorIds: knownInstructorIds.size > 0 ? knownInstructorIds : undefined,
-      lateEndDateThreshold
+      knownInstructorIds: knownInstructorIds.size > 0 ? knownInstructorIds : undefined
     });
-    const { data: allActivitiesRaw, error: allActivitiesError } = await supabase.from('activities').select('*');
-    if (allActivitiesError) throw new Error(allActivitiesError.message || 'activities_read_failed');
-    const undatedRows = (Array.isArray(allActivitiesRaw) ? allActivitiesRaw : [])
-      .map(normalizeActivityRow)
+    const undatedRows = allRows
       .filter((row) => !isActivityInactive(row))
       .filter((row) => !hasAnyActivityDate(row));
     return {
       month,
-      late_end_date_threshold: lateEndDateThreshold || '',
       ...exceptionSummary,
       undatedRows,
       undatedCount: undatedRows.length,
       _source: 'supabase'
     };
   } catch (error) {
-    return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0, undatedRows: [], undatedCount: 0 }, error);
+    return buildSupabaseErrorPayload({ rows: [], month, totalExceptionRows: 0, totalExceptionInstances: 0, undatedRows: [], undatedCount: 0 }, error);
   }
 }
 
@@ -2025,6 +1954,7 @@ const ALLOWED_ACTIVITY_COLUMNS = new Set([
   'row_id',
   'activity_family',
   'activity_manager',
+  'district',
   'authority',
   'school',
   'grade',
@@ -2175,11 +2105,18 @@ async function updateActivityInSupabase(payload = {}) {
   );
   const hasMeetingDateChange = Object.keys(changes).some((k) => /^date_\d+$/.test(k));
   const hasExplicitEndDate = Object.prototype.hasOwnProperty.call(changes, 'end_date');
-  if (hasMeetingDateChange && !hasExplicitEndDate) {
-    const derivedEnd = deriveEndDateFromDates(changes);
-    changes.end_date = derivedEnd || null;
-  }
   if (!rowId) throw new Error('missing_row_id');
+  if (hasMeetingDateChange && !hasExplicitEndDate) {
+    const { data: existingRow, error: existingError } = await supabase
+      .from('activities')
+      .select(Array.from({ length: 35 }, (_, idx) => `date_${idx + 1}`).join(','))
+      .eq('row_id', rowId)
+      .maybeSingle();
+    if (existingError) throw buildSupabaseMutationError('saveActivity', existingError, 'save_failed');
+    const mergedDates = { ...(existingRow || {}), ...changes };
+    const derivedEnd = deriveEndDateFromDates(mergedDates);
+    if (derivedEnd) changes.end_date = derivedEnd;
+  }
   if (!Object.keys(changes).length) throw new Error('No changes to submit');
   const debugPayload = { source_sheet: sourceSheet, source_row_id: rowId, changes };
   logActivityMutationDebug('request', 'saveActivity', debugPayload, { table: 'activities' });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -718,8 +718,15 @@ function shellUserDisplayName() {
 
 function exceptionsNavCount() {
   const entry = state.screenDataCache?.exceptions;
+  const explicit = Number(entry?.data?.totalExceptionInstances ?? entry?.data?.summary?.totalExceptionInstances);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
   const rows = Array.isArray(entry?.data?.rows) ? entry.data.rows : [];
-  return exceptionDisplayGroupCount(rows);
+  const rowCount = exceptionDisplayGroupCount(rows);
+  if (rowCount > 0) return rowCount;
+  const dashboardKey = buildScreenDataCacheKey('dashboard', state);
+  const dashboardEntry = state.screenDataCache?.[dashboardKey] || state.screenDataCache?.dashboard;
+  const dashboardCount = Number(dashboardEntry?.data?.summary?.totalExceptionInstances ?? dashboardEntry?.data?.summary?.exceptions_count ?? dashboardEntry?.data?.totals?.exceptions_count);
+  return Number.isFinite(dashboardCount) && dashboardCount > 0 ? dashboardCount : 0;
 }
 
 function navLabelHtmlForRoute(route) {

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -90,11 +90,6 @@ function renderKpiCard(k) {
   return cardBtn;
 }
 
-const MANAGER_DISPLAY_NAMES = {
-  'גיל נאמן':               'מחוז צפון',
-  'לינוי שמואל מזרחי':      'מחוז דרום',
-};
-
 const ACTIVITY_TYPE_ORDER = [
   { key: 'course',       label: 'קורסים' },
   { key: 'after_school', label: 'אפטרסקול' },
@@ -110,9 +105,9 @@ function renderStructuredSummary(summary, ym, byManager) {
   const counts = summary?.counts && typeof summary.counts === 'object' ? summary.counts : {};
   const missingInstructorCount = pickNumericFallback(counts, 'missing_instructor', summary?.missing_instructor_count);
   const missingStartDateCount = pickNumericFallback(counts, 'missing_start_date', summary?.missing_start_date_count ?? summary?.missing_date_count);
-  const lateEndCount = pickNumericFallback(counts, 'late_end_date', summary?.late_end_date_count);
+  const endDateOutOfSyncCount = pickNumericFallback(counts, 'end_date_out_of_sync', summary?.end_date_out_of_sync_count);
   const endDatePassedCount = pickNumericFallback(counts, 'end_date_passed', summary?.end_date_passed_count);
-  const exceptionsTotalField = getStrictNumericField(summary, 'totalExceptionRows');
+  const exceptionsTotalField = getStrictNumericField(summary, 'totalExceptionInstances');
   const exceptionsTotalFallback = getStrictNumericField(summary, 'exceptions_count');
   const exceptionsTotalResolved = exceptionsTotalField.ok
     ? exceptionsTotalField.value
@@ -123,7 +118,7 @@ function renderStructuredSummary(summary, ym, byManager) {
   const operationalUniqueCount = operationalUniqueField.ok ? operationalUniqueField.value : 0;
   const missingInstructor = missingInstructorCount;
   const missingStartDate  = missingStartDateCount;
-  const lateEnd = escapeHtml(String(lateEndCount));
+  const endDateOutOfSync = escapeHtml(String(endDateOutOfSyncCount));
   const endDatePassed = escapeHtml(String(endDatePassedCount));
 
   const typeCounts = summary?.active_type_counts || {};
@@ -142,7 +137,7 @@ function renderStructuredSummary(summary, ym, byManager) {
     (row) => row.activity_manager && row.activity_manager !== 'activity_manager' && row.activity_manager !== 'unassigned' && row.activity_manager !== 'ללא' && row.activity_manager !== 'ללא מנהל'
   );
   const districtByName = districtRows.reduce((acc, row) => {
-    const label = MANAGER_DISPLAY_NAMES[row.activity_manager] || row.activity_manager;
+    const label = row.activity_manager;
     acc[label] = row;
     return acc;
   }, {});
@@ -169,10 +164,10 @@ function renderStructuredSummary(summary, ym, byManager) {
       <p class="ds-summary-panel__text"><strong>סה״כ חריגות: ${escapeHtml(String(exceptionsTotalResolved))}</strong></p>
       <p class="ds-summary-panel__text">
         חריגות תפעוליות: <strong>${escapeHtml(String(operationalUniqueCount))}</strong>
-        <span class="ds-muted"> (חסר מדריך: ${escapeHtml(String(missingInstructor))} · חסר תאריך התחלה: ${escapeHtml(String(missingStartDate))})</span>
+        <span class="ds-muted"> (ללא מדריך: ${escapeHtml(String(missingInstructor))} · ללא תאריך התחלה: ${escapeHtml(String(missingStartDate))})</span>
       </p>
-      <p class="ds-summary-panel__text">תאריך סיום מאוחר: <strong>${lateEnd}</strong></p>
-      <p class="ds-summary-panel__text">תאריך סיום חלף: <strong>${endDatePassed}</strong></p>
+      <p class="ds-summary-panel__text">סיום לא מעודכן: <strong>${endDateOutOfSync}</strong></p>
+      <p class="ds-summary-panel__text">הסתיימה ולא נסגרה: <strong>${endDatePassed}</strong></p>
     </div>
   </div>`;
 }
@@ -378,8 +373,7 @@ export const dashboardScreen = {
     const kpiCards = filterKpiCards(_kpiSource, showOnly).map((card) => {
       if (card?.action !== 'kpi|exceptions') return card;
       const totalExceptions =
-        data?.summary?.totalExceptionRows ??
-        data?.summary?.total_exception_rows ??
+        data?.summary?.totalExceptionInstances ??
         data?.summary?.exceptions_count ??
         data?.totals?.exceptions_count ??
         0;
@@ -392,8 +386,8 @@ export const dashboardScreen = {
     const managerCards = managers
       .map((row) => {
         const mgr = encodeURIComponent(row.activity_manager);
-        const displayName = MANAGER_DISPLAY_NAMES[row.activity_manager] || row.activity_manager;
-        const isDistrict = !!MANAGER_DISPLAY_NAMES[row.activity_manager];
+        const displayName = row.activity_manager;
+        const isDistrict = true;
         const exceptionsValue = Number(row.exceptions ?? 0);
         const allStats = [
           { label: 'תוכניות פעילות', value: row.total_long      ?? 0, action: `mstat|${mgr}|long` },
@@ -680,7 +674,7 @@ export const dashboardScreen = {
         } else if (kind === 'exceptions') {
           state.route = 'exceptions';
           state.exceptionsMonthYm = state.dashboardMonthYm || currentMonthYm();
-          resetExceptionsFilters(name);
+          resetExceptionsFilters('');
         }
         ui.closeAll();
         rerender();

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -17,7 +17,7 @@ import {
 } from './shared/activity-list-filters.js';
 import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
 import { isEmptyValue } from '../utils/empty-value.js';
-import { normalizedExceptionTypes } from './shared/exceptions-metrics.js';
+import { EXCEPTION_TYPE_ORDER, normalizedExceptionTypes } from './shared/exceptions-metrics.js';
 
 const EXCEPTIONS_SCOPE = 'exceptions';
 
@@ -48,7 +48,7 @@ function exceptionCardTone(row, fallbackTone = 'other') {
   const type = normalizedExceptionTypes(row)[0] || fallbackTone;
   if (type === 'missing_start_date') return 'waiting-date';
   if (type === 'end_date_passed') return 'ended-open';
-  if (type === 'late_end_date') return 'late-end';
+  if (type === 'end_date_out_of_sync') return 'end-date-sync';
   if (type === 'missing_instructor') return 'missing-instructor';
   return 'other';
 }
@@ -116,9 +116,7 @@ function exceptionDrawerHtml(row, hideRowId) {
   const grade = String(row.grade || '').trim();
   const classGroup = String(row.class_group || '').trim();
   const classDisplay = [grade, classGroup].filter(Boolean).join(' ');
-  const lateThreshold = String(row?._late_end_date_threshold || '').trim();
-  const lateHits = Array.isArray(row?._late_end_date_hits) ? row._late_end_date_hits : [];
-  const lateHitsHe = lateHits.map((date) => formatDateHe(date) || String(date || '').trim()).filter(Boolean).join(', ');
+  const calculatedEndDate = String(row?._calculated_end_date || '').trim();
 
   return `<div class="ds-details-grid" dir="rtl">
     ${hideRowId ? '' : `<p><strong>${escapeHtml(hebrewColumn('RowID'))}:</strong> ${escapeHtml(String(row.RowID || '—'))}</p>`}
@@ -137,8 +135,7 @@ function exceptionDrawerHtml(row, hideRowId) {
     ${fieldRow(hebrewColumn('end_date'),    endDate)}
     ${fieldRow(hebrewColumn('sessions'),    row.sessions)}
     ${fieldRow(hebrewColumn('status'),      row.status)}
-    ${lateThreshold ? fieldRow('סף חריגת תאריך סיום מאוחר', formatDateHe(lateThreshold) || lateThreshold) : ''}
-    ${lateHitsHe ? fieldRow('מפגשים אחרי הסף', lateHitsHe) : ''}
+    ${calculatedEndDate ? fieldRow('תאריך סיום מחושב', formatDateHe(calculatedEndDate) || calculatedEndDate) : ''}
     ${row.notes ? fieldRow('הערות', row.notes) : ''}
   </div>`;
 }
@@ -159,21 +156,21 @@ export const exceptionsScreen = {
     const hideRowId = !!state?.clientSettings?.hide_row_id_in_ui;
     const toolbarHtml = filtersToolbarHtml(EXCEPTIONS_SCOPE, allRows, state, {
       filterFields: EXCEPTION_FILTER_FIELDS,
-      searchPlaceholder: 'חיפוש חריגות קורסים…',
+      searchPlaceholder: 'חיפוש חריגות…',
       optionsOverrides: getFilterOptionOverrides(state?.clientSettings || {})
     });
     const waitingDateRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('missing_start_date'));
     const endDatePassedRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('end_date_passed'));
-    const lateEndDateRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('late_end_date'));
+    const endDateOutOfSyncRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('end_date_out_of_sync'));
     const noInstructorRows = filteredRows.filter((row) => normalizedExceptionTypes(row).includes('missing_instructor'));
-    const mainTypes = new Set(['missing_start_date', 'late_end_date', 'end_date_passed', 'missing_instructor']);
+    const mainTypes = new Set(EXCEPTION_TYPE_ORDER);
     const otherExceptionRows = filteredRows.filter((row) => normalizedExceptionTypes(row).some((type) => !mainTypes.has(type)));
     const hasAnyRows = filteredRows.length > 0;
     const groups = [
-      { key: 'waiting-date', title: 'פעילויות ממתינות לתיאום תאריך', rows: waitingDateRows },
-      { key: 'ended-open', title: 'פעילויות פתוחות שהסתיימו', rows: endDatePassedRows },
-      { key: 'late-end', title: 'פעילויות עם תאריך סיום מאוחר', rows: lateEndDateRows },
-      { key: 'missing-instructor', title: 'פעילויות ללא מדריך', rows: noInstructorRows },
+      { key: 'ended-open', title: 'הסתיימה ולא נסגרה', rows: endDatePassedRows },
+      { key: 'end-date-sync', title: 'סיום לא מעודכן', rows: endDateOutOfSyncRows },
+      { key: 'missing-instructor', title: 'ללא מדריך', rows: noInstructorRows },
+      { key: 'waiting-date', title: 'ללא תאריך התחלה', rows: waitingDateRows },
       ...(otherExceptionRows.length ? [{ key: 'other', title: 'חריגות נוספות', rows: otherExceptionRows }] : [])
     ].filter((group) => group.rows.length > 0);
 

--- a/frontend/src/screens/shared/activity-gap-filter.js
+++ b/frontend/src/screens/shared/activity-gap-filter.js
@@ -15,8 +15,7 @@ export function activityGapTypes(row = {}) {
   if (!instructorName && !emp1 && !emp2) types.push('missing_instructor');
 
   const start = normalizedDate(row?.start_date ?? row?.date_start);
-  const date1 = normalizedDate(row?.date_1 ?? row?.Date1);
-  if (!start && !date1) types.push('missing_start_date');
+  if (!start) types.push('missing_start_date');
   return types;
 }
 

--- a/frontend/src/screens/shared/exceptions-metrics.js
+++ b/frontend/src/screens/shared/exceptions-metrics.js
@@ -2,30 +2,38 @@ function asList(rows) {
   return Array.isArray(rows) ? rows : [];
 }
 
-export function normalizedExceptionTypes(row) {
-  if (Array.isArray(row?.exception_types)) {
-    return row.exception_types.map((type) => String(type || '').trim()).filter(Boolean);
-  }
-  return [row?.exception_type].map((type) => String(type || '').trim()).filter(Boolean);
+export const EXCEPTION_TYPE_ORDER = [
+  'end_date_passed',
+  'end_date_out_of_sync',
+  'missing_instructor',
+  'missing_start_date'
+];
+
+const LEGACY_EXCEPTION_TYPE_ALIASES = {
+  late_end_date: 'end_date_out_of_sync',
+  dangerous_end_date: 'end_date_out_of_sync',
+  meeting_after_end_date: 'end_date_out_of_sync',
+  meeting_after_end: 'end_date_out_of_sync',
+  open_ended_not_closed: 'end_date_passed'
+};
+
+export function normalizeExceptionType(type) {
+  const key = String(type || '').trim();
+  return LEGACY_EXCEPTION_TYPE_ALIASES[key] || key;
 }
 
-
-const EXCEPTION_DISPLAY_GROUP_TYPES = ['missing_start_date', 'end_date_passed', 'late_end_date', 'missing_instructor'];
+export function normalizedExceptionTypes(row) {
+  const rawTypes = Array.isArray(row?.exception_types)
+    ? row.exception_types
+    : [row?.exception_type];
+  return [...new Set(rawTypes.map(normalizeExceptionType).filter(Boolean))];
+}
 
 export function exceptionDisplayGroupCount(rows) {
   let total = 0;
-  const mainTypes = new Set(EXCEPTION_DISPLAY_GROUP_TYPES);
   for (const row of asList(rows)) {
     const types = normalizedExceptionTypes(row);
-    if (!types.length) {
-      total += 1;
-      continue;
-    }
-    const uniqueTypes = new Set(types);
-    for (const type of EXCEPTION_DISPLAY_GROUP_TYPES) {
-      if (uniqueTypes.has(type)) total += 1;
-    }
-    if ([...uniqueTypes].some((type) => !mainTypes.has(type))) total += 1;
+    total += types.length || 1;
   }
   return total;
 }
@@ -50,12 +58,10 @@ export function uniqueExceptionActivityCount(rows, predicate) {
   return seen.size;
 }
 
-/** חריגות תפעוליות = רק סוגי חריגה מעמוד חריגות שאינם חסר מדריך / חסר תאריך התחלה */
+/** Total exception occurrences across the canonical exception groups. */
 export function computeOperationalExceptionsTotal({ rows, fallback = 0 } = {}) {
   const list = asList(rows);
-  if (list.length > 0) {
-    return uniqueExceptionActivityCount(list, (types) => types.includes('late_end_date'));
-  }
+  if (list.length > 0) return exceptionDisplayGroupCount(list);
   const n = Number(fallback);
   return Number.isFinite(n) ? n : 0;
 }

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -72,17 +72,19 @@ export function financeStatusVariant(value) {
 /** חריגות: עוצמת chip לפי סוג */
 export function exceptionTypeVariant(exceptionType) {
   const k = String(exceptionType || '').trim();
-  if (k === 'late_end_date' || k === 'dangerous_end_date' || k === 'end_date_passed') return 'danger';
+  if (k === 'end_date_out_of_sync' || k === 'late_end_date' || k === 'dangerous_end_date' || k === 'end_date_passed') return 'danger';
   if (k === 'missing_instructor' || k === 'missing_start_date') return 'warning';
   return 'neutral';
 }
 
 export const HEBREW_EXCEPTION_TYPE = {
-  missing_instructor:       'חסר מדריך',
-  missing_start_date:       'חסר תאריך התחלה',
-  late_end_date:            'תאריך סיום מאוחר',
-  end_date_passed:          'תאריך סיום חלף',
-  dangerous_end_date:       'תאריך סיום',
+  missing_instructor:       'ללא מדריך',
+  missing_start_date:       'ללא תאריך התחלה',
+  late_end_date:            'סיום לא מעודכן',
+  end_date_out_of_sync:     'סיום לא מעודכן',
+  end_date_passed:          'הסתיימה ולא נסגרה',
+  open_ended_not_closed:    'הסתיימה ולא נסגרה',
+  dangerous_end_date:       'סיום לא מעודכן',
   missing_activity_manager: 'חסר מנהל פעילות',
   missing_school:           'חסרה בית ספר',
   missing_authority:        'חסרה רשות',

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11353,7 +11353,7 @@ select.ds-input {
 
 .ds-exception-group[data-exception-group="waiting-date"] { --exception-group-color: #a16207; }
 .ds-exception-group[data-exception-group="ended-open"] { --exception-group-color: #b91c1c; }
-.ds-exception-group[data-exception-group="late-end"] { --exception-group-color: #6d28d9; }
+.ds-exception-group[data-exception-group="end-date-sync"] { --exception-group-color: #6d28d9; }
 .ds-exception-group[data-exception-group="missing-instructor"] { --exception-group-color: #1d4ed8; }
 .ds-exception-group[data-exception-group="other"] { --exception-group-color: #475569; }
 
@@ -11405,16 +11405,16 @@ select.ds-input {
   overflow: hidden;
   cursor: pointer;
   text-align: right;
-  border: 1px solid color-mix(in srgb, var(--exception-card-color) 10%, var(--ds-border));
+  border: 1px solid color-mix(in srgb, var(--exception-card-color) 7%, var(--ds-border));
   border-radius: 11px;
   background: color-mix(in srgb, var(--exception-card-color) 2%, var(--ds-surface));
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.045);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.035);
   transition: box-shadow 0.14s ease, border-color 0.14s ease, background 0.14s ease;
 }
 
 .ds-exception-card[data-exception-tone="waiting-date"] { --exception-card-color: #a16207; }
 .ds-exception-card[data-exception-tone="ended-open"] { --exception-card-color: #b91c1c; }
-.ds-exception-card[data-exception-tone="late-end"] { --exception-card-color: #6d28d9; }
+.ds-exception-card[data-exception-tone="end-date-sync"] { --exception-card-color: #6d28d9; }
 .ds-exception-card[data-exception-tone="missing-instructor"] { --exception-card-color: #1d4ed8; }
 .ds-exception-card[data-exception-tone="other"] { --exception-card-color: #475569; }
 
@@ -11430,8 +11430,7 @@ select.ds-input {
 }
 
 .ds-exception-card__accent {
-  flex: 0 0 3px;
-  background: color-mix(in srgb, var(--exception-card-color) 46%, #fff);
+  display: none;
 }
 
 .ds-exception-card__content {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 488;
+const CACHE_VERSION = 489;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260530_activity_exceptions_end_date_sync.sql
+++ b/supabase/migrations/20260530_activity_exceptions_end_date_sync.sql
@@ -1,0 +1,66 @@
+-- Keep public.activities.end_date synchronized with the latest meeting date.
+-- If a row has no date_1..date_35 values, the trigger leaves end_date unchanged.
+
+alter table public.activities add column if not exists district text;
+
+create or replace function public.activities_calculated_end_date_from_meetings(p_row public.activities)
+returns text
+language plpgsql
+immutable
+as $$
+declare
+  latest_date text;
+begin
+  select max(v)
+    into latest_date
+  from unnest(array[
+    nullif(btrim(p_row.date_1), ''),  nullif(btrim(p_row.date_2), ''),
+    nullif(btrim(p_row.date_3), ''),  nullif(btrim(p_row.date_4), ''),
+    nullif(btrim(p_row.date_5), ''),  nullif(btrim(p_row.date_6), ''),
+    nullif(btrim(p_row.date_7), ''),  nullif(btrim(p_row.date_8), ''),
+    nullif(btrim(p_row.date_9), ''),  nullif(btrim(p_row.date_10), ''),
+    nullif(btrim(p_row.date_11), ''), nullif(btrim(p_row.date_12), ''),
+    nullif(btrim(p_row.date_13), ''), nullif(btrim(p_row.date_14), ''),
+    nullif(btrim(p_row.date_15), ''), nullif(btrim(p_row.date_16), ''),
+    nullif(btrim(p_row.date_17), ''), nullif(btrim(p_row.date_18), ''),
+    nullif(btrim(p_row.date_19), ''), nullif(btrim(p_row.date_20), ''),
+    nullif(btrim(p_row.date_21), ''), nullif(btrim(p_row.date_22), ''),
+    nullif(btrim(p_row.date_23), ''), nullif(btrim(p_row.date_24), ''),
+    nullif(btrim(p_row.date_25), ''), nullif(btrim(p_row.date_26), ''),
+    nullif(btrim(p_row.date_27), ''), nullif(btrim(p_row.date_28), ''),
+    nullif(btrim(p_row.date_29), ''), nullif(btrim(p_row.date_30), ''),
+    nullif(btrim(p_row.date_31), ''), nullif(btrim(p_row.date_32), ''),
+    nullif(btrim(p_row.date_33), ''), nullif(btrim(p_row.date_34), ''),
+    nullif(btrim(p_row.date_35), '')
+  ]) as dates(v)
+  where v ~ '^\d{4}-\d{2}-\d{2}$';
+
+  return latest_date;
+end;
+$$;
+
+create or replace function public.activities_sync_end_date_from_meetings()
+returns trigger
+language plpgsql
+as $$
+declare
+  calculated_end text;
+begin
+  calculated_end := public.activities_calculated_end_date_from_meetings(new);
+  if calculated_end is not null then
+    new.end_date := calculated_end;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_activities_sync_end_date_from_meetings on public.activities;
+create trigger trg_activities_sync_end_date_from_meetings
+before insert or update of
+  date_1, date_2, date_3, date_4, date_5, date_6, date_7, date_8, date_9, date_10,
+  date_11, date_12, date_13, date_14, date_15, date_16, date_17, date_18, date_19, date_20,
+  date_21, date_22, date_23, date_24, date_25, date_26, date_27, date_28, date_29, date_30,
+  date_31, date_32, date_33, date_34, date_35
+on public.activities
+for each row
+execute function public.activities_sync_end_date_from_meetings();

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 488;
+const SW_ENTRY_VERSION = 489;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/api-undated-activities.test.mjs
+++ b/tests/api-undated-activities.test.mjs
@@ -38,7 +38,7 @@ function activeCourse(overrides = {}) {
   });
 }
 
-test('active course without start_date and date_1 appears as missing_start_date exception', () => {
+test('active activity without start_date appears as missing_start_date exception', () => {
   const row = activeCourse({ start_date: '', end_date: '', date_1: '' });
 
   assert.deepEqual(rowExceptionTypesFromActivity(row), ['missing_start_date']);
@@ -50,7 +50,7 @@ test('active course without start_date and date_1 appears as missing_start_date 
   assert.ok(model.rows[0].exception_types.includes('missing_start_date'));
 });
 
-test('month filter does not hide a course that has no start_date and no date_1 from exceptions', () => {
+test('month filter does not hide an activity that has no start_date from exceptions', () => {
   const row = activeCourse({ RowID: 'A-2', start_date: null, end_date: '', date_1: null });
 
   const mayModel = buildExceptionsModelFromRows([row], '2026-05', { include_rows: true });
@@ -79,13 +79,13 @@ test('activity with date_1 is matched by meeting dates before start/end fallback
   assert.equal(rowMatchesActivitiesFilters(row, { month: '2026-05', activity_type: 'all' }), false);
 });
 
-test('entering a valid start_date or date_1 removes missing_start_date automatically', () => {
+test('only a valid start_date removes missing_start_date automatically', () => {
   assert.equal(rowExceptionTypesFromActivity(activeCourse({ start_date: '', date_1: '' })).includes('missing_start_date'), true);
   assert.equal(rowExceptionTypesFromActivity(activeCourse({ start_date: '2026-05-10', date_1: '' })).includes('missing_start_date'), false);
-  assert.equal(rowExceptionTypesFromActivity(activeCourse({ start_date: '', date_1: '2026-05-10' })).includes('missing_start_date'), false);
+  assert.equal(rowExceptionTypesFromActivity(activeCourse({ start_date: '', date_1: '2026-05-10' })).includes('missing_start_date'), true);
 });
 
-test('late_end_date is computed from threshold and date_1..date_35 (not end_date)', () => {
+test('end_date_out_of_sync is computed from latest date_1..date_35', () => {
   const row = activeCourse({
     RowID: 'A-10',
     start_date: '2026-05-01',
@@ -93,22 +93,19 @@ test('late_end_date is computed from threshold and date_1..date_35 (not end_date
     date_1: '2026-06-16',
     date_2: '2026-06-10'
   });
-  const types = rowExceptionTypesFromActivity(row, { lateEndDateThreshold: '2026-06-15' });
-  assert.equal(types.includes('late_end_date'), true);
-  assert.deepEqual(row._late_end_date_hits, ['2026-06-16']);
-  assert.equal(row._late_end_date_threshold, '2026-06-15');
+  const types = rowExceptionTypesFromActivity(row);
+  assert.equal(types.includes('end_date_out_of_sync'), true);
+  assert.equal(row._calculated_end_date, '2026-06-16');
 });
 
-test('without valid threshold, late_end_date is not inferred and keeps safe fallback metadata', () => {
+test('matching end_date and latest meeting date does not create end_date_out_of_sync', () => {
   const row = activeCourse({
     RowID: 'A-11',
-    end_date: '2026-05-01',
+    end_date: '2026-06-20',
     date_1: '2026-06-20'
   });
-  const types = rowExceptionTypesFromActivity(row, { lateEndDateThreshold: 'not-a-date' });
-  assert.equal(types.includes('late_end_date'), false);
-  assert.deepEqual(row._late_end_date_hits, []);
-  assert.equal(row._late_end_date_threshold, '');
+  const types = rowExceptionTypesFromActivity(row);
+  assert.equal(types.includes('end_date_out_of_sync'), false);
 });
 
 
@@ -122,24 +119,25 @@ test('textual null markers in start_date/date_1 are treated as missing_start_dat
   assert.equal(rowExceptionTypesFromActivity(undefinedWhitespace).includes('missing_start_date'), true);
 });
 
-test('closed and non-course rows are excluded from course exceptions', () => {
+test('closed rows are excluded while non-course activities can still have exceptions', () => {
   const workshop = activeCourse({ RowID: 'A-8', activity_type: 'workshop', start_date: '', date_1: '' });
   const closed = activeCourse({ RowID: 'A-9', status: 'סגור', start_date: '', date_1: '' });
 
   const model = buildExceptionsModelFromRows([workshop, closed], '2026-05', { include_rows: true });
 
-  assert.equal(model.totalExceptionRows, 0);
-  assert.equal(model.rows.length, 0);
-  assert.equal(model.counts.missing_start_date, 0);
+  assert.equal(model.totalExceptionRows, 1);
+  assert.equal(model.rows.length, 1);
+  assert.equal(model.counts.missing_start_date, 1);
 });
 
-test('Supabase missing-start candidates are loaded broadly and filtered in code', async () => {
+test('Supabase exceptions read uses a single activities source and computes in code', async () => {
   const source = await readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
 
-  const block = source.match(/const \[missingStartResult[\s\S]*?\] = await Promise\.all\(\[([\s\S]*?)\n    \]\);/);
-  assert.ok(block, 'readExceptionsFromSupabase should fetch parallel exception candidate queries');
-  assert.match(block[1], /queryBase\(\),/);
-  assert.doesNotMatch(block[1], /start_date\.is\.null,start_date\.eq\.[\s\S]*date_1\.is\.null,date_1\.eq\./);
+  const block = source.match(/async function readExceptionsFromSupabase[\s\S]*?function syncContactToSupabase/);
+  assert.ok(block, 'readExceptionsFromSupabase should exist');
+  assert.match(block[0], /supabase\.from\('activities'\)\.select\('\*'\)/);
+  assert.match(block[0], /buildExceptionsModelFromRows\(allRows/);
+  assert.doesNotMatch(block[0], /missingStartResult|lateEndDateResult|late_end_date_threshold/);
 });
 
 test('allActivities export path reads all activities without applying month/date filters', async () => {

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -343,7 +343,7 @@ test('backend has all 3 exception type keys in counts object', async () => {
   }
   assert.match(src, /missing_instructor:\s*0/);
   assert.match(src, /missing_start_date:\s*0/);
-  assert.match(src, /late_end_date:\s*0/);
+  assert.match(src, /end_date_out_of_sync:\s*0|late_end_date:\s*0/);
 });
 
 test('frontend exceptions screen uses single row action by RowID', async () => {
@@ -378,21 +378,21 @@ test('frontend exceptions screen renders only non-empty groups', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
   assert.match(src, /\.filter\(\(group\) => group\.rows\.length > 0\)/,
     'empty exception groups should be filtered out');
-  assert.match(src, /return dsCard\(\{ title: `\$\{title\} · \$\{rows\.length\}`/,
+  assert.match(src, /const groupTitle = `\$\{title\} · \$\{rows\.length\}`/,
     'group titles should include item count');
 });
 
 test('frontend exception Hebrew labels describe the exception details clearly', async () => {
   const src = await read('frontend/src/screens/shared/ui-hebrew.js');
-  assert.match(src, /missing_instructor:\s+'חסר מדריך'/);
-  assert.match(src, /missing_start_date:\s+'חסר תאריך התחלה'/);
-  assert.match(src, /late_end_date:\s+'תאריך סיום מאוחר'/);
+  assert.match(src, /missing_instructor:\s+'ללא מדריך'/);
+  assert.match(src, /missing_start_date:\s+'ללא תאריך התחלה'/);
+  assert.match(src, /end_date_out_of_sync:\s+'סיום לא מעודכן'/);
 });
 
-test('exceptions screen separates end_date_passed and late_end_date into distinct group titles', async () => {
+test('exceptions screen separates end_date_passed and end_date_out_of_sync into distinct group titles', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
-  assert.match(src, /פעילויות פתוחות שהסתיימו/);
-  assert.match(src, /פעילויות עם תאריך סיום מאוחר/);
+  assert.match(src, /הסתיימה ולא נסגרה/);
+  assert.match(src, /סיום לא מעודכן/);
   assert.doesNotMatch(src, /פעילויות עם חריגת תאריך סיום/);
 });
 
@@ -402,13 +402,13 @@ test('exceptions screen group count matches rendered clickable cards', () => {
     month: '2026-05',
     rows: [
       { RowID: '1', activity_name: 'א', authority: 'ר1', school: 'ב1', exception_types: ['end_date_passed'] },
-      { RowID: '2', activity_name: 'ב', authority: 'ר1', school: 'ב1', exception_types: ['late_end_date'] },
-      { RowID: '3', activity_name: 'ג', authority: 'ר1', school: 'ב1', exception_types: ['late_end_date', 'missing_instructor'] }
+      { RowID: '2', activity_name: 'ב', authority: 'ר1', school: 'ב1', exception_types: ['end_date_out_of_sync'] },
+      { RowID: '3', activity_name: 'ג', authority: 'ר1', school: 'ב1', exception_types: ['end_date_out_of_sync', 'missing_instructor'] }
     ]
   };
   const html = exceptionsScreen.render(data, { state });
-  assert.match(html, /פעילויות פתוחות שהסתיימו · 1/);
-  assert.match(html, /פעילויות עם תאריך סיום מאוחר · 2/);
+  assert.match(html, /הסתיימה ולא נסגרה · 1/);
+  assert.match(html, /סיום לא מעודכן · 2/);
   const clickableCards = (html.match(/data-card-action="exception:/g) || []).length;
   assert.equal(clickableCards, 4, 'each grouped appearance must be rendered as a clickable card');
   assert.doesNotMatch(html, /data-action="delete"/);

--- a/tests/exceptions-canonical-logic.test.mjs
+++ b/tests/exceptions-canonical-logic.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function installStorage(name) {
+  if (globalThis[name]) return;
+  const store = new Map();
+  globalThis[name] = {
+    getItem: (key) => store.has(key) ? store.get(key) : null,
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+}
+
+installStorage('sessionStorage');
+installStorage('localStorage');
+
+const {
+  rowExceptionTypesFromActivity,
+  buildExceptionsModelFromRows,
+  normalizeActivityRow
+} = await import('../frontend/src/api.js');
+
+function activity(overrides = {}) {
+  return normalizeActivityRow({
+    RowID: overrides.RowID || 'A-1',
+    row_id: overrides.RowID || 'A-1',
+    activity_type: 'course',
+    status: 'פעיל',
+    district: 'מחוז צפון',
+    activity_manager: 'לא משויך',
+    activity_name: 'פעילות בדיקה',
+    authority: 'רשות',
+    school: 'בית ספר',
+    start_date: '2026-05-01',
+    end_date: '2026-06-10',
+    instructor_name: 'מדריכה',
+    emp_id: 'E-1',
+    ...overrides
+  });
+}
+
+test('open activity with future end_date is not ended-not-closed', () => {
+  const row = activity({ status: 'פתוח', end_date: '2999-01-01' });
+  assert.equal(rowExceptionTypesFromActivity(row).includes('end_date_passed'), false);
+});
+
+test('open activity with past end_date is ended-not-closed', () => {
+  const row = activity({ status: 'פתוח', end_date: '2000-01-01' });
+  assert.equal(rowExceptionTypesFromActivity(row).includes('end_date_passed'), true);
+});
+
+test('end_date different from latest meeting date is end_date_out_of_sync', () => {
+  const row = activity({ end_date: '2026-06-07', date_1: '2026-06-08', date_2: '2026-06-14' });
+  assert.equal(rowExceptionTypesFromActivity(row).includes('end_date_out_of_sync'), true);
+});
+
+test('end_date equal to latest meeting date is not end_date_out_of_sync', () => {
+  const row = activity({ end_date: '2026-06-14', date_1: '2026-06-08', date_2: '2026-06-14' });
+  assert.equal(rowExceptionTypesFromActivity(row).includes('end_date_out_of_sync'), false);
+});
+
+test('activity without instructor appears as missing_instructor', () => {
+  const row = activity({ instructor_name: '', emp_id: '', instructor_name_2: '', emp_id_2: '' });
+  assert.equal(rowExceptionTypesFromActivity(row).includes('missing_instructor'), true);
+});
+
+test('activity without start_date appears as missing_start_date', () => {
+  const row = activity({ start_date: null, date_1: '2026-05-01' });
+  assert.equal(rowExceptionTypesFromActivity(row).includes('missing_start_date'), true);
+});
+
+test('unassigned manager with valid district is counted under the district and totals are exception instances', () => {
+  const row = activity({ RowID: 'DIST-1', activity_manager: 'לא משויך', district: 'מחוז דרום', start_date: null, instructor_name: '', emp_id: '' });
+  const model = buildExceptionsModelFromRows([row], '2026-05', { include_rows: true });
+  assert.equal(model.counts.missing_start_date, 1);
+  assert.equal(model.counts.missing_instructor, 1);
+  assert.equal(model.totalExceptionRows, 1);
+  assert.equal(model.totalExceptionInstances, 2);
+  assert.equal(model.byDistrict['מחוז דרום'], 2);
+});


### PR DESCRIPTION
### Motivation

- Unify exception computation into a single canonical model so all screens use one consistent source of truth for exception instances and labels. 
- Replace confusing legacy labels with short user-facing names and ensure counts represent exception *instances* consistently across UI, dashboard and header. 
- Ensure `end_date` is kept in sync with meeting dates and that district-based summaries use the internal `district` field, not `activity_manager`.

### Description

- Centralized exception classification in `frontend/src/api.js` and introduced helper functions (`calculatedEndDateFromActivityDates`, `todayLocalIsoDate`, `isOpenStatus`, `districtDisplayKey`) and a single `buildExceptionsModelFromRows` flow that emits `end_date_out_of_sync`, `end_date_passed`, `missing_instructor`, `missing_start_date` and counts instances consistently. 
- Normalized legacy types and counting helpers in `frontend/src/screens/shared/exceptions-metrics.js`, and switched header/nav badge logic to prefer `totalExceptionInstances` with fallbacks in `frontend/src/main.js`. 
- Updated exceptions UI in `frontend/src/screens/exceptions.js` to use short Hebrew labels and compact cards, and changed drawer details to show only calculated fields (e.g. calculated end date) in the detail pane. 
- Updated dashboard to aggregate by `district` (internal field) and to show exception-instance totals consistently; also adjusted manager/district card rendering and KPI wiring in `frontend/src/screens/dashboard.js`. 
- Make `end_date` auto-derived on client save when meeting dates change (`updateActivityInSupabase` / `upsertActivityToSupabase`) and added a Supabase migration/trigger `supabase/migrations/20260530_activity_exceptions_end_date_sync.sql` to keep DB `end_date` synchronized with the latest meeting date. 
- Renamed and normalized Hebrew labels in `frontend/src/screens/shared/ui-hebrew.js`, adjusted styles for compact exception cards in `frontend/src/styles/main.css`, and bumped service-worker/cache versions in `sw.js` / `frontend/sw.js` to force fresh asset loads after deploy. 
- Tests: added `tests/exceptions-canonical-logic.test.mjs` and updated several existing tests to match the new canonical behavior and labels.

### Testing

- Ran targeted automated suites: `node --test tests/exceptions-canonical-logic.test.mjs tests/api-undated-activities.test.mjs tests/exceptions-all-types.test.mjs tests/service-worker-pwa-cache.test.mjs` — all targeted tests passed (41 passed, 0 failed). 
- Built production bundle with `npm run build` — build succeeded and assets were produced. 
- A wider `npm test -- --test-reporter=spec` run was attempted earlier and stopped on unrelated legacy fixture/mock failures; those failures are outside the implemented exception logic changes and the focused test matrix above passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aeeaad4d0832bba043a147897fd48)