### PR TITLE
Split activities screen into fixed operational period tabs

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 534;
+const CACHE_VERSION = 535;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BXqqEOFh.js",
+  "./assets/index-Buztl8O9.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-wJztvAXA.css",
+  "./assets/style-BgtAg3uo.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./index.html",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BXqqEOFh.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-wJztvAXA.css">
+  <script type="module" crossorigin src="./assets/index-Buztl8O9.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BgtAg3uo.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 534;
+const CACHE_VERSION = 535;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BXqqEOFh.js",
+  "./assets/index-Buztl8O9.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-wJztvAXA.css",
+  "./assets/style-BgtAg3uo.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./index.html",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -154,7 +154,7 @@ async function readActivitiesFromSupabase(filters = {}) {
     if (error) throw new Error(error.message || 'activities_read_failed');
     const rows = (Array.isArray(data) ? data : [])
       .map(normalizeActivityRow)
-      .filter((row) => !isActivityInactive(row))
+      .filter((row) => filters?.include_inactive ? true : !isActivityInactive(row))
       .filter((row) => rowMatchesActivitiesFilters(row, filters));
     return { rows, _source: 'supabase' };
   } catch (error) {
@@ -1380,7 +1380,7 @@ function invalidateScreenDataByAction(action) {
     saveActivity: ['activities:', 'activityDetail:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     addActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     deleteActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'archive', 'end-dates', 'exceptions:'],
-    submitEditRequest: ['edit-requests'],
+    submitEditRequest: ['activities:', 'edit-requests'],
     reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:', 'exceptions:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:'],
     addUser: ['permissions', 'dashboard:'],
     deactivateUser: ['permissions', 'dashboard:'],
@@ -2302,6 +2302,34 @@ function deriveEndDateFromDates(sanitized = {}) {
   return last || null;
 }
 
+
+function synchronizeStartDateAndFirstMeeting(payload = {}, existing = {}) {
+  const out = { ...(payload || {}) };
+  const hasStart = Object.prototype.hasOwnProperty.call(out, 'start_date');
+  const hasDate1 = Object.prototype.hasOwnProperty.call(out, 'date_1');
+  const nextStart = normalizeDateFieldForSupabase(out.start_date);
+  const nextDate1 = normalizeDateFieldForSupabase(out.date_1);
+  const existingStart = normalizeDateFieldForSupabase(existing?.start_date);
+  const existingDate1 = normalizeDateFieldForSupabase(existing?.date_1);
+
+  if (hasStart && !hasDate1) {
+    out.date_1 = nextStart;
+  } else if (hasDate1 && !hasStart) {
+    out.start_date = nextDate1;
+  } else if (hasStart && hasDate1) {
+    if (nextStart && nextStart !== nextDate1 && nextDate1 === existingDate1 && nextStart !== existingStart) {
+      out.date_1 = nextStart;
+    } else if (nextDate1 && nextStart !== nextDate1 && nextStart === existingStart && nextDate1 !== existingDate1) {
+      out.start_date = nextDate1;
+    } else if (nextStart || nextDate1) {
+      const canonical = nextStart || nextDate1;
+      out.start_date = canonical;
+      out.date_1 = canonical;
+    }
+  }
+  return out;
+}
+
 function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true } = {}) {
   const sanitized = {};
   const source = payload && typeof payload === 'object' ? payload : {};
@@ -2327,7 +2355,7 @@ function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true 
 
 async function upsertActivityToSupabase(payload = {}) {
   const act = payload?.activity || payload || {};
-  const row = sanitizeActivityPayloadForSupabase(sanitizeActivityPayload(act), { includeRowId: true });
+  const row = sanitizeActivityPayloadForSupabase(synchronizeStartDateAndFirstMeeting(sanitizeActivityPayload(act)), { includeRowId: true });
   const derivedEnd = deriveEndDateFromDates(row);
   const existingEndDate = normalizeDateFieldForSupabase(row.end_date);
   const startDate = normalizeDateFieldForSupabase(row.start_date);
@@ -2375,10 +2403,10 @@ async function updateActivityInSupabase(payload = {}) {
     if (existingError) throw buildSupabaseMutationError('saveActivity', existingError, 'save_failed');
     existingForNormalization = existingRow || {};
   }
-  let normalizedChangesSource = rawChanges;
+  let normalizedChangesSource = synchronizeStartDateAndFirstMeeting(rawChanges, existingForNormalization || {});
   if (existingForNormalization && oneDayTypeFromActivityFields(rawChanges.activity_type || existingForNormalization.activity_type, rawChanges.item_type || existingForNormalization.item_type)) {
     const normalizedFullRow = assertValidOneDayActivityRow(normalizeOneDayActivityForSave({ ...existingForNormalization, ...rawChanges }));
-    normalizedChangesSource = { ...rawChanges };
+    normalizedChangesSource = { ...normalizedChangesSource };
     ['activity_family', 'activity_type', 'item_type', 'status', 'start_date', 'end_date', 'date_1'].forEach((key) => {
       normalizedChangesSource[key] = normalizedFullRow[key];
     });
@@ -3337,7 +3365,7 @@ export const api = {
       return acc;
     }, {});
     const normalizedChanges = sanitizeActivityPayloadForSupabase(
-      mapMeetingDateFieldNamesToSupabase(reducedChanges),
+      synchronizeStartDateAndFirstMeeting(mapMeetingDateFieldNamesToSupabase(reducedChanges)),
       { includeRowId: false }
     );
     const debugPayload = { source_sheet: sourceSheet, source_row_id: rowId, changes: normalizedChanges };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -957,8 +957,7 @@ function closeMobileNav() {
 
 function buildScreenDataCacheKey(route, cacheState = state) {
   if (route === 'activities') {
-    const ym = cacheState.activitiesMonthYm && /^\d{4}-\d{2}$/.test(cacheState.activitiesMonthYm) ? cacheState.activitiesMonthYm : 'current';
-    return `activities:${ym}`;
+    return 'activities:periods';
   }
   if (route === 'dashboard') {
     const ym = cacheState.dashboardMonthYm && /^\d{4}-\d{2}$/.test(cacheState.dashboardMonthYm) ? cacheState.dashboardMonthYm : 'default';

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -2,9 +2,7 @@ import { escapeHtml } from './shared/html.js';
 import { exportActivitiesToExcel } from './shared/excel-export.js';
 import { formatDateHe, formatActivityDateColumnsHe } from './shared/format-date.js';
 import {
-  hebrewColumn,
-  visibleActivityCategoryLabel,
-  ACTIVITY_TAB_ORDER
+  visibleActivityCategoryLabel
 } from './shared/ui-hebrew.js';
 import { bindActivityEditForm as bindActivityEditFormShared } from './shared/bind-activity-edit-form.js';
 import {
@@ -40,11 +38,68 @@ import {
 import { readActivitiesGapFromQuery, syncActivitiesGapQuery, isActivitiesGapQueryValue } from './shared/route-query.js';
 import { rowMatchesActivityGapFilter } from './shared/activity-gap-filter.js';
 import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shared/view-switcher.js';
-import { ACTIVITY_SEASON_OPTIONS, isSummerActivity, normalizeActivitySeason } from './shared/summer-activity.js';
+import { ACTIVITY_SEASON_OPTIONS, normalizeActivitySeason } from './shared/summer-activity.js';
 import { showToast } from './shared/toast.js';
 
 const inflightActivityDetailRequests = new Map();
 const ADD_ACTIVITY_TYPE_ORDER = ['workshop', 'escape_room', 'tour', 'after_school'];
+
+const ACTIVITY_PERIOD_TABS = [
+  { key: 'school_2026', label: 'תשפ״ו / 2026', start: '', end: '2026-06-30' },
+  { key: 'summer_2026', label: 'קיץ 2026', start: '2026-07-01', end: '2026-08-31' },
+  { key: 'school_2027', label: 'תשפ״ז / 2027', start: '2026-09-01', end: '2027-06-30' },
+  { key: 'archive', label: 'ארכיון / הסתיימו', archive: true }
+];
+const DEFAULT_ACTIVITY_PERIOD_TAB = 'summer_2026';
+const INACTIVE_ACTIVITY_STATUSES = new Set(['סגור', 'נמחק', 'closed', 'deleted', 'inactive']);
+
+function normalizeActivityPeriodTab(value) {
+  const key = String(value || '').trim();
+  return ACTIVITY_PERIOD_TABS.some((tab) => tab.key === key) ? key : DEFAULT_ACTIVITY_PERIOD_TAB;
+}
+
+function normalizedActivityStartDate(row = {}) {
+  const value = String(row?.start_date ?? row?.date_start ?? '').trim().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : '';
+}
+
+function isInactiveActivityStatus(row = {}) {
+  return INACTIVE_ACTIVITY_STATUSES.has(String(row?.status || '').trim().toLowerCase()) || INACTIVE_ACTIVITY_STATUSES.has(String(row?.status || '').trim());
+}
+
+function activityPeriodKey(row = {}) {
+  if (isInactiveActivityStatus(row)) return 'archive';
+  const start = normalizedActivityStartDate(row);
+  if (!start) return 'archive';
+  if (start <= '2026-06-30') return 'school_2026';
+  if (start >= '2026-07-01' && start <= '2026-08-31') return 'summer_2026';
+  if (start >= '2026-09-01' && start <= '2027-06-30') return 'school_2027';
+  return 'archive';
+}
+
+function activityPeriodLabelForKey(key) {
+  return ACTIVITY_PERIOD_TABS.find((tab) => tab.key === key)?.label || '';
+}
+
+function activityPeriodRows(rows, periodKey) {
+  const activeKey = normalizeActivityPeriodTab(periodKey);
+  return (Array.isArray(rows) ? rows : []).filter((row) => activityPeriodKey(row) === activeKey);
+}
+
+function activityPeriodTabsHtml(rows, activeKey) {
+  const safeActiveKey = normalizeActivityPeriodTab(activeKey);
+  const counts = ACTIVITY_PERIOD_TABS.reduce((acc, tab) => ({ ...acc, [tab.key]: 0 }), {});
+  (Array.isArray(rows) ? rows : []).forEach((row) => {
+    const key = activityPeriodKey(row);
+    counts[key] = (counts[key] || 0) + 1;
+  });
+  return `<div class="ds-activities-period-tabs" role="tablist" aria-label="תקופות פעילות" dir="rtl">
+    ${ACTIVITY_PERIOD_TABS.map((tab) => `<button type="button" class="ds-chip ds-chip--tab ds-activities-period-tab${tab.key === safeActiveKey ? ' is-active' : ''}" role="tab" aria-selected="${tab.key === safeActiveKey ? 'true' : 'false'}" data-activity-period-tab="${escapeHtml(tab.key)}">
+      <span>${escapeHtml(tab.label)}</span><strong>${escapeHtml(String(counts[tab.key] || 0))}</strong>
+    </button>`).join('')}
+  </div>`;
+}
+
 
 function isAdminUser(state) {
   return state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
@@ -452,8 +507,6 @@ function applyClientFilters(rows, state, settings) {
     out = out.filter((row) => isShortFamily(row, oneDayTypes));
   } else if (state.activityQuickFamily === 'long') {
     out = out.filter((row) => !isShortFamily(row, oneDayTypes));
-  } else if (state.activityQuickFamily === 'summer') {
-    out = out.filter(isSummerActivity);
   }
   if (state.activityQuickManager) {
     out = out.filter((row) => matchesQuickDistrictOrManager(row, state.activityQuickManager));
@@ -462,76 +515,6 @@ function applyClientFilters(rows, state, settings) {
     out = out.filter((row) => isEndingInMonth(row, state.activitiesMonthYm));
   }
   return out;
-}
-
-function currentYm() {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-}
-
-function shiftYm(ym, delta) {
-  const base = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
-  const d = base ? new Date(Number(base[1]), Number(base[2]) - 1, 1) : new Date();
-  d.setMonth(d.getMonth() + delta);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-}
-
-function monthBounds(ym) {
-  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
-  if (!m) return null;
-  const y = Number(m[1]);
-  const mo = Number(m[2]);
-  return {
-    start: `${y}-${String(mo).padStart(2, '0')}-01`,
-    end: `${y}-${String(mo).padStart(2, '0')}-${String(new Date(y, mo, 0).getDate()).padStart(2, '0')}`
-  };
-}
-
-function activityOverlapsMonth(row, ym) {
-  const bounds = monthBounds(ym);
-  if (!bounds) return true;
-  const candidates = [];
-  const pushDate = (value) => {
-    const date = String(value || '').trim().slice(0, 10);
-    if (/^\d{4}-\d{2}-\d{2}$/.test(date)) candidates.push(date);
-  };
-  const cols = Array.isArray(row?.meeting_dates) ? row.meeting_dates : [];
-  const dateCols = Array.isArray(row?.date_cols) ? row.date_cols : [];
-  cols.forEach(pushDate);
-  dateCols.forEach(pushDate);
-  for (let i = 1; i <= 35; i++) {
-    pushDate(row?.[`date_${i}`]);
-    pushDate(row?.[`Date${i}`]);
-  }
-  pushDate(row?.start_date);
-  pushDate(row?.end_date);
-  if (!candidates.length) return false;
-  return candidates.some((date) => date >= bounds.start && date <= bounds.end);
-}
-
-function hasAnyActivityDate(row) {
-  const pushDate = (value) => /^\d{4}-\d{2}-\d{2}$/.test(String(value || '').trim().slice(0, 10));
-  if (pushDate(row?.start_date) || pushDate(row?.end_date)) return true;
-  const cols = Array.isArray(row?.meeting_dates) ? row.meeting_dates : [];
-  const dateCols = Array.isArray(row?.date_cols) ? row.date_cols : [];
-  if (cols.some(pushDate) || dateCols.some(pushDate)) return true;
-  for (let i = 1; i <= 35; i++) {
-    if (pushDate(row?.[`date_${i}`]) || pushDate(row?.[`Date${i}`])) return true;
-  }
-  return false;
-}
-
-function monthLabel(ym) {
-  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
-  if (!m) return '';
-  return `${m[1]}-${m[2]}`;
-}
-
-const HE_MONTHS = ['ינואר','פברואר','מרץ','אפריל','מאי','יוני','יולי','אוגוסט','ספטמבר','אוקטובר','נובמבר','דצמבר'];
-function heMonthLabel(ym) {
-  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
-  if (!m) return monthLabel(ym);
-  return HE_MONTHS[Number(m[2]) - 1] || monthLabel(ym);
 }
 
 
@@ -559,10 +542,8 @@ function applyActivitiesGapFilter(rows, gapFilter) {
 
 function applyActivitiesLocalFilters(rows, state, settings) {
   const filters = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
-  if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
   const familyRows = applyClientFilters(rows, state, settings);
-  const monthRows = familyRows.filter((row) => activityOverlapsMonth(row, state.activitiesMonthYm) || !hasAnyActivityDate(row));
-  const gapRows = applyActivitiesGapFilter(monthRows, state.activitiesGapFilter);
+  const gapRows = applyActivitiesGapFilter(familyRows, state.activitiesGapFilter);
   prepareRowsForSearch(gapRows, ACTIVITY_SEARCH_FIELDS);
   return applyLocalFilters(gapRows, filters, { filterFields: ACTIVITY_FILTER_FIELDS }).sort(compareActivityDefaultOrder);
 }
@@ -752,17 +733,18 @@ function nextMeetingDate(row) {
 
 export const activitiesScreen = {
   async load({ api, state }) {
-    if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
+    state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
     return api.activities({
       activity_type: 'all',
-      month: state.activitiesMonthYm
+      include_inactive: true
     });
   },
 
   render(data, { state }) {
     const allRows       = Array.isArray(data?.rows) ? data.rows : [];
-    if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
-    const filteredRows  = applyActivitiesLocalFilters(allRows, state, state?.clientSettings);
+    state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
+    const periodRows    = activityPeriodRows(allRows, state.activityPeriodTab);
+    const filteredRows  = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
 
     const listFilters   = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
     const { visible: safeRows, hasMore, total, nextCount } = splitVisibleRows(filteredRows, listFilters);
@@ -847,8 +829,8 @@ export const activitiesScreen = {
 
     const tableSection =
       safeRows.length === 0
-        ? dsEmptyState(allRows.length === 0
-            ? 'אין פעילויות רשומות בחודש זה'
+        ? dsEmptyState(periodRows.length === 0
+            ? 'אין פעילויות להצגה בתקופה זו'
             : 'לא נמצאו פעילויות התואמות לסינון הנוכחי')
         : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--activities-list" dir="rtl">
                 <colgroup>
@@ -873,20 +855,20 @@ export const activitiesScreen = {
       ${bareFilters}
       <div class="ds-activities-main-toolbar__actions">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
-        ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-export-all title="ייצוא כל הפעילויות לאקסל">ייצוא לאקסל</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-admin-summary title="סיכום אדמין לכלל הפעילויות">סיכום אדמין</button>` : ''}
+        ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-export-all title="ייצוא הפעילויות בלשונית הפעילה לאקסל">ייצוא לאקסל</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-admin-summary title="סיכום אדמין ללשונית הפעילה">סיכום אדמין</button>` : ''}
         ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">+</button>` : ''}
       </div>
     </div>`;
 
-    const titleNavRow = `<nav class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" aria-label="ניווט חודשי לפעילויות" dir="rtl">
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-prev aria-label="חודש קודם" title="חודש קודם" ${isNavLoading ? 'disabled' : ''}>▶</button>
-      <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(heMonthLabel(state.activitiesMonthYm))} · ${total} פעילויות ${navLoadingChip}</h2>
-      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-next aria-label="חודש הבא" title="חודש הבא" ${isNavLoading ? 'disabled' : ''}>◀</button>
-    </nav>`;
+    const titleNavRow = `<div class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" dir="rtl">
+      <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(activityPeriodLabelForKey(state.activityPeriodTab))} · ${total} פעילויות ${navLoadingChip}</h2>
+    </div>`;
+    const periodTabs = activityPeriodTabsHtml(allRows, state.activityPeriodTab);
 
     const html = dsScreenStack(`<section class="ds-activities-screen">
       ${viewSwitcher}
       ${titleNavRow}
+      ${periodTabs}
       ${mainToolbar}
       ${dsCard({ body: tableSection, padded: false })}
     </section>`);
@@ -936,7 +918,9 @@ export const activitiesScreen = {
     })();
 
     const activitiesRows = Array.isArray(data?.rows) ? data.rows : [];
-    const filteredRows      = applyActivitiesLocalFilters(activitiesRows, state, state?.clientSettings);
+    state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
+    const periodRows = activityPeriodRows(activitiesRows, state.activityPeriodTab);
+    const filteredRows      = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
     const canSeePrivateNotes = ['operation_manager', 'admin'].includes(state?.user?.display_role);
     const canEditActivity   = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -971,6 +955,7 @@ export const activitiesScreen = {
           if (idx >= 0) arr.splice(idx, 1);
         };
         removeByRowId(activitiesRows);
+        removeByRowId(periodRows);
         removeByRowId(filteredRows);
         return;
       }
@@ -980,11 +965,10 @@ export const activitiesScreen = {
     };
     const scheduleQuietRefresh = async () => {
       try {
-        const refreshMonth = state.activitiesMonthYm || currentYm();
-        const fresh = await api.activities({ activity_type: 'all', month: refreshMonth });
+        const fresh = await api.activities({ activity_type: 'all', include_inactive: true });
         const freshRows = Array.isArray(fresh?.rows) ? fresh.rows : [];
         activitiesRows.splice(0, activitiesRows.length, ...freshRows);
-        state.screenDataCache[`activities:${refreshMonth}`] = { data: { ...fresh, rows: activitiesRows }, t: Date.now() };
+        state.screenDataCache['activities:periods'] = { data: { ...fresh, rows: activitiesRows }, t: Date.now() };
       } catch {
         // keep local optimistic view on failure
       }
@@ -1020,6 +1004,11 @@ export const activitiesScreen = {
             }
           } catch (err) {
             console.warn('[activity-refresh-after-save:failed]', { sourceRowId, error: err?.message || String(err) });
+          }
+          const savedPeriod = activityPeriodKey({ ...(activitiesRows.find((row) => String(row?.RowID || '') === String(sourceRowId || '')) || {}), ...(changes || {}) });
+          if (savedPeriod !== state.activityPeriodTab) {
+            state.activityPeriodTab = savedPeriod;
+            showToast('הפעילות נשמרה בתקופה אחרת והועברה ללשונית המתאימה.', 'info', 3600);
           }
           rerenderLocal();
           void scheduleQuietRefresh();
@@ -1138,22 +1127,8 @@ export const activitiesScreen = {
       state.activityEndingCurrentMonth = false;
       state.activitiesGapFilter = '';
       syncActivitiesGapQuery('');
-      state.activityTab = 'all';
       state.activityFinanceStatus = '';
     } });
-    const runMonthShift = (delta) => {
-      if (state.activitiesNavLoading) return;
-      const startedAt = Date.now();
-      state.activitiesNavLoading = true;
-      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), delta);
-      rerenderLocal();
-      const minMs = 420;
-      setTimeout(() => {
-        state.activitiesNavLoading = false;
-        rerenderLocal();
-      }, Math.max(0, minMs - (Date.now() - startedAt)));
-    };
-
     async function loadAllActivitiesForAdmin() {
       return typeof api.allActivities === 'function' ? api.allActivities() : api.activities({ activity_type: 'all' });
     }
@@ -1166,7 +1141,8 @@ export const activitiesScreen = {
       btn.textContent = 'מייצא…';
       try {
         const res = await loadAllActivitiesForAdmin();
-        exportActivitiesToExcel(Array.isArray(res?.rows) ? res.rows : [], 'כל_הפעילויות');
+        const rows = activityPeriodRows(Array.isArray(res?.rows) ? res.rows : [], state.activityPeriodTab);
+        exportActivitiesToExcel(rows, `פעילויות_${activityPeriodLabelForKey(state.activityPeriodTab) || 'תקופה'}`);
       } catch (err) {
         console.error('Failed to export all activities to Excel', err);
       } finally {
@@ -1183,7 +1159,8 @@ export const activitiesScreen = {
       try {
         const res = await loadAllActivitiesForAdmin();
         const drawerContent = document.querySelector('.ds-drawer__content');
-        if (drawerContent) drawerContent.innerHTML = renderAdminActivitiesSummary(Array.isArray(res?.rows) ? res.rows : [], state?.clientSettings || {});
+        const rows = activityPeriodRows(Array.isArray(res?.rows) ? res.rows : [], state.activityPeriodTab);
+        if (drawerContent) drawerContent.innerHTML = renderAdminActivitiesSummary(rows, state?.clientSettings || {});
       } catch (err) {
         console.error('[admin-summary:failed]', err);
         const drawerContent = document.querySelector('.ds-drawer__content');
@@ -1193,8 +1170,13 @@ export const activitiesScreen = {
       }
     });
 
-    root.querySelector('[data-activities-month-prev]')?.addEventListener('click', () => runMonthShift(-1));
-    root.querySelector('[data-activities-month-next]')?.addEventListener('click', () => runMonthShift(1));
+    root.querySelectorAll('[data-activity-period-tab]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        state.activityPeriodTab = normalizeActivityPeriodTab(btn.getAttribute('data-activity-period-tab'));
+        ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = 200;
+        rerenderLocal();
+      });
+    });
     root.querySelector(`[data-list-show-more="${ACTIVITIES_SCOPE}"]`)?.addEventListener('click', (ev) => {
       const next = Number(ev.currentTarget?.dataset?.nextCount || 200);
       ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = next;
@@ -1283,7 +1265,7 @@ export const activitiesScreen = {
       const startDate = String(form.querySelector('[name="start_date"]')?.value || '').trim();
       const prev = Array.from(container.querySelectorAll('input[data-add-session-date]')).map((input) => String(input.value || '').trim());
       container.innerHTML = Array.from({ length: sessions }, (_, idx) => {
-        const value = prev[idx] || computeNextSessionDate(startDate, idx);
+        const value = idx === 0 ? (startDate || prev[idx] || '') : (prev[idx] || computeNextSessionDate(startDate, idx));
         return `<label class="ds-add-date-row"><span>מפגש ${idx + 1}</span><input class="ds-input ds-input--sm" type="date" data-add-session-date="${idx + 1}" value="${escapeHtml(value)}"></label>`;
       }).join('');
     }
@@ -1307,6 +1289,13 @@ export const activitiesScreen = {
       form.querySelector('[data-add-sessions]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
       form.querySelector('[name="start_date"]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
       form.querySelector('[name="one_day_date"]')?.addEventListener('change', () => syncSessionDateRows(form), addActivitySig);
+      form.querySelector('[data-add-date-rows]')?.addEventListener('change', (ev) => {
+        const firstDate = ev.target.closest('input[data-add-session-date="1"]');
+        if (!firstDate) return;
+        const startDateInput = form.querySelector('[name="start_date"]');
+        if (startDateInput) startDateInput.value = String(firstDate.value || '').trim();
+        syncSessionDateRows(form);
+      }, addActivitySig);
       bindEntityFieldToggle(form, 'authority');
       bindEntityFieldToggle(form, 'school');
     }
@@ -1414,7 +1403,14 @@ export const activitiesScreen = {
         meetingDateValues = dateInputs.map((input) => String(input.value || '').trim());
         dateInputs.forEach((input, index) => {
           payload[`Date${index + 1}`] = String(input.value || '').trim();
+          payload[`date_${index + 1}`] = String(input.value || '').trim();
         });
+        const firstMeetingDate = String(meetingDateValues[0] || payload.start_date || '').trim();
+        if (firstMeetingDate) {
+          payload.start_date = firstMeetingDate;
+          payload.Date1 = firstMeetingDate;
+          payload.date_1 = firstMeetingDate;
+        }
       }
       if (!payload.end_date) {
         const lastDate = meetingDateValues.filter(Boolean).pop();
@@ -1453,15 +1449,14 @@ export const activitiesScreen = {
         const rsp = await api.addActivity(payload);
         console.info('[addActivity] success', rsp);
         clearScreenDataCache?.();
-        const hasSavedDate = !!String(payload.start_date || payload.end_date || meetingDateValues.find(Boolean) || '').trim();
-        const activityMonth = String(payload.start_date || payload.end_date || meetingDateValues.find(Boolean) || '').slice(0, 7);
-        const savedToOtherMonth = /^\d{4}-\d{2}$/.test(activityMonth) && state.activitiesMonthYm !== activityMonth;
-        if (statusEl) statusEl.textContent = hasSavedDate
-          ? (savedToOtherMonth ? 'הפעילות נשמרה לחודש אחר. עוברים לחודש הפעילות.' : 'הפעילות נשמרה')
-          : 'הפעילות נשמרה ללא תאריך ותופיע ברשימת ממתינות לתיאום תאריך.';
-        showToast(savedToOtherMonth ? 'הפעילות נשמרה לחודש אחר. עוברים לחודש הפעילות.' : 'הפעילות נשמרה', 'success', 3000);
-        if (savedToOtherMonth) {
-          state.activitiesMonthYm = activityMonth;
+        const savedPeriod = activityPeriodKey(payload);
+        const savedToOtherPeriod = savedPeriod !== state.activityPeriodTab;
+        if (statusEl) statusEl.textContent = savedToOtherPeriod
+          ? 'הפעילות נשמרה בתקופה אחרת והועברה ללשונית המתאימה.'
+          : 'הפעילות נשמרה';
+        showToast(savedToOtherPeriod ? 'הפעילות נשמרה בתקופה אחרת והועברה ללשונית המתאימה.' : 'הפעילות נשמרה', 'success', 3000);
+        if (savedToOtherPeriod) {
+          state.activityPeriodTab = savedPeriod;
         }
         ui?.closeModal?.();
         await scheduleQuietRefresh();

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -190,6 +190,7 @@ function goActivitiesDrill(state, patch) {
   state.activityTab = patch.activityTab ?? 'all';
   state.activityFinanceStatus = patch.activityFinanceStatus ?? '';
   state.activityQuickFamily = patch.activityQuickFamily ?? '';
+  state.activityPeriodTab = patch.activityPeriodTab || (patch.activityQuickFamily === 'summer' ? 'summer_2026' : (state.activityPeriodTab || 'summer_2026'));
   state.activityQuickManager = patch.activityQuickManager ?? '';
   state.activityEndingCurrentMonth = !!patch.activityEndingCurrentMonth;
   state.activitiesMonthYm = patch.activitiesMonthYm || state.dashboardMonthYm || currentMonthYm();
@@ -627,7 +628,8 @@ export const dashboardScreen = {
       }
       if (action === 'kpi|summer') {
         goActivitiesDrill(state, {
-          activityQuickFamily: 'summer',
+          activityQuickFamily: '',
+          activityPeriodTab: 'summer_2026',
           activitiesMonthYm: SUMMER_DEFAULT_MONTH_YM,
           resetActivityListFilters: true
         });

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -217,7 +217,8 @@ function buildMeetingDatesSnapshot(form) {
   normalized.forEach((value) => {
     if (/^\d{4}-\d{2}-\d{2}$/.test(value)) endDate = value;
   });
-  return { dates: normalized, endDate };
+  const startDate = /^\d{4}-\d{2}-\d{2}$/.test(normalized[0] || '') ? normalized[0] : '';
+  return { dates: normalized, startDate, endDate };
 }
 
 function hasMeetingDatesChanged(form, initialValues = {}) {
@@ -276,6 +277,7 @@ export function bindActivityEditForm(contentRoot, {
       for (let i = 0; i < 35; i++) {
         changes[`meeting_date_${i}`] = snapshot.dates[i];
       }
+      changes.start_date = snapshot.startDate;
       changes.end_date = snapshot.endDate;
     }
 

--- a/frontend/src/screens/shared/view-switcher.js
+++ b/frontend/src/screens/shared/view-switcher.js
@@ -19,10 +19,6 @@ export function renderActivitiesViewSwitcher(state, activeRoute) {
       const isActive = route === activeRoute;
       return `<button type="button" class="ds-btn ds-btn--sm ds-btn--accent ds-activities-view-btn${isActive ? ' is-active' : ''}" data-route-switch="${escapeHtml(route)}" ${isActive ? 'aria-current="page"' : ''}>${escapeHtml(label)}</button>`;
     });
-  if (activeRoute === 'activities') {
-    const isSummerActive = String(state?.activityQuickFamily || '') === 'summer';
-    buttons.push(`<button type="button" class="ds-btn ds-btn--sm ds-activities-view-btn ds-activities-view-btn--summer${isSummerActive ? ' is-active' : ''}" data-activities-summer-filter ${isSummerActive ? 'aria-pressed="true"' : 'aria-pressed="false"'}>${escapeHtml('קיץ')}</button>`);
-  }
   if (!buttons.length) return '';
   return `<div class="ds-activities-view-switcher" dir="rtl" aria-label="מעבר בין תצוגות פעילות">${buttons.join('')}</div>`;
 }
@@ -36,14 +32,6 @@ export function bindActivitiesViewSwitcher(root, state, rerender) {
       if (!availableRoutes.has(route) || state.route === route) return;
       state.activityQuickFamily = '';
       state.route = route;
-      rerender();
-    });
-  });
-  root.querySelectorAll('[data-activities-summer-filter]').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      state.activityQuickFamily = String(state?.activityQuickFamily || '') === 'summer' ? '' : 'summer';
-      state.activityEndingCurrentMonth = false;
-      state.activityTab = 'all';
       rerender();
     });
   });

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -82,6 +82,7 @@ export const state = {
   routes: [],
   effectiveRoutes: [],
   activityTab: 'all',
+  activityPeriodTab: 'summer_2026',
   activityFinanceStatus: '',
   activityQuickFamily: '',
   activityQuickManager: '',
@@ -152,6 +153,7 @@ export function setSession(session) {
     state.effectiveRoutes = [];
     state.route = 'login';
     state.activityTab = 'all';
+    state.activityPeriodTab = 'summer_2026';
     state.activityFinanceStatus = '';
     state.activityQuickFamily = '';
     state.activityQuickManager = '';

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11886,3 +11886,24 @@ select.ds-input {
   font-size: 0.78em;
   font-weight: 800;
 }
+
+/* Activities period tabs */
+.ds-activities-period-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin: 4px 0 10px;
+}
+.ds-activities-period-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.ds-activities-period-tab strong {
+  min-width: 1.75em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 534;
+const CACHE_VERSION = 535;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 534;
+const SW_ENTRY_VERSION = 535;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -26,6 +26,7 @@ const { activitiesScreen } = await import('../frontend/src/screens/activities.js
 function baseState() {
   return {
     activitiesMonthYm: '2026-04',
+    activityPeriodTab: 'school_2026',
     user: { display_role: 'admin', can_add_activity: true },
     clientSettings: { hide_emp_id_on_screens: true, dropdown_options: {} },
     activityListFilters: {},
@@ -183,74 +184,39 @@ test('activities quick filters include one-day summer rows by family and distric
   assert.doesNotMatch(html, /תוכנית שנתית/);
 });
 
-test('activities summer quick filter matches activity_season and summer start dates only', () => {
+test('activities period tabs split rows by start_date and default to summer 2026', () => {
   const state = baseState();
-  state.activitiesMonthYm = '2026-07';
-  state.routes = ['activities', 'week', 'month'];
-  state.activityQuickFamily = 'summer';
+  delete state.activityPeriodTab;
   const data = {
     rows: [
-      {
-        RowID: 'SUMMER-1',
-        activity_name: 'פעילות מדעים',
-        activity_season: 'summer_2026',
-        activity_type: 'workshop',
-        authority: 'רשות א',
-        school: 'בית ספר א',
-        start_date: '',
-        end_date: ''
-      },
-      {
-        RowID: 'SUMMER-2',
-        activity_name: 'פעילות יולי',
-        activity_season: 'regular',
-        activity_type: 'workshop',
-        authority: 'רשות א',
-        school: 'בית ספר א',
-        start_date: '2026-07-01',
-        end_date: '2026-07-01'
-      },
-      {
-        RowID: 'NOT-SUMMER-NOTES',
-        activity_name: 'פעילות עם הערת קיץ',
-        activity_season: 'regular',
-        activity_type: 'workshop',
-        authority: 'רשות ג',
-        school: 'בית ספר ג',
-        start_date: '2026-04-05',
-        end_date: '2026-04-05',
-        notes: 'פעילות קיץ'
-      },
-      {
-        RowID: 'REGULAR-1',
-        activity_name: 'פעילות רגילה',
-        activity_season: 'regular',
-        activity_type: 'course',
-        authority: 'רשות ב',
-        school: 'בית ספר ב',
-        start_date: '2026-04-06',
-        end_date: '2026-04-06'
-      }
+      { RowID: 'SCHOOL-2026', activity_name: 'פעילות יוני', activity_type: 'workshop', authority: 'רשות א', school: 'בית ספר א', start_date: '2026-06-30' },
+      { RowID: 'SUMMER-2026', activity_name: 'פעילות יולי', activity_type: 'workshop', authority: 'רשות ב', school: 'בית ספר ב', start_date: '2026-07-01' },
+      { RowID: 'SCHOOL-2027', activity_name: 'פעילות ספטמבר', activity_type: 'course', authority: 'רשות ג', school: 'בית ספר ג', start_date: '2026-09-01' },
+      { RowID: 'ARCHIVE-CLOSED', activity_name: 'פעילות סגורה', activity_type: 'course', authority: 'רשות ד', school: 'בית ספר ד', start_date: '2026-07-10', status: 'סגור' }
     ]
   };
 
   const html = activitiesScreen.render(data, { state });
 
-  assert.match(html, /data-route-switch="week"[\s\S]*data-route-switch="month"[\s\S]*data-activities-summer-filter/);
-  assert.match(html, /ds-activities-view-btn--summer is-active/);
-  assert.match(html, /פעילות מדעים/);
+  assert.match(html, /data-activity-period-tab="school_2026"[\s\S]*תשפ״ו \/ 2026[\s\S]*<strong>1<\/strong>/);
+  assert.match(html, /aria-selected="true" data-activity-period-tab="summer_2026"/);
+  assert.match(html, /data-activity-period-tab="school_2027"[\s\S]*<strong>1<\/strong>/);
+  assert.match(html, /data-activity-period-tab="archive"[\s\S]*<strong>1<\/strong>/);
   assert.match(html, /פעילות יולי/);
-  assert.doesNotMatch(html, /פעילות עם הערת קיץ/);
-  assert.doesNotMatch(html, /פעילות רגילה/);
+  assert.doesNotMatch(html, /פעילות יוני/);
+  assert.doesNotMatch(html, /פעילות ספטמבר/);
+  assert.doesNotMatch(html, /פעילות סגורה/);
+  assert.doesNotMatch(html, /כל הפעילויות/);
 });
 
-test('activities view switcher shows summer button next to week and month when inactive', () => {
+test('activities view switcher keeps week and month routes without an all/summer mixing button', () => {
   const state = baseState();
   state.routes = ['activities', 'week', 'month'];
   const html = activitiesScreen.render({ rows: [] }, { state });
 
-  assert.match(html, /data-route-switch="week"[\s\S]*>שבוע<\/button>[\s\S]*data-route-switch="month"[\s\S]*>חודש<\/button>[\s\S]*data-activities-summer-filter[\s\S]*>קיץ<\/button>/);
-  assert.doesNotMatch(html, /ds-activities-view-btn--summer is-active/);
+  assert.match(html, /data-route-switch="week"[\s\S]*>שבוע<\/button>[\s\S]*data-route-switch="month"[\s\S]*>חודש<\/button>/);
+  assert.doesNotMatch(html, /data-activities-summer-filter/);
+  assert.doesNotMatch(html, /ds-activities-view-btn--summer/);
 });
 
 test('activities source includes admin summary all-activities loading and no district buckets', async () => {
@@ -347,7 +313,7 @@ test('admin all-activities Excel export is imported and logs failures', async ()
   const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
   assert.match(source, /import \{ exportActivitiesToExcel \} from '\.\/shared\/excel-export\.js';/);
   assert.match(source, /data-activities-export-all/);
-  assert.match(source, /exportActivitiesToExcel\(Array\.isArray\(res\?\.rows\) \? res\.rows : \[\], 'כל_הפעילויות'\)/);
+  assert.match(source, /const rows = activityPeriodRows/);
   assert.match(source, /catch \(err\) \{[\s\S]*console\.error\('Failed to export all activities to Excel', err\);/);
 });
 


### PR DESCRIPTION
### Motivation

- Reorganize the Activities screen so activities are shown in separate fixed period tabs (school 2026, summer 2026, school 2027, archive) instead of a single mixed table while keeping the single Supabase `activities` table as the source of truth.
- Determine period assignment solely from `start_date` and enforce `start_date = date_1` on create and edit flows to keep meeting 1 and start date synchronized.
- Keep existing UX and downstream screens working (exceptions, dashboard, week/month, archive) while avoiding schema changes or new database tables.

### Description

- Added operational period model and UI tabs (`activityPeriodKey`, `activityPeriodTabsHtml`) and rendered a period tab bar with labels and counts; default tab is `summer_2026`. (frontend/src/screens/activities.js, frontend/src/styles/main.css)
- Load all activities (including inactive/archive rows) from Supabase and then filter rows in the client by the selected period so no new Supabase tables are created; changed API read to accept `include_inactive`. (frontend/src/api.js, frontend/src/screens/activities.js)
- Enforced `start_date = date_1` synchronization in add/edit/save flows by introducing `synchronizeStartDateAndFirstMeeting` and updating add/edit payload handling so creating or editing start/date_1 keeps them equal. (frontend/src/api.js, frontend/src/screens/shared/bind-activity-edit-form.js, frontend/src/screens/activities.js)
- Replaced the prior month-focused navigation on the activities screen with fixed period tabs, removed the summer-mixing view-switch button, and wired dashboard KPI drill to open the summer tab when appropriate. (frontend/src/screens/shared/view-switcher.js, frontend/src/screens/dashboard.js, frontend/src/state.js)
- Updated client cache key for activities to `activities:periods` and preserved targeted cache invalidation for activity mutations; added focused CSS for the new period tabs and bumped Service Worker cache versions. (frontend/src/main.js, frontend/src/styles/main.css, frontend/sw.js, sw.js, dist/*)
- Files with notable edits: `frontend/src/screens/activities.js`, `frontend/src/api.js`, `frontend/src/state.js`, `frontend/src/main.js`, `frontend/src/screens/dashboard.js`, `frontend/src/screens/shared/bind-activity-edit-form.js`, `frontend/src/screens/shared/view-switcher.js`, `frontend/src/styles/main.css`, `frontend/sw.js`, `sw.js`, plus rebuilt `dist` assets and an updated test file.

### Testing

- Ran focused static checks with `npm run check:changed` and `node --check` on modified files, and all JS syntax checks passed.
- Ran unit tests for the modified screens: `node --test tests/activities-screen.test.mjs tests/activity-one-day-family-regression.test.mjs` and additional API mutation tests; all focused tests passed (final run: 29 tests passed, 0 failed).
- Performed a frontend build with `npm run check:build` (`vite build` + postbuild steps) and the build completed successfully and produced updated `dist` assets.
- Bumped `CACHE_VERSION` / `SW_ENTRY_VERSION` in `frontend/sw.js` and `sw.js` (534 → 535) and confirmed the built `dist/index.html` points to the new bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f050cf468832ba5e1e80c6319735b)