### PR TITLE
Fix summer dashboard activity drilldown

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 529;
+const CACHE_VERSION = 530;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BWghBSQQ.js",
+  "./assets/index-D7uM-o_k.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BWghBSQQ.js"></script>
+  <script type="module" crossorigin src="./assets/index-D7uM-o_k.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 529;
+const CACHE_VERSION = 530;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BWghBSQQ.js",
+  "./assets/index-D7uM-o_k.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -233,7 +233,11 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
   const m = i % 2 === 0 ? '00' : '30';
   return `${h}:${m}`;
 });
-const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set(['workshop', 'tour', 'escape_room']);
+const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set([
+  'workshop', 'workshops', 'סדנה', 'סדנאות',
+  'tour', 'tours', 'סיור', 'סיורים',
+  'escape_room', 'escaperoom', 'חדר_בריחה', 'חדר בריחה', 'חדרי_בריחה', 'חדרי בריחה'
+]);
 
 function isOneDayActivityTypeValue(value) {
   return ONE_DAY_ACTIVITY_TYPE_KEYS.has(normalizeActivityTypeKey(value));

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -2,6 +2,7 @@ import { escapeHtml } from './shared/html.js';
 import { dsCard, dsScreenStack } from './shared/layout.js';
 import { computeOperationalExceptionsTotal } from './shared/exceptions-metrics.js';
 import { syncActivitiesGapQuery } from './shared/route-query.js';
+import { SUMMER_DEFAULT_MONTH_YM } from './shared/summer-activity.js';
 
 const HEBREW_MONTHS = [
   'ינואר',
@@ -174,6 +175,16 @@ function renderStructuredSummary(summary, ym, byManager) {
   </div>`;
 }
 
+function resetActivitiesListFilters(state) {
+  state.listFilters = state.listFilters || {};
+  const prevVisibleCount = state.listFilters.activities?.visibleCount;
+  state.listFilters.activities = {
+    q: '',
+    appliedQ: '',
+    visibleCount: typeof prevVisibleCount === 'number' ? prevVisibleCount : 200
+  };
+}
+
 function goActivitiesDrill(state, patch) {
   state.route = 'activities';
   state.activityTab = patch.activityTab ?? 'all';
@@ -181,7 +192,8 @@ function goActivitiesDrill(state, patch) {
   state.activityQuickFamily = patch.activityQuickFamily ?? '';
   state.activityQuickManager = patch.activityQuickManager ?? '';
   state.activityEndingCurrentMonth = !!patch.activityEndingCurrentMonth;
-  state.activitiesMonthYm = state.dashboardMonthYm || currentMonthYm();
+  state.activitiesMonthYm = patch.activitiesMonthYm || state.dashboardMonthYm || currentMonthYm();
+  if (patch.resetActivityListFilters) resetActivitiesListFilters(state);
   if (Object.prototype.hasOwnProperty.call(patch, 'activitiesGapFilter')) {
     state.activitiesGapFilter = patch.activitiesGapFilter || '';
     syncActivitiesGapQuery(state.activitiesGapFilter);
@@ -614,7 +626,11 @@ export const dashboardScreen = {
         return;
       }
       if (action === 'kpi|summer') {
-        goActivitiesDrill(state, { activityQuickFamily: 'summer' });
+        goActivitiesDrill(state, {
+          activityQuickFamily: 'summer',
+          activitiesMonthYm: SUMMER_DEFAULT_MONTH_YM,
+          resetActivityListFilters: true
+        });
         ui.closeAll();
         rerender();
         return;

--- a/frontend/src/screens/shared/summer-activity.js
+++ b/frontend/src/screens/shared/summer-activity.js
@@ -1,5 +1,6 @@
 const SUMMER_START_DATE = '2026-07-01';
 const SUMMER_END_DATE = '2026-08-31';
+export const SUMMER_DEFAULT_MONTH_YM = SUMMER_START_DATE.slice(0, 7);
 export const ACTIVITY_SEASON_REGULAR = 'regular';
 export const ACTIVITY_SEASON_SUMMER_2026 = 'summer_2026';
 export const ACTIVITY_SEASON_OPTIONS = [

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 529;
+const CACHE_VERSION = 530;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 529;
+const SW_ENTRY_VERSION = 530;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/dashboard-district-metrics.test.mjs
+++ b/tests/dashboard-district-metrics.test.mjs
@@ -56,3 +56,47 @@ test('dashboard district cards display total active activities including summer/
   assert.match(html, /mstat\|%D7%9E%D7%97%D7%95%D7%96%20%D7%A6%D7%A4%D7%95%D7%9F\|activities/);
   assert.match(html, /<span class="ds-manager-stat__value">2<\/span>/);
 });
+
+test('dashboard summer KPI drill opens activities on July 2026 with summer filter', () => {
+  const appState = {
+    dashboardMonthYm: '2026-05',
+    activitiesMonthYm: '2026-05',
+    activityQuickFamily: '',
+    activityQuickManager: '',
+    activitiesGapFilter: '',
+    route: 'dashboard',
+    user: { display_role: 'admin' },
+    screenDataCache: {},
+    listFilters: { activities: { q: 'מאי', appliedQ: 'מאי', activity_manager: 'מחוז ישן', visibleCount: 150 } }
+  };
+  let cardHandler = null;
+  let rerenders = 0;
+  const root = {
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    addEventListener: () => {}
+  };
+  dashboardScreen.bind({
+    root,
+    ui: {
+      bindInteractiveCards: (_root, handler) => { cardHandler = handler; },
+      closeAll: () => {}
+    },
+    state: appState,
+    api: {},
+    rerender: () => { rerenders += 1; },
+    clearScreenDataCache: () => {},
+    data: { month: '2026-05' }
+  });
+
+  assert.equal(typeof cardHandler, 'function');
+  cardHandler('kpi|summer');
+
+  assert.equal(appState.route, 'activities');
+  assert.equal(appState.activityQuickFamily, 'summer');
+  assert.equal(appState.activitiesMonthYm, '2026-07');
+  assert.equal(appState.activityQuickManager, '');
+  assert.equal(appState.activitiesGapFilter, '');
+  assert.deepEqual(appState.listFilters.activities, { q: '', appliedQ: '', visibleCount: 150 });
+  assert.equal(rerenders, 1);
+});


### PR DESCRIPTION
### Motivation
- The dashboard "קיץ" KPI drilled into the activities screen but left the month filter on a previous value, so summer activities (which start July 2026) were not shown by default. 
- The drilldown must explicitly open the activities view with the summer family and the correct July 2026 month and avoid being hidden by persisted list filters or stale SW cache.

### Description
- Make `goActivitiesDrill` accept an explicit `activitiesMonthYm` and add `resetActivityListFilters` to clear persisted activities list filters when requested. (changes in `frontend/src/screens/dashboard.js`).
- Export a shared `SUMMER_DEFAULT_MONTH_YM` from `frontend/src/screens/shared/summer-activity.js` (derived from `SUMMER_START_DATE`) and use it when drilling from the dashboard summer KPI so the month becomes `2026-07`.
- Ensure the summer KPI drill now calls `goActivitiesDrill(state, { activityQuickFamily: 'summer', activitiesMonthYm: SUMMER_DEFAULT_MONTH_YM, resetActivityListFilters: true })` so both family and month are set and previous list filters are cleared.
- Add common aliases for one-day activity types (including multiple escape-room aliases) to `ONE_DAY_ACTIVITY_TYPE_KEYS` to match existing option aliases and to satisfy screen tests (`frontend/src/screens/activities.js`).
- Bump service worker/cache version to `530` in `frontend/sw.js` and `sw.js` (and aligned `dist` outputs) so clients fetch the updated assets and do not serve stale behavior from the SW cache.
- Add a focused regression test `tests/dashboard-district-metrics.test.mjs` that simulates clicking the dashboard summer KPI and asserts `route === 'activities'`, `activityQuickFamily === 'summer'`, `activitiesMonthYm === '2026-07'`, and that previous list filters were reset.

### Testing
- Ran `npm run check:changed` (focused JS checks) and it completed successfully.
- Ran `npm run check:build` (full frontend build) and it completed successfully with the dist updated.
- Ran `node --test tests/dashboard-district-metrics.test.mjs` and the new summer drilldown test passed.
- Ran `node --test tests/activities-screen.test.mjs` and all activity-screen tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e85630870832bb93ce62ec6728ba4)