### PR TITLE
Normalize activity_type aliases and refresh activity_name dropdown on type change

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 526;
+const CACHE_VERSION = 527;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DI4NDwzY.js",
+  "./assets/index-BNE25R1d.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DI4NDwzY.js"></script>
+  <script type="module" crossorigin src="./assets/index-BNE25R1d.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 526;
+const CACHE_VERSION = 527;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DI4NDwzY.js",
+  "./assets/index-BNE25R1d.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -30,6 +30,8 @@ import {
   getActivityTypesByFamily,
   getActivityNamesForType,
   getRosterUsers,
+  activityTypeMatches,
+  normalizeActivityTypeKey,
   getManagerUsers,
   getFilterOptionOverrides,
   cleanUnique,
@@ -231,25 +233,7 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
   const m = i % 2 === 0 ? '00' : '30';
   return `${h}:${m}`;
 });
-const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set([
-  'workshop',
-  'workshops',
-  'סדנה',
-  'סדנאות',
-  'tour',
-  'tours',
-  'סיור',
-  'סיורים',
-  'escape_room',
-  'escaperoom',
-  'חדר_בריחה'
-]);
-
-function normalizeActivityTypeKey(value) {
-  const raw = String(value || '').trim().toLowerCase();
-  if (!raw) return '';
-  return raw.replace(/[\s-]+/g, '_').replace(/^חדרי_בריחה$/, 'חדר_בריחה');
-}
+const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set(['workshop', 'tour', 'escape_room', 'escaperoom', 'חדר_בריחה', 'חדרי_בריחה']);
 
 function isOneDayActivityTypeValue(value) {
   return ONE_DAY_ACTIVITY_TYPE_KEYS.has(normalizeActivityTypeKey(value));
@@ -636,7 +620,7 @@ function buildFallbackOptionsFromRows(rows) {
     rows.forEach((row) => {
       const label = String(row?.activity_name || '').trim();
       const type  = String(row?.activity_type  || '').trim();
-      const sig   = `${label}|${type}`;
+      const sig   = `${label}|${normalizeActivityTypeKey(type) || type}`;
       if (!label || seen.has(sig)) return;
       seen.add(sig);
       out.push({
@@ -1226,13 +1210,15 @@ export const activitiesScreen = {
       const noInput = form.querySelector('[data-add-activity-no]');
       if (!typeSel || !nameSel || !noInput) return;
       const all = decodeJsonAttr(form.dataset.addActivityNames, []);
-      const type = String(typeSel.value || '').trim();
-      const list = all.filter((o) => {
-        const parent = String(o?.parent_value || o?.activity_type || '').trim();
-        return !parent || parent === type;
-      });
+      const type = normalizeActivityTypeKey(typeSel.value);
+      const hasTagged = all.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
+      let list = all.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, type));
+      if (!list.length && !hasTagged) list = all;
       const current = String(nameSel.value || '').trim();
-      nameSel.innerHTML = optionsHtml(list.map((o) => o.label), current, 'בחרו שם פעילות');
+      const currentStillValid = list.some((o) => String(o?.label || '').trim() === current);
+      const nextValue = currentStillValid ? current : '';
+      nameSel.innerHTML = optionsHtml(list.map((o) => o.label), nextValue, 'בחרו שם פעילות');
+      nameSel.value = nextValue;
       const hit = list.find((o) => String(o?.label || '').trim() === String(nameSel.value || '').trim());
       noInput.value = String(hit?.activity_no || '');
     }
@@ -1365,10 +1351,11 @@ export const activitiesScreen = {
       const authorityValue = authorityCustom || get('authority');
       const schoolValue = schoolCustom || get('school');
       const selectedName = get('activity_name');
+      const selectedType = normalizeActivityTypeKey(get('activity_type'));
       const hit = activityMap.find((x) => {
         const label = String(x?.label || '').trim();
-        const parent = String(x?.parent_value || x?.activity_type || '').trim();
-        return label === selectedName && (!parent || parent === get('activity_type'));
+        const parent = x?.parent_value || x?.activity_type;
+        return label === selectedName && activityTypeMatches(parent, selectedType);
       });
       const pickEmp = (name) => {
         const u = roster.find((r) => String(r?.name || '').trim() === name);

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatDateHeWithWeekday, formatTimeShort, formatTimeRangeShort, formatActivityDateColumnsHe } from './format-date.js';
-import { activityManagerDisplayName, cleanActivityManagerName, getManagerUsers, NO_ACTIVITY_MANAGER_LABEL, resolveActivityInstructorName } from './activity-options.js';
+import { activityManagerDisplayName, activityTypeMatches, cleanActivityManagerName, getManagerUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, resolveActivityInstructorName } from './activity-options.js';
 import { ACTIVITY_SEASON_OPTIONS, activitySeasonLabel, normalizeActivitySeason } from './summer-activity.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
@@ -206,25 +206,19 @@ function resolveActivityNameOptions(settings, activityType) {
     if (Array.isArray(arr) && arr.length > 0) { all = normalizeActivityNameOptions(arr); break; }
   }
   if (!all.length) return [];
-  const type = String(activityType || '').trim().toLowerCase();
+  const type = normalizeActivityTypeKey(activityType);
   if (!type) return all;
-  const filtered = all.filter((o) => {
-    const parent = String(o?.parent_value || o?.activity_type || '').trim().toLowerCase();
-    return !parent || parent === type;
-  });
+  const filtered = all.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, type));
   // Fall back to full list only when nothing is tagged — avoids empty dropdown for legacy data.
   const hasTagged = all.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
   return (filtered.length || hasTagged) ? filtered : all;
 }
 
 function buildActivityNameOpts(options, safeValue, activityType) {
-  const normalizedType = String(activityType || '').trim().toLowerCase();
-  let filtered = (Array.isArray(options) ? options : []).filter((o) => {
-    const parent = String(o?.parent_value || o?.activity_type || '').trim();
-    if (!parent) return true;
-    return parent.toLowerCase() === normalizedType;
-  });
-  if (!filtered.length) filtered = Array.isArray(options) ? options : [];
+  const normalizedType = normalizeActivityTypeKey(activityType);
+  let filtered = (Array.isArray(options) ? options : []).filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, normalizedType));
+  const hasTagged = (Array.isArray(options) ? options : []).some((o) => String(o?.parent_value || o?.activity_type || '').trim());
+  if (!filtered.length && !hasTagged) filtered = Array.isArray(options) ? options : [];
   const all = filtered.slice();
   if (safeValue && !all.some((o) => String(o?.label || '').trim() === safeValue)) {
     all.unshift({ label: safeValue, activity_no: '', parent_value: activityType });
@@ -356,7 +350,7 @@ function headerHtml(row, { mode = 'single', summaryDate = '', exportAction = tru
 
 function blockActivityDetails(row, { settings = {} } = {}) {
   const activityType = String(row.activity_type || '').trim();
-  const allActivityNames = resolveActivityNameOptions(settings, activityType);
+  const allActivityNames = resolveActivityNameOptions(settings, '');
   if (!allActivityNames.length) {
     // eslint-disable-next-line no-console
     console.warn('[activity-edit] activity name options missing from client settings');

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -72,6 +72,30 @@ export function resolveActivityInstructorName(row = {}, { secondary = false } = 
 
 export const NO_ACTIVITY_MANAGER_LABEL = 'ללא';
 
+const ACTIVITY_TYPE_ALIASES = new Map([
+  ['סדנה', 'workshop'],
+  ['סדנאות', 'workshop'],
+  ['workshop', 'workshop'],
+  ['workshops', 'workshop'],
+  ['חדר בריחה', 'escape_room'],
+  ['חדר_בריחה', 'escape_room'],
+  ['חדרי בריחה', 'escape_room'],
+  ['חדרי_בריחה', 'escape_room'],
+  ['escape_room', 'escape_room'],
+  ['escaperoom', 'escape_room'],
+  ['סיור', 'tour'],
+  ['סיורים', 'tour'],
+  ['tour', 'tour'],
+  ['tours', 'tour'],
+  ['קורס', 'course'],
+  ['קורסים', 'course'],
+  ['course', 'course'],
+  ['courses', 'course'],
+  ['אפטרסקול', 'after_school'],
+  ['after_school', 'after_school'],
+  ['afterschool', 'after_school']
+]);
+
 function text(value) {
   return String(value == null ? '' : value).trim();
 }
@@ -85,6 +109,19 @@ export function cleanActivityManagerName(value) {
 
 export function activityManagerDisplayName(value) {
   return cleanActivityManagerName(value) || NO_ACTIVITY_MANAGER_LABEL;
+}
+
+export function normalizeActivityTypeKey(value) {
+  const clean = text(value).replace(/[\u2010-\u2015]/g, '_').replace(/[-\s]+/g, '_').toLowerCase();
+  if (!clean) return '';
+  return ACTIVITY_TYPE_ALIASES.get(clean) || clean;
+}
+
+export function activityTypeMatches(value, expected) {
+  const left = normalizeActivityTypeKey(value);
+  const right = normalizeActivityTypeKey(expected);
+  if (!right) return true;
+  return !left || left === right;
 }
 
 function isExplicitlyInactive(value) {
@@ -159,11 +196,11 @@ export function getActivityTypesByFamily(settings, family) {
 }
 
 export function getActivityNamesForType(settings, activityType) {
-  const type = text(activityType);
+  const type = normalizeActivityTypeKey(activityType);
   return getActivityCatalog(settings)
     .filter((row) => {
-      const parent = text(row.activity_type || row.parent_value || row.type);
-      return !type || parent === type;
+      const parent = row.activity_type || row.parent_value || row.type;
+      return !type || activityTypeMatches(parent, type);
     });
 }
 

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -2,6 +2,7 @@ import { translateApiErrorForUser } from './ui-hebrew.js';
 import { showToast } from './toast.js';
 import { formatDateHe } from './format-date.js';
 import { escapeHtml } from './html.js';
+import { activityTypeMatches, normalizeActivityTypeKey } from './activity-options.js';
 import { state } from '../../state.js';
 
 function setEditMode(form, editing) {
@@ -458,23 +459,24 @@ export function bindActivityEditForm(contentRoot, {
           if (nameSel && nameSel.dataset.allActivityNames) {
             let allOptions = [];
             try { allOptions = JSON.parse(decodeURIComponent(nameSel.dataset.allActivityNames)); } catch { allOptions = []; }
-            const newType = String(typeEl.value || '').trim().toLowerCase();
-            let filtered = allOptions.filter((o) => {
-              const parent = String(o?.parent_value || o?.activity_type || '').trim();
-              if (!parent) return true;
-              return parent.toLowerCase() === newType;
-            });
-            if (!filtered.length) filtered = allOptions;
+            const newType = normalizeActivityTypeKey(typeEl.value);
+            const hasTagged = allOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
+            let filtered = allOptions.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, newType));
+            if (!filtered.length && !hasTagged) filtered = allOptions;
+            const current = String(nameSel.value || '').trim();
+            const currentStillValid = filtered.some((o) => String(o?.label || '').trim() === current);
             const optsHtml = ['<option value="">—</option>']
               .concat(filtered.map((o) => {
                 const label = String(o?.label || '').trim();
                 const actNo = String(o?.activity_no || '').trim();
                 const actType = String(o?.parent_value || o?.activity_type || '').trim();
-                return `<option value="${label}" data-activity-no="${actNo}" data-activity-type="${actType}">${label}</option>`;
+                return `<option value="${escapeHtml(label)}" data-activity-no="${escapeHtml(actNo)}" data-activity-type="${escapeHtml(actType)}">${escapeHtml(label)}</option>`;
               }))
               .join('');
             nameSel.innerHTML = optsHtml;
-            nameSel.value = '';
+            nameSel.value = currentStillValid ? current : '';
+            const hidden = form.querySelector('[data-activity-no]');
+            if (hidden) hidden.value = currentStillValid ? detectActivityNoByName(form, current) : '';
           }
         }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 526;
+const CACHE_VERSION = 527;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 526;
+const SW_ENTRY_VERSION = 527;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -406,3 +406,131 @@ test('all-activities Excel filename keeps Hebrew base and date stamp', async () 
     globalThis.Blob = originalBlob;
   }
 });
+
+const { JSDOM } = await import('jsdom');
+const { getActivityNamesForType } = await import('../frontend/src/screens/shared/activity-options.js');
+const { activityWorkDrawerHtml } = await import('../frontend/src/screens/shared/activity-detail-html.js');
+const { bindActivityEditForm } = await import('../frontend/src/screens/shared/bind-activity-edit-form.js');
+
+function activityNameSettings() {
+  return {
+    dropdown_options: {
+      activity_names: [
+        { label: 'חדר בריחה חלל', activity_no: 'ER-1', activity_type: 'חדר בריחה' },
+        { label: 'סדנת רובוטיקה', activity_no: 'WS-1', activity_type: 'workshop' },
+        { label: 'סיור מדעים', activity_no: 'TR-1', activity_type: 'סיור' }
+      ]
+    },
+    one_day_activity_types: ['חדר בריחה', 'סדנה', 'סיור'],
+    program_activity_types: ['קורס']
+  };
+}
+
+test('activity name filtering normalizes Hebrew and English activity type aliases', () => {
+  const settings = activityNameSettings();
+
+  const escapeNames = getActivityNamesForType(settings, 'escape_room').map((item) => item.label);
+  assert.deepEqual(escapeNames, ['חדר בריחה חלל']);
+
+  const workshopNames = getActivityNamesForType(settings, 'סדנאות').map((item) => item.label);
+  assert.deepEqual(workshopNames, ['סדנת רובוטיקה']);
+});
+
+test('activity edit form refreshes activity_name options and clears stale name when activity_type changes', () => {
+  const settings = activityNameSettings();
+  const dom = new JSDOM(`<main id="root">${activityWorkDrawerHtml({
+    RowID: 'A-1',
+    activity_name: 'חדר בריחה חלל',
+    activity_no: 'ER-1',
+    activity_type: 'חדר בריחה',
+    status: 'פעיל'
+  }, { settings, canEdit: true, canDirectEdit: true })}</main>`);
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousAbortController = globalThis.AbortController;
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.AbortController = dom.window.AbortController;
+  try {
+    const root = dom.window.document.querySelector('#root');
+    bindActivityEditForm(root, { api: { saveActivity: async () => ({ ok: true }) } });
+
+    const form = root.querySelector('[data-drawer-form]');
+    const typeSelect = form.querySelector('select[name="activity_type"]');
+    const nameSelect = form.querySelector('[data-role="activity-name-select"]');
+    const noInput = form.querySelector('[data-activity-no]');
+
+    assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['חדר בריחה חלל']);
+    typeSelect.value = 'סדנה';
+    typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['סדנת רובוטיקה']);
+    assert.equal(nameSelect.value, '');
+    assert.equal(noInput.value, '');
+    assert.doesNotMatch(nameSelect.textContent, /חדר בריחה חלל/);
+  } finally {
+    globalThis.window = previousWindow;
+    globalThis.document = previousDocument;
+    globalThis.AbortController = previousAbortController;
+  }
+});
+
+test('activity add form refreshes activity_name options and clears stale name when activity_type changes', () => {
+  const settings = activityNameSettings();
+  const state = baseState();
+  state.clientSettings = settings;
+  state.user = { display_role: 'admin', role: 'admin', can_add_activity: true };
+  const dom = new JSDOM('<body><main id="root"></main></body>', { url: 'https://example.test/dashboard_system/' });
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousAbortController = globalThis.AbortController;
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.AbortController = dom.window.AbortController;
+  try {
+    const root = dom.window.document.querySelector('#root');
+    root.innerHTML = activitiesScreen.render({ rows: [] }, { state });
+    activitiesScreen.bind({
+      root,
+      data: { rows: [] },
+      state,
+      rerender: () => {},
+      rerenderActivitiesView: () => {},
+      clearScreenDataCache: () => {},
+      api: { activities: async () => ({ rows: [] }), allActivities: async () => ({ rows: [] }) },
+      ui: {
+        bindInteractiveCards: () => {},
+        openModal: ({ content }) => {
+          const modal = dom.window.document.createElement('div');
+          modal.className = 'ds-modal__content';
+          modal.innerHTML = content;
+          dom.window.document.body.appendChild(modal);
+        }
+      }
+    });
+
+    root.querySelector('[data-activities-add-btn]').click();
+    const form = dom.window.document.querySelector('[data-add-activity-form]');
+    const typeSelect = form.querySelector('[data-add-activity-type]');
+    const nameSelect = form.querySelector('[data-add-activity-name]');
+    const noInput = form.querySelector('[data-add-activity-no]');
+
+    typeSelect.value = 'חדר בריחה';
+    typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['חדר בריחה חלל']);
+    nameSelect.value = 'חדר בריחה חלל';
+    nameSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    assert.equal(noInput.value, 'ER-1');
+
+    typeSelect.value = 'workshop';
+    typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['סדנת רובוטיקה']);
+    assert.equal(nameSelect.value, '');
+    assert.equal(noInput.value, '');
+    assert.doesNotMatch(nameSelect.textContent, /חדר בריחה חלל/);
+  } finally {
+    globalThis.window = previousWindow;
+    globalThis.document = previousDocument;
+    globalThis.AbortController = previousAbortController;
+  }
+});


### PR DESCRIPTION
### Motivation
- The activity name dropdown sometimes continued to show options from the previous `activity_type` when switching types (e.g. switching from "חדר בריחה" to "סדנה").
- The code compared raw strings in several places, so Hebrew labels and English technical keys (e.g. `חדר בריחה` vs `escape_room`) did not always match the same category.
- The goal was to normalize activity type keys and ensure the `activity_name` list and `activity_no` are rebuilt/cleared when `activity_type` changes in both add and edit flows.

### Description
- Added shared normalization and matching utilities `normalizeActivityTypeKey` and `activityTypeMatches` in `frontend/src/screens/shared/activity-options.js` and switched all name/type filtering to use them instead of direct string equality. 
- Updated filtering logic for `getActivityNamesForType`, `resolveActivityNameOptions`, `buildActivityNameOpts`, the add form `refreshActivityNameSelect`, the edit drawer change handler in `bind-activity-edit-form`, and the add form submission lookup to use normalized matching. 
- Ensured change listeners on `activity_type` in both the add form and the edit drawer rebuild the `activity_name` options, keep the current name only if still valid for the new type, and clear `activity_no` when the selection becomes invalid. 
- Files changed: `frontend/src/screens/shared/activity-options.js`, `frontend/src/screens/activities.js`, `frontend/src/screens/shared/activity-detail-html.js`, `frontend/src/screens/shared/bind-activity-edit-form.js`, test additions in `tests/activities-screen.test.mjs`, and Service Worker / dist updates (`frontend/sw.js`, `sw.js`, `dist/*`).

### Testing
- Ran the focused unit tests with `node --test tests/activities-screen.test.mjs` and all tests in that file passed. 
- Ran the frontend checks with `npm run check:changed` which ran `node --check` over modified files and returned clean, and ran `npm run check:build` which built the `dist` artifacts successfully. 
- Bumped Service Worker cache/version from `526` to `527` in `frontend/sw.js` and `sw.js` and confirmed `dist` was rebuilt so the updated bundle and cache version are included in `dist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da5e6ad24832b95471d2d8074e685)