### PR TITLE
הוספת מנגנון 'פריסת פעילות' (הפקת מסמך קיץ)

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 539;
+const CACHE_VERSION = 540;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-jK7gFIuc.js",
+  "./assets/index-CQ3oDfK4.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-jK7gFIuc.js"></script>
+  <script type="module" crossorigin src="./assets/index-CQ3oDfK4.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-edU4PRxs.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 539;
+const CACHE_VERSION = 540;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-jK7gFIuc.js",
+  "./assets/index-CQ3oDfK4.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -42,6 +42,7 @@ const MUTATING_ACTIONS = {
   updateProposalAgreementStatus: true,
   deleteProposalAgreement: true,
   saveProposalAgreementItems: true
+  ,saveActivityLayoutStatus: true
   ,deleteActivity: true
 };
 
@@ -66,6 +67,7 @@ const READ_ACTIONS = {
   editRequests: true,
   permissions: true,
   proposalsAgreements: true,
+  activityLayoutStatuses: true,
   adminSettings: true,
   adminLists: true,
   listSheets: true,
@@ -2974,6 +2976,39 @@ export const api = {
     const supabaseData = await readActivitiesFromSupabase(resolvedFilters);
     if (supabaseData) return normalizeData(supabaseData);
     return normalizeData(buildSupabaseErrorPayload({ rows: [] }, 'activities_supabase_failed', { filters: resolvedFilters }));
+  },
+  activityLayoutStatuses: async (payload = {}) => {
+    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    if (!['admin', 'operation_manager'].includes(role)) throw new Error('activity_layout_forbidden');
+    const season = String(payload?.season || 'summer_2026').trim() || 'summer_2026';
+    const { data, error } = await supabase
+      .from('activity_layout_statuses')
+      .select('season,authority,school,sent,sent_at,sent_by')
+      .eq('season', season);
+    if (error) throw new Error(error.message || 'activity_layout_statuses_read_failed');
+    return { rows: Array.isArray(data) ? data : [], _source: 'supabase' };
+  },
+  saveActivityLayoutStatus: async (payload = {}) => {
+    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    if (!['admin', 'operation_manager'].includes(role)) throw new Error('activity_layout_forbidden');
+    const row = {
+      season: String(payload?.season || 'summer_2026').trim() || 'summer_2026',
+      authority: String(payload?.authority || '').trim(),
+      school: String(payload?.school || '').trim(),
+      sent: payload?.sent === true || String(payload?.sent || '').trim().toLowerCase() === 'yes',
+      sent_at: payload?.sent_at || new Date().toISOString(),
+      sent_by: String(payload?.sent_by || state?.user?.full_name || state?.user?.user_id || '').trim()
+    };
+    if (!row.authority || !row.school) throw new Error('missing_activity_layout_status_fields');
+    const { data, error } = await supabase
+      .from('activity_layout_statuses')
+      .upsert(row, { onConflict: 'season,authority,school' })
+      .select('season,authority,school,sent,sent_at,sent_by')
+      .single();
+    if (error) throw new Error(error.message || 'activity_layout_status_save_failed');
+    clearScreenDataCache();
+    deletePersistedCacheByPrefixes(['activities:']);
+    return { ok: true, row: data || row };
   },
   activityDetail: (source_row_id, source_sheet) => readActivityDetailFromSupabase(source_row_id, source_sheet),
   activityDates: (source_row_id, source_sheet) => readActivityDatesFromSupabase(source_row_id, source_sheet),

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -40,6 +40,7 @@ import { rowMatchesActivityGapFilter } from './shared/activity-gap-filter.js';
 import { renderActivitiesViewSwitcher, bindActivitiesViewSwitcher } from './shared/view-switcher.js';
 import { ACTIVITY_SEASON_OPTIONS, normalizeActivitySeason } from './shared/summer-activity.js';
 import { showToast } from './shared/toast.js';
+import taasiyedaLogoSrc from '../../assets/logo1.png';
 
 const inflightActivityDetailRequests = new Map();
 const ADD_ACTIVITY_TYPE_ORDER = ['workshop', 'escape_room', 'tour', 'after_school'];
@@ -52,6 +53,8 @@ const ACTIVITY_PERIOD_TABS = [
 ];
 const DEFAULT_ACTIVITY_PERIOD_TAB = 'school_2026';
 const INACTIVE_ACTIVITY_STATUSES = new Set(['סגור', 'נמחק', 'closed', 'deleted', 'inactive']);
+const ACTIVITY_LAYOUT_SEASON = 'summer_2026';
+const ACTIVITY_LAYOUT_ALLOWED_ROLES = new Set(['admin', 'operation_manager']);
 
 function normalizeActivityPeriodTab(value) {
   const key = String(value || '').trim();
@@ -731,6 +734,233 @@ function nextMeetingDate(row) {
   return future.length ? future[0] : '';
 }
 
+function canUseActivityLayout(state) {
+  const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+  return ACTIVITY_LAYOUT_ALLOWED_ROLES.has(role);
+}
+
+function cleanText(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function normalizeTime(value) {
+  const raw = cleanText(value);
+  const match = raw.match(/(\d{1,2})[:.](\d{2})/);
+  if (!match) return raw;
+  return `${String(match[1]).padStart(2, '0')}:${match[2]}`;
+}
+
+function activityLayoutDate(row = {}) {
+  const direct = cleanText(row.activity_date || row.date || row.start_date || row.date_start).slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(direct)) return direct;
+  const cols = Array.isArray(row.meeting_dates) ? row.meeting_dates : Array.isArray(row.date_cols) ? row.date_cols : [];
+  const first = cols.map((d) => cleanText(d).slice(0, 10)).filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)).sort()[0];
+  return first || '';
+}
+
+function activityLayoutStartTime(row = {}) {
+  return normalizeTime(row.start_time || row.time_start || row.activity_start_time || row.hour_start || row.from_time);
+}
+
+function activityLayoutEndTime(row = {}) {
+  return normalizeTime(row.end_time || row.time_end || row.activity_end_time || row.hour_end || row.to_time);
+}
+
+function activityLayoutInstructors(row = {}) {
+  return [row.instructor_name, row.instructor_name_2, row.Instructor, row.Instructor2]
+    .map(cleanText)
+    .filter(Boolean)
+    .filter((value, index, arr) => arr.indexOf(value) === index)
+    .join(', ');
+}
+
+function isActivityLayoutRowComplete(row = {}) {
+  return Boolean(
+    cleanText(row.school) &&
+    cleanText(row.authority) &&
+    activityLayoutDate(row) &&
+    activityLayoutStartTime(row) &&
+    activityLayoutEndTime(row) &&
+    cleanText(row.activity_name) &&
+    activityLayoutInstructors(row)
+  );
+}
+
+function formatActivityLayoutDate(date) {
+  const raw = cleanText(date).slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const [y, m, d] = raw.split('-');
+  return `${d}.${m}.${y}`;
+}
+
+function formatActivityLayoutDateRange(dates = []) {
+  const safe = dates.filter(Boolean).sort();
+  if (!safe.length) return '—';
+  const first = formatActivityLayoutDate(safe[0]);
+  const last = formatActivityLayoutDate(safe[safe.length - 1]);
+  return first === last ? first : `${first}–${last}`;
+}
+
+function activityLayoutStatusKey({ season = ACTIVITY_LAYOUT_SEASON, authority = '', school = '' } = {}) {
+  return [season, authority, school].map(cleanText).join('||');
+}
+
+function localActivityLayoutStatuses() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem('ds_activity_layout_statuses') || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeLocalActivityLayoutStatus(row) {
+  try {
+    const rows = localActivityLayoutStatuses();
+    const key = activityLayoutStatusKey(row);
+    const next = rows.filter((item) => activityLayoutStatusKey(item) !== key);
+    next.push(row);
+    localStorage.setItem('ds_activity_layout_statuses', JSON.stringify(next));
+  } catch {
+    /* local persistence is best-effort fallback only */
+  }
+}
+
+function activityLayoutStatusesMap(rows = []) {
+  const map = new Map();
+  (Array.isArray(rows) ? rows : []).forEach((row) => {
+    const key = activityLayoutStatusKey(row);
+    if (key) map.set(key, row);
+  });
+  return map;
+}
+
+function readyActivityLayoutSchools(rows = [], statuses = []) {
+  const groups = new Map();
+  const schoolsWithIncompleteRows = new Set();
+  (Array.isArray(rows) ? rows : []).forEach((row) => {
+    const authority = cleanText(row.authority);
+    const school = cleanText(row.school);
+    if (school && !isActivityLayoutRowComplete(row)) schoolsWithIncompleteRows.add(school);
+    if (!authority || !school) return;
+    const key = activityLayoutStatusKey({ authority, school });
+    if (!groups.has(key)) groups.set(key, { season: ACTIVITY_LAYOUT_SEASON, authority, school, rows: [], dates: [] });
+    const group = groups.get(key);
+    group.rows.push(row);
+    const date = activityLayoutDate(row);
+    if (date) group.dates.push(date);
+  });
+  const statusMap = activityLayoutStatusesMap(statuses);
+  return [...groups.values()]
+    .filter((group) => group.rows.length && !schoolsWithIncompleteRows.has(group.school) && group.rows.every(isActivityLayoutRowComplete))
+    .map((group) => ({
+      ...group,
+      count: group.rows.length,
+      dateRange: formatActivityLayoutDateRange(group.dates),
+      status: statusMap.get(activityLayoutStatusKey(group)) || null
+    }))
+    .sort((a, b) => cleanText(a.authority).localeCompare(cleanText(b.authority), 'he') || cleanText(a.school).localeCompare(cleanText(b.school), 'he'));
+}
+
+function activityLayoutRowsForDocument(group) {
+  return (Array.isArray(group?.rows) ? group.rows : [])
+    .map((row) => ({
+      date: activityLayoutDate(row),
+      startTime: activityLayoutStartTime(row),
+      endTime: activityLayoutEndTime(row),
+      activityName: cleanText(row.activity_name),
+      instructors: activityLayoutInstructors(row)
+    }))
+    .sort((a, b) => String(a.date).localeCompare(String(b.date)) || String(a.startTime).localeCompare(String(b.startTime)));
+}
+
+function cleanDocumentTitlePart(value) {
+  return cleanText(value)
+    .replace(/["“”]/g, '')
+    .replace(/[\\/:*?<>|]/g, '')
+    .replace(/\s{2,}/g, ' ');
+}
+
+function activityLayoutDocumentTitle(group) {
+  return cleanDocumentTitlePart(`פריסת פעילות - ${group?.school || ''} - ${group?.authority || ''}`);
+}
+
+function activityLayoutDocumentHtml(group) {
+  const rows = activityLayoutRowsForDocument(group);
+  const title = activityLayoutDocumentTitle(group);
+  const tableRows = rows.map((row) => `<tr>
+    <td>${escapeHtml(formatActivityLayoutDate(row.date))}</td>
+    <td>${escapeHtml(row.startTime)}</td>
+    <td>${escapeHtml(row.endTime)}</td>
+    <td>${escapeHtml(row.activityName)}</td>
+    <td>${escapeHtml(row.instructors)}</td>
+  </tr>`).join('');
+  return `<!doctype html><html lang="he" dir="rtl"><head><meta charset="utf-8"><title>${escapeHtml(title)}</title><style>
+    @page { size: A4; margin: 16mm; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #eef2f7; color: #0f172a; font-family: Arial, "Noto Sans Hebrew", sans-serif; line-height: 1.65; }
+    .screen-actions { display: flex; justify-content: center; gap: 10px; padding: 18px; }
+    .print-btn { border: 0; border-radius: 999px; background: #2563eb; color: #fff; padding: 10px 18px; font-weight: 700; cursor: pointer; }
+    .doc { width: 210mm; min-height: 297mm; margin: 0 auto 24px; background: #fff; padding: 18mm; box-shadow: 0 16px 40px rgba(15,23,42,.16); }
+    .doc-logo { display: block; width: 145px; max-height: 70px; object-fit: contain; margin: 0 0 16px auto; }
+    h1 { margin: 0 0 18px; text-align: center; font-size: 24px; }
+    .meta { margin: 0 0 20px; font-size: 16px; }
+    .meta div { margin: 2px 0; }
+    p { margin: 0 0 14px; }
+    h2 { margin: 24px 0 10px; font-size: 18px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 14px; }
+    th, td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: right; vertical-align: top; }
+    th { background: #f1f5f9; font-weight: 700; }
+    .signature { margin-top: 24px; }
+    @media print { body { background: #fff; } .screen-actions { display: none !important; } .doc { width: auto; min-height: auto; margin: 0; padding: 0; box-shadow: none; } }
+  </style></head><body><div class="screen-actions"><button class="print-btn" type="button" onclick="window.print()">הדפסה / שמירה כ־PDF</button></div><main class="doc">
+    <img class="doc-logo" src="${escapeHtml(taasiyedaLogoSrc)}" alt="תעשיידע">
+    <h1>פריסת פעילות</h1>
+    <section class="meta" aria-label="פרטי לקוח">
+      <div><strong>לכבוד:</strong> </div>
+      <div><strong>בית ספר:</strong> ${escapeHtml(group?.school || '')}</div>
+      <div><strong>רשות:</strong> ${escapeHtml(group?.authority || '')}</div>
+    </section>
+    <p>שלום רב,</p>
+    <p>בהמשך לתיאום ולשיבוץ הפעילויות מול בית הספר, מצורפת פריסת הפעילויות המתוכננת במסגרת קיץ תשפ"ו | 2026.</p>
+    <p>נבקש לעבור על הפריסה ולעדכן את צוות תעשיידע מראש במקרה של שינוי בלוחות הזמנים, בהרכב הקבוצות, במיקום הפעילות או בכל צורך תפעולי אחר, כדי שנוכל להיערך בהתאם.</p>
+    <h2>טבלת פריסת הפעילות</h2>
+    <table><thead><tr><th>תאריך</th><th>שעת התחלה</th><th>שעת סיום</th><th>פעילות / סדנה</th><th>מדריך</th></tr></thead><tbody>${tableRows}</tbody></table>
+    <div class="signature">בברכה,<br>תעשיידע</div>
+  </main></body></html>`;
+}
+
+function openActivityLayoutDocument(group) {
+  const html = activityLayoutDocumentHtml(group);
+  const title = activityLayoutDocumentTitle(group);
+  const win = window.open('', '_blank');
+  if (!win) {
+    showToast('הדפדפן חסם פתיחת חלון חדש. יש לאפשר חלונות קופצים ולנסות שוב.', 'error');
+    return;
+  }
+  win.document.open();
+  win.document.write(html);
+  win.document.close();
+  try { win.document.title = title; } catch { /* ignore */ }
+}
+
+function activityLayoutListHtml(groups = []) {
+  const rows = (Array.isArray(groups) ? groups : []).map((group) => {
+    const status = group.status?.sent ? `✓ נשלח${group.status?.sent_at ? ` — ${escapeHtml(formatActivityLayoutDate(cleanText(group.status.sent_at).slice(0, 10)))}` : ''}` : 'לא נשלח';
+    const key = encodeURIComponent(activityLayoutStatusKey(group));
+    return `<tr>
+      <td><button type="button" class="ds-link-btn" data-activity-layout-open="${key}">${escapeHtml(group.school)}</button></td>
+      <td>${escapeHtml(group.authority)}</td>
+      <td>${escapeHtml(String(group.count || 0))}</td>
+      <td>${escapeHtml(group.dateRange || '—')}</td>
+      <td><span class="ds-chip ds-chip--status${group.status?.sent ? ' ds-chip--ok' : ''}">${status}</span></td>
+      <td class="ds-actions-cell"><button type="button" class="ds-btn ds-btn--sm" data-activity-layout-open="${key}">הפק מסמך</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activity-layout-sent="${key}">סמן כנשלח</button></td>
+    </tr>`;
+  }).join('');
+  if (!rows) return '<div class="ds-empty" dir="rtl"><p class="ds-empty__msg">אין בתי ספר מוכנים להפקת פריסת פעילות בשלב זה.</p></div>';
+  return dsTableWrap(`<table class="ds-table" dir="rtl"><thead><tr><th>בית ספר</th><th>רשות</th><th>מספר פעילויות</th><th>טווח תאריכים</th><th>סטטוס שליחה</th><th>פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
+}
+
 export const activitiesScreen = {
   async load({ api, state }) {
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
@@ -756,6 +986,7 @@ export const activitiesScreen = {
     const canDeleteActivity = ['admin', 'operation_manager'].includes(role);
     const canAddActivity = !!state?.user?.can_add_activity || role === 'operation_manager' || role === 'admin';
     const isAdmin = isAdminUser(state);
+    const canUseLayout = canUseActivityLayout(state) && state.activityPeriodTab === ACTIVITY_LAYOUT_SEASON;
 
     const rosterUsers = getRosterUsers(state?.clientSettings || {});
     const instructorByEmpId = rosterUsers.reduce((acc, user) => {
@@ -855,6 +1086,7 @@ export const activitiesScreen = {
       ${bareFilters}
       <div class="ds-activities-main-toolbar__actions">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
+        ${canUseLayout ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activity-layout-list title="פריסת פעילות לבתי ספר עם שיבוץ מלא">פריסת פעילות</button>` : ''}
         ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-export-all title="ייצוא הפעילויות בלשונית הפעילה לאקסל">ייצוא לאקסל</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-admin-summary title="סיכום אדמין ללשונית הפעילה">סיכום אדמין</button>` : ''}
         ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">+</button>` : ''}
       </div>
@@ -920,6 +1152,59 @@ export const activitiesScreen = {
     const activitiesRows = Array.isArray(data?.rows) ? data.rows : [];
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
     const periodRows = activityPeriodRows(activitiesRows, state.activityPeriodTab);
+    let activityLayoutGroups = [];
+
+    async function loadActivityLayoutStatuses() {
+      if (!canUseActivityLayout(state)) return localActivityLayoutStatuses();
+      if (typeof api?.activityLayoutStatuses !== 'function') return localActivityLayoutStatuses();
+      try {
+        const res = await api.activityLayoutStatuses({ season: ACTIVITY_LAYOUT_SEASON });
+        return Array.isArray(res?.rows) ? res.rows : localActivityLayoutStatuses();
+      } catch (err) {
+        console.warn('[activity-layout] status read failed; using local fallback', err);
+        return localActivityLayoutStatuses();
+      }
+    }
+
+    function groupByActivityLayoutKey(key) {
+      const decoded = cleanText(decodeURIComponent(String(key || '')));
+      return activityLayoutGroups.find((group) => activityLayoutStatusKey(group) === decoded) || null;
+    }
+
+    async function renderActivityLayoutDrawerContent() {
+      const statuses = await loadActivityLayoutStatuses();
+      activityLayoutGroups = readyActivityLayoutSchools(activityPeriodRows(activitiesRows, ACTIVITY_LAYOUT_SEASON), statuses);
+      const content = document.querySelector('.ds-drawer__content');
+      if (content) content.innerHTML = activityLayoutListHtml(activityLayoutGroups);
+    }
+
+    async function markActivityLayoutSent(group, button) {
+      if (!group || !canUseActivityLayout(state)) return;
+      if (button) button.disabled = true;
+      const sentAt = new Date().toISOString();
+      const sentBy = cleanText(state?.user?.full_name || state?.user?.user_id || state?.user?.emp_id || '');
+      const row = {
+        season: ACTIVITY_LAYOUT_SEASON,
+        authority: group.authority,
+        school: group.school,
+        sent: true,
+        sent_at: sentAt,
+        sent_by: sentBy
+      };
+      try {
+        if (typeof api?.saveActivityLayoutStatus === 'function') {
+          await api.saveActivityLayoutStatus(row);
+        }
+        writeLocalActivityLayoutStatus(row);
+        await renderActivityLayoutDrawerContent();
+        showToast('סטטוס פריסת הפעילות סומן כנשלח.', 'success');
+      } catch (err) {
+        console.error('[activity-layout] save sent status failed', err);
+        showToast('שמירת סטטוס השליחה נכשלה.', 'error');
+      } finally {
+        if (button) button.disabled = false;
+      }
+    }
     const filteredRows      = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
     const canSeePrivateNotes = ['operation_manager', 'admin'].includes(state?.user?.display_role);
     const canEditActivity   = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
@@ -1169,6 +1454,36 @@ export const activitiesScreen = {
         btn.disabled = false;
       }
     });
+
+    root.querySelector('[data-activity-layout-list]')?.addEventListener('click', async (ev) => {
+      if (!canUseActivityLayout(state) || state.activityPeriodTab !== ACTIVITY_LAYOUT_SEASON || !ui) return;
+      const btn = ev.currentTarget;
+      btn.disabled = true;
+      ui.openDrawer({
+        title: 'פריסת פעילות',
+        content: '<div class="ds-loading-card" dir="rtl" role="status"><div class="ds-spinner" aria-hidden="true"></div><p>טוען בתי ספר מוכנים להפקה...</p></div>'
+      });
+      try {
+        await renderActivityLayoutDrawerContent();
+      } finally {
+        btn.disabled = false;
+      }
+    });
+
+    if (root._activityLayoutDocAbort) root._activityLayoutDocAbort.abort();
+    root._activityLayoutDocAbort = new AbortController();
+    document.addEventListener('click', async (ev) => {
+      const openBtn = ev.target.closest?.('[data-activity-layout-open]');
+      const sentBtn = ev.target.closest?.('[data-activity-layout-sent]');
+      if (!openBtn && !sentBtn) return;
+      if (!canUseActivityLayout(state)) return;
+      const group = groupByActivityLayoutKey((openBtn || sentBtn).getAttribute(openBtn ? 'data-activity-layout-open' : 'data-activity-layout-sent'));
+      if (!group) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      if (openBtn) openActivityLayoutDocument(group);
+      if (sentBtn) await markActivityLayoutSent(group, sentBtn);
+    }, { signal: root._activityLayoutDocAbort.signal });
 
     root.querySelectorAll('[data-activity-period-tab]').forEach((btn) => {
       btn.addEventListener('click', () => {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 539;
+const CACHE_VERSION = 540;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260602_create_activity_layout_statuses.sql
+++ b/supabase/migrations/20260602_create_activity_layout_statuses.sql
@@ -1,0 +1,59 @@
+-- Store manual send status for summer activity-layout documents per school + authority.
+
+create table if not exists public.activity_layout_statuses (
+  season text not null,
+  authority text not null,
+  school text not null,
+  sent boolean not null default false,
+  sent_at timestamptz,
+  sent_by text not null default '',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint activity_layout_statuses_pk primary key (season, authority, school),
+  constraint activity_layout_statuses_season_not_blank check (btrim(season) <> ''),
+  constraint activity_layout_statuses_authority_not_blank check (btrim(authority) <> ''),
+  constraint activity_layout_statuses_school_not_blank check (btrim(school) <> '')
+);
+
+create or replace function public.set_activity_layout_statuses_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists activity_layout_statuses_set_updated_at on public.activity_layout_statuses;
+create trigger activity_layout_statuses_set_updated_at
+before update on public.activity_layout_statuses
+for each row execute function public.set_activity_layout_statuses_updated_at();
+
+alter table public.activity_layout_statuses enable row level security;
+
+drop policy if exists activity_layout_statuses_select_ops on public.activity_layout_statuses;
+drop policy if exists activity_layout_statuses_insert_ops on public.activity_layout_statuses;
+drop policy if exists activity_layout_statuses_update_ops on public.activity_layout_statuses;
+
+create policy activity_layout_statuses_select_ops
+on public.activity_layout_statuses
+for select
+to authenticated
+using (public.app_is_admin_or_operation_manager());
+
+create policy activity_layout_statuses_insert_ops
+on public.activity_layout_statuses
+for insert
+to authenticated
+with check (public.app_is_admin_or_operation_manager());
+
+create policy activity_layout_statuses_update_ops
+on public.activity_layout_statuses
+for update
+to authenticated
+using (public.app_is_admin_or_operation_manager())
+with check (public.app_is_admin_or_operation_manager());
+
+revoke all on public.activity_layout_statuses from anon;
+grant select, insert, update on public.activity_layout_statuses to authenticated;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 539;
+const SW_ENTRY_VERSION = 540;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להוסיף בממשק הקיים כלי מהיר ופשוט להפקת מסמך פריסת פעילות להדפסה/שמירה כ‑PDF עבור בתי ספר עם שיבוץ קיץ מלא, בלי יצירת PDF אוטומטי בשרת או שליחת מיילים. 
- לאפשר רק לתפקידים `admin` ו־`operation_manager` לגשת למנגנון ולסמן ידנית ש־"נשלח" ברמת season+authority+school.

### Description
- הוספתי כפתור חדש בלוח הפעילויות (בלשונית הקיץ בלבד) בשם "פריסת פעילות" שמוצג רק למשתמשים עם תפקיד `admin` או `operation_manager` ובו רשימת בתי ספר שמסוננים כך שרק בתי ספר שכל פעילויות הקיץ שלהם מכילות את השדות הנדרשים (בית ספר, רשות, תאריך, שעת התחלה, שעת סיום, שם פעילות, מדריך) יוצגו.
- הוספתי לוגיקה בצד ה־frontend ליצירת עיבוד וקיבוץ לפי שדה `season+authority+school`, כולל מיון שורות לפי תאריך ושעת התחלה; יכולת לפתוח מסמך HTML נקי להדפסה/שמירה כ‑PDF עם כותרת (`document.title`) מותאמת ובדיקות ניקוי שם קובץ בסיסיות.
- הוספתי flow לשמירת סטטוס "נשלח" (fields: `season`, `authority`, `school`, `sent`, `sent_at`, `sent_by`) עם גיבוי ב־`localStorage` כשאין גישה ל־API; השמירה מבוצעת רק בלחיצה מפורשת על "סמן כנשלח".
- API: הוספתי קריאות מאובטחות ב־`frontend/src/api.js`: `activityLayoutStatuses` לקריאה ו־`saveActivityLayoutStatus` לשמירה (נגישות רק ל־`admin`/`operation_manager`).
- DB: הוספתי migration מינימלי `supabase/migrations/20260602_create_activity_layout_statuses.sql` שמוסיף את הטבלה `activity_layout_statuses` עם מפתח פריימרי `season, authority, school` ו‑RLS שמאפשר רק admin/operation_manager לקרוא/לכתוב.
- Service Worker: הגדלתי את `CACHE_VERSION` (539 → 540) ב־`frontend/sw.js` ו־`sw.js` כדי להבטיח ריענון קאש של ה־frontend לאחר פריסה.
- UI/UX: המסמך מיושר RTL, מותאם ל‑A4, כולל לוגו תעשיידע וחיץ הדפסה/שמירה כ‑PDF (כפתור שמפעיל `window.print()`; הכפתור מוסתר בהדפסה).
- קוד נשאר ממוקד ופשוט: אין מנגנון יצירת PDF בשרת, אין שליחת מיילים, אין העלאת קבצים, ואין שינוי הרשאות מעבר למה שנדרש להצגת הכפתור ולפעולות.

### Testing
- הרצת `npm run check:changed` — עבר ללא שגיאות על הקבצים ששונו.
- הרצת `npm run build` — build עבר בהצלחה (Vite סימן אזהרת גודל chunk אך ה־build הצליח וה‑dist נוצר). 
- בדקתי שה־Service Worker cache version עודכן ל־540 כך שהקבצים החדשים יכנסו לתוקף אחרי פריסה.
- לא בוצעו בדיקות ידניות בדפדפן בתוך המשימה הזאת (דרושה בדיקה ידנית על סביבת UI להשלמת רשימת הבדיקות שנקבעה בתתקנון), אך הקוד כולל fallback ל־`localStorage` למצב בו קריאה ל־API אינה זמינה.

שינויים עיקריים (קבצים): `frontend/src/screens/activities.js`, `frontend/src/api.js`, `supabase/migrations/20260602_create_activity_layout_statuses.sql`, `frontend/sw.js`, `sw.js` (cache bump) ובנייה של `dist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5818755c832baf807c26b4216c03)