### PR TITLE
Fix one-day activity type/name separation

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 530;
+const CACHE_VERSION = 531;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-D7uM-o_k.js",
+  "./assets/index-LJvnq4vG.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-D7uM-o_k.js"></script>
+  <script type="module" crossorigin src="./assets/index-LJvnq4vG.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 530;
+const CACHE_VERSION = 531;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-D7uM-o_k.js",
+  "./assets/index-LJvnq4vG.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import { state, setSession, clearScreenDataCache } from './state.js';
 import { deletePersistedCacheByPrefixes } from './cache-persist.js';
 import { hebrewRole } from './screens/shared/ui-hebrew.js';
-import { cleanActivityManagerName, NO_ACTIVITY_MANAGER_LABEL, resolveActivityInstructorName } from './screens/shared/activity-options.js';
+import { cleanActivityManagerName, NO_ACTIVITY_MANAGER_LABEL, normalizeOneDayActivityType, resolveActivityInstructorName } from './screens/shared/activity-options.js';
 import { EXCEPTION_TYPE_ORDER, normalizedExceptionTypes } from './screens/shared/exceptions-metrics.js';
 import { isSummerActivity, normalizeActivitySeason } from './screens/shared/summer-activity.js';
 import { supabase, supabaseConfig } from './supabase-client.js';
@@ -180,6 +180,7 @@ const CLOSED_STATUS = 'סגור';
 const OPEN_STATUS = 'פתוח';
 const LEGACY_ACTIVE_STATUS = 'פעיל';
 const DELETED_STATUS = 'נמחק';
+const GENERIC_ONE_DAY_ACTIVITY_NAMES = new Set(['סדנה', 'סדנאות', 'סיור', 'סיורים', 'חדר בריחה', 'חדרי בריחה']);
 
 function oneDayTypeFromActivityFields(activityType, itemType) {
   return canonicalOneDayActivityType(activityType) || canonicalOneDayActivityType(itemType);
@@ -226,12 +227,7 @@ function canonicalActivityTypeToken(value) {
 }
 
 function canonicalOneDayActivityType(value) {
-  const raw = String(value || '').trim();
-  const compact = canonicalActivityTypeToken(raw);
-  if (compact === 'workshop' || compact === 'workshops' || raw === 'סדנה' || raw === 'סדנאות') return 'workshop';
-  if (compact === 'tour' || compact === 'tours' || raw === 'סיור' || raw === 'סיורים') return 'tour';
-  if (compact === 'escape_room' || compact === 'escaperoom' || raw === 'חדר בריחה' || raw === 'חדר_בריחה' || raw === 'חדרי בריחה' || raw === 'חדרי_בריחה') return 'escape_room';
-  return '';
+  return normalizeOneDayActivityType(value);
 }
 
 function normalizeActivityTypeValue(value) {
@@ -2136,14 +2132,20 @@ function logActivityMutationDebug(stage, operation, payload, extra = {}) {
 }
 
 function assertValidOneDayActivityRow(row = {}) {
-  if (!canonicalOneDayActivityType(row.activity_type || row.item_type)) return row;
+  const canonicalType = canonicalOneDayActivityType(row.activity_type || row.item_type);
+  if (!canonicalType) return row;
+  row.activity_type = canonicalType;
+  row.item_type = canonicalType;
+  row.activity_family = 'one_day';
   const name = String(row.activity_name || '').trim();
-  if (!name) throw new Error('יש להזין שם פעילות חד־יומית לפני השמירה');
+  if (!name || GENERIC_ONE_DAY_ACTIVITY_NAMES.has(name)) throw new Error('יש לבחור שם פעילות מתוך הרשימה');
   const selectedDate = normalizeDateFieldForSupabase(row.date_1 || row.start_date || row.end_date);
   if (!selectedDate) throw new Error('יש לבחור תאריך תקין לפעילות חד־יומית לפני השמירה');
   row.start_date = selectedDate;
   row.end_date = selectedDate;
   row.date_1 = selectedDate;
+  if (String(row.status || '').trim() === LEGACY_ACTIVE_STATUS) row.status = OPEN_STATUS;
+  if (![OPEN_STATUS, CLOSED_STATUS, DELETED_STATUS].includes(String(row.status || '').trim())) row.status = OPEN_STATUS;
   return row;
 }
 

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -30,8 +30,10 @@ import {
   getActivityTypesByFamily,
   getActivityNamesForType,
   getRosterUsers,
+  activityTypeDisplayLabel,
   activityTypeMatches,
   normalizeActivityTypeKey,
+  normalizeOneDayActivityType,
   getManagerUsers,
   getFilterOptionOverrides,
   cleanUnique,
@@ -233,17 +235,11 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
   const m = i % 2 === 0 ? '00' : '30';
   return `${h}:${m}`;
 });
-const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set([
-  'workshop', 'workshops', 'סדנה', 'סדנאות',
-  'tour', 'tours', 'סיור', 'סיורים',
-  'escape_room', 'escaperoom', 'חדר_בריחה', 'חדר בריחה', 'חדרי_בריחה', 'חדרי בריחה'
-]);
-
 function isOneDayActivityTypeValue(value) {
-  return ONE_DAY_ACTIVITY_TYPE_KEYS.has(normalizeActivityTypeKey(value));
+  return Boolean(normalizeOneDayActivityType(value));
 }
 
-function optionsHtml(values, selected = '', placeholder = '—') {
+function optionsHtml(values, selected = '', placeholder = '—', labelFn = null) {
   const safeSelected = String(selected || '');
   const uniq = [];
   const seen = new Set();
@@ -256,7 +252,7 @@ function optionsHtml(values, selected = '', placeholder = '—') {
   if (safeSelected && !seen.has(safeSelected)) uniq.unshift(safeSelected);
   return [`<option value="">${escapeHtml(placeholder)}</option>`]
     .concat(
-      uniq.map((v) => `<option value="${escapeHtml(v)}"${v === safeSelected ? ' selected' : ''}>${escapeHtml(v)}</option>`)
+      uniq.map((v) => `<option value="${escapeHtml(v)}"${v === safeSelected ? ' selected' : ''}>${escapeHtml(typeof labelFn === 'function' ? (labelFn(v) || v) : v)}</option>`)
     )
     .join('');
 }
@@ -374,7 +370,7 @@ function addActivityModalHtml(settings) {
         <label class="ds-activity-add-field ds-activity-add-field--compact"><span>סוג פעילות</span>
           <select class="ds-input" name="activity_type" data-add-activity-type
             data-all-types="${escapeHtml(JSON.stringify(allTypes))}">
-            ${optionsHtml(allTypes, initialType)}
+            ${optionsHtml(allTypes.map((type) => normalizeActivityTypeKey(type) || type), normalizeActivityTypeKey(initialType) || initialType, '—', activityTypeDisplayLabel)}
           </select>
         </label>
         <label class="ds-activity-add-field ds-activity-add-field--wide"><span>שם פעילות</span>
@@ -1239,7 +1235,8 @@ export const activitiesScreen = {
       if (typeSel) {
         let allTypes = [];
         try { allTypes = JSON.parse(typeSel.dataset.allTypes || '[]'); } catch {}
-        typeSel.innerHTML = optionsHtml(allTypes, allTypes[0] || '');
+        const normalizedTypes = allTypes.map((type) => normalizeActivityTypeKey(type) || type);
+        typeSel.innerHTML = optionsHtml(normalizedTypes, normalizedTypes[0] || '', '—', activityTypeDisplayLabel);
       }
       refreshActivityNameSelect(form);
       syncSessionDateRows(form);
@@ -1356,7 +1353,7 @@ export const activitiesScreen = {
       const authorityValue = authorityCustom || get('authority');
       const schoolValue = schoolCustom || get('school');
       const selectedName = get('activity_name');
-      const selectedType = normalizeActivityTypeKey(get('activity_type'));
+      const selectedType = normalizeOneDayActivityType(get('activity_type')) || normalizeActivityTypeKey(get('activity_type'));
       const hit = activityMap.find((x) => {
         const label = String(x?.label || '').trim();
         const parent = x?.parent_value || x?.activity_type;
@@ -1418,12 +1415,18 @@ export const activitiesScreen = {
         payload.end_date = lastDate || payload.start_date || null;
       }
 
+      if (isOneDay && (!String(payload.activity_name || '').trim() || GENERIC_ONE_DAY_ACTIVITY_NAMES.has(String(payload.activity_name || '').trim()))) {
+        if (statusEl) statusEl.textContent = 'יש לבחור שם פעילות מתוך הרשימה';
+        form.dataset.submitting = 'no';
+        return;
+      }
+
       const required = [
         ['activity_type', 'סוג פעילות'],
         ['activity_name', 'שם פעילות'],
         ['authority', 'רשות'],
         ['school', 'בית ספר'],
-        ...(isOneDay ? [['start_date', 'תאריך פעילות חד־יומית']] : [])
+        ...(isOneDay ? [['start_date', 'תאריך פעילות חד־יומית'], ['end_date', 'תאריך סיום'], ['date_1', 'תאריך פעילות']] : [])
       ];
       const missing = required.filter(([key]) => !String(payload[key] || '').trim()).map(([, label]) => label);
       if (missing.length) {

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatDateHeWithWeekday, formatTimeShort, formatTimeRangeShort, formatActivityDateColumnsHe } from './format-date.js';
-import { activityManagerDisplayName, activityTypeMatches, cleanActivityManagerName, getManagerUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, resolveActivityInstructorName } from './activity-options.js';
+import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName } from './activity-options.js';
 import { ACTIVITY_SEASON_OPTIONS, activitySeasonLabel, normalizeActivitySeason } from './summer-activity.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
@@ -22,11 +22,12 @@ const ACTIVITY_NAME_LABEL = {
 };
 
 function activityTypeLabel(type) {
-  return ACTIVITY_TYPE_PILL_LABEL[String(type || '').trim()] || 'פעילות';
+  const normalized = normalizeActivityTypeKey(type);
+  return ACTIVITY_TYPE_PILL_LABEL[normalized] || activityTypeDisplayLabel(type) || 'פעילות';
 }
 
 function activityNameLabel(type) {
-  return ACTIVITY_NAME_LABEL[String(type || '').trim()] || 'שם פעילות';
+  return ACTIVITY_NAME_LABEL[normalizeActivityTypeKey(type)] || 'שם פעילות';
 }
 
 function fallback(v) {
@@ -130,8 +131,8 @@ function normalizeActivityNameOptions(raw) {
       out.push({
         label,
         activity_no: String(o.activity_no || '').trim(),
-        parent_value: String(o.parent_value || o.activity_type || '').trim(),
-        activity_type: String(o.activity_type || o.parent_value || '').trim()
+        parent_value: normalizeActivityTypeKey(o.parent_value || o.activity_type || ''),
+        activity_type: normalizeActivityTypeKey(o.activity_type || o.parent_value || '')
       });
     }
   });
@@ -139,14 +140,20 @@ function normalizeActivityNameOptions(raw) {
 }
 
 function selectHtml({ name, value, options, klass = 'ds-input', placeholder = '—', attrs = '' }) {
-  const safeValue = String(value || '').trim();
-  const normalized = toOptions(options);
-  const all = normalized.includes(safeValue) || !safeValue ? normalized : [safeValue, ...normalized];
+  const safeValue = normalizeActivityTypeKey(value) || String(value || '').trim();
+  const normalized = toOptions(options).map((option) => normalizeActivityTypeKey(option) || option);
+  const seen = new Set();
+  const unique = normalized.filter((option) => {
+    if (!option || seen.has(option)) return false;
+    seen.add(option);
+    return true;
+  });
+  const all = unique.includes(safeValue) || !safeValue ? unique : [safeValue, ...unique];
   const opts = [`<option value="">${escapeHtml(placeholder)}</option>`]
     .concat(
       all.map((o) => {
         const selected = o === safeValue ? ' selected' : '';
-        return `<option value="${escapeHtml(o)}"${selected}>${escapeHtml(o)}</option>`;
+        return `<option value="${escapeHtml(o)}"${selected}>${escapeHtml(activityTypeDisplayLabel(o) || o)}</option>`;
       })
     )
     .join('');
@@ -349,14 +356,15 @@ function headerHtml(row, { mode = 'single', summaryDate = '', exportAction = tru
 }
 
 function blockActivityDetails(row, { settings = {} } = {}) {
-  const activityType = String(row.activity_type || '').trim();
+  const activityType = normalizeActivityTypeKey(row.activity_type || row.item_type);
   const allActivityNames = resolveActivityNameOptions(settings, '');
   if (!allActivityNames.length) {
     // eslint-disable-next-line no-console
     console.warn('[activity-edit] activity name options missing from client settings');
   }
-  const statusOptions = ['פעיל', 'סגור'];
-  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : 'פעיל';
+  const isOneDay = Boolean(normalizeOneDayActivityType(activityType));
+  const statusOptions = isOneDay ? ['פתוח', 'סגור', 'נמחק'] : ['פעיל', 'סגור'];
+  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : (isOneDay ? 'פתוח' : 'פעיל');
 
   return `
     <section class="activity-drawer__section activity-drawer__section--edit-group" data-mode="edit" hidden>

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -72,6 +72,14 @@ export function resolveActivityInstructorName(row = {}, { secondary = false } = 
 
 export const NO_ACTIVITY_MANAGER_LABEL = 'ללא';
 
+export const ONE_DAY_ACTIVITY_TYPE_LABELS = {
+  workshop: 'סדנה',
+  tour: 'סיור',
+  escape_room: 'חדר בריחה'
+};
+
+const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set(Object.keys(ONE_DAY_ACTIVITY_TYPE_LABELS));
+
 const ACTIVITY_TYPE_ALIASES = new Map([
   ['סדנה', 'workshop'],
   ['סדנאות', 'workshop'],
@@ -117,11 +125,29 @@ export function normalizeActivityTypeKey(value) {
   return ACTIVITY_TYPE_ALIASES.get(clean) || clean;
 }
 
+export function normalizeOneDayActivityType(value) {
+  const normalized = normalizeActivityTypeKey(value);
+  return ONE_DAY_ACTIVITY_TYPE_KEYS.has(normalized) ? normalized : '';
+}
+
+export function isOneDayActivityType(value) {
+  return Boolean(normalizeOneDayActivityType(value));
+}
+
+export function activityTypeDisplayLabel(value) {
+  const oneDay = normalizeOneDayActivityType(value);
+  if (oneDay) return ONE_DAY_ACTIVITY_TYPE_LABELS[oneDay];
+  const normalized = normalizeActivityTypeKey(value);
+  if (normalized === 'course') return 'קורס';
+  if (normalized === 'after_school') return 'חוג אפטרסקול';
+  return text(value);
+}
+
 export function activityTypeMatches(value, expected) {
   const left = normalizeActivityTypeKey(value);
   const right = normalizeActivityTypeKey(expected);
   if (!right) return true;
-  return !left || left === right;
+  return Boolean(left) && left === right;
 }
 
 function isExplicitlyInactive(value) {
@@ -161,9 +187,9 @@ export function getActivityCatalog(settings) {
       value: text(row?.value || row?.activity_name || row?.label),
       activity_name: text(row?.activity_name || row?.value || row?.label),
       activity_no: text(row?.activity_no),
-      activity_type: text(row?.activity_type || row?.parent_value || row?.type),
-      parent_value: text(row?.parent_value || row?.activity_type || row?.type),
-      type: text(row?.type || row?.activity_type || row?.parent_value),
+      activity_type: normalizeActivityTypeKey(row?.activity_type || row?.parent_value || row?.type),
+      parent_value: normalizeActivityTypeKey(row?.parent_value || row?.activity_type || row?.type),
+      type: normalizeActivityTypeKey(row?.type || row?.activity_type || row?.parent_value),
       active: row?.active,
       sort_order: row?.sort_order
     }))
@@ -180,7 +206,7 @@ export function getActivityTypes(settings) {
   const catalog = getActivityCatalog(settings);
   const fromCatalog = cleanUnique(
     catalog
-      .map((item) => item.activity_type || item.parent_value || item.type)
+      .map((item) => normalizeActivityTypeKey(item.activity_type || item.parent_value || item.type))
       .filter(Boolean)
   );
   if (fromCatalog.length) return fromCatalog;
@@ -188,8 +214,8 @@ export function getActivityTypes(settings) {
 }
 
 export function getActivityTypesByFamily(settings, family) {
-  const oneDayTypes = uniqueSorted(settings?.one_day_activity_types || []);
-  const programTypes = uniqueSorted(settings?.program_activity_types || []);
+  const oneDayTypes = uniqueSorted((settings?.one_day_activity_types || []).map(normalizeActivityTypeKey));
+  const programTypes = uniqueSorted((settings?.program_activity_types || []).map(normalizeActivityTypeKey));
   if (family === 'short') return oneDayTypes;
   if (family === 'long') return programTypes;
   return uniqueSorted([...oneDayTypes, ...programTypes]);

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -2,7 +2,7 @@ import { translateApiErrorForUser } from './ui-hebrew.js';
 import { showToast } from './toast.js';
 import { formatDateHe } from './format-date.js';
 import { escapeHtml } from './html.js';
-import { activityTypeMatches, normalizeActivityTypeKey } from './activity-options.js';
+import { activityTypeMatches, normalizeActivityTypeKey, normalizeOneDayActivityType } from './activity-options.js';
 import { state } from '../../state.js';
 
 function setEditMode(form, editing) {
@@ -23,6 +23,8 @@ function setStatus(statusEl, kind, text) {
   statusEl.classList.remove('is-pending', 'is-error', 'is-success', 'is-warning');
   if (kind) statusEl.classList.add(kind);
 }
+
+const GENERIC_ONE_DAY_ACTIVITY_NAMES = new Set(['סדנה', 'סדנאות', 'סיור', 'סיורים', 'חדר בריחה', 'חדרי בריחה']);
 
 function detectActivityNoByName(form, activityName) {
   const sel = form.querySelector('[data-role="activity-name-select"]');
@@ -221,6 +223,19 @@ export function bindActivityEditForm(contentRoot, {
         changes[`meeting_date_${i}`] = snapshot.dates[i];
       }
       changes.end_date = snapshot.endDate;
+    }
+
+    const effectiveType = normalizeOneDayActivityType(changes.activity_type || initialValues.activity_type || '');
+    if (effectiveType) {
+      const effectiveName = String(changes.activity_name ?? form.querySelector('[name="activity_name"]')?.value ?? initialValues.activity_name ?? '').trim();
+      if (!effectiveName || GENERIC_ONE_DAY_ACTIVITY_NAMES.has(effectiveName)) {
+        setStatus(statusEl, 'is-error', 'יש לבחור שם פעילות מתוך הרשימה');
+        showToast('יש לבחור שם פעילות מתוך הרשימה', 'error', 2600);
+        return;
+      }
+      changes.activity_type = effectiveType;
+      changes.item_type = effectiveType;
+      if (String(changes.status || '').trim() === 'פעיל') changes.status = 'פתוח';
     }
 
     try {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 530;
+const CACHE_VERSION = 531;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260602_normalize_one_day_activities.sql
+++ b/supabase/migrations/20260602_normalize_one_day_activities.sql
@@ -1,7 +1,21 @@
 -- Normalize existing one-day activities that have safe, non-conflicting type gaps.
--- Conflicting rows are intentionally only reported for manual review.
+-- Conflicting or missing-name rows are intentionally reported for manual review.
 
 alter table public.activities add column if not exists item_type text;
+
+-- Canonicalize one-day activity_type aliases. This is safe because these Hebrew labels
+-- are only the general one-day type labels, not specific activity names.
+update public.activities
+set
+  activity_family = 'one_day',
+  activity_type = case
+    when activity_type in ('סדנה', 'סדנאות', 'workshops') then 'workshop'
+    when activity_type in ('סיור', 'סיורים', 'tours') then 'tour'
+    when activity_type in ('חדר בריחה', 'חדרי בריחה', 'חדר_בריחה', 'חדרי_בריחה', 'escaperoom') then 'escape_room'
+    else activity_type
+  end,
+  updated_at = now()
+where activity_type in ('סדנה', 'סדנאות', 'workshops', 'סיור', 'סיורים', 'tours', 'חדר בריחה', 'חדרי בריחה', 'חדר_בריחה', 'חדרי_בריחה', 'escaperoom');
 
 update public.activities
 set
@@ -30,14 +44,48 @@ where activity_family = 'one_day'
   and activity_type = 'escape_room'
   and nullif(btrim(coalesce(item_type, '')), '') is null;
 
+-- Status conversion is safe and automatic for all one-day rows, including rows
+-- that still need manual review for names or item_type conflicts.
 update public.activities
 set
   status = 'פתוח',
   updated_at = now()
 where activity_family = 'one_day'
   and activity_type in ('tour', 'workshop', 'escape_room')
-  and item_type = activity_type
   and status = 'פעיל';
+
+create or replace view public.one_day_activity_exceptions as
+select
+  row_id,
+  activity_family,
+  activity_type,
+  item_type,
+  activity_name,
+  status,
+  start_date,
+  end_date,
+  date_1,
+  updated_at,
+  array_remove(array[
+    case when nullif(btrim(coalesce(activity_name, '')), '') is null then 'missing_activity_name' end,
+    case when activity_name in ('סדנה', 'סדנאות', 'סיור', 'סיורים', 'חדר בריחה', 'חדרי בריחה') then 'generic_activity_name' end,
+    case when nullif(btrim(coalesce(item_type, '')), '') is null then 'missing_item_type' end,
+    case when nullif(btrim(coalesce(item_type, '')), '') is not null and item_type <> activity_type then 'item_type_conflict' end,
+    case when status = 'פעיל' then 'legacy_active_status' end
+  ], null) as exception_reasons
+from public.activities
+where activity_family = 'one_day'
+  and activity_type in ('tour', 'workshop', 'escape_room')
+  and (
+    nullif(btrim(coalesce(activity_name, '')), '') is null
+    or activity_name in ('סדנה', 'סדנאות', 'סיור', 'סיורים', 'חדר בריחה', 'חדרי בריחה')
+    or nullif(btrim(coalesce(item_type, '')), '') is null
+    or item_type <> activity_type
+    or status = 'פעיל'
+  );
+
+comment on view public.one_day_activity_exceptions is
+  'Manual-review report for one-day activities with missing/generic activity_name, missing or conflicting item_type, or legacy active status. The migration only auto-fixes safe type/status/item_type-null cases.';
 
 create or replace view public.one_day_activity_type_conflicts as
 select
@@ -51,11 +99,8 @@ select
   end_date,
   date_1,
   updated_at
-from public.activities
-where activity_family = 'one_day'
-  and activity_type in ('tour', 'workshop', 'escape_room')
-  and nullif(btrim(coalesce(item_type, '')), '') is not null
-  and item_type <> activity_type;
+from public.one_day_activity_exceptions
+where 'item_type_conflict' = any(exception_reasons);
 
 comment on view public.one_day_activity_type_conflicts is
   'Manual-review list for one-day activities whose activity_type and item_type conflict; migration does not auto-fix these rows.';

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 530;
+const SW_ENTRY_VERSION = 531;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activity-one-day-family-regression.test.mjs
+++ b/tests/activity-one-day-family-regression.test.mjs
@@ -121,3 +121,32 @@ test('conflicting one-day item_type is corrected to canonical activity_type on s
   assert.equal(row.start_date, '2026-06-21');
   assert.equal(row.end_date, '2026-06-21');
 });
+
+test('one-day activity save rejects generic type labels as activity_name', () => {
+  assert.throws(() => normalizeForSave({
+    activity_type: 'סדנה',
+    activity_family: 'one_day',
+    activity_name: 'סדנה',
+    start_date: '2026-06-18'
+  }), /יש לבחור שם פעילות מתוך הרשימה/);
+});
+
+test('Hebrew one-day type label saves canonical activity_type and selected specific name', () => {
+  const row = normalizeForSave({
+    activity_type: 'סדנה',
+    item_type: 'חדר בריחה',
+    activity_family: 'program',
+    activity_name: 'צמידי שמש',
+    start_date: '2026-06-19',
+    status: 'פעיל'
+  });
+
+  assert.equal(row.activity_type, 'workshop');
+  assert.equal(row.item_type, 'workshop');
+  assert.equal(row.activity_family, 'one_day');
+  assert.equal(row.activity_name, 'צמידי שמש');
+  assert.equal(row.start_date, '2026-06-19');
+  assert.equal(row.end_date, '2026-06-19');
+  assert.equal(row.date_1, '2026-06-19');
+  assert.equal(row.status, 'פתוח');
+});

--- a/tests/activity-options-catalog.test.mjs
+++ b/tests/activity-options-catalog.test.mjs
@@ -33,3 +33,19 @@ test('activity names filter supports activity_type/parent_value/type', () => {
   assert.equal(byWorkshop.length, 1);
   assert.equal(byWorkshop[0].label, 'פעילות ב');
 });
+
+test('one-day activity names are filtered by canonical type aliases', () => {
+  const mixedSettings = {
+    dropdown_options: {
+      activity_names: [
+        { label: 'צמידי שמש', parent_value: 'סדנה', activity_no: '201' },
+        { label: 'התנסות בתעשייה', activity_type: 'tour', activity_no: '202' },
+        { label: 'תמיר - איפה דדי', type: 'חדר בריחה', activity_no: '203' }
+      ]
+    }
+  };
+
+  assert.deepEqual(getActivityNamesForType(mixedSettings, 'workshop').map((row) => row.label), ['צמידי שמש']);
+  assert.deepEqual(getActivityNamesForType(mixedSettings, 'סיור').map((row) => row.label), ['התנסות בתעשייה']);
+  assert.deepEqual(getActivityNamesForType(mixedSettings, 'escape_room').map((row) => row.label), ['תמיר - איפה דדי']);
+});


### PR DESCRIPTION
### Motivation
- Clarify and enforce the separation between canonical activity type (e.g. `workshop`, `tour`, `escape_room`) and the specific activity name (e.g. `צמידי שמש`), so generic labels like “סדנה” are not saved as an activity instance name.
- Normalize legacy and user-provided one-day type inputs to canonical keys and ensure saved rows are consistent (`activity_type` == `item_type`, `activity_family = 'one_day'`).
- Prevent invalid partial saves and provide a controlled migration path for existing data and Service Worker cache invalidation so clients receive the changes.

### Description
- Added canonical one-day type helpers and display labels in `frontend/src/screens/shared/activity-options.js`, including `normalizeOneDayActivityType`, `activityTypeDisplayLabel` and type key normalization usage across the catalog APIs.
- Hardened save/validation logic in `frontend/src/api.js` so one-day activities are normalized before save, require a non-generic `activity_name`, synchronize `start_date`/`end_date`/`date_1`, convert legacy `פעיל` to `פתוח`, and enforce `item_type === activity_type`.
- Updated add/edit UI flows to filter activity-name options by canonical type, clear stale names on type change, reject generic names, and set the correct `activity_type`/`item_type`/`activity_family` in `frontend/src/screens/activities.js`, `frontend/src/screens/shared/activity-detail-html.js` and `frontend/src/screens/shared/bind-activity-edit-form.js`.
- Extended the DB migration `supabase/migrations/20260602_normalize_one_day_activities.sql` to canonicalize one-day type aliases, auto-fill safe `item_type` nulls, convert legacy statuses, and expose a manual-review `one_day_activity_exceptions` view (plus a conflict view) for rows needing human attention.
- Added regression tests for canonical one-day saves, rejection of generic names, and canonical-type filtering in `tests/activity-one-day-family-regression.test.mjs` and `tests/activity-options-catalog.test.mjs`.
- Bumped Service Worker `CACHE_VERSION` / `SW_ENTRY_VERSION` and rebuilt `dist` so PWA clients pick up the JS/CSS changes and do not serve stale cached assets.

### Testing
- Ran focused JS checks and unit tests: `node --check frontend/src/api.js && node --check frontend/src/screens/activities.js && node --check frontend/src/screens/shared/activity-detail-html.js && node --check frontend/src/screens/shared/bind-activity-edit-form.js && node --check frontend/src/screens/shared/activity-options.js && node --test tests/activity-one-day-family-regression.test.mjs tests/activity-options-catalog.test.mjs`; all tests passed.
- Ran the task-focused verification commands `npm run check:changed` and built the frontend with `npm run check:build`; both checks succeeded and a new `dist` was produced with SW cache version bumped to ensure clients will fetch the updated assets.
- Migration: added `supabase/migrations/20260602_normalize_one_day_activities.sql` which auto-fixes safe cases and creates a manual-review view for exceptions (no blind renames of ambiguous activity_name entries were performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb4386654832ba0192877ab18d711)