### PR TITLE
Normalize and validate one-day activities (workshop / tour / escape_room)

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 528;
+const CACHE_VERSION = 529;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BdawCusM.js",
+  "./assets/index-BWghBSQQ.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BdawCusM.js"></script>
+  <script type="module" crossorigin src="./assets/index-BWghBSQQ.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 528;
+const CACHE_VERSION = 529;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BdawCusM.js",
+  "./assets/index-BWghBSQQ.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -177,9 +177,17 @@ function buildSupabaseErrorPayload(base, error, extra = {}) {
 
 const ACTIVITIES_TABLE = 'activities';
 const CLOSED_STATUS = 'סגור';
+const OPEN_STATUS = 'פתוח';
+const LEGACY_ACTIVE_STATUS = 'פעיל';
 const DELETED_STATUS = 'נמחק';
 
+function oneDayTypeFromActivityFields(activityType, itemType) {
+  return canonicalOneDayActivityType(activityType) || canonicalOneDayActivityType(itemType);
+}
+
 function normalizeActivityRow(row = {}) {
+  const canonicalOneDayType = oneDayTypeFromActivityFields(row?.activity_type, row?.item_type);
+  const isLegacyOneDay = canonicalOneDayType && (String(row?.activity_family || '').trim() === 'one_day' || !String(row?.item_type || '').trim());
   const rowId = String(row?.row_id ?? row?.RowID ?? '').trim();
   const activitySeason = normalizeActivitySeason(row?.activity_season ?? row?.activitySeason);
   const normalized = {
@@ -190,6 +198,10 @@ function normalizeActivityRow(row = {}) {
     source_table: ACTIVITIES_TABLE,
     activity_season: activitySeason,
     activitySeason,
+    activity_family: isLegacyOneDay ? 'one_day' : row?.activity_family,
+    activity_type: canonicalOneDayType || row?.activity_type,
+    item_type: canonicalOneDayType || row?.item_type || row?.activity_type || '',
+    status: isLegacyOneDay && String(row?.status || '').trim() === LEGACY_ACTIVE_STATUS ? OPEN_STATUS : row?.status,
     date_start: row?.start_date ?? row?.date_start ?? '',
     date_end: row?.end_date ?? row?.date_end ?? ''
   };
@@ -207,15 +219,29 @@ function normalizeActivityRow(row = {}) {
 }
 
 
+function canonicalActivityTypeToken(value) {
+  const raw = String(value || '').trim();
+  const lower = raw.toLowerCase();
+  return lower.replace(/[\u2010-\u2015]/g, '_').replace(/[\s_-]+/g, '_');
+}
+
+function canonicalOneDayActivityType(value) {
+  const raw = String(value || '').trim();
+  const compact = canonicalActivityTypeToken(raw);
+  if (compact === 'workshop' || compact === 'workshops' || raw === 'סדנה' || raw === 'סדנאות') return 'workshop';
+  if (compact === 'tour' || compact === 'tours' || raw === 'סיור' || raw === 'סיורים') return 'tour';
+  if (compact === 'escape_room' || compact === 'escaperoom' || raw === 'חדר בריחה' || raw === 'חדר_בריחה' || raw === 'חדרי בריחה' || raw === 'חדרי_בריחה') return 'escape_room';
+  return '';
+}
+
 function normalizeActivityTypeValue(value) {
   const raw = String(value || '').trim();
   const lower = raw.toLowerCase();
-  const compact = lower.replace(/[\s_-]+/g, '');
+  const compact = canonicalActivityTypeToken(raw).replace(/_/g, '');
+  const oneDayType = canonicalOneDayActivityType(raw);
+  if (oneDayType) return oneDayType;
   if (compact === 'course' || raw === 'קורס' || raw === 'קורסים') return 'course';
-  if (compact === 'workshop' || raw === 'סדנה' || raw === 'סדנאות') return 'workshop';
-  if (compact === 'tour' || raw === 'סיור' || raw === 'סיורים') return 'tour';
   if (compact === 'afterschool' || raw === 'חוג אפטרסקול' || raw === 'אפטרסקול') return 'after_school';
-  if (compact === 'escaperoom' || raw === 'חדר בריחה') return 'escape_room';
   return lower || raw;
 }
 
@@ -238,7 +264,7 @@ function isProgramActivity(row) {
 }
 
 function isOneDayActivity(row) {
-  return String(row?.activity_family || '').trim() === 'one_day';
+  return String(row?.activity_family || '').trim() === 'one_day' || Boolean(oneDayTypeFromActivityFields(row?.activity_type, row?.item_type));
 }
 
 function getActivityDateColumns(row = {}) {
@@ -2109,22 +2135,49 @@ function logActivityMutationDebug(stage, operation, payload, extra = {}) {
   });
 }
 
-function sanitizeActivityPayload(act = {}) {
+function assertValidOneDayActivityRow(row = {}) {
+  if (!canonicalOneDayActivityType(row.activity_type || row.item_type)) return row;
+  const name = String(row.activity_name || '').trim();
+  if (!name) throw new Error('יש להזין שם פעילות חד־יומית לפני השמירה');
+  const selectedDate = normalizeDateFieldForSupabase(row.date_1 || row.start_date || row.end_date);
+  if (!selectedDate) throw new Error('יש לבחור תאריך תקין לפעילות חד־יומית לפני השמירה');
+  row.start_date = selectedDate;
+  row.end_date = selectedDate;
+  row.date_1 = selectedDate;
+  return row;
+}
+
+function normalizeOneDayActivityForSave(act = {}) {
   const row = { ...act };
+  const canonicalType = oneDayTypeFromActivityFields(row.activity_type, row.item_type);
+  if (!canonicalType) return row;
+  row.activity_family = 'one_day';
+  row.activity_type = canonicalType;
+  row.item_type = canonicalType;
+  if (String(row.status || '').trim() === LEGACY_ACTIVE_STATUS) row.status = OPEN_STATUS;
+  if (!String(row.status || '').trim()) row.status = OPEN_STATUS;
+  const selectedDate = normalizeDateFieldForSupabase(row.date_1 || row.Date1 || row.one_day_date || row.start_date || row.end_date);
+  if (selectedDate) {
+    row.start_date = selectedDate;
+    row.end_date = selectedDate;
+    row.date_1 = selectedDate;
+    row.Date1 = selectedDate;
+  }
+  return row;
+}
+
+function sanitizeActivityPayload(act = {}) {
+  const row = normalizeOneDayActivityForSave({ ...act });
   delete row.source;
   delete row.source_sheet;
   delete row.source_table;
   delete row.RowID;
   if (!row.row_id) row.row_id = String(act.row_id || act.RowID || `ACT-${crypto.randomUUID?.() || Date.now()}`).trim();
-  const normalizeActivityTypeKey = (value) => String(value || '').trim().toLowerCase().replace(/[\s-]+/g, '_').replace(/^חדרי_בריחה$/, 'חדר_בריחה');
-  const oneDayTypeKeys = new Set([
-    'workshop', 'workshops', 'סדנה', 'סדנאות',
-    'tour', 'tours', 'סיור', 'סיורים',
-    'escape_room', 'escaperoom', 'חדר_בריחה'
-  ]);
-  const normalizedType = normalizeActivityTypeKey(row.activity_type || act.activity_type || '');
-  if (oneDayTypeKeys.has(normalizedType)) {
+  const normalizedType = oneDayTypeFromActivityFields(row.activity_type || act.activity_type, row.item_type || act.item_type);
+  if (normalizedType) {
     row.activity_family = 'one_day';
+    row.activity_type = normalizedType;
+    row.item_type = normalizedType;
   } else {
     const normalizedFamily = String(row.activity_family || '').trim();
     if (normalizedFamily === 'one_day' || normalizedFamily === 'program') {
@@ -2133,14 +2186,15 @@ function sanitizeActivityPayload(act = {}) {
       row.activity_family = String(act.source || '').trim() === 'short' ? 'one_day' : 'program';
     }
   }
-  row.status = String(row.status || 'פעיל');
+  row.status = String(row.status || (normalizedType ? OPEN_STATUS : LEGACY_ACTIVE_STATUS));
+  if (normalizedType && row.status === LEGACY_ACTIVE_STATUS) row.status = OPEN_STATUS;
   row.activity_season = normalizeActivitySeason(row.activity_season ?? act.activitySeason);
   for (let i = 1; i <= 35; i++) {
     const lower = `date_${i}`;
     const oldDateKey = `Date${i}`;
     if (row[lower] === undefined && act[oldDateKey] !== undefined) row[lower] = act[oldDateKey];
   }
-  return row;
+  return assertValidOneDayActivityRow(row);
 }
 
 const ALLOWED_ACTIVITY_COLUMNS = new Set([
@@ -2153,6 +2207,7 @@ const ALLOWED_ACTIVITY_COLUMNS = new Set([
   'grade',
   'class_group',
   'activity_type',
+  'item_type',
   'activity_season',
   'activity_no',
   'activity_name',
@@ -2295,13 +2350,33 @@ async function upsertActivityToSupabase(payload = {}) {
 async function updateActivityInSupabase(payload = {}) {
   const rowId = String(payload?.source_row_id || payload?.row_id || payload?.RowID || '').trim();
   const sourceSheet = String(payload?.source_sheet || 'activities').trim() || 'activities';
-  const changes = sanitizeActivityPayloadForSupabase(
-    mapMeetingDateFieldNamesToSupabase({ ...(payload?.changes || {}) }),
-    { includeRowId: false }
-  );
+  if (!rowId) throw new Error('missing_row_id');
+  const rawChanges = mapMeetingDateFieldNamesToSupabase({ ...(payload?.changes || {}) });
+  let existingForNormalization = null;
+  const needsExisting = Object.keys(rawChanges).some((key) => ['activity_type', 'item_type', 'activity_family', 'activity_name', 'start_date', 'end_date', 'date_1', 'status'].includes(key) || /^date_\d+$/.test(key));
+  if (needsExisting) {
+    const { data: existingRow, error: existingError } = await supabase
+      .from('activities')
+      .select('*')
+      .eq('row_id', rowId)
+      .maybeSingle();
+    if (existingError) throw buildSupabaseMutationError('saveActivity', existingError, 'save_failed');
+    existingForNormalization = existingRow || {};
+  }
+  let normalizedChangesSource = rawChanges;
+  if (existingForNormalization && oneDayTypeFromActivityFields(rawChanges.activity_type || existingForNormalization.activity_type, rawChanges.item_type || existingForNormalization.item_type)) {
+    const normalizedFullRow = assertValidOneDayActivityRow(normalizeOneDayActivityForSave({ ...existingForNormalization, ...rawChanges }));
+    normalizedChangesSource = { ...rawChanges };
+    ['activity_family', 'activity_type', 'item_type', 'status', 'start_date', 'end_date', 'date_1'].forEach((key) => {
+      normalizedChangesSource[key] = normalizedFullRow[key];
+    });
+    if (Object.prototype.hasOwnProperty.call(rawChanges, 'activity_name')) {
+      normalizedChangesSource.activity_name = normalizedFullRow.activity_name;
+    }
+  }
+  const changes = sanitizeActivityPayloadForSupabase(normalizedChangesSource, { includeRowId: false });
   const hasMeetingDateChange = Object.keys(changes).some((k) => /^date_\d+$/.test(k));
   const hasExplicitEndDate = Object.prototype.hasOwnProperty.call(changes, 'end_date');
-  if (!rowId) throw new Error('missing_row_id');
   if (hasMeetingDateChange && !hasExplicitEndDate) {
     const { data: existingRow, error: existingError } = await supabase
       .from('activities')
@@ -3503,5 +3578,7 @@ export {
   buildExceptionsModelFromRows,
   normalizeActivityRow,
   sanitizeActivityPayload,
-  sanitizeActivityPayloadForSupabase
+  sanitizeActivityPayloadForSupabase,
+  normalizeOneDayActivityForSave,
+  canonicalOneDayActivityType
 };

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -233,7 +233,7 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
   const m = i % 2 === 0 ? '00' : '30';
   return `${h}:${m}`;
 });
-const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set(['workshop', 'tour', 'escape_room', 'escaperoom', 'חדר_בריחה', 'חדרי_בריחה']);
+const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set(['workshop', 'tour', 'escape_room']);
 
 function isOneDayActivityTypeValue(value) {
   return ONE_DAY_ACTIVITY_TYPE_KEYS.has(normalizeActivityTypeKey(value));
@@ -902,8 +902,9 @@ export const activitiesScreen = {
       const allRows = Array.isArray(data?.rows) ? data.rows : [];
       const overdue = allRows.filter((row) => {
         const status = String(row?.status || '').trim();
+        const isLegacyActiveOneDay = isOneDayActivityTypeValue(row?.activity_type || row?.item_type) && status === 'פעיל';
         if (status === 'סגור' || status === 'closed' || status === 'inactive') return false;
-        if (status !== 'פתוח') return false;
+        if (status !== 'פתוח' && !isLegacyActiveOneDay) return false;
         const endRaw = String(row?.end_date || '').trim();
         if (!endRaw) return false;
         const endDate = new Date(endRaw);
@@ -1373,7 +1374,8 @@ export const activitiesScreen = {
         school: schoolValue,
         grade: get('grade'),
         class_group: get('class_group'),
-        activity_type: get('activity_type'),
+        activity_type: selectedType || get('activity_type'),
+        item_type: isOneDay ? selectedType : '',
         activity_season: normalizeActivitySeason(get('activity_season')),
         activity_name: selectedName,
         activity_no: String(hit?.activity_no || get('activity_no') || ''),
@@ -1388,7 +1390,7 @@ export const activitiesScreen = {
         emp_id_2: pickEmp(get('instructor_name_2')),
         start_date: isOneDay ? oneDayDate : get('start_date'),
         end_date: isOneDay ? oneDayDate || null : get('end_date') || null,
-        status: 'פעיל',
+        status: isOneDay ? 'פתוח' : 'פעיל',
         notes: get('notes')
       };
       if (isOneDay) {
@@ -1416,7 +1418,8 @@ export const activitiesScreen = {
         ['activity_type', 'סוג פעילות'],
         ['activity_name', 'שם פעילות'],
         ['authority', 'רשות'],
-        ['school', 'בית ספר']
+        ['school', 'בית ספר'],
+        ...(isOneDay ? [['start_date', 'תאריך פעילות חד־יומית']] : [])
       ];
       const missing = required.filter(([key]) => !String(payload[key] || '').trim()).map(([, label]) => label);
       if (missing.length) {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 528;
+const CACHE_VERSION = 529;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260602_normalize_one_day_activities.sql
+++ b/supabase/migrations/20260602_normalize_one_day_activities.sql
@@ -1,0 +1,61 @@
+-- Normalize existing one-day activities that have safe, non-conflicting type gaps.
+-- Conflicting rows are intentionally only reported for manual review.
+
+alter table public.activities add column if not exists item_type text;
+
+update public.activities
+set
+  item_type = 'tour',
+  status = case when status = 'פעיל' then 'פתוח' else status end,
+  updated_at = now()
+where activity_family = 'one_day'
+  and activity_type = 'tour'
+  and nullif(btrim(coalesce(item_type, '')), '') is null;
+
+update public.activities
+set
+  item_type = 'workshop',
+  status = case when status = 'פעיל' then 'פתוח' else status end,
+  updated_at = now()
+where activity_family = 'one_day'
+  and activity_type = 'workshop'
+  and nullif(btrim(coalesce(item_type, '')), '') is null;
+
+update public.activities
+set
+  item_type = 'escape_room',
+  status = case when status = 'פעיל' then 'פתוח' else status end,
+  updated_at = now()
+where activity_family = 'one_day'
+  and activity_type = 'escape_room'
+  and nullif(btrim(coalesce(item_type, '')), '') is null;
+
+update public.activities
+set
+  status = 'פתוח',
+  updated_at = now()
+where activity_family = 'one_day'
+  and activity_type in ('tour', 'workshop', 'escape_room')
+  and item_type = activity_type
+  and status = 'פעיל';
+
+create or replace view public.one_day_activity_type_conflicts as
+select
+  row_id,
+  activity_family,
+  activity_type,
+  item_type,
+  activity_name,
+  status,
+  start_date,
+  end_date,
+  date_1,
+  updated_at
+from public.activities
+where activity_family = 'one_day'
+  and activity_type in ('tour', 'workshop', 'escape_room')
+  and nullif(btrim(coalesce(item_type, '')), '') is not null
+  and item_type <> activity_type;
+
+comment on view public.one_day_activity_type_conflicts is
+  'Manual-review list for one-day activities whose activity_type and item_type conflict; migration does not auto-fix these rows.';

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 528;
+const SW_ENTRY_VERSION = 529;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activity-one-day-family-regression.test.mjs
+++ b/tests/activity-one-day-family-regression.test.mjs
@@ -38,6 +38,9 @@ test('new tour activity is normalized as one_day before Supabase insert', () => 
 
   assert.equal(row.activity_type, 'tour');
   assert.equal(row.activity_family, 'one_day');
+  assert.equal(row.item_type, 'tour');
+  assert.equal(row.status, 'פתוח');
+  assert.equal(row.date_1, '2026-06-15');
 });
 
 test('new workshop activity is normalized as one_day before Supabase insert', () => {
@@ -52,6 +55,8 @@ test('new workshop activity is normalized as one_day before Supabase insert', ()
 
   assert.equal(row.activity_type, 'workshop');
   assert.equal(row.activity_family, 'one_day');
+  assert.equal(row.item_type, 'workshop');
+  assert.equal(row.status, 'פתוח');
 });
 
 test('one-day Hebrew and escape-room activity types override wrong family/source values', () => {
@@ -60,9 +65,12 @@ test('one-day Hebrew and escape-room activity types override wrong family/source
       activity_type: activityType,
       activity_family: 'program',
       source: 'long',
+      activity_name: `בדיקה ${activityType}`,
       start_date: '2026-06-17'
     });
     assert.equal(row.activity_family, 'one_day', `${activityType} should be one_day`);
+    assert.equal(row.activity_type, row.item_type, `${activityType} activity_type and item_type should match`);
+    assert.equal(row.status, 'פתוח', `${activityType} should save as open`);
   }
 });
 
@@ -79,6 +87,37 @@ test('saved one-day activity appears in activities month filter when displayed m
   }));
 
   assert.equal(savedRow.activity_family, 'one_day');
+  assert.equal(savedRow.status, 'פתוח');
   assert.equal(rowMatchesActivitiesFilters(savedRow, { month: '2026-06', activity_type: 'all' }), true);
   assert.equal(rowMatchesActivitiesFilters(savedRow, { month: '2026-07', activity_type: 'all' }), false);
+});
+
+
+test('one-day save rejects missing activity name and date', () => {
+  assert.throws(() => normalizeForSave({
+    activity_type: 'tour',
+    activity_name: '',
+    start_date: '2026-06-20'
+  }), /שם פעילות/);
+
+  assert.throws(() => normalizeForSave({
+    activity_type: 'workshop',
+    activity_name: 'סדנה ללא תאריך'
+  }), /תאריך תקין/);
+});
+
+test('conflicting one-day item_type is corrected to canonical activity_type on save', () => {
+  const row = normalizeForSave({
+    activity_type: 'workshop',
+    item_type: 'escape_room',
+    activity_name: 'סדנת תיקון',
+    date_1: '2026-06-21',
+    status: 'פעיל'
+  });
+
+  assert.equal(row.activity_type, 'workshop');
+  assert.equal(row.item_type, 'workshop');
+  assert.equal(row.status, 'פתוח');
+  assert.equal(row.start_date, '2026-06-21');
+  assert.equal(row.end_date, '2026-06-21');
 });


### PR DESCRIPTION
### Motivation
- Fix inconsistent save/display of one-day activities (`workshop`, `tour`, `escape_room` and Hebrew variants) that caused missing/incorrect `item_type`, `activity_family`, `activity_name`, `date_1` and status values. 
- Ensure new saves and updates always produce canonical, queryable rows so activities appear reliably in lists, filters and week/month views. 
- Provide a safe data migration to correct existing rows and a view for manual-review of conflicting rows. 
- Bust Service Worker cache so clients receive the updated JS that implements the fixes.

### Description
- Added centralized normalization and validation for one-day activities in `frontend/src/api.js` (`canonicalOneDayActivityType`/`oneDayTypeFromActivityFields`, `normalizeOneDayActivityForSave`, `assertValidOneDayActivityRow`) and applied it for both insert (`addActivity`/`upsertActivityToSupabase`) and update (`updateActivityInSupabase`) flows so `activity_family='one_day'`, `activity_type` and `item_type` are canonical, `status` maps `פעיל`→`פתוח`, and `start_date`/`end_date`/`date_1` are consistent. 
- Hardened the add/edit UI logic in `frontend/src/screens/activities.js` to set `item_type` for one-day saves, require `activity_name` and a valid date for one-day activities, and treat legacy `פעיל` as `פתוח` for display fallbacks. 
- Added a controlled Supabase migration `supabase/migrations/20260602_normalize_one_day_activities.sql` that adds `item_type` where missing, converts safe `status = 'פעיל'` → `'פתוח'`, and creates `public.one_day_activity_type_conflicts` view for manual review of conflicting rows. 
- Bumped Service Worker cache versions in `frontend/sw.js` and `sw.js` so clients will fetch the new bundles, and rebuilt `dist` assets. 
- Updated and extended tests in `tests/activity-one-day-family-regression.test.mjs` to cover canonicalization, required fields, date propagation and conflict correction.

### Testing
- Ran `node --test tests/activity-one-day-family-regression.test.mjs` and all tests passed (6/6). 
- Ran focused checks with `npm run check:changed` which completed the node checks for modified files. 
- Ran `npm run check:build` (frontend build) which completed successfully and produced `dist` (build warnings about chunk size only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e8363f9b8832b9ac5d0dc3df9906d)