### PR TITLE
Fix one-day activity_family normalization for tours/workshops and add migration/tests

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 525;
+const CACHE_VERSION = 526;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BSUw1XW5.js",
+  "./assets/index-DI4NDwzY.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BSUw1XW5.js"></script>
+  <script type="module" crossorigin src="./assets/index-DI4NDwzY.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 525;
+const CACHE_VERSION = 526;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BSUw1XW5.js",
+  "./assets/index-DI4NDwzY.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2122,13 +2122,13 @@ function sanitizeActivityPayload(act = {}) {
     'tour', 'tours', 'סיור', 'סיורים',
     'escape_room', 'escaperoom', 'חדר_בריחה'
   ]);
-  const normalizedFamily = String(row.activity_family || '').trim();
-  if (normalizedFamily === 'one_day' || normalizedFamily === 'program') {
-    row.activity_family = normalizedFamily;
+  const normalizedType = normalizeActivityTypeKey(row.activity_type || act.activity_type || '');
+  if (oneDayTypeKeys.has(normalizedType)) {
+    row.activity_family = 'one_day';
   } else {
-    const normalizedType = normalizeActivityTypeKey(row.activity_type || act.activity_type || '');
-    if (oneDayTypeKeys.has(normalizedType)) {
-      row.activity_family = 'one_day';
+    const normalizedFamily = String(row.activity_family || '').trim();
+    if (normalizedFamily === 'one_day' || normalizedFamily === 'program') {
+      row.activity_family = normalizedFamily;
     } else {
       row.activity_family = String(act.source || '').trim() === 'short' ? 'one_day' : 'program';
     }
@@ -3501,5 +3501,7 @@ export {
   rowExceptionTypesFromActivity,
   getActivityExceptions,
   buildExceptionsModelFromRows,
-  normalizeActivityRow
+  normalizeActivityRow,
+  sanitizeActivityPayload,
+  sanitizeActivityPayloadForSupabase
 };

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1359,7 +1359,7 @@ export const activitiesScreen = {
       const roster = decodeJsonAttr(form.dataset.addRosterUsers, []);
       const fd = new (window?.FormData || FormData)(form);
       const get = (k) => String(fd.get(k) || '').trim();
-      const familySource = get('source') || 'catalog';
+      const formSource = get('source') || 'catalog';
       const authorityCustom = get('authority_custom');
       const schoolCustom = get('school_custom');
       const authorityValue = authorityCustom || get('authority');
@@ -1379,7 +1379,7 @@ export const activitiesScreen = {
       const oneDayDate = String(get('one_day_date') || get('start_date') || get('end_date') || '').trim();
       let meetingDateValues = [];
       const payload = {
-        source: familySource,
+        source: isOneDay ? 'short' : (formSource === 'short' ? 'long' : formSource),
         activity_family: isOneDay ? 'one_day' : 'program',
         activity_manager: get('activity_manager'),
         authority: authorityValue,

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 525;
+const CACHE_VERSION = 526;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260601_fix_one_day_activity_family.sql
+++ b/supabase/migrations/20260601_fix_one_day_activity_family.sql
@@ -1,0 +1,20 @@
+-- Fix existing active one-day activities that were accidentally stored as programs.
+-- Do not rely on created_at (not present in every production database).
+UPDATE public.activities
+SET activity_family = 'one_day'
+WHERE COALESCE(status, '') <> 'נמחק'
+  AND COALESCE(activity_family, '') <> 'one_day'
+  AND lower(replace(replace(btrim(COALESCE(activity_type, '')), '-', '_'), ' ', '_')) IN (
+    'tour',
+    'tours',
+    'סיור',
+    'סיורים',
+    'workshop',
+    'workshops',
+    'סדנה',
+    'סדנאות',
+    'escape_room',
+    'escaperoom',
+    'חדר_בריחה',
+    'חדרי_בריחה'
+  );

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 525;
+const SW_ENTRY_VERSION = 526;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activity-one-day-family-regression.test.mjs
+++ b/tests/activity-one-day-family-regression.test.mjs
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function installStorage(name) {
+  if (globalThis[name]) return;
+  const store = new Map();
+  globalThis[name] = {
+    getItem: (key) => store.has(key) ? store.get(key) : null,
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+}
+
+installStorage('sessionStorage');
+installStorage('localStorage');
+
+const {
+  rowMatchesActivitiesFilters,
+  sanitizeActivityPayload,
+  sanitizeActivityPayloadForSupabase,
+  normalizeActivityRow
+} = await import('../frontend/src/api.js');
+
+function normalizeForSave(payload) {
+  return sanitizeActivityPayloadForSupabase(sanitizeActivityPayload(payload), { includeRowId: true });
+}
+
+test('new tour activity is normalized as one_day before Supabase insert', () => {
+  const row = normalizeForSave({
+    activity_type: 'tour',
+    activity_family: 'program',
+    source: 'long',
+    activity_name: 'סיור בדיקה',
+    start_date: '2026-06-15',
+    end_date: '2026-06-15'
+  });
+
+  assert.equal(row.activity_type, 'tour');
+  assert.equal(row.activity_family, 'one_day');
+});
+
+test('new workshop activity is normalized as one_day before Supabase insert', () => {
+  const row = normalizeForSave({
+    activity_type: 'workshop',
+    activity_family: 'program',
+    source: 'long',
+    activity_name: 'סדנת בדיקה',
+    start_date: '2026-06-16',
+    end_date: '2026-06-16'
+  });
+
+  assert.equal(row.activity_type, 'workshop');
+  assert.equal(row.activity_family, 'one_day');
+});
+
+test('one-day Hebrew and escape-room activity types override wrong family/source values', () => {
+  for (const activityType of ['סיור', 'סיורים', 'סדנה', 'סדנאות', 'escape_room', 'escaperoom', 'חדר בריחה', 'חדר_בריחה']) {
+    const row = normalizeForSave({
+      activity_type: activityType,
+      activity_family: 'program',
+      source: 'long',
+      start_date: '2026-06-17'
+    });
+    assert.equal(row.activity_family, 'one_day', `${activityType} should be one_day`);
+  }
+});
+
+test('saved one-day activity appears in activities month filter when displayed month matches', () => {
+  const savedRow = normalizeActivityRow(normalizeForSave({
+    row_id: 'ACT-ONE-DAY-REGRESSION',
+    activity_type: 'tour',
+    activity_family: 'program',
+    source: 'long',
+    activity_name: 'סיור שמופיע במסך',
+    start_date: '2026-06-18',
+    end_date: '2026-06-18',
+    status: 'פעיל'
+  }));
+
+  assert.equal(savedRow.activity_family, 'one_day');
+  assert.equal(rowMatchesActivitiesFilters(savedRow, { month: '2026-06', activity_type: 'all' }), true);
+  assert.equal(rowMatchesActivitiesFilters(savedRow, { month: '2026-07', activity_type: 'all' }), false);
+});


### PR DESCRIPTION
### Motivation

- Activities created as `tour`/`workshop`/`escape_room` were sometimes saved with `activity_family = 'program'` (or `source = 'long'`) causing them to be filtered out from the one-day lists, so the save/normalization flow must force these types to `one_day` regardless of incoming payload.

### Description

- Change sanitization in `frontend/src/api.js` so `sanitizeActivityPayload` first detects `activity_type` (normalized) and forces `activity_family = 'one_day'` for known one-day type keys before honoring an incoming `activity_family` or `source` value.
- Update the add-activity form in `frontend/src/screens/activities.js` to set the outgoing `source` to `short` for one-day types (and to map an explicit `source='short'` to `long` when appropriate) so UI submissions no longer misclassify tours/workshops.
- Exported `sanitizeActivityPayload`/`sanitizeActivityPayloadForSupabase` for focused regression tests, added `tests/activity-one-day-family-regression.test.mjs`, and added a cautious Supabase migration `supabase/migrations/20260601_fix_one_day_activity_family.sql` that updates existing active one-day rows without touching deleted rows or relying on `created_at`.
- Bumped Service Worker cache constants (`CACHE_VERSION` and `SW_ENTRY_VERSION`) to `526` and updated checked-in `dist` artifacts (`dist/sw.js`, `dist/frontend/sw.js`, `dist/index.html`) so clients will drop old caches and pick the new code.

Changed files: `frontend/src/api.js`, `frontend/src/screens/activities.js`, `frontend/sw.js`, `sw.js`, `dist/sw.js`, `dist/frontend/sw.js`, `dist/index.html`, `tests/activity-one-day-family-regression.test.mjs`, `supabase/migrations/20260601_fix_one_day_activity_family.sql`.

### Testing

- Ran `node --test tests/activity-one-day-family-regression.test.mjs` and all 4 regression tests passed.
- Ran focused checks `npm run check:changed` which ran syntax checks on changed files and completed successfully.
- Ran `npm run check:build` (which runs `vite build` and `scripts/postbuild-dist.mjs`) and the build completed successfully with updated `dist` files.
- Ran `node --test tests/service-worker-pwa-cache.test.mjs` and the service-worker cache/version tests passed, confirming the SW cache bump was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d37e4c220832b8beda19cdf2a313c)