### PR TITLE
Use sessionStorage for month selection, clean legacy localStorage, and bump SW cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 527;
+const CACHE_VERSION = 528;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BNE25R1d.js",
+  "./assets/index-BdawCusM.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BNE25R1d.js"></script>
+  <script type="module" crossorigin src="./assets/index-BdawCusM.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 527;
+const CACHE_VERSION = 528;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BNE25R1d.js",
+  "./assets/index-BdawCusM.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/month.js
+++ b/frontend/src/screens/month.js
@@ -12,7 +12,7 @@ import {
   bindLocalFilters
 } from './shared/activity-list-filters.js';
 import { activityManagerDisplayName, getFilterOptionOverrides } from './shared/activity-options.js';
-import { calendarMonthStorageKey } from '../state.js';
+import { calendarMonthSessionKey, cleanupLegacyCalendarMonthLocalStorage } from '../state.js';
 import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shared/view-switcher.js';
 
 const inflightActivityDetailRequests = new Map();
@@ -425,8 +425,9 @@ export const monthScreen = {
       state.monthYm = targetYm;
       state.monthNavLoading = true;
       try {
-        const calKey = calendarMonthStorageKey(state.user?.user_id);
-        if (calKey) localStorage.setItem(calKey, state.monthYm);
+        cleanupLegacyCalendarMonthLocalStorage(state.user?.user_id);
+        const calKey = calendarMonthSessionKey(state.user?.user_id);
+        if (calKey) sessionStorage.setItem(calKey, state.monthYm);
       } catch { /* ignore */ }
 
       try {
@@ -486,6 +487,11 @@ export const monthScreen = {
     todayBtn?.addEventListener('click', () => {
       if (state.monthNavLoading) return;
       state.monthYm = localYmd().slice(0, 7);
+      try {
+        cleanupLegacyCalendarMonthLocalStorage(state.user?.user_id);
+        const calKey = calendarMonthSessionKey(state.user?.user_id);
+        if (calKey) sessionStorage.setItem(calKey, state.monthYm);
+      } catch { /* ignore */ }
       rerender?.();
     });
 

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -29,8 +29,28 @@ if (!sessionStorage.getItem('ds_session_alive')) {
   localStorage.removeItem('dashboard_user');
 }
 
-function calendarMonthStorageKey(userId) {
+function legacyCalendarMonthStorageKey(userId) {
   return userId ? `dashboard_calendar_month_ym:${userId}` : null;
+}
+
+function calendarMonthSessionKey(userId) {
+  return userId ? `dashboard_calendar_month_ym_session:${userId}` : null;
+}
+
+function cleanupLegacyCalendarMonthLocalStorage(userId) {
+  try {
+    localStorage.removeItem('dashboard_calendar_month_ym');
+    const specificKey = legacyCalendarMonthStorageKey(userId);
+    if (specificKey) localStorage.removeItem(specificKey);
+    const keys = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('dashboard_calendar_month_ym:')) keys.push(key);
+    }
+    keys.forEach((key) => localStorage.removeItem(key));
+  } catch {
+    /* ignore */
+  }
 }
 
 function normalizeBoolPermission(value) {
@@ -51,9 +71,9 @@ function normalizeStoredUserFlags(user) {
 }
 
 const _initStoredUser = normalizeStoredUserFlags(JSON.parse(localStorage.getItem('dashboard_user') || 'null'));
-const _initCalKey = calendarMonthStorageKey(_initStoredUser?.user_id);
-const _initMonthYm = (_initCalKey && localStorage.getItem(_initCalKey)) || '';
-if (_initCalKey) { try { localStorage.removeItem('dashboard_calendar_month_ym'); } catch { /* ignore */ } }
+const _initCalKey = calendarMonthSessionKey(_initStoredUser?.user_id);
+const _initMonthYm = (_initCalKey && sessionStorage.getItem(_initCalKey)) || '';
+cleanupLegacyCalendarMonthLocalStorage(_initStoredUser?.user_id);
 
 export const state = {
   token: localStorage.getItem('dashboard_token') || '',
@@ -145,7 +165,12 @@ export function setSession(session) {
     state.openEditRequestsCount = null;
     localStorage.removeItem('dashboard_token');
     localStorage.removeItem('dashboard_user');
-    try { localStorage.removeItem('dashboard_calendar_month_ym'); } catch { /* ignore */ }
+    cleanupLegacyCalendarMonthLocalStorage(state.user?.user_id);
+    try {
+      Object.keys(sessionStorage)
+        .filter((key) => key === 'dashboard_calendar_month_ym_session' || key.startsWith('dashboard_calendar_month_ym_session:'))
+        .forEach((key) => sessionStorage.removeItem(key));
+    } catch { /* ignore */ }
     sessionStorage.removeItem('ds_session_alive');
     return;
   }
@@ -165,9 +190,9 @@ export function setSession(session) {
   state.user.can_edit_direct = normalizeBoolPermission(state.user.can_edit_direct);
   state.user.can_request_edit = normalizeBoolPermission(state.user.can_request_edit);
   state.user.finance_access = normalizeBoolPermission(state.user.finance_access);
-  const newCalKey = calendarMonthStorageKey(state.user.user_id);
-  state.monthYm = (newCalKey && localStorage.getItem(newCalKey)) || '';
-  try { localStorage.removeItem('dashboard_calendar_month_ym'); } catch { /* ignore */ }
+  const newCalKey = calendarMonthSessionKey(state.user.user_id);
+  state.monthYm = (newCalKey && sessionStorage.getItem(newCalKey)) || '';
+  cleanupLegacyCalendarMonthLocalStorage(state.user.user_id);
   state.screenDataCache = {};
   state.openEditRequestsCount = null;
   localStorage.setItem('dashboard_token', session.token);
@@ -175,4 +200,4 @@ export function setSession(session) {
   sessionStorage.setItem('ds_session_alive', '1');
 }
 
-export { defaultClientSettings, calendarMonthStorageKey };
+export { defaultClientSettings, calendarMonthSessionKey, cleanupLegacyCalendarMonthLocalStorage };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 527;
+const CACHE_VERSION = 528;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 527;
+const SW_ENTRY_VERSION = 528;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/month-calendar-session.test.mjs
+++ b/tests/month-calendar-session.test.mjs
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+class MemoryStorage {
+  constructor(entries = {}) {
+    this.store = new Map(Object.entries(entries).map(([k, v]) => [k, String(v)]));
+  }
+  get length() { return this.store.size; }
+  key(index) { return Array.from(this.store.keys())[index] ?? null; }
+  getItem(key) { return this.store.has(String(key)) ? this.store.get(String(key)) : null; }
+  setItem(key, value) { this.store.set(String(key), String(value)); }
+  removeItem(key) { this.store.delete(String(key)); }
+  clear() { this.store.clear(); }
+}
+
+const RealDate = globalThis.Date;
+function installFixedJune2026Date() {
+  globalThis.Date = class FixedDate extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) return new RealDate('2026-06-01T12:00:00Z');
+      return new RealDate(...args);
+    }
+    static now() { return new RealDate('2026-06-01T12:00:00Z').getTime(); }
+    static parse(value) { return RealDate.parse(value); }
+    static UTC(...args) { return RealDate.UTC(...args); }
+  };
+}
+
+test.after(() => {
+  globalThis.Date = RealDate;
+});
+
+async function importFreshState() {
+  return import(`../frontend/src/state.js?month-session-test=${Date.now()}-${Math.random()}`);
+}
+
+test('legacy localStorage month does not set the month screen default on a new entry', async () => {
+  installFixedJune2026Date();
+  globalThis.localStorage = new MemoryStorage({
+    dashboard_user: JSON.stringify({ user_id: 'u1' }),
+    dashboard_token: 'token',
+    'dashboard_calendar_month_ym:u1': '2026-05'
+  });
+  globalThis.sessionStorage = new MemoryStorage({ ds_session_alive: '1' });
+
+  const { state } = await importFreshState();
+  assert.equal(state.monthYm, '');
+  assert.equal(globalThis.localStorage.getItem('dashboard_calendar_month_ym:u1'), null);
+
+  const { monthScreen } = await import('../frontend/src/screens/month.js');
+  let requestedYm = '';
+  await monthScreen.load({
+    state,
+    api: { month: ({ ym }) => { requestedYm = ym; return Promise.resolve({ month: ym, cells: [], items_by_id: {} }); } }
+  });
+
+  assert.equal(requestedYm, '2026-06');
+});
+
+test('sessionStorage month is used only as the temporary month selection for the active session', async () => {
+  installFixedJune2026Date();
+  globalThis.localStorage = new MemoryStorage({
+    dashboard_user: JSON.stringify({ user_id: 'u1' }),
+    dashboard_token: 'token',
+    'dashboard_calendar_month_ym:u1': '2026-04'
+  });
+  globalThis.sessionStorage = new MemoryStorage({
+    ds_session_alive: '1',
+    'dashboard_calendar_month_ym_session:u1': '2026-05'
+  });
+
+  const { state, calendarMonthSessionKey } = await importFreshState();
+  assert.equal(calendarMonthSessionKey('u1'), 'dashboard_calendar_month_ym_session:u1');
+  assert.equal(state.monthYm, '2026-05');
+  assert.equal(globalThis.localStorage.getItem('dashboard_calendar_month_ym:u1'), null);
+
+  const { monthScreen } = await import('../frontend/src/screens/month.js');
+  let requestedYm = '';
+  await monthScreen.load({
+    state,
+    api: { month: ({ ym }) => { requestedYm = ym; return Promise.resolve({ month: ym, cells: [], items_by_id: {} }); } }
+  });
+
+  assert.equal(requestedYm, '2026-05');
+});


### PR DESCRIPTION
### Motivation
- The month screen default was being loaded from a persistent `localStorage` key (`dashboard_calendar_month_ym:<userId>`), which made users see an old month on a new session instead of the current `YYYY-MM` month.

### Description
- Changed month persistence to per-session storage by adding `calendarMonthSessionKey` and writing/reading `sessionStorage` instead of `localStorage`, and moved month-related logic from `localStorage` to `sessionStorage` in `frontend/src/state.js` and `frontend/src/screens/month.js`.
- Added `cleanupLegacyCalendarMonthLocalStorage` to safely remove legacy `dashboard_calendar_month_ym` keys (both the generic and any `dashboard_calendar_month_ym:*` entries) so existing installs are not stuck on an old month.
- Updated month navigation and the Today button to persist temporary choices only in the active session and not in persistent storage, preserving in-session navigation behavior.
- Added regression tests `tests/month-calendar-session.test.mjs`, bumped Service Worker cache/version to `528`, and rebuilt `dist` artifacts (`dist/index.html`, `dist/frontend/sw.js`, `dist/sw.js`) to point to the new bundle.

### Testing
- Ran focused checks with `npm run check:changed` which validated syntax for changed files and completed successfully.
- Ran targeted tests `node --test tests/month-calendar-session.test.mjs tests/calendar-navigation.test.mjs tests/service-worker-pwa-cache.test.mjs` and all tests passed.
- Performed a production build via `npm run check:build` (calls `vite build` and postbuild script) and the `dist` output was updated successfully; Service Worker cache version was bumped and SW-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcb0a30fc832baec1b962018be9e6)