### PR TITLE
Add business_development_manager role and activity UI defaults

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 537;
+const CACHE_VERSION = 539;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Bwc8Q7ia.js",
+  "./assets/index-jK7gFIuc.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-Doa6WaB1.css",
+  "./assets/style-edU4PRxs.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Bwc8Q7ia.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-Doa6WaB1.css">
+  <script type="module" crossorigin src="./assets/index-jK7gFIuc.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-edU4PRxs.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 537;
+const CACHE_VERSION = 539;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Bwc8Q7ia.js",
+  "./assets/index-jK7gFIuc.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-Doa6WaB1.css",
+  "./assets/style-edU4PRxs.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1480,7 +1480,8 @@ function normalizeData(data) {
 }
 
 
-const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
+const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
+const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
 const PROPOSALS_AGREEMENTS_COLUMNS = 'id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,created_at,updated_at';
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
@@ -1517,8 +1518,17 @@ function canUseProposalsAgreementsApi() {
   return PROPOSALS_AGREEMENTS_ALLOWED_ROLES.has(role);
 }
 
+function canManageProposalsAgreementsApi() {
+  const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+  return PROPOSALS_AGREEMENTS_MANAGE_ROLES.has(role);
+}
+
 function assertCanUseProposalsAgreementsApi() {
   if (!canUseProposalsAgreementsApi()) throw new Error('proposals_agreements_forbidden');
+}
+
+function assertCanManageProposalsAgreementsApi() {
+  if (!canManageProposalsAgreementsApi()) throw new Error('proposals_agreements_forbidden');
 }
 
 function cleanProposalAgreementText(value) {
@@ -1854,7 +1864,7 @@ async function readProposalsAgreementsFromSupabase() {
 }
 
 const USER_PUBLIC_COLUMNS = 'user_id,email,name,role,display_role,is_active,permissions,auth_user_id';
-const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager']);
+const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 const ROLES_WITH_DIRECT_EDIT = new Set(['admin', 'operation_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
@@ -1864,6 +1874,7 @@ const SUPABASE_ROLE_ROUTES = {
   finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   instructor: ['my-data', 'week', 'month']
 };
@@ -1939,16 +1950,17 @@ function buildBootstrapFromUser(userRow) {
   const flat = flattenUserRow(userRow);
   const role = normalizeSupabaseRole(flat.role);
   const allowedRoutes = [...(SUPABASE_ROLE_ROUTES[role] || SUPABASE_ROLE_ROUTES.authorized_user)];
-  const hasFinanceAccess = permissionFlagYes(parsePermissions(userRow?.permissions).finance_access);
+  const isBusinessDevelopmentManager = role === 'business_development_manager';
+  const hasFinanceAccess = isBusinessDevelopmentManager ? false : permissionFlagYes(parsePermissions(userRow?.permissions).finance_access);
   const financeIdx = allowedRoutes.indexOf('finance');
   if (hasFinanceAccess && financeIdx === -1) allowedRoutes.push('finance');
   if (!hasFinanceAccess && financeIdx >= 0) allowedRoutes.splice(financeIdx, 1);
   if (permissionFlagYes(flat.view_catalog) && !allowedRoutes.includes('catalog')) allowedRoutes.push('catalog');
   if ((permissionFlagYes(flat.view_orders) || permissionFlagYes(flat.view_invitations)) && !allowedRoutes.includes('orders')) allowedRoutes.push('orders');
-  const canEditDirect = permissionFlagYes(flat.can_edit_direct);
-  const canRequestEdit = canEditDirect || permissionFlagYes(flat.can_request_edit);
-  const canReviewRequests = ['admin', 'operation_manager'].includes(role) || permissionFlagYes(flat.can_review_requests);
-  if ((canRequestEdit || canReviewRequests || permissionFlagYes(flat.view_edit_requests)) && !allowedRoutes.includes('edit-requests')) {
+  const canEditDirect = isBusinessDevelopmentManager ? false : permissionFlagYes(flat.can_edit_direct);
+  const canRequestEdit = isBusinessDevelopmentManager ? false : (canEditDirect || permissionFlagYes(flat.can_request_edit));
+  const canReviewRequests = isBusinessDevelopmentManager ? false : (['admin', 'operation_manager'].includes(role) || permissionFlagYes(flat.can_review_requests));
+  if (!isBusinessDevelopmentManager && (canRequestEdit || canReviewRequests || permissionFlagYes(flat.view_edit_requests)) && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
   return {
@@ -3083,6 +3095,7 @@ export const api = {
         finance: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
         activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
         domain_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
+        business_development_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' },
         instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
         instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' }
       }
@@ -3121,7 +3134,7 @@ export const api = {
     return buildSupabaseErrorPayload({ categories: [] }, 'admin_lists_supabase_failed');
   },
   addProposalAgreement: async (payload) => {
-    assertCanUseProposalsAgreementsApi();
+    assertCanManageProposalsAgreementsApi();
     const insert = sanitizeProposalAgreementPayload(payload);
     await upsertProposalClientContactIfNeeded({ ...insert, _contact_original: payload?._contact_original });
     const { data, error } = await supabase
@@ -3133,7 +3146,7 @@ export const api = {
     return { ok: true, row: normalizeProposalAgreementRow(data) };
   },
   updateProposalAgreement: async (id, payload) => {
-    assertCanUseProposalsAgreementsApi();
+    assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(id);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
     const patch = sanitizeProposalAgreementPayload(payload);
@@ -3149,7 +3162,7 @@ export const api = {
   },
 
   deleteProposalAgreement: async (id) => {
-    assertCanUseProposalsAgreementsApi();
+    assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(id);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
     const { error } = await supabase
@@ -3160,7 +3173,7 @@ export const api = {
     return { ok: true, id: rowId };
   },
   updateProposalAgreementStatus: async (id, status, approvalNote = '') => {
-    assertCanUseProposalsAgreementsApi();
+    assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(id);
     const cleanStatus = cleanProposalAgreementText(status);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
@@ -3213,7 +3226,7 @@ export const api = {
   },
 
   saveProposalAgreementCustomDocumentSections: async (proposalId, sections) => {
-    assertCanUseProposalsAgreementsApi();
+    assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(proposalId);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
     const cleanSections = (Array.isArray(sections) ? sections : []).map((section) => ({
@@ -3231,7 +3244,7 @@ export const api = {
     return { ok: true, row: normalizeProposalAgreementRow(data) };
   },
   saveProposalAgreementItems: async (proposalId, items) => {
-    assertCanUseProposalsAgreementsApi();
+    assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(proposalId);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
     const { error: delError } = await supabase
@@ -3516,8 +3529,22 @@ export const api = {
       if (['user_id', 'role', 'active', 'full_name', 'entry_code', 'emp_id', 'display_role2'].includes(k)) return;
       permissions[k] = v;
     });
+    const nextRole = row.role || existing.data.role;
+    if (nextRole === 'business_development_manager') {
+      Object.assign(permissions, {
+        can_add_activity: 'no',
+        can_edit_direct: 'no',
+        can_request_edit: 'no',
+        can_review_requests: 'no',
+        view_admin: 'no',
+        view_permissions: 'no',
+        finance_access: 'no',
+        view_catalog: 'yes',
+        view_orders: 'yes'
+      });
+    }
     const patch = {
-      role: row.role || existing.data.role,
+      role: nextRole,
       is_active: String(row.active || '').toLowerCase() !== 'no',
       name: row.full_name ?? existing.data.name,
       emp_id: row.emp_id ?? existing.data.emp_id,
@@ -3531,12 +3558,15 @@ export const api = {
     return { ok: true };
   },
   addUser: async (row) => {
-    const permissions = { can_request_edit: 'yes' };
+    const role = String(row?.role || 'instructor').trim();
+    const permissions = role === 'business_development_manager'
+      ? { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' }
+      : { can_request_edit: 'yes' };
     const insert = {
       user_id: String(row?.user_id || '').trim(),
       email: null,
       name: String(row?.full_name || '').trim(),
-      role: String(row?.role || 'instructor').trim(),
+      role,
       emp_id: String(row?.user_id || '').trim(),
       is_active: true,
       entry_code: String(row?.entry_code || '').trim(),

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -50,7 +50,7 @@ const ACTIVITY_PERIOD_TABS = [
   { key: 'school_2027', label: 'תשפ״ז / 2027', start: '2026-09-01', end: '2027-06-30' },
   { key: 'archive', label: 'ארכיון / הסתיימו', archive: true }
 ];
-const DEFAULT_ACTIVITY_PERIOD_TAB = 'summer_2026';
+const DEFAULT_ACTIVITY_PERIOD_TAB = 'school_2026';
 const INACTIVE_ACTIVITY_STATUSES = new Set(['סגור', 'נמחק', 'closed', 'deleted', 'inactive']);
 
 function normalizeActivityPeriodTab(value) {
@@ -1337,7 +1337,6 @@ export const activitiesScreen = {
       const roster = decodeJsonAttr(form.dataset.addRosterUsers, []);
       const fd = new (window?.FormData || FormData)(form);
       const get = (k) => String(fd.get(k) || '').trim();
-      const formSource = get('source') || 'catalog';
       const authorityCustom = get('authority_custom');
       const schoolCustom = get('school_custom');
       const authorityValue = authorityCustom || get('authority');
@@ -1363,7 +1362,7 @@ export const activitiesScreen = {
       const oneDayDate = String(get('one_day_date') || get('start_date') || get('end_date') || '').trim();
       let meetingDateValues = [];
       const payload = {
-        source: isOneDay ? 'short' : (formSource === 'short' ? 'long' : formSource),
+        source: isOneDay ? 'short' : 'long',
         activity_family: isOneDay ? 'one_day' : 'program',
         activity_manager: get('activity_manager'),
         authority: authorityValue,
@@ -1371,7 +1370,7 @@ export const activitiesScreen = {
         grade: get('grade'),
         class_group: get('class_group'),
         activity_type: selectedType || get('activity_type'),
-        item_type: isOneDay ? selectedType : '',
+        item_type: selectedType || get('activity_type'),
         activity_season: normalizeActivitySeason(get('activity_season')),
         activity_name: selectedName,
         activity_no: String(hit?.activity_no || get('activity_no') || ''),

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -302,10 +302,10 @@ function saveDashboardMonthToStorage(ym) {
 export const dashboardScreen = {
   async load({ api, state }) {
     let ym = state.dashboardMonthYm;
-    if (!ym || !/^\d{4}-\d{2}$/.test(ym)) {
-      ym = loadDashboardMonthFromStorage() || currentMonthYm();
-    }
     const now = currentMonthYm();
+    if (!ym || !/^\d{4}-\d{2}$/.test(ym)) {
+      ym = now;
+    }
     if (ym > now) {
       ym = now;
       saveDashboardMonthToStorage(ym);

--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -24,6 +24,7 @@ const PERMISSION_ROLE_OPTIONS = [
   'finance',
   'activities_manager',
   'domain_manager',
+  'business_development_manager',
   'instructor_manager'
 ];
 

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1,7 +1,8 @@
 import { escapeHtml } from './shared/html.js';
 import { dsCard, dsEmptyState, dsPageHeader, dsScreenStack, dsTableWrap } from './shared/layout.js';
 
-export const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
+export const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
+export const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
 const SEARCH_DEBOUNCE_MS = 280;
 
 const ACTIVITY_TYPE_GROUP_OPTIONS = ['קיץ תשפ״ו', 'שנת הלימודים תשפ״ז', 'קיץ תשפ״ו ושנת הלימודים תשפ״ז'];
@@ -63,6 +64,10 @@ function userRole(state) {
 
 export function canAccessProposalsAgreements(state) {
   return PROPOSALS_AGREEMENTS_ALLOWED_ROLES.has(userRole(state));
+}
+
+export function canManageProposalsAgreements(state) {
+  return PROPOSALS_AGREEMENTS_MANAGE_ROLES.has(userRole(state));
 }
 
 function text(value) {
@@ -1294,17 +1299,18 @@ function drawerActionButtons(row, state) {
   const status = text(row?.status) || 'draft';
   const role = state ? String(state?.user?.display_role || state?.user?.role || '').trim() : '';
   const isAdminRole = role === 'admin';
+  const canManage = PROPOSALS_AGREEMENTS_MANAGE_ROLES.has(role);
   const buttons = [];
 
   buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-preview="${escapeHtml(row.id)}">תצוגה מקדימה</button>`);
 
-  if (['draft', 'returned_for_changes'].includes(status) || isAdminRole) {
+  if (canManage && (['draft', 'returned_for_changes'].includes(status) || isAdminRole)) {
     buttons.push(`<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-edit-row="${escapeHtml(row.id)}">עריכה</button>`);
   }
-  if (['draft', 'returned_for_changes'].includes(status)) {
+  if (canManage && ['draft', 'returned_for_changes'].includes(status)) {
     buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-edit-document="${escapeHtml(row.id)}">עריכת מסמך</button>`);
   }
-  if (['draft', 'returned_for_changes'].includes(status) && !isAdminRole) {
+  if (canManage && ['draft', 'returned_for_changes'].includes(status) && !isAdminRole) {
     buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="pending_approval" data-pa-action-id="${escapeHtml(row.id)}">שליחה לאישור</button>`);
   }
   if (isAdminRole) {
@@ -1475,6 +1481,7 @@ export const proposalsAgreementsScreen = {
       return dsScreenStack(`${dsPageHeader('הצעות מחיר', 'גישה מוגבלת למורשים בלבד')}${dsEmptyState('אין לך הרשאה לצפות במסך זה')}`);
     }
     const rows = displayRows(data, {});
+    const canManage = canManageProposalsAgreements(state);
     const rawRows = Array.isArray(data?.rows) ? data.rows.map(normalizeProposalAgreementRow) : [];
     return dsScreenStack(`
       ${dsPageHeader('הצעות מחיר')}
@@ -1483,7 +1490,7 @@ export const proposalsAgreementsScreen = {
           <label class="ds-pa-search"><span>חיפוש</span><input class="ds-input ds-input--sm" data-pa-search placeholder="חיפוש מקומי" autocomplete="off"></label>
           ${filterSelectHtml('activity_type_group', 'סוג הצעה', ACTIVITY_TYPE_GROUP_OPTIONS)}
           ${statusFilterHtml()}
-          <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-add>+ הצעה חדשה</button>
+          ${canManage ? '<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-pa-add>+ הצעה חדשה</button>' : ''}
         </div>
         <div class="ds-pa-local-status" aria-live="polite">מציג <strong data-pa-results-count>${rows.length}</strong> רשומות</div>
         <div data-pa-form-host hidden></div>
@@ -1494,6 +1501,7 @@ export const proposalsAgreementsScreen = {
   },
   bind({ root, data, state, api }) {
     if (!root || data?.unauthorized || !canAccessProposalsAgreements(state)) return;
+    const canManage = canManageProposalsAgreements(state);
     if (root._paAbort) root._paAbort.abort();
     const abortController = new AbortController();
     root._paAbort = abortController;
@@ -1931,7 +1939,7 @@ export const proposalsAgreementsScreen = {
     };
 
     // ── Add button ────────────────────────────────────────────────────────────
-    root.querySelector('[data-pa-add]')?.addEventListener('click', () => openForm('add'), { signal });
+    if (canManage) root.querySelector('[data-pa-add]')?.addEventListener('click', () => openForm('add'), { signal });
 
     // ── Input handler (items calc) ────────────────────────────────────────────
     root.addEventListener('input', (event) => {
@@ -2018,6 +2026,7 @@ export const proposalsAgreementsScreen = {
 
       const editBtn = event.target.closest?.('[data-pa-edit-row]');
       if (editBtn) {
+        if (!canManage) return;
         const row = rowWithCentralContact(data.rows.find((item) => text(item.id) === text(editBtn.dataset.paEditRow)));
         const host = root.querySelector('[data-pa-inline-form]');
         if (host && row) {
@@ -2045,6 +2054,7 @@ export const proposalsAgreementsScreen = {
 
       const editDocumentBtn = event.target.closest?.('[data-pa-edit-document]');
       if (editDocumentBtn) {
+        if (!canManage) return;
         const id = text(editDocumentBtn.dataset.paEditDocument);
         const row = data.rows.find((r) => text(r.id) === id);
         if (!row || text(row.status) === 'approved') return;
@@ -2072,6 +2082,7 @@ export const proposalsAgreementsScreen = {
 
       const docSaveBtn = event.target.closest?.('[data-pa-doc-save]');
       if (docSaveBtn) {
+        if (!canManage) return;
         const id = text(docSaveBtn.dataset.paDocSave);
         const row = data.rows.find((r) => text(r.id) === id);
         const wrap = docSaveBtn.closest('[data-pa-doc-edit-wrap]');
@@ -2096,6 +2107,7 @@ export const proposalsAgreementsScreen = {
 
       const docResetBtn = event.target.closest?.('[data-pa-doc-reset]');
       if (docResetBtn) {
+        if (!canManage) return;
         const id = text(docResetBtn.dataset.paDocReset);
         const row = data.rows.find((r) => text(r.id) === id);
         if (!row) return;
@@ -2155,6 +2167,7 @@ export const proposalsAgreementsScreen = {
 
       const statusActionBtn = event.target.closest?.('[data-pa-status-action]');
       if (statusActionBtn) {
+        if (!canManage) return;
         const newStatus = text(statusActionBtn.dataset.paStatusAction);
         const id = text(statusActionBtn.dataset.paActionId);
         if (!newStatus || !id) return;

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -12,6 +12,7 @@ export const HEBREW_ROLE = {
   finance: 'כספים',
   activities_manager: 'מנהל/ת פעילויות',
   domain_manager: 'מנהל/ת תחום',
+  business_development_manager: 'מנהלת פיתוח עסקי',
   instructor_manager: 'מנהל/ת הדרכה / מדריך/ת מנהל/ת'
 };
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -7853,8 +7853,8 @@ select.ds-input {
 .ds-activities-view-switcher {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  gap: 4px;
+  justify-content: center;
+  gap: 6px;
   padding: 0 4px 4px;
   direction: rtl;
 }
@@ -8487,14 +8487,14 @@ select.ds-input {
   table-layout: fixed;
 }
 
-.ds-table--activities-list col.ds-activities-col--program   { width: 11%; }
-.ds-table--activities-list col.ds-activities-col--authority  { width: 10%; }
-.ds-table--activities-list col.ds-activities-col--school     { width: 10%; }
-.ds-table--activities-list col.ds-activities-col--instructor { width: 11%; }
+.ds-table--activities-list col.ds-activities-col--program   { width: 13%; }
+.ds-table--activities-list col.ds-activities-col--authority  { width: 11%; }
+.ds-table--activities-list col.ds-activities-col--school     { width: 11%; }
+.ds-table--activities-list col.ds-activities-col--instructor { width: 12%; }
 .ds-table--activities-list col.ds-activities-col--manager    { width: 10%; }
 .ds-table--activities-list col.ds-activities-col--date       { width: 9%; }
 .ds-table--activities-list col.ds-activities-col--meetings   { width: 9%; }
-.ds-table--activities-list col.ds-activities-col--notes      { width: 31%; }
+.ds-table--activities-list col.ds-activities-col--notes      { width: 25%; }
 
 .ds-table--activities-list th,
 .ds-table--activities-list td {
@@ -11893,7 +11893,9 @@ select.ds-input {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
-  margin: 4px 0 10px;
+  justify-content: center;
+  margin: 4px auto 10px;
+  text-align: center;
 }
 .ds-activities-period-tab {
   display: inline-flex;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 538;
+const CACHE_VERSION = 539;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260602_add_business_development_manager_role.sql
+++ b/supabase/migrations/20260602_add_business_development_manager_role.sql
@@ -1,0 +1,138 @@
+-- Add the business_development_manager role without changing existing roles.
+
+alter table public.users
+  drop constraint if exists users_role_check;
+
+alter table public.users
+  add constraint users_role_check check (
+    role in (
+      'admin',
+      'operation_manager',
+      'authorized_user',
+      'instructor',
+      'finance',
+      'activities_manager',
+      'domain_manager',
+      'instructor_manager',
+      'business_development_manager'
+    )
+  );
+
+-- Keep login RPC validation aligned with users_role_check so this role does not fail with invalid_role.
+drop function if exists public.login_user_by_entry_code(text, text);
+create function public.login_user_by_entry_code(p_login text, p_entry_code text)
+returns table (
+  status text,
+  user_id text,
+  email text,
+  name text,
+  role text,
+  emp_id text,
+  is_active boolean,
+  permissions jsonb,
+  created_at timestamptz,
+  updated_at timestamptz
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with input as (
+    select trim(coalesce(p_login, '')) as login, trim(coalesce(p_entry_code, '')) as code
+  ), candidate as (
+    select u.*
+    from public.users u
+    cross join input i
+    where u.user_id = i.login
+       or u.email = i.login
+       or u.emp_id = i.login
+    order by case
+      when u.user_id = i.login then 1
+      when u.email = i.login then 2
+      when u.emp_id = i.login then 3
+      else 4
+    end, u.created_at desc
+    limit 1
+  ), diagnostic as (
+    select
+      case
+        when (select i.login from input i) = '' or (select i.code from input i) = '' then 'missing_user_id_or_entry_code'
+        when not exists (select 1 from candidate) then 'user_not_found'
+        when not (select c.is_active from candidate c) then 'inactive_user'
+        when trim(coalesce((select c.entry_code from candidate c), '')) <> (select i.code from input i) then 'entry_code_mismatch'
+        when coalesce((select c.role from candidate c), '') not in (
+          'admin',
+          'operation_manager',
+          'authorized_user',
+          'instructor',
+          'finance',
+          'activities_manager',
+          'domain_manager',
+          'instructor_manager',
+          'business_development_manager'
+        ) then 'invalid_role'
+        else 'ok'
+      end as status
+  )
+  select
+    d.status,
+    case when d.status = 'ok' then c.user_id end as user_id,
+    case when d.status = 'ok' then c.email end as email,
+    case when d.status = 'ok' then c.name end as name,
+    case when d.status = 'ok' then c.role end as role,
+    case when d.status = 'ok' then c.emp_id end as emp_id,
+    case when d.status = 'ok' then c.is_active end as is_active,
+    case when d.status = 'ok' then c.permissions end as permissions,
+    case when d.status = 'ok' then c.created_at end as created_at,
+    case when d.status = 'ok' then c.updated_at end as updated_at
+  from diagnostic d
+  left join candidate c on true;
+$$;
+
+revoke all on function public.login_user_by_entry_code(text, text) from public;
+grant execute on function public.login_user_by_entry_code(text, text) to anon, authenticated;
+
+-- Proposals/agreements currently use one role predicate for read and write RLS policies.
+-- Add the new role to the existing predicate so the screen can load for this role.
+create or replace function public.app_can_use_proposals_agreements()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_current_role() in ('domain_manager', 'operation_manager', 'admin', 'business_development_manager'), false)
+$$;
+
+revoke all on function public.app_can_use_proposals_agreements() from public;
+grant execute on function public.app_can_use_proposals_agreements() to authenticated;
+
+-- Keep business_development_manager read-only in proposals/agreements at the database layer.
+create or replace function public.app_can_manage_proposals_agreements()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.app_current_role() in ('domain_manager', 'operation_manager', 'admin'), false)
+$$;
+
+revoke all on function public.app_can_manage_proposals_agreements() from public;
+grant execute on function public.app_can_manage_proposals_agreements() to authenticated;
+
+drop policy if exists proposals_agreements_insert_allowed_roles on public.proposals_agreements;
+drop policy if exists proposals_agreements_update_allowed_roles on public.proposals_agreements;
+
+create policy proposals_agreements_insert_allowed_roles
+on public.proposals_agreements
+for insert
+to authenticated
+with check (public.app_can_manage_proposals_agreements());
+
+create policy proposals_agreements_update_allowed_roles
+on public.proposals_agreements
+for update
+to authenticated
+using (public.app_can_manage_proposals_agreements())
+with check (public.app_can_manage_proposals_agreements());

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 538;
+const SW_ENTRY_VERSION = 539;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -184,7 +184,7 @@ test('activities quick filters include one-day summer rows by family and distric
   assert.doesNotMatch(html, /תוכנית שנתית/);
 });
 
-test('activities period tabs split rows by start_date and default to summer 2026', () => {
+test('activities period tabs split rows by start_date and default to school 2026', () => {
   const state = baseState();
   delete state.activityPeriodTab;
   const data = {
@@ -199,11 +199,11 @@ test('activities period tabs split rows by start_date and default to summer 2026
   const html = activitiesScreen.render(data, { state });
 
   assert.match(html, /data-activity-period-tab="school_2026"[\s\S]*תשפ״ו \/ 2026[\s\S]*<strong>1<\/strong>/);
-  assert.match(html, /aria-selected="true" data-activity-period-tab="summer_2026"/);
+  assert.match(html, /aria-selected="true" data-activity-period-tab="school_2026"/);
   assert.match(html, /data-activity-period-tab="school_2027"[\s\S]*<strong>1<\/strong>/);
   assert.match(html, /data-activity-period-tab="archive"[\s\S]*<strong>1<\/strong>/);
-  assert.match(html, /פעילות יולי/);
-  assert.doesNotMatch(html, /פעילות יוני/);
+  assert.match(html, /פעילות יוני/);
+  assert.doesNotMatch(html, /פעילות יולי/);
   assert.doesNotMatch(html, /פעילות ספטמבר/);
   assert.doesNotMatch(html, /פעילות סגורה/);
   assert.doesNotMatch(html, /כל הפעילויות/);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -57,8 +57,9 @@ const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
 const ACT_NAV_FILE = new URL('../frontend/src/screens/shared/act-nav-grid.js', import.meta.url);
 const SCREEN_FILE = new URL('../frontend/src/screens/proposals-agreements.js', import.meta.url);
 const MIGRATION_FILE = new URL('../supabase/migrations/20260518_create_proposals_agreements.sql', import.meta.url);
+const ROLE_UPDATE_MIGRATION_FILE = new URL('../supabase/migrations/20260602_add_business_development_manager_role.sql', import.meta.url);
 
-const { proposalsAgreementsScreen, canAccessProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS } = await import('../frontend/src/screens/proposals-agreements.js');
+const { proposalsAgreementsScreen, canAccessProposalsAgreements, canManageProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS } = await import('../frontend/src/screens/proposals-agreements.js');
 
 function stateFor(role) {
   return {
@@ -128,9 +129,10 @@ const sampleContactOptions = [
   }
 ];
 
-test('screen authorization allows only domain_manager, operation_manager and admin', () => {
-  for (const role of ['domain_manager', 'operation_manager', 'admin']) {
+test('screen authorization includes business development manager', () => {
+  for (const role of ['domain_manager', 'operation_manager', 'admin', 'business_development_manager']) {
     assert.equal(canAccessProposalsAgreements(stateFor(role)), true, `${role} should be allowed`);
+    assert.equal(canManageProposalsAgreements(stateFor(role)), role !== 'business_development_manager', `${role} management access mismatch`);
     const html = proposalsAgreementsScreen.render({ rows: [] }, { state: stateFor(role) });
     assert.match(html, /הצעות/);
     assert.doesNotMatch(html, /אין לך הרשאה/);
@@ -151,8 +153,21 @@ test('proposals-agreements route is registered and role-gated in route definitio
   assert.match(apiSource, /admin: \[[^\]]*'proposals-agreements'/);
   assert.match(apiSource, /operation_manager: \[[^\]]*'proposals-agreements'/);
   assert.match(apiSource, /domain_manager: \[[^\]]*'proposals-agreements'/);
+  assert.match(apiSource, /business_development_manager: \[[^\]]*'proposals-agreements'/);
   assert.doesNotMatch(apiSource, /authorized_user: \[[^\]]*'proposals-agreements'/);
   assert.doesNotMatch(apiSource, /instructor: \[[^\]]*'proposals-agreements'/);
+});
+
+
+
+test('role update migration allows business development manager for login and proposals', async () => {
+  const migration = await readFile(ROLE_UPDATE_MIGRATION_FILE, 'utf8');
+  assert.match(migration, /users_role_check check[\s\S]*'business_development_manager'/);
+  assert.match(migration, /login_user_by_entry_code[\s\S]*'business_development_manager'[\s\S]*then 'invalid_role'/);
+  assert.match(migration, /app_current_role\(\) in \('domain_manager', 'operation_manager', 'admin', 'business_development_manager'\)/);
+  assert.match(migration, /app_can_manage_proposals_agreements[\s\S]*app_current_role\(\) in \('domain_manager', 'operation_manager', 'admin'\)/);
+  assert.match(migration, /for insert[\s\S]*with check \(public\.app_can_manage_proposals_agreements\(\)\)/);
+  assert.match(migration, /for update[\s\S]*using \(public\.app_can_manage_proposals_agreements\(\)\)/);
 });
 
 test('table structure includes all required columns including status', () => {


### PR DESCRIPTION
### Motivation
- Introduce a new read-only business role `business_development_manager` so business users can view catalog, orders, proposals/agreements and activity-related screens without edit/admin rights.
- Apply small, focused UI/usability fixes for activities/dashboard screens and ensure clients receive fresh assets after deploy by bumping SW cache version.

### Description
- Add `business_development_manager` to the valid role set and route map (`VALID_SUPABASE_ROLES`, `SUPABASE_ROLE_ROUTES`) and include it in permission UI options (`PERMISSION_ROLE_OPTIONS`) and Hebrew labels (`HEBREW_ROLE`). Files: `frontend/src/api.js`, `frontend/src/screens/permissions.js`, `frontend/src/screens/shared/ui-hebrew.js`.
- Create server migration `supabase/migrations/20260602_add_business_development_manager_role.sql` that updates the `users.role` CHECK, login RPC validation and RLS predicates, and introduces a read/write split for proposals/agreements so the new role can view but not modify proposals. (adds `app_can_use_proposals_agreements` and `app_can_manage_proposals_agreements`).
- Split proposals/agreements checks into read vs manage (`PROPOSALS_AGREEMENTS_ALLOWED_ROLES` vs `PROPOSALS_AGREEMENTS_MANAGE_ROLES`) and gate write API functions to the manage predicate; keep viewing allowed for `business_development_manager`. Files: `frontend/src/api.js`, `frontend/src/screens/proposals-agreements.js`.
- Enforce conservative defaults for the new role in `roleDefaults` and when creating/updating users so it has viewing access only and no add/edit/request/review/admin/finance rights. File: `frontend/src/api.js`.
- Activities UI/UX tweaks: default activity period tab changed to `school_2026` (תשפ"ו / 2026) while preserving manual selection, center the week/month view switcher and activity period tabs, slightly widen program/authority/school/instructor columns and narrow `notes`, and ensure `addActivity` payloads derive `source`, `activity_family` and `item_type` automatically from visible selections. Files: `frontend/src/screens/activities.js`, `frontend/src/styles/main.css`.
- Dashboard default month handling: when no valid `state.dashboardMonthYm` is set use the current month (`currentMonthYm()`) rather than an earlier fallback. File: `frontend/src/screens/dashboard.js`.
- Bump Service Worker cache/import version to `539` and rebuild distributed assets so browsers pick up the UI/permission changes. Files: `frontend/sw.js`, `sw.js`, `dist/*`.

### Testing
- Ran focused verification with `npm run check:changed` which performs `node --check` and targeted tests; all focused checks passed.
- Ran the screen/unit tests used during development: `node --test tests/activities-screen.test.mjs`, `node --test tests/service-worker-pwa-cache.test.mjs`, and updated `tests/proposals-agreements-screen.test.mjs`; all focused tests passed with no failures.
- Built production assets with `npm run build` and ran `npm run check:build`; build completed successfully (Vite produced a large JS chunk warning only) and SW cache versions were bumped consistently in both `frontend/sw.js` and the root `sw.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f52fe94b8832babff32d13e7ecb5c)