### PR TITLE
Fix activity edit: make activity_name depend on activity_type and reset on change

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 531;
+const CACHE_VERSION = 532;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-LJvnq4vG.js",
+  "./assets/index-g695UQB9.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-LJvnq4vG.js"></script>
+  <script type="module" crossorigin src="./assets/index-g695UQB9.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 531;
+const CACHE_VERSION = 532;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-LJvnq4vG.js",
+  "./assets/index-g695UQB9.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -223,13 +223,11 @@ function resolveActivityNameOptions(settings, activityType) {
 
 function buildActivityNameOpts(options, safeValue, activityType) {
   const normalizedType = normalizeActivityTypeKey(activityType);
-  let filtered = (Array.isArray(options) ? options : []).filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, normalizedType));
-  const hasTagged = (Array.isArray(options) ? options : []).some((o) => String(o?.parent_value || o?.activity_type || '').trim());
-  if (!filtered.length && !hasTagged) filtered = Array.isArray(options) ? options : [];
+  const sourceOptions = Array.isArray(options) ? options : [];
+  let filtered = sourceOptions.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, normalizedType));
+  const hasTagged = sourceOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
+  if (!filtered.length && !hasTagged) filtered = sourceOptions;
   const all = filtered.slice();
-  if (safeValue && !all.some((o) => String(o?.label || '').trim() === safeValue)) {
-    all.unshift({ label: safeValue, activity_no: '', parent_value: activityType });
-  }
   return [`<option value="">—</option>`]
     .concat(
       all.map((o) => {
@@ -371,13 +369,13 @@ function blockActivityDetails(row, { settings = {} } = {}) {
       <h3 class="activity-drawer__section-title">פרטי פעילות</h3>
       <div class="activity-drawer__details-edit-grid">
         ${fieldEditOnly(
+          'סוג פעילות',
+          selectHtml({ name: 'activity_type', value: activityType, options: resolveAllActivityTypes(settings), placeholder: 'בחרו סוג פעילות' })
+        )}
+        ${fieldEditOnly(
           activityNameLabel(activityType),
           activityNameSelectHtml('activity_name', row.activity_name, allActivityNames, activityType),
           'activity-drawer__field--full'
-        )}
-        ${fieldEditOnly(
-          'סוג פעילות',
-          selectHtml({ name: 'activity_type', value: activityType, options: resolveAllActivityTypes(settings), placeholder: 'בחרו סוג פעילות' })
         )}
         ${fieldEditOnly(
           'סטטוס',

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -33,6 +33,53 @@ function detectActivityNoByName(form, activityName) {
   return opt ? String(opt.dataset.activityNo || '') : '';
 }
 
+
+function activityNameOptionsForType(allOptions, activityType) {
+  const sourceOptions = Array.isArray(allOptions) ? allOptions : [];
+  const normalizedType = normalizeActivityTypeKey(activityType);
+  const hasTagged = sourceOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
+  let filtered = sourceOptions.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, normalizedType));
+  if (!filtered.length && !hasTagged) filtered = sourceOptions;
+  return { filtered, hasTagged };
+}
+
+function renderActivityNameOptions(options) {
+  return ['<option value="">—</option>']
+    .concat((Array.isArray(options) ? options : []).map((o) => {
+      const label = String(o?.label || '').trim();
+      const actNo = String(o?.activity_no || '').trim();
+      const actType = String(o?.parent_value || o?.activity_type || '').trim();
+      return `<option value="${escapeHtml(label)}" data-activity-no="${escapeHtml(actNo)}" data-activity-type="${escapeHtml(actType)}">${escapeHtml(label)}</option>`;
+    }))
+    .join('');
+}
+
+function syncActivityNoFromName(form) {
+  const nameSel = form.querySelector('[data-role="activity-name-select"]');
+  const hidden = form.querySelector('[data-activity-no]');
+  if (!nameSel || !hidden) return;
+  const currentName = String(nameSel.value || '').trim();
+  hidden.value = currentName ? detectActivityNoByName(form, currentName) : '';
+}
+
+function validateActivityTypeAndName(form, statusEl) {
+  const typeEl = form.querySelector('[name="activity_type"]');
+  const nameSel = form.querySelector('[data-role="activity-name-select"]');
+  if (!typeEl || !nameSel) return true;
+  const selectedType = normalizeActivityTypeKey(typeEl.value);
+  if (!selectedType) return true;
+  const optionList = Array.from(nameSel.options).filter((opt) => String(opt.value || '').trim());
+  if (!optionList.length) return true;
+  const selectedName = String(nameSel.value || '').trim();
+  const selectedOption = selectedName ? optionList.find((opt) => opt.value === selectedName) : null;
+  const hasTagged = optionList.some((opt) => String(opt.dataset.activityType || '').trim());
+  const isMatchingType = selectedOption && (!hasTagged || activityTypeMatches(selectedOption.dataset.activityType, selectedType));
+  if (selectedName && isMatchingType) return true;
+  setStatus(statusEl, 'is-error', 'יש לבחור שם פעילות מתוך הרשימה המתאימה לסוג הפעילות');
+  showToast('יש לבחור שם פעילות מתוך הרשימה המתאימה לסוג הפעילות', 'error', 2600);
+  return false;
+}
+
 function addDays(dateStr, days) {
   if (!dateStr) return '';
   const d = new Date(`${dateStr}T12:00:00`);
@@ -224,6 +271,8 @@ export function bindActivityEditForm(contentRoot, {
       }
       changes.end_date = snapshot.endDate;
     }
+
+    if (!validateActivityTypeAndName(form, statusEl)) return;
 
     const effectiveType = normalizeOneDayActivityType(changes.activity_type || initialValues.activity_type || '');
     if (effectiveType) {
@@ -450,6 +499,7 @@ export function bindActivityEditForm(contentRoot, {
     updateMeetingWeekdays(form);
     updateMoreDatesToggle(form);
     updateEndDateDisplay(form);
+    syncActivityNoFromName(form);
     const initialValues = {};
     form.querySelectorAll('[name]').forEach((el) => {
       const name = el.getAttribute('name');
@@ -475,23 +525,10 @@ export function bindActivityEditForm(contentRoot, {
             let allOptions = [];
             try { allOptions = JSON.parse(decodeURIComponent(nameSel.dataset.allActivityNames)); } catch { allOptions = []; }
             const newType = normalizeActivityTypeKey(typeEl.value);
-            const hasTagged = allOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
-            let filtered = allOptions.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, newType));
-            if (!filtered.length && !hasTagged) filtered = allOptions;
-            const current = String(nameSel.value || '').trim();
-            const currentStillValid = filtered.some((o) => String(o?.label || '').trim() === current);
-            const optsHtml = ['<option value="">—</option>']
-              .concat(filtered.map((o) => {
-                const label = String(o?.label || '').trim();
-                const actNo = String(o?.activity_no || '').trim();
-                const actType = String(o?.parent_value || o?.activity_type || '').trim();
-                return `<option value="${escapeHtml(label)}" data-activity-no="${escapeHtml(actNo)}" data-activity-type="${escapeHtml(actType)}">${escapeHtml(label)}</option>`;
-              }))
-              .join('');
-            nameSel.innerHTML = optsHtml;
-            nameSel.value = currentStillValid ? current : '';
-            const hidden = form.querySelector('[data-activity-no]');
-            if (hidden) hidden.value = currentStillValid ? detectActivityNoByName(form, current) : '';
+            const { filtered } = activityNameOptionsForType(allOptions, newType);
+            nameSel.innerHTML = renderActivityNameOptions(filtered);
+            nameSel.value = '';
+            syncActivityNoFromName(form);
           }
         }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 531;
+const CACHE_VERSION = 532;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 531;
+const SW_ENTRY_VERSION = 532;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activity-edit-dependent-name.test.mjs
+++ b/tests/activity-edit-dependent-name.test.mjs
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { activityWorkDrawerHtml } from '../frontend/src/screens/shared/activity-detail-html.js';
+
+function installStorageMocks() {
+  if (!globalThis.sessionStorage) {
+    const sessionStore = new Map();
+    globalThis.sessionStorage = {
+      getItem: (key) => sessionStore.has(key) ? sessionStore.get(key) : null,
+      setItem: (key, value) => sessionStore.set(key, String(value)),
+      removeItem: (key) => sessionStore.delete(key),
+      clear: () => sessionStore.clear()
+    };
+  }
+  if (!globalThis.localStorage) {
+    const localStore = new Map();
+    globalThis.localStorage = {
+      getItem: (key) => localStore.has(key) ? localStore.get(key) : null,
+      setItem: (key, value) => localStore.set(key, String(value)),
+      removeItem: (key) => localStore.delete(key),
+      clear: () => localStore.clear()
+    };
+  }
+}
+
+test('activity edit loads type before filtered name and resets name when type changes', async () => {
+  installStorageMocks();
+  const { bindActivityEditForm } = await import('../frontend/src/screens/shared/bind-activity-edit-form.js');
+  const settings = {
+    one_day_activity_types: ['workshop', 'tour'],
+    program_activity_types: ['course'],
+    dropdown_options: {
+      activity_names: [
+        { label: 'סדנת רובוטיקה', activity_no: 'W-1', activity_type: 'workshop' },
+        { label: 'סיור מוזיאון', activity_no: 'T-1', activity_type: 'tour' },
+        { label: 'קורס תכנות', activity_no: 'C-1', activity_type: 'course' }
+      ]
+    }
+  };
+  const html = activityWorkDrawerHtml({
+    RowID: 'A-1',
+    source_sheet: 'activities',
+    activity_type: 'workshop',
+    item_type: 'workshop',
+    activity_name: 'סדנת רובוטיקה',
+    activity_no: 'W-1',
+    status: 'פתוח'
+  }, { canEdit: true, canDirectEdit: true, settings });
+  const dom = new JSDOM(`<main>${html}</main>`);
+  const previousAbortController = globalThis.AbortController;
+  globalThis.AbortController = dom.window.AbortController;
+  try {
+    const root = dom.window.document.querySelector('main');
+    bindActivityEditForm(root, { api: {}, ui: {} });
+
+    const typeSelect = root.querySelector('select[name="activity_type"]');
+    const nameSelect = root.querySelector('[data-role="activity-name-select"]');
+    assert.ok(typeSelect.compareDocumentPosition(nameSelect) & dom.window.Node.DOCUMENT_POSITION_FOLLOWING);
+    assert.equal(typeSelect.value, 'workshop');
+    assert.deepEqual(Array.from(nameSelect.options).map((opt) => opt.value), ['', 'סדנת רובוטיקה']);
+    assert.equal(nameSelect.value, 'סדנת רובוטיקה');
+
+    typeSelect.value = 'tour';
+    typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    assert.equal(nameSelect.value, '');
+    assert.deepEqual(Array.from(nameSelect.options).map((opt) => opt.value), ['', 'סיור מוזיאון']);
+    assert.equal(root.querySelector('[data-activity-no]').value, '');
+  } finally {
+    globalThis.AbortController = previousAbortController;
+  }
+});


### PR DESCRIPTION
### Motivation
- Prevent saving or showing activity names that don't match the selected `activity_type` when editing an activity. 
- Ensure the edit form loads and validates fields in the correct logical order so existing data is restored consistently. 
- Avoid stale client-side cache serving old bundles after this UI change by bumping the Service Worker cache version.

### Description
- Reordered the edit form fields so `activity_type` appears/loads before `activity_name` and `activity_name` options are rendered only for the selected type by updating `frontend/src/screens/shared/activity-detail-html.js`.
- Added client-side helpers to filter name options by type, render options, sync `activity_no`, and validate the type/name pair before save in `frontend/src/screens/shared/bind-activity-edit-form.js`.
- When the user changes `activity_type` during editing the code now resets the `activity_name` selection and the hidden `activity_no` to avoid mismatched combinations.
- Bumped Service Worker cache versions to `532` in `frontend/sw.js` and `sw.js` and rebuilt `dist/` so browsers pick up the new bundle.
- Added a focused regression test `tests/activity-edit-dependent-name.test.mjs` that asserts `activity_type` is loaded first, name options are filtered, and the name is cleared when type changes.

### Testing
- Ran focused checks with `npm run check:changed` which passed for the changed files.
- Executed the new focused test with `node --test tests/activity-edit-dependent-name.test.mjs` which passed.
- Built the frontend with `npm run check:build` (runs `npm run build`) and produced a new `dist/` with updated SW hashes and cache version; the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecfbca0e8832b828a60667f5104ed)