### PR TITLE
Filter activity names by selected activity type and bump Service Worker cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 532;
+const CACHE_VERSION = 533;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-g695UQB9.js",
+  "./assets/index-DL0tAv17.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-g695UQB9.js"></script>
+  <script type="module" crossorigin src="./assets/index-DL0tAv17.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BnVNy4a5.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 532;
+const CACHE_VERSION = 533;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-g695UQB9.js",
+  "./assets/index-DL0tAv17.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -26,9 +26,7 @@ import {
 import {
   activityManagerDisplayName,
   getActivityCatalog,
-  getActivityTypes,
   getActivityTypesByFamily,
-  getActivityNamesForType,
   getRosterUsers,
   activityTypeDisplayLabel,
   activityTypeMatches,
@@ -45,6 +43,7 @@ import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shar
 import { ACTIVITY_SEASON_OPTIONS, isSummerActivity, normalizeActivitySeason } from './shared/summer-activity.js';
 
 const inflightActivityDetailRequests = new Map();
+const ADD_ACTIVITY_TYPE_ORDER = ['workshop', 'escape_room', 'tour', 'after_school'];
 
 function isAdminUser(state) {
   return state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
@@ -322,7 +321,7 @@ function datalistHtml(id, values) {
 
 function addActivityModalHtml(settings) {
   const allActivityNames = getActivityCatalog(settings);
-  const allTypes = getActivityTypes(settings);
+  const allTypes = ADD_ACTIVITY_TYPE_ORDER.slice();
   const rosterUsers = getRosterUsers(settings);
   const rosterNames = rosterUsers.map((u) => u.name);
   const managerRoleNames = getManagerUsers(settings);
@@ -334,8 +333,8 @@ function addActivityModalHtml(settings) {
     ? managerRoleNames
     : mergeOptions(settings, ['activity_manager', 'activity_managers']);
   const instructorOptions = rosterNames.length ? rosterNames : mergeOptions(settings, ['instructor_name', 'instructor_names']);
-  const initialType = allTypes[0] || '';
-  const initialActivityNames = getActivityNamesForType(settings, initialType);
+  const initialType = '';
+  const initialActivityNames = [];
   const sessionsList = Array.from({ length: 35 }, (_, i) => String(i + 1));
 
   const authorityField = `
@@ -370,12 +369,12 @@ function addActivityModalHtml(settings) {
         <label class="ds-activity-add-field ds-activity-add-field--compact"><span>סוג פעילות</span>
           <select class="ds-input" name="activity_type" data-add-activity-type
             data-all-types="${escapeHtml(JSON.stringify(allTypes))}">
-            ${optionsHtml(allTypes.map((type) => normalizeActivityTypeKey(type) || type), normalizeActivityTypeKey(initialType) || initialType, '—', activityTypeDisplayLabel)}
+            ${optionsHtml(allTypes.map((type) => normalizeActivityTypeKey(type) || type), '', 'בחרו סוג פעילות', activityTypeDisplayLabel)}
           </select>
         </label>
         <label class="ds-activity-add-field ds-activity-add-field--wide"><span>שם פעילות</span>
-          <select class="ds-input" name="activity_name" data-add-activity-name>
-            ${optionsHtml(initialActivityNames.map((o) => o.label), '', 'בחרו שם פעילות')}
+          <select class="ds-input" name="activity_name" data-add-activity-name disabled>
+            ${optionsHtml(initialActivityNames.map((o) => o.label), '', 'בחרו קודם סוג פעילות')}
           </select>
         </label>
         <input type="hidden" name="activity_no" value="" data-add-activity-no>
@@ -1213,12 +1212,13 @@ export const activitiesScreen = {
       const all = decodeJsonAttr(form.dataset.addActivityNames, []);
       const type = normalizeActivityTypeKey(typeSel.value);
       const hasTagged = all.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
-      let list = all.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, type));
-      if (!list.length && !hasTagged) list = all;
+      let list = type ? all.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, type)) : [];
+      if (type && !list.length && !hasTagged) list = all;
       const current = String(nameSel.value || '').trim();
       const currentStillValid = list.some((o) => String(o?.label || '').trim() === current);
       const nextValue = currentStillValid ? current : '';
-      nameSel.innerHTML = optionsHtml(list.map((o) => o.label), nextValue, 'בחרו שם פעילות');
+      nameSel.innerHTML = optionsHtml(list.map((o) => o.label), nextValue, type ? 'בחרו שם פעילות' : 'בחרו קודם סוג פעילות');
+      nameSel.disabled = !type;
       nameSel.value = nextValue;
       const hit = list.find((o) => String(o?.label || '').trim() === String(nameSel.value || '').trim());
       noInput.value = String(hit?.activity_no || '');
@@ -1236,7 +1236,7 @@ export const activitiesScreen = {
         let allTypes = [];
         try { allTypes = JSON.parse(typeSel.dataset.allTypes || '[]'); } catch {}
         const normalizedTypes = allTypes.map((type) => normalizeActivityTypeKey(type) || type);
-        typeSel.innerHTML = optionsHtml(normalizedTypes, normalizedTypes[0] || '', '—', activityTypeDisplayLabel);
+        typeSel.innerHTML = optionsHtml(normalizedTypes, '', 'בחרו סוג פעילות', activityTypeDisplayLabel);
       }
       refreshActivityNameSelect(form);
       syncSessionDateRows(form);
@@ -1359,6 +1359,11 @@ export const activitiesScreen = {
         const parent = x?.parent_value || x?.activity_type;
         return label === selectedName && activityTypeMatches(parent, selectedType);
       });
+      if (!selectedType || !selectedName || !hit) {
+        if (statusEl) statusEl.textContent = 'יש לבחור סוג פעילות ושם פעילות מתוך הרשימה המסוננת';
+        form.dataset.submitting = 'no';
+        return;
+      }
       const pickEmp = (name) => {
         const u = roster.find((r) => String(r?.name || '').trim() === name);
         return String(u?.emp_id || '').trim();

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -4,6 +4,7 @@ import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatch
 import { ACTIVITY_SEASON_OPTIONS, activitySeasonLabel, normalizeActivitySeason } from './summer-activity.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
+const ACTIVITY_EDIT_TYPE_ORDER = ['workshop', 'escape_room', 'tour', 'after_school'];
 
 const ACTIVITY_TYPE_PILL_LABEL = {
   course: 'קורס',
@@ -223,6 +224,7 @@ function resolveActivityNameOptions(settings, activityType) {
 
 function buildActivityNameOpts(options, safeValue, activityType) {
   const normalizedType = normalizeActivityTypeKey(activityType);
+  if (!normalizedType) return '<option value="">בחרו קודם סוג פעילות</option>';
   const sourceOptions = Array.isArray(options) ? options : [];
   let filtered = sourceOptions.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, normalizedType));
   const hasTagged = sourceOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
@@ -243,9 +245,11 @@ function buildActivityNameOpts(options, safeValue, activityType) {
 
 function activityNameSelectHtml(name, value, options, activityType) {
   const safeValue = String(value || '').trim();
+  const normalizedType = normalizeActivityTypeKey(activityType);
   const allJson = escapeHtml(encodeURIComponent(JSON.stringify(Array.isArray(options) ? options : [])));
-  const opts = buildActivityNameOpts(options, safeValue, activityType);
-  return `<select class="ds-input" name="${escapeHtml(name)}" data-role="activity-name-select" data-all-activity-names="${allJson}">${opts}</select>`;
+  const opts = buildActivityNameOpts(options, safeValue, normalizedType);
+  const disabled = normalizedType ? '' : ' disabled';
+  return `<select class="ds-input" name="${escapeHtml(name)}" data-role="activity-name-select" data-all-activity-names="${allJson}"${disabled}>${opts}</select>`;
 }
 
 function autoEndDate(row) {
@@ -280,14 +284,8 @@ function fieldEditOnly(label, editHtml, extraClass = '') {
   `;
 }
 
-function resolveAllActivityTypes(settings) {
-  const seen = new Set();
-  const out = [];
-  [...(settings?.one_day_activity_types || []), ...(settings?.program_activity_types || [])].forEach((v) => {
-    const s = String(v || '').trim();
-    if (s && !seen.has(s)) { seen.add(s); out.push(s); }
-  });
-  return out;
+function resolveAllActivityTypes() {
+  return ACTIVITY_EDIT_TYPE_ORDER.slice();
 }
 
 function fieldViewOnly(label, viewHtml) {

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -100,6 +100,10 @@ const ACTIVITY_TYPE_ALIASES = new Map([
   ['course', 'course'],
   ['courses', 'course'],
   ['אפטרסקול', 'after_school'],
+  ['חוג אפטרסקול', 'after_school'],
+  ['חוג_אפטרסקול', 'after_school'],
+  ['חוגי אפטרסקול', 'after_school'],
+  ['חוגי_אפטרסקול', 'after_school'],
   ['after_school', 'after_school'],
   ['afterschool', 'after_school']
 ]);

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -37,13 +37,16 @@ function detectActivityNoByName(form, activityName) {
 function activityNameOptionsForType(allOptions, activityType) {
   const sourceOptions = Array.isArray(allOptions) ? allOptions : [];
   const normalizedType = normalizeActivityTypeKey(activityType);
+  if (!normalizedType) return { filtered: [], hasTagged: sourceOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim()) };
   const hasTagged = sourceOptions.some((o) => String(o?.parent_value || o?.activity_type || '').trim());
   let filtered = sourceOptions.filter((o) => activityTypeMatches(o?.parent_value || o?.activity_type, normalizedType));
   if (!filtered.length && !hasTagged) filtered = sourceOptions;
   return { filtered, hasTagged };
 }
 
-function renderActivityNameOptions(options) {
+function renderActivityNameOptions(options, activityType = '') {
+  const normalizedType = normalizeActivityTypeKey(activityType);
+  if (!normalizedType) return '<option value="">בחרו קודם סוג פעילות</option>';
   return ['<option value="">—</option>']
     .concat((Array.isArray(options) ? options : []).map((o) => {
       const label = String(o?.label || '').trim();
@@ -67,7 +70,11 @@ function validateActivityTypeAndName(form, statusEl) {
   const nameSel = form.querySelector('[data-role="activity-name-select"]');
   if (!typeEl || !nameSel) return true;
   const selectedType = normalizeActivityTypeKey(typeEl.value);
-  if (!selectedType) return true;
+  if (!selectedType) {
+    setStatus(statusEl, 'is-error', 'יש לבחור סוג פעילות לפני שם פעילות');
+    showToast('יש לבחור סוג פעילות לפני שם פעילות', 'error', 2600);
+    return false;
+  }
   const optionList = Array.from(nameSel.options).filter((opt) => String(opt.value || '').trim());
   if (!optionList.length) return true;
   const selectedName = String(nameSel.value || '').trim();
@@ -499,6 +506,9 @@ export function bindActivityEditForm(contentRoot, {
     updateMeetingWeekdays(form);
     updateMoreDatesToggle(form);
     updateEndDateDisplay(form);
+    const typeEl = form.querySelector('[name="activity_type"]');
+    const nameSel = form.querySelector('[data-role="activity-name-select"]');
+    if (nameSel) nameSel.disabled = !normalizeActivityTypeKey(typeEl?.value);
     syncActivityNoFromName(form);
     const initialValues = {};
     form.querySelectorAll('[name]').forEach((el) => {
@@ -526,7 +536,8 @@ export function bindActivityEditForm(contentRoot, {
             try { allOptions = JSON.parse(decodeURIComponent(nameSel.dataset.allActivityNames)); } catch { allOptions = []; }
             const newType = normalizeActivityTypeKey(typeEl.value);
             const { filtered } = activityNameOptionsForType(allOptions, newType);
-            nameSel.innerHTML = renderActivityNameOptions(filtered);
+            nameSel.innerHTML = renderActivityNameOptions(filtered, newType);
+            nameSel.disabled = !newType;
             nameSel.value = '';
             syncActivityNoFromName(form);
           }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 532;
+const CACHE_VERSION = 533;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 532;
+const SW_ENTRY_VERSION = 533;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -314,21 +314,11 @@ test('activities screen wires add-activity form submit to api.addActivity flow',
   assert.match(source, /document\.addEventListener\('submit'[\s\S]*submitAddActivityForm/);
   assert.match(source, /await api\.addActivity\(payload\)/);
   assert.match(source, /statusEl\) statusEl\.textContent = `שגיאה בשמירה:/);
-  assert.match(source, /const allTypes = getActivityTypes\(settings\);/);
+  assert.match(source, /const ADD_ACTIVITY_TYPE_ORDER = \['workshop', 'escape_room', 'tour', 'after_school'\]/);
   assert.doesNotMatch(source, /data-add-family=/);
-  assert.match(source, /const ONE_DAY_ACTIVITY_TYPE_KEYS = new Set\(\[/);
   assert.match(source, /'workshop'/);
-  assert.match(source, /'workshops'/);
-  assert.match(source, /'סדנה'/);
-  assert.match(source, /'סדנאות'/);
   assert.match(source, /'tour'/);
-  assert.match(source, /'tours'/);
-  assert.match(source, /'סיור'/);
-  assert.match(source, /'סיורים'/);
   assert.match(source, /'escape_room'/);
-  assert.match(source, /'escaperoom'/);
-  assert.match(source, /'חדר_בריחה'/);
-  assert.match(source, /חדרי_בריחה/);
   assert.match(source, /sessionsInput\.disabled = isOneDay/);
   assert.match(source, /sessionsField\.style\.display = isOneDay \? 'none' : ''/);
   assert.match(source, /activity_family: isOneDay \? 'one_day' : 'program'/);
@@ -461,7 +451,7 @@ test('activity edit form refreshes activity_name options and clears stale name w
     const noInput = form.querySelector('[data-activity-no]');
 
     assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['חדר בריחה חלל']);
-    typeSelect.value = 'סדנה';
+    typeSelect.value = 'workshop';
     typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
 
     assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['סדנת רובוטיקה']);
@@ -515,7 +505,7 @@ test('activity add form refreshes activity_name options and clears stale name wh
     const nameSelect = form.querySelector('[data-add-activity-name]');
     const noInput = form.querySelector('[data-add-activity-no]');
 
-    typeSelect.value = 'חדר בריחה';
+    typeSelect.value = 'escape_room';
     typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
     assert.deepEqual(Array.from(nameSelect.options).map((option) => option.value).filter(Boolean), ['חדר בריחה חלל']);
     nameSelect.value = 'חדר בריחה חלל';


### PR DESCRIPTION
### Motivation
- Ensure the UI requires the user to pick an activity type first and then only show activity names that belong to that type to avoid mismatched saves and stale values.
- Prevent cases where a type (e.g. "חדר בריחה") is selected but the activity name belongs to another family, and make the edit/add flows safer and clearer.
- Ensure users get the new JavaScript after deploy by bumping the Service Worker cache version.

### Description
- Require selecting `activity_type` before `activity_name`: the add form now starts with `activity_name` disabled and empty until a type is chosen, and the edit drawer disables the name select if no valid type is present (`activities.js`, `activity-detail-html.js`, `bind-activity-edit-form.js`).
- Filter name options by the normalized activity type and reset `activity_name`/`activity_no` when the type changes, and prevent submit/save when the selected name does not belong to the filtered catalog (client-side validation added to add/edit handlers).
- Introduce explicit ordered type lists used in the add/edit UI (`ADD_ACTIVITY_TYPE_ORDER` / `ACTIVITY_EDIT_TYPE_ORDER`) limited to the requested categories `workshop`, `escape_room`, `tour`, `after_school` so the visual order and available choices match the requirement.
- Add Hebrew alias mappings for the after-school type to `ACTIVITY_TYPE_ALIASES` so Hebrew labels like `חוג אפטרסקול` map to `after_school` for filtering.
- Bump Service Worker versions (`CACHE_VERSION` and `SW_ENTRY_VERSION`) from `532` to `533` in `frontend/sw.js` and root `sw.js` to invalidate old caches after deploy.
- Update focused tests to reflect the new behavior and UI text prompts for selecting type before name (`tests/activities-screen.test.mjs` changes).

### Testing
- Ran focused unit tests: `node --test tests/activity-edit-dependent-name.test.mjs tests/activities-screen.test.mjs` and all tests passed (21 tests, 0 failures).
- Ran lint/consistency checks: `npm run check:changed` (node --check on changed files) — completed without errors.
- Frontend/build verification: `npm run check:build` (invokes `vite build` + postbuild) — build succeeded; precache entries regenerated and `dist` updated, and SW cache versions were bumped.
- Confirmed Service Worker cache/version files updated: `frontend/sw.js` and `sw.js` now reference version `533`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1edce2721c832b95b3b86449eb661e)