### PR TITLE
Default activities to תשפ״ו (school_2026) and optimize contacts search (debounce + client-side)

### DIFF
--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -6,8 +6,7 @@ import {
   ensureActivityListFilters,
   prepareRowsForSearch,
   applyLocalFilters,
-  filtersToolbarHtml,
-  bindLocalFilters
+  filtersToolbarHtml
 } from './shared/activity-list-filters.js';
 import { getManagerUsers } from './shared/activity-options.js';
 
@@ -264,6 +263,16 @@ function renderLetterSection(letter, authoritiesMap) {
   </div>`;
 }
 
+function activeContactRows(tab, instrRows, schoolRows) {
+  return tab === 'instr' ? instrRows : schoolRows;
+}
+
+function contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr = true, canViewSchool = true) {
+  if (tab === 'instr' && canViewInstr) return instrTabHtml(instrRows, filters).body;
+  if (tab === 'school' && canViewSchool) return schoolTabHtml(schoolRows, filters).body;
+  return dsEmptyState('לא נמצאו אנשי קשר');
+}
+
 function schoolTabHtml(rows, filters) {
   const filtered = applyLocalFilters(rows, filters, { filterFields: [] });
   if (filtered.length === 0) return { filtered, body: dsEmptyState('לא נמצאו אנשי קשר') };
@@ -313,16 +322,9 @@ export const contactsScreen = {
     ).join('');
 
     let searchInput = '';
-    let listHtml    = '';
+    const listHtml = contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr, canViewSchool);
 
-    if (tab === 'instr' && canViewInstr) {
-      const { body } = instrTabHtml(instrRows, filters);
-      listHtml = body;
-    } else if (tab === 'school' && canViewSchool) {
-      const { body } = schoolTabHtml(schoolRows, filters);
-      listHtml = body;
-    }
-    searchInput = filtersToolbarHtml(CONTACTS_SCOPE, tab === 'instr' ? instrRows : schoolRows, state, {
+    searchInput = filtersToolbarHtml(CONTACTS_SCOPE, activeContactRows(tab, instrRows, schoolRows), state, {
       searchPlaceholder: 'חיפוש לפי שם / תפקיד / טלפון / מייל / רשות / בית ספר…',
       filterFields: [],
       search: true
@@ -350,8 +352,6 @@ export const contactsScreen = {
         rerender();
       });
     });
-    bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, { debounceMs: 150 });
-
     const bindCopyBtns = (container) => {
       container.querySelectorAll('[data-copy-email]').forEach((btn) => {
         if (btn._copyBound) return;
@@ -367,22 +367,86 @@ export const contactsScreen = {
         });
       });
     };
-    bindCopyBtns(root);
-
-    root.querySelectorAll('[data-alpha-btn]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const letter = btn.dataset.alphaBtn;
-        const isOpen = btn.getAttribute('aria-expanded') === 'true';
-        root.querySelectorAll('[data-alpha-btn]').forEach((b) => b.setAttribute('aria-expanded', 'false'));
-        root.querySelectorAll('[data-alpha-btn]').forEach((b) => b.classList.remove('is-active'));
-        root.querySelectorAll('[data-letter-section]').forEach((s) => { s.hidden = true; });
-        if (!isOpen) {
-          btn.setAttribute('aria-expanded', 'true');
-          btn.classList.add('is-active');
-          const section = root.querySelector(`[data-letter-section="${letter}"]`);
-          if (section) section.hidden = false;
-        }
+    const openInstructorDrawer = (action) => {
+      if (!action.startsWith('icontact:')) return;
+      const empId = decodeURIComponent(action.slice('icontact:'.length));
+      const hit = instrRows.find((r) => String(r.emp_id || '') === String(empId));
+      if (!hit) return;
+      ui.openDrawer({
+        title: hit.full_name || hit.emp_id || 'איש קשר',
+        content: instrDrawerHtml(hit, hideEmpIds)
       });
+      requestAnimationFrame(() => {
+        const drawer = document.querySelector('.ds-drawer__body, .ds-drawer, [data-drawer]');
+        if (drawer) bindCopyBtns(drawer);
+        else bindCopyBtns(document.body);
+      });
+    };
+
+    const bindAlphaBtns = (container = root) => {
+      container.querySelectorAll('[data-alpha-btn]').forEach((btn) => {
+        if (btn.dataset.alphaBound === 'yes') return;
+        btn.dataset.alphaBound = 'yes';
+        btn.addEventListener('click', () => {
+          const letter = btn.dataset.alphaBtn;
+          const isOpen = btn.getAttribute('aria-expanded') === 'true';
+          root.querySelectorAll('[data-alpha-btn]').forEach((b) => b.setAttribute('aria-expanded', 'false'));
+          root.querySelectorAll('[data-alpha-btn]').forEach((b) => b.classList.remove('is-active'));
+          root.querySelectorAll('[data-letter-section]').forEach((section) => { section.hidden = true; });
+          if (!isOpen) {
+            btn.setAttribute('aria-expanded', 'true');
+            btn.classList.add('is-active');
+            const section = root.querySelector(`[data-letter-section="${letter}"]`);
+            if (section) section.hidden = false;
+          }
+        });
+      });
+    };
+
+    const bindContactsListInteractions = (container = root) => {
+      bindCopyBtns(container);
+      bindAlphaBtns(container);
+      ui?.bindInteractiveCards(container, openInstructorDrawer);
+    };
+
+    bindContactsListInteractions(root);
+
+    const renderContactsListOnly = () => {
+      const listWrap = root.querySelector('.contacts-list-wrap');
+      if (!listWrap) return;
+      const currentTab = state?.contactsTab || (data?.can_view_instructors !== false ? 'instr' : 'school');
+      const filters = ensureActivityListFilters(state, CONTACTS_SCOPE);
+      listWrap.innerHTML = contactListHtml(currentTab, instrRows, schoolRows, filters, data?.can_view_instructors !== false, data?.can_view_schools !== false);
+      bindContactsListInteractions(listWrap);
+    };
+
+    const filters = ensureActivityListFilters(state, CONTACTS_SCOPE);
+    const searchInput = root.querySelector(`[data-filter-search="${CONTACTS_SCOPE}"]`);
+    const clearBtn = root.querySelector(`[data-filter-clear="${CONTACTS_SCOPE}"]`);
+    let searchTimer;
+    searchInput?.addEventListener('input', (ev) => {
+      const nextValue = ev.target?.value || '';
+      filters.q = nextValue;
+      clearTimeout(searchTimer);
+      const applySearch = () => {
+        filters.appliedQ = nextValue;
+        filters.visibleCount = 200;
+        renderContactsListOnly();
+      };
+      if (!nextValue.trim()) {
+        applySearch();
+        return;
+      }
+      searchTimer = setTimeout(applySearch, 200);
+    });
+    clearBtn?.addEventListener('click', () => {
+      clearTimeout(searchTimer);
+      filters.q = '';
+      filters.appliedQ = '';
+      filters.visibleCount = 200;
+      if (searchInput) searchInput.value = '';
+      renderContactsListOnly();
+      searchInput?.focus();
     });
 
     const decodePayload = (node) => {
@@ -499,51 +563,47 @@ export const contactsScreen = {
       };
     };
 
-    root.querySelectorAll('[data-contact-action]').forEach((btn) => {
-      btn.addEventListener('click', (ev) => {
+    root._contactsActionContext = {
+      instrRows,
+      schoolRows,
+      decodePayload,
+      openInstructorEditor,
+      openSchoolEditor
+    };
+    if (!root._contactsActionBound) {
+      root._contactsActionBound = true;
+      root.addEventListener('click', (ev) => {
+        const btn = ev.target?.closest?.('[data-contact-action]');
+        if (!btn || !root.contains(btn)) return;
         ev.preventDefault();
         ev.stopPropagation();
+        const ctx = root._contactsActionContext || {};
         const action = btn.dataset.contactAction;
         if (action === 'add-instr') {
-          openInstructorEditor({}, true);
+          ctx.openInstructorEditor?.({}, true);
           return;
         }
         if (action === 'add-school') {
-          openSchoolEditor({}, true);
+          ctx.openSchoolEditor?.({}, true);
           return;
         }
         if (action === 'edit-instr') {
-          const payload = decodePayload(btn);
-          const hit = instrRows.find((r) => String(r.emp_id || '') === String(payload.emp_id || ''));
-          if (hit) openInstructorEditor(hit, false);
+          const payload = ctx.decodePayload?.(btn) || {};
+          const hit = (ctx.instrRows || []).find((r) => String(r.emp_id || '') === String(payload.emp_id || ''));
+          if (hit) ctx.openInstructorEditor?.(hit, false);
           return;
         }
         if (action === 'edit-school') {
-          const payload = decodePayload(btn);
+          const payload = ctx.decodePayload?.(btn) || {};
           const idx = Number(payload._row_index);
           const hit = Number.isFinite(idx)
-            ? schoolRows.find((r) => Number(r._row_index) === idx)
+            ? (ctx.schoolRows || []).find((r) => Number(r._row_index) === idx)
             : null;
-          if (hit) openSchoolEditor(hit, false);
+          if (hit) ctx.openSchoolEditor?.(hit, false);
         }
       });
-    });
+    }
 
-    ui?.bindInteractiveCards(root, (action) => {
-      if (!action.startsWith('icontact:')) return;
-      const empId = decodeURIComponent(action.slice('icontact:'.length));
-      const hit = instrRows.find((r) => String(r.emp_id || '') === String(empId));
-      if (!hit) return;
-      ui.openDrawer({
-        title: hit.full_name || hit.emp_id || 'איש קשר',
-        content: instrDrawerHtml(hit, hideEmpIds)
-      });
-      requestAnimationFrame(() => {
-        const drawer = document.querySelector('.ds-drawer__body, .ds-drawer, [data-drawer]');
-        if (drawer) bindCopyBtns(drawer);
-        else bindCopyBtns(document.body);
-      });
-    });
   }
 };
 

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -190,7 +190,7 @@ function goActivitiesDrill(state, patch) {
   state.activityTab = patch.activityTab ?? 'all';
   state.activityFinanceStatus = patch.activityFinanceStatus ?? '';
   state.activityQuickFamily = patch.activityQuickFamily ?? '';
-  state.activityPeriodTab = patch.activityPeriodTab || (patch.activityQuickFamily === 'summer' ? 'summer_2026' : (state.activityPeriodTab || 'summer_2026'));
+  state.activityPeriodTab = patch.activityPeriodTab || (patch.activityQuickFamily === 'summer' ? 'summer_2026' : (state.activityPeriodTab || 'school_2026'));
   state.activityQuickManager = patch.activityQuickManager ?? '';
   state.activityEndingCurrentMonth = !!patch.activityEndingCurrentMonth;
   state.activitiesMonthYm = patch.activitiesMonthYm || state.dashboardMonthYm || currentMonthYm();

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -82,7 +82,7 @@ export const state = {
   routes: [],
   effectiveRoutes: [],
   activityTab: 'all',
-  activityPeriodTab: 'summer_2026',
+  activityPeriodTab: 'school_2026',
   activityFinanceStatus: '',
   activityQuickFamily: '',
   activityQuickManager: '',
@@ -153,7 +153,7 @@ export function setSession(session) {
     state.effectiveRoutes = [];
     state.route = 'login';
     state.activityTab = 'all';
-    state.activityPeriodTab = 'summer_2026';
+    state.activityPeriodTab = 'school_2026';
     state.activityFinanceStatus = '';
     state.activityQuickFamily = '';
     state.activityQuickManager = '';

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 540;
+const CACHE_VERSION = 541;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 540;
+const SW_ENTRY_VERSION = 541;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Make the Activities screen show תשפ״ו / 2026 by default on normal entry while keeping the ability to switch to summer / next year / archive manually. 
- Fix a responsiveness regression on the Contacts screen where typing caused heavy work (full rerender / repeated listeners / server calls) and made the UI feel stuck. 

### Description
- Changed the initial activity period from `summer_2026` to `school_2026` and preserved existing session/patch logic so explicit selections and drill-downs still work (`frontend/src/state.js`, `frontend/src/screens/dashboard.js`).
- Reworked Contacts search to perform client-side filtering of already-loaded rows, update only the `.contacts-list-wrap` HTML, and avoid full-screen rerenders; added a debounce of ~200ms and guarded binding to prevent duplicate listeners and repeated API calls (`frontend/src/screens/contacts.js`).
- Bumped service-worker/cache versions to clear old caches after deploy in both `frontend/sw.js` and root `sw.js` (`CACHE_VERSION`/`SW_ENTRY_VERSION` bumped to 541).

### Testing
- Ran focused checks with `npm run check:changed` which validated changed files with `node --check` (passed). 
- Ran the PWA service-worker tests `node --test tests/service-worker-pwa-cache.test.mjs` which passed. 
- Built the frontend with `npm run check:build` (Vite build + postbuild) which completed successfully. 
- Executed focused smoke scripts that exercise: default activity period (checked `state.activityPeriodTab === 'school_2026'`) and a JSDOM-based contacts search flow that verified client-side debounce and list-only updates (both succeeded). 
- Attempted the full `tests/activities-screen.test.mjs` but the runner fails in this environment due to a PNG import in the test harness (`ERR_UNKNOWN_FILE_EXTENSION`), so that focused Node test was not completed here (this is an environmental limitation, not a functional regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5e2b0d5c832ba2c179580b1d1ac3)