### PR TITLE
Compact catalog syllabus print grid

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 524;
+const CACHE_VERSION = 525;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BiMo0LfC.js",
+  "./assets/index-BSUw1XW5.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BiMo0LfC.js"></script>
+  <script type="module" crossorigin src="./assets/index-BSUw1XW5.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 524;
+const CACHE_VERSION = 525;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BiMo0LfC.js",
+  "./assets/index-BSUw1XW5.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/catalog.js
+++ b/frontend/src/screens/catalog.js
@@ -139,13 +139,13 @@ html,body{overflow-x:hidden}
 .catalog-step-dot{width:36px;height:36px;border-radius:50%;background:#e8f5e0;border:1.5px solid #c2e0a0;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:900;color:#2d5a3d}
 .catalog-step-label{font-size:10px;font-weight:700;color:#2d5a3d}
 .catalog-step-arrow{color:var(--color-border-secondary,#cbd5e1);font-size:16px;margin:0 4px 16px;flex-shrink:0}
-.catalog-syllabus-section{grid-column:1/-1;display:grid;gap:14px;min-width:0;direction:rtl;text-align:right}
-.catalog-syl-wrap{display:grid;gap:12px}
-.catalog-syllabus-item{display:grid;grid-template-columns:auto minmax(0,1fr);gap:16px;align-items:flex-start;background:rgba(255,254,251,.95);border:1px solid rgba(224,216,202,.9);border-radius:22px;padding:18px 20px;box-shadow:0 10px 28px rgba(15,45,31,.05)}
-.catalog-syllabus-badge{width:42px;height:42px;border-radius:50%;background:#e5f4e7;border:1px solid #b8d9bd;color:#1f4a30;display:flex;align-items:center;justify-content:center;font-weight:900;font-size:15px;line-height:1;flex:0 0 42px}
-.catalog-syllabus-content{min-width:0;display:grid;gap:7px}
-.catalog-syllabus-title{margin:0;color:#102519;font-size:16px;line-height:1.45;font-weight:900;overflow-wrap:anywhere;unicode-bidi:plaintext}
-.catalog-syllabus-desc{margin:0;color:#4f6358;font-size:14px;line-height:1.8;overflow-wrap:anywhere;unicode-bidi:plaintext;white-space:pre-line}
+.catalog-syllabus-section{grid-column:1/-1;display:grid;gap:10px;min-width:0;direction:rtl;text-align:right}
+.catalog-syl-wrap{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;align-items:stretch}
+.catalog-syllabus-item{min-width:0;width:100%;box-sizing:border-box;display:grid;grid-template-columns:auto minmax(0,1fr);gap:8px;align-items:flex-start;background:rgba(255,254,251,.95);border:1px solid rgba(224,216,202,.9);border-radius:14px;padding:10px 11px;box-shadow:0 6px 16px rgba(15,45,31,.045);break-inside:avoid;page-break-inside:avoid}
+.catalog-syllabus-badge{width:28px;height:28px;border-radius:50%;background:#e5f4e7;border:1px solid #b8d9bd;color:#1f4a30;display:flex;align-items:center;justify-content:center;font-weight:900;font-size:12px;line-height:1;flex:0 0 28px}
+.catalog-syllabus-content{min-width:0;display:grid;gap:4px}
+.catalog-syllabus-title{margin:0;color:#102519;font-size:.82rem;line-height:1.28;font-weight:900;overflow-wrap:anywhere;unicode-bidi:plaintext}
+.catalog-syllabus-desc{margin:0;color:#4f6358;font-size:.74rem;line-height:1.35;overflow-wrap:anywhere;unicode-bidi:plaintext;white-space:pre-line}
 .catalog-strip{background:#f7f6fb;border:1px solid #ddd8f0;border-radius:10px;padding:10px 12px}
 .catalog-strip h3{font-size:13.5px;font-weight:700;background:#e5f5ee;color:#1a6645;border-radius:6px;padding:4px 8px;display:inline-block;margin:0 0 10px}
 .catalog-strip-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
@@ -176,10 +176,10 @@ html,body{overflow-x:hidden}
 .catalog-box table tr:nth-child(even) td{background:#f7f6fb}
 .catalog-list-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
 @media (max-width:1024px){.catalog-quick-grid{display:flex}}
-@media (max-width:900px){.catalog-detail-actions{padding:0}.catalog-a4-wrap{padding:0}.catalog-a4{width:100%;min-height:auto;padding:16px;border-radius:18px}.catalog-hero-top{padding:18px;border-radius:var(--border-radius-lg,18px)}.catalog-frame-grid{grid-template-columns:1fr 1fr}.catalog-list-grid{grid-template-columns:1fr}.catalog-content-grid{grid-template-columns:1fr}.catalog-footer{flex-direction:column}}
+@media (max-width:900px){.catalog-detail-actions{padding:0}.catalog-a4-wrap{padding:0}.catalog-a4{width:100%;min-height:auto;padding:16px;border-radius:18px}.catalog-hero-top{padding:18px;border-radius:var(--border-radius-lg,18px)}.catalog-frame-grid{grid-template-columns:1fr 1fr}.catalog-list-grid{grid-template-columns:1fr}.catalog-content-grid{grid-template-columns:1fr}.catalog-syl-wrap{grid-template-columns:repeat(2,minmax(0,1fr))}.catalog-footer{flex-direction:column}}
 @media (max-width:1100px){.catalog-groups{grid-template-columns:1fr}.catalog-group-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 @media (max-width:760px){.catalog-header h2{font-size:24px}.catalog-toolbar{align-items:stretch}.catalog-filter-field{flex:1 1 100%;min-width:0;font-size:12px}}
-@media (max-width:640px){.catalog-frame-grid,.catalog-list-grid,.catalog-strip-grid,.catalog-mini-card-grid{grid-template-columns:1fr}.catalog-card{min-height:62px}.catalog-group-grid{grid-template-columns:1fr}.catalog-content-card{padding:18px}.catalog-quick-grid{display:grid;grid-template-columns:1fr}.catalog-quick-card{border-radius:16px;align-items:flex-start;justify-content:space-between}.catalog-hero-top{padding:24px 20px}.catalog-syllabus-item{grid-template-columns:1fr;gap:10px}.catalog-syllabus-badge{width:max-content;min-width:42px;padding:0 12px;border-radius:999px}}
+@media (max-width:640px){.catalog-frame-grid,.catalog-list-grid,.catalog-strip-grid,.catalog-mini-card-grid{grid-template-columns:1fr}.catalog-card{min-height:62px}.catalog-group-grid{grid-template-columns:1fr}.catalog-content-card{padding:18px}.catalog-quick-grid{display:grid;grid-template-columns:1fr}.catalog-quick-card{border-radius:16px;align-items:flex-start;justify-content:space-between}.catalog-hero-top{padding:24px 20px}.catalog-syl-wrap{grid-template-columns:1fr}.catalog-syllabus-item{grid-template-columns:1fr;gap:7px}.catalog-syllabus-badge{width:max-content;min-width:34px;height:24px;padding:0 10px;border-radius:999px}}
 @media (max-width:430px){.catalog-a4{padding:14px}.catalog-hero-top{padding:16px}.catalog-content-card p{font-size:13px}}
 @media print {
   @page{size:A4 portrait;margin:0}
@@ -197,8 +197,15 @@ html,body{overflow-x:hidden}
   body.catalog-printing .catalog-print-page .catalog-hero-top{padding:14mm 12mm !important;border-radius:18px !important}
   body.catalog-printing .catalog-print-page .catalog-content-grid{gap:6mm !important}
   body.catalog-printing .catalog-print-page .catalog-content-card{padding:7mm !important;border-radius:16px !important}
+  body.catalog-printing .catalog-print-page .catalog-syllabus-section{gap:3mm !important}
+  body.catalog-printing .catalog-print-page .catalog-syl-wrap{grid-template-columns:repeat(3,minmax(0,1fr)) !important;gap:3mm !important;align-items:stretch !important;break-inside:auto !important;page-break-inside:auto !important}
+  body.catalog-printing .catalog-print-page .catalog-syllabus-item{min-width:0 !important;width:100% !important;box-sizing:border-box !important;padding:2.8mm 3mm !important;border-radius:10px !important;gap:2.2mm !important;min-height:auto !important;height:auto !important;break-inside:avoid-page !important;page-break-inside:avoid !important;box-shadow:none !important}
+  body.catalog-printing .catalog-print-page .catalog-syllabus-badge{width:7mm !important;height:7mm !important;flex-basis:7mm !important;font-size:9.5px !important}
+  body.catalog-printing .catalog-print-page .catalog-syllabus-content{gap:1.2mm !important}
+  body.catalog-printing .catalog-print-page .catalog-syllabus-title{font-size:9.8px !important;line-height:1.25 !important}
+  body.catalog-printing .catalog-print-page .catalog-syllabus-desc{font-size:8.8px !important;line-height:1.3 !important}
   body.catalog-printing .catalog-print-page .catalog-footer{page-break-inside:avoid;break-inside:avoid}
-  body.catalog-printing .card,body.catalog-printing .catalog-content-card,body.catalog-printing .catalog-syl-wrap,body.catalog-printing .g2,body.catalog-printing .catalog-content-grid,body.catalog-printing .catalog-hero-top,body.catalog-printing .catalog-syllabus-item{page-break-inside:avoid;break-inside:avoid}
+  body.catalog-printing .card,body.catalog-printing .catalog-content-card,body.catalog-printing .g2,body.catalog-printing .catalog-content-grid,body.catalog-printing .catalog-hero-top{page-break-inside:avoid;break-inside:avoid}
   body.catalog-printing .catalog-hero-top::after{display:none}
 }
 `;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 524;
+const CACHE_VERSION = 525;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 524;
+const SW_ENTRY_VERSION = 525;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The catalog print output spanned three pages due to a tall/wide syllabus layout, so the syllabus area needs a compact, balanced 3-column grid for A4 printing without applying a global `zoom`.
- Prevent large page jumps caused by an overly-large or unbalanced syllabus card and avoid changing the existing `window.print` / double-print prevention logic.

### Description
- Convert the syllabus wrapper to a 3-column CSS grid and make syllabus items compact and uniform by updating `.catalog-syl-wrap`, `.catalog-syllabus-item`, `.catalog-syllabus-badge`, `.catalog-syllabus-title`, and `.catalog-syllabus-desc` in `frontend/src/screens/catalog.js` (tighter gaps, smaller padding, consistent widths, adjusted fonts, and responsive fallbacks to 2/1 columns).
- Add print-specific overrides so the A4 print layout forces three columns, reduces gaps/padding, sets item sizes to `auto`, and carefully adjust `break-inside`/`page-break-inside` to avoid large page jumps for syllabus items.
- Bump Service Worker cache/version constants from `524` to `525` in `frontend/sw.js` and `sw.js`, and update build artifacts so precache and root SW are synchronized with the new bundle.
- Files changed: `frontend/src/screens/catalog.js`, `frontend/sw.js`, `sw.js`, and rebuilt artifacts `dist/index.html`, `dist/sw.js`, `dist/frontend/sw.js` (no changes to `window.print` logic).

### Testing
- Ran `npm run check:changed`, which performed `node --check` on the modified files and completed successfully.
- Ran `npm run check:build` (which runs `vite build` + `scripts/postbuild-dist.mjs`) and the production build completed successfully and updated `dist` precache entries.
- Ran the focused screen test `node --test tests/catalog-screen-display.test.mjs` where the visible assertions related to syllabus rendering passed, but the test process in this non-interactive environment did not exit before the run timeout (assertions printed as passing).
- Verified with `rg` that `CACHE_VERSION = 525`, `SW_ENTRY_VERSION = 525`, and the compiled `catalog-syl-wrap` 3-column rule exist in the built assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be180e9b0832b911b9b414d767b2a)