### PR TITLE
Improve summer ‘פריסת פעילות’ UX — highlighted button, compact drawer, class column, SW cache bump

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 540;
+const CACHE_VERSION = 541;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CQ3oDfK4.js",
+  "./assets/index-BWPGZ4gq.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-edU4PRxs.css",
+  "./assets/style-RaaXqnQU.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CQ3oDfK4.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-edU4PRxs.css">
+  <script type="module" crossorigin src="./assets/index-BWPGZ4gq.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-RaaXqnQU.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 540;
+const CACHE_VERSION = 541;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CQ3oDfK4.js",
+  "./assets/index-BWPGZ4gq.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-edU4PRxs.css",
+  "./assets/style-RaaXqnQU.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -774,6 +774,22 @@ function activityLayoutInstructors(row = {}) {
     .join(', ');
 }
 
+function activityLayoutClassGroup(row = {}) {
+  const grade = cleanText(row.grade || row.Grade || row.school_grade || row.class_grade || row.layer || row.class_layer);
+  const classGroup = cleanText(row.class_group || row.classGroup || row.group || row.group_name || row.class_name || row.class);
+  const formatGrade = (value) => {
+    if (!value) return '';
+    if (/^כיתה(?:\s|$)/.test(value)) return value;
+    return `כיתה ${value}`;
+  };
+  const formatGroup = (value) => {
+    if (!value) return '';
+    if (/^(?:קבוצה|כיתה)(?:\s|$)/.test(value)) return value;
+    return `קבוצה ${value}`;
+  };
+  return [formatGrade(grade), formatGroup(classGroup)].filter(Boolean).join(' / ');
+}
+
 function isActivityLayoutRowComplete(row = {}) {
   return Boolean(
     cleanText(row.school) &&
@@ -868,6 +884,7 @@ function activityLayoutRowsForDocument(group) {
       date: activityLayoutDate(row),
       startTime: activityLayoutStartTime(row),
       endTime: activityLayoutEndTime(row),
+      classGroup: activityLayoutClassGroup(row),
       activityName: cleanText(row.activity_name),
       instructors: activityLayoutInstructors(row)
     }))
@@ -892,6 +909,7 @@ function activityLayoutDocumentHtml(group) {
     <td>${escapeHtml(formatActivityLayoutDate(row.date))}</td>
     <td>${escapeHtml(row.startTime)}</td>
     <td>${escapeHtml(row.endTime)}</td>
+    <td>${escapeHtml(row.classGroup)}</td>
     <td>${escapeHtml(row.activityName)}</td>
     <td>${escapeHtml(row.instructors)}</td>
   </tr>`).join('');
@@ -902,7 +920,7 @@ function activityLayoutDocumentHtml(group) {
     .screen-actions { display: flex; justify-content: center; gap: 10px; padding: 18px; }
     .print-btn { border: 0; border-radius: 999px; background: #2563eb; color: #fff; padding: 10px 18px; font-weight: 700; cursor: pointer; }
     .doc { width: 210mm; min-height: 297mm; margin: 0 auto 24px; background: #fff; padding: 18mm; box-shadow: 0 16px 40px rgba(15,23,42,.16); }
-    .doc-logo { display: block; width: 145px; max-height: 70px; object-fit: contain; margin: 0 0 16px auto; }
+    .doc-logo { display: block; width: 145px; max-height: 70px; object-fit: contain; margin: 0 auto 16px 0; }
     h1 { margin: 0 0 18px; text-align: center; font-size: 24px; }
     .meta { margin: 0 0 20px; font-size: 16px; }
     .meta div { margin: 2px 0; }
@@ -911,7 +929,7 @@ function activityLayoutDocumentHtml(group) {
     table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 14px; }
     th, td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: right; vertical-align: top; }
     th { background: #f1f5f9; font-weight: 700; }
-    .signature { margin-top: 24px; }
+    .signature { margin-top: 24px; text-align: left; direction: rtl; }
     @media print { body { background: #fff; } .screen-actions { display: none !important; } .doc { width: auto; min-height: auto; margin: 0; padding: 0; box-shadow: none; } }
   </style></head><body><div class="screen-actions"><button class="print-btn" type="button" onclick="window.print()">הדפסה / שמירה כ־PDF</button></div><main class="doc">
     <img class="doc-logo" src="${escapeHtml(taasiyedaLogoSrc)}" alt="תעשיידע">
@@ -925,7 +943,7 @@ function activityLayoutDocumentHtml(group) {
     <p>בהמשך לתיאום ולשיבוץ הפעילויות מול בית הספר, מצורפת פריסת הפעילויות המתוכננת במסגרת קיץ תשפ"ו | 2026.</p>
     <p>נבקש לעבור על הפריסה ולעדכן את צוות תעשיידע מראש במקרה של שינוי בלוחות הזמנים, בהרכב הקבוצות, במיקום הפעילות או בכל צורך תפעולי אחר, כדי שנוכל להיערך בהתאם.</p>
     <h2>טבלת פריסת הפעילות</h2>
-    <table><thead><tr><th>תאריך</th><th>שעת התחלה</th><th>שעת סיום</th><th>פעילות / סדנה</th><th>מדריך</th></tr></thead><tbody>${tableRows}</tbody></table>
+    <table><thead><tr><th>תאריך</th><th>שעת התחלה</th><th>שעת סיום</th><th>כיתה</th><th>פעילות / סדנה</th><th>מדריך</th></tr></thead><tbody>${tableRows || '<tr><td colspan="6">לא נמצאו שיבוצים להצגה.</td></tr>'}</tbody></table>
     <div class="signature">בברכה,<br>תעשיידע</div>
   </main></body></html>`;
 }
@@ -946,19 +964,17 @@ function openActivityLayoutDocument(group) {
 
 function activityLayoutListHtml(groups = []) {
   const rows = (Array.isArray(groups) ? groups : []).map((group) => {
-    const status = group.status?.sent ? `✓ נשלח${group.status?.sent_at ? ` — ${escapeHtml(formatActivityLayoutDate(cleanText(group.status.sent_at).slice(0, 10)))}` : ''}` : 'לא נשלח';
+    const isSent = !!group.status?.sent;
     const key = encodeURIComponent(activityLayoutStatusKey(group));
     return `<tr>
       <td><button type="button" class="ds-link-btn" data-activity-layout-open="${key}">${escapeHtml(group.school)}</button></td>
       <td>${escapeHtml(group.authority)}</td>
       <td>${escapeHtml(String(group.count || 0))}</td>
-      <td>${escapeHtml(group.dateRange || '—')}</td>
-      <td><span class="ds-chip ds-chip--status${group.status?.sent ? ' ds-chip--ok' : ''}">${status}</span></td>
-      <td class="ds-actions-cell"><button type="button" class="ds-btn ds-btn--sm" data-activity-layout-open="${key}">הפק מסמך</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activity-layout-sent="${key}">סמן כנשלח</button></td>
+      <td class="ds-actions-cell"><button type="button" class="ds-btn ds-btn--sm" data-activity-layout-open="${key}">הפק מסמך</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activity-layout-sent="${key}"${isSent ? ' disabled aria-disabled="true"' : ''}>${isSent ? 'נשלח' : 'סמן כנשלח'}</button></td>
     </tr>`;
   }).join('');
   if (!rows) return '<div class="ds-empty" dir="rtl"><p class="ds-empty__msg">אין בתי ספר מוכנים להפקת פריסת פעילות בשלב זה.</p></div>';
-  return dsTableWrap(`<table class="ds-table" dir="rtl"><thead><tr><th>בית ספר</th><th>רשות</th><th>מספר פעילויות</th><th>טווח תאריכים</th><th>סטטוס שליחה</th><th>פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
+  return dsTableWrap(`<table class="ds-table" dir="rtl"><thead><tr><th>בית ספר</th><th>רשות</th><th>מספר פעילויות</th><th>פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
 }
 
 export const activitiesScreen = {
@@ -1086,7 +1102,7 @@ export const activitiesScreen = {
       ${bareFilters}
       <div class="ds-activities-main-toolbar__actions">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
-        ${canUseLayout ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activity-layout-list title="פריסת פעילות לבתי ספר עם שיבוץ מלא">פריסת פעילות</button>` : ''}
+        ${canUseLayout ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn ds-activities-toolbar-btn--layout" data-activity-layout-list title="פריסת פעילות לבתי ספר עם שיבוץ מלא">פריסת פעילות</button>` : ''}
         ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-export-all title="ייצוא הפעילויות בלשונית הפעילה לאקסל">ייצוא לאקסל</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-admin-summary title="סיכום אדמין ללשונית הפעילה">סיכום אדמין</button>` : ''}
         ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">+</button>` : ''}
       </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9727,6 +9727,20 @@ select.ds-input {
   white-space: nowrap;
 }
 
+.ds-activities-main-toolbar__actions .ds-activities-toolbar-btn--layout {
+  border-color: rgba(37, 99, 235, 0.56);
+  background: linear-gradient(180deg, rgba(239, 246, 255, 0.96), rgba(219, 234, 254, 0.78));
+  color: #1d4ed8;
+  font-weight: 800;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.14), 0 10px 26px rgba(37, 99, 235, 0.2);
+}
+
+.ds-activities-main-toolbar__actions .ds-activities-toolbar-btn--layout:hover,
+.ds-activities-main-toolbar__actions .ds-activities-toolbar-btn--layout:focus-visible {
+  border-color: rgba(37, 99, 235, 0.78);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2), 0 12px 30px rgba(37, 99, 235, 0.25);
+}
+
 .ds-admin-summary {
   display: grid;
   gap: 1rem;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 540;
+const CACHE_VERSION = 541;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 540;
+const SW_ENTRY_VERSION = 541;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- להעלות את נראות כפתור "פריסת פעילות" בעמוד קיץ כדי שיהיה ברור כפעולה מרכזית ללא שינוי טקסט או מיקום. 
- לפשט את חלון הצד של פריסת פעילות כך שיוצג מידע ממוקד לקריאה מהירה (בית ספר, רשות וכמות פעילויות). 
- להעשיר את מסמך הלקוח בעמודת "כיתה" שמציגה את השכבה/כיתה/קבוצה כפי שמופיע בנתונים הקיימים וליישר לוח חתימה ולוגו לשמאל במסמך. 
- לעדכן את גרסת ה־Service Worker/קאש כדי לוודא פריסה נקייה מקאש ישן.

### Description
- הוחלפה ההופעה של כפתור ה"פריסת פעילות" להוסיף מחלקת עיצוב ייעודית `ds-activities-toolbar-btn--layout` עם טיפול glow עדין ו־hover/focus מודגש ללא שינוי טקסט/מיקום (`frontend/src/screens/activities.js`, `frontend/src/styles/main.css`).
- צומצם ה־drawer של פריסת פעילות להצגת טבלה פשוטה של שורות שמכילות רק `בית ספר`, `רשות`, `מספר פעילויות` ועמודת פעולות עם הכפתורים "הפק מסמך" ו־"סמן כנשלח" (כפתור השליחה נעשה מנוטרל אם כבר נשלח). (`frontend/src/screens/activities.js`).
- נוספה הפונקציה `activityLayoutClassGroup` שמאחדת שדות שכבה/כיתה/קבוצה קיימים ושומרת על קריאות; הוכנסה עמודת `כיתה` לשורות שיוצרות את מסמך ה־HTML ללקוח כך שהטבלה במסמך היא: `תאריך | שעת התחלה | שעת סיום | כיתה | פעילות / סדנה | מדריך`. (`frontend/src/screens/activities.js`).
- בליל המסמך (HTML) הוזזה תמונת הלוגו לשמאל על־ידי שינוי מגרות ה־CSS והחתימה בסוף המסמך מיושרת לשמאל, בעוד שהתוכן נשאר RTL בעברית. (`frontend/src/screens/activities.js`).
- בוצע bump של גרסאות הקאש מ־540 ל־541 ב־`frontend/sw.js` ו־`sw.js` וההרצה של ה־build שיצרה עדכונים ב־`dist` לקבצי כניסה/סטייל שהשתנו.

### Testing
- ריצה של `node --check frontend/src/screens/activities.js` עברה בהצלחה. 
- בניית הפרונטאנד בעזרת `npm run build` הצליחה וה־`dist` נבנה בהצלחה. 
- הרצת הבדיקה הממוקדת `npm run check:changed` הסתיימה בהצלחה. 
- הרצת `npm run check:build` הסתיימה בהצלחה (כולל `npm run build`). 
- `node --test tests/activities-screen.test.mjs` נכשל בסביבה הזו עקב מגבלת Node בהטענת קבצי תמונה (ייבוא PNG ישיר במודול ESM), שזהו מגבלה של סביבת הבדיקה ולא שגיאת הלוגיקה שנוספה כאן.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5edb74a8832b933673b4ade02319)