### PR TITLE
Fix catalog A4 print sizing

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 521;
+const CACHE_VERSION = 523;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BEX5Xwd5.js",
+  "./assets/index-Dj32DjJo.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-C9yZ2wAg.css",
+  "./assets/style-BnVNy4a5.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./index.html",

--- a/dist/index.html
+++ b/dist/index.html
@@ -11,12 +11,14 @@
   <meta name="apple-mobile-web-app-title" content="Dashboard-Taasiyeda" />
   <link rel="manifest" href="./manifest.json" />
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
-  <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
+  <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BEX5Xwd5.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-C9yZ2wAg.css">
+  <script type="module" crossorigin src="./assets/index-Dj32DjJo.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>
-  <main id="app"></main>
+  <main id="app"></main>
+</body>
+</html>
 </body>
 </html>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 521;
+const CACHE_VERSION = 523;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BEX5Xwd5.js",
+  "./assets/index-Dj32DjJo.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-C9yZ2wAg.css",
+  "./assets/style-BnVNy4a5.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./index.html",

--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -159,17 +159,22 @@ html,body{overflow-x:hidden}
 @media (max-width:640px){.catalog-frame-grid,.catalog-list-grid,.catalog-strip-grid,.catalog-mini-card-grid{grid-template-columns:1fr}.catalog-card{min-height:62px}.catalog-group-grid{grid-template-columns:1fr}.catalog-content-card{padding:18px}.catalog-quick-grid{display:grid;grid-template-columns:1fr}.catalog-quick-card{border-radius:16px;align-items:flex-start;justify-content:space-between}.catalog-hero-top{padding:24px 20px}.catalog-syllabus-item{grid-template-columns:1fr;gap:10px}.catalog-syllabus-badge{width:max-content;min-width:42px;padding:0 12px;border-radius:999px}}
 @media (max-width:430px){.catalog-a4{padding:14px}.catalog-hero-top{padding:16px}.catalog-content-card p{font-size:13px}}
 @media print {
-  @page{size:A4 portrait;margin:11mm 13mm 13mm 13mm}
-  html,body,body > *{display:block !important}
+  @page{size:A4 portrait;margin:0}
+  html,body{background:#fff !important;margin:0 !important;padding:0 !important;width:auto !important;min-width:0 !important;overflow:visible !important}
   body *{visibility:hidden !important}
-  .catalog-print-zone,.catalog-print-zone *{visibility:visible !important}
-  .catalog-print-zone{position:absolute;inset:0;background:#fff}
-  .catalog-print-hide{display:none !important}
-  *{-webkit-print-color-adjust:exact !important;print-color-adjust:exact !important}
-  .catalog-a4{box-shadow:none !important;border:none !important;border-radius:0 !important;padding:0 !important;width:100% !important}
-  .pg{padding:0;gap:10px}
-  .card{padding:12px 14px}
-  .card,.catalog-content-card,.catalog-syl-wrap,.g2,.catalog-content-grid{page-break-inside:avoid}
+  body > *:has(.catalog-screen.catalog-print-zone){display:block !important}
+  .catalog-screen.catalog-print-zone,.catalog-screen.catalog-print-zone *{visibility:visible !important}
+  .catalog-screen.catalog-print-zone{position:static !important;display:block !important;inset:auto !important;width:100% !important;max-width:none !important;min-height:0 !important;margin:0 !important;padding:0 !important;background:#fff !important;color:#000 !important;box-shadow:none !important;border:0 !important;gap:0 !important}
+  .catalog-screen .catalog-print-hide,.catalog-screen .catalog-print-hide *{display:none !important;visibility:hidden !important}
+  .catalog-a4-wrap.catalog-print-zone{position:static !important;display:block !important;width:100% !important;max-width:none !important;margin:0 !important;padding:0 !important;background:#fff !important}
+  .catalog-print-page{width:210mm !important;min-height:297mm !important;height:auto !important;margin:0 auto !important;padding:12mm 14mm !important;box-sizing:border-box !important;background:#fff !important;page-break-after:always;break-after:page;-webkit-print-color-adjust:exact !important;print-color-adjust:exact !important}
+  .catalog-print-page:last-child{page-break-after:auto;break-after:auto}
+  .catalog-a4.catalog-print-page{max-width:none !important;box-shadow:none !important;border:none !important;border-radius:0 !important;overflow:visible !important}
+  .catalog-print-page .catalog-hero-top{padding:14mm 12mm !important;border-radius:18px !important}
+  .catalog-print-page .catalog-content-grid{gap:6mm !important}
+  .catalog-print-page .catalog-content-card{padding:7mm !important;border-radius:16px !important}
+  .catalog-print-page .catalog-footer{page-break-inside:avoid;break-inside:avoid}
+  .card,.catalog-content-card,.catalog-syl-wrap,.g2,.catalog-content-grid,.catalog-hero-top,.catalog-syllabus-item{page-break-inside:avoid;break-inside:avoid}
   .catalog-hero-top::after{display:none}
 }
 `;
@@ -686,7 +691,7 @@ export const catalogScreen = {
         <span class="catalog-print-bar-name">${escapeHtml(printTitle)}</span>
         <button class="catalog-print-btn" data-catalog-print>הדפסה / PDF</button>
       </div>
-      <div class="catalog-a4-wrap catalog-print-zone"><article class="catalog-a4 ${a4ToneClass} ${a4ThemeClass}" data-catalog-page="1">
+      <div class="catalog-a4-wrap catalog-print-zone"><article class="catalog-a4 catalog-print-page ${a4ToneClass} ${a4ThemeClass}" data-catalog-page="1">
         <header class="catalog-a4-header">
           <div class="catalog-hero-top"><div class="catalog-domain-icon" aria-hidden="true">${escapeHtml((selected.domain || selected.name || 'ת').trim().slice(0, 1))}</div><div class="catalog-hero-main">${renderGefenBadge(selected)}<h1>${escapeHtml(selected.name)}</h1>${heroLead ? `<p class="catalog-subtitle">${escapeHtml(heroLead)}</p>` : ''}${renderQualityTags(selected)}</div>${renderQuickInfoCards(selected)}</div>
         </header>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11197,10 +11197,10 @@ select.ds-input {
   }
 
   /* Hide everything except the preview overlay */
-  body > *:not(#pa-preview-overlay) {
+  body:has(#pa-preview-overlay) > *:not(#pa-preview-overlay) {
     display: none !important;
   }
-  body * {
+  body:has(#pa-preview-overlay) * {
     visibility: hidden !important;
   }
   #pa-preview-overlay,

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 522;
+const CACHE_VERSION = 523;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 522;
+const SW_ENTRY_VERSION = 523;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The catalog printed at screen width instead of a physical A4 page; printing must produce true A4 portrait pages with correct mm sizing, padding and page breaks while hiding dashboard UI chrome and avoiding interference with the proposal preview print rules.
- Service Worker cache needed bump so new CSS/JS are loaded after deploy and old cached assets do not prevent the fix from taking effect.

### Description
- Add a dedicated print page class by emitting `catalog-print-page` on the rendered catalog article and update the catalog template to include it (`frontend/src/screens/catalog.js`).
- Replace/extend print CSS so the printed document uses `@page { size: A4 portrait; margin: 0; }` and defines `.catalog-print-page { width: 210mm; min-height: 297mm; padding: 12mm 14mm; box-sizing: border-box; background: #fff; page-break-after: always; break-after: page; }` plus a `:last-child` rule to disable breaking after the final page, and hide non-catalog UI (`.catalog-print-hide`, toolbars, buttons) while keeping the catalog zone visible (changes in `frontend/src/screens/catalog.js` and adjustments in `frontend/src/styles/main.css`).
- Scope the proposal-preview print hiding rules so they only apply when `#pa-preview-overlay` exists to avoid accidentally hiding the catalog (change in `frontend/src/styles/main.css`).
- Bump Service Worker/cache versions to `523` in both `sw.js` and `frontend/sw.js`, rebuild the frontend and update `dist` artifacts so the new JS/CSS filenames and precache lists are referenced (`dist/index.html`, `dist/sw.js`, `dist/frontend/sw.js`).

### Testing
- Ran `npm run check:changed` and `node --check` on `frontend/src/screens/catalog.js`, `frontend/sw.js`, `sw.js`, `dist/frontend/sw.js` and `dist/sw.js`, and these checks passed with no syntax errors.
- Ran `npm run check:build` (which runs `npm run build`) and the production build completed and `dist` artifacts were updated successfully.
- Ran the focused unit tests `node --test tests/catalog-screen-display.test.mjs` and all catalog assertions printed as passing; the test process did not exit cleanly before a timeout due to a lingering handle, so a CI rerun (or full test run) is recommended to confirm process completion.
- Files changed: `frontend/src/screens/catalog.js`, `frontend/src/styles/main.css`, `frontend/sw.js`, `sw.js`, and rebuilt `dist` files (`dist/index.html`, `dist/sw.js`, `dist/frontend/sw.js`, and updated asset references).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bd20b220c832b8145610c887471c9)