### PR TITLE
Add support for one-time activities with dedicated UI

### DIFF
--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -541,28 +541,89 @@ function buildDateChipsHtml(schedule, isOnce) {
     .join('') || '<div class="activity-drawer__date-chip">—</div>';
 }
 
+function buildOneDayViewHtml(schedule, row, datesLoading) {
+  if (datesLoading) {
+    return `<div class="activity-drawer__oneday-info" data-mode="view" data-dates-view-chips>
+      <div class="activity-drawer__date-chip ds-muted" aria-busy="true">טוען...</div>
+    </div>`;
+  }
+  const firstMeeting = schedule[0] || {};
+  const dateVal = String(firstMeeting?.date || '').trim();
+  const dateDisplay = dateVal ? formatDateHe(dateVal) : '—';
+  const weekdayDisplay = dateVal ? fmtWeekdayShort(dateVal) : '—';
+  const timeRange = (String(row.start_time || '').trim() && String(row.end_time || '').trim())
+    ? formatTimeRangeShort(row.start_time, row.end_time)
+    : '—';
+  return `<div class="activity-drawer__oneday-info" data-mode="view" data-dates-view-chips>
+    <div class="activity-drawer__field">
+      <div class="activity-drawer__label">תאריך הפעילות</div>
+      <div class="activity-drawer__value" data-oneday-date-display>${escapeHtml(dateDisplay)}</div>
+    </div>
+    <div class="activity-drawer__field">
+      <div class="activity-drawer__label">יום בשבוע</div>
+      <div class="activity-drawer__value" data-oneday-weekday-display>${escapeHtml(weekdayDisplay)}</div>
+    </div>
+    <div class="activity-drawer__field">
+      <div class="activity-drawer__label">שעות הפעילות</div>
+      <div class="activity-drawer__value">${escapeHtml(timeRange)}</div>
+    </div>
+  </div>`;
+}
+
 function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
   const schedule = Array.isArray(row?.meeting_schedule) ? row.meeting_schedule : [];
   const activityType = String(row.activity_type || '').trim();
   const isOnce = ONCE_TYPES.includes(activityType);
+  const loadingAttr = datesLoading ? ' data-dates-loading="true"' : '';
+
+  if (isOnce) {
+    const firstMeeting = schedule[0] || {};
+    const dateVal = String(firstMeeting?.date || '').trim();
+    const oneDayEditCard = `
+      <div class="activity-drawer__date-card" data-meeting-index="0">
+        <div class="activity-drawer__date-card-top">
+          <span class="activity-drawer__meeting-index">תאריך הפעילות</span>
+          <span class="activity-drawer__date-card-top-aside">
+            <span class="activity-drawer__weekday">${escapeHtml(fmtWeekdayShort(dateVal))}</span>
+          </span>
+        </div>
+        ${inputHtml({
+          name: 'meeting_date_0',
+          value: dateVal,
+          type: 'date',
+          attrs: 'data-role="meeting-date" data-meeting-index="0" data-meeting-idx="0" data-oneday-date',
+        })}
+        <input type="hidden" name="meeting_performed_0" value="${escapeHtml(String(firstMeeting?.performed || 'no'))}">
+      </div>
+    `;
+    return `
+      <section class="activity-drawer__section" data-dates-section${loadingAttr}>
+        <div class="activity-drawer__section-head">
+          <h3 class="activity-drawer__section-title">תאריך ושעות פעילות</h3>
+          ${canEdit ? '<button type="button" class="activity-drawer__action" data-action="start-edit" data-mode="view">✏️ עריכה</button>' : ''}
+        </div>
+        ${buildOneDayViewHtml(schedule, row, datesLoading)}
+        <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit hidden>
+          ${oneDayEditCard}
+        </div>
+      </section>
+    `;
+  }
+
   const computedEnd = autoEndDate(row);
   const doneFromSchedule = countDoneMeetings(schedule);
   const doneFallback = numericOrNull(row?.meetings_done);
   const done = doneFromSchedule > 0 ? doneFromSchedule : (doneFallback ?? 0);
   const total = numericOrNull(row?.meetings_total) ?? schedule.length ?? 0;
   const progressPct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
-  const viewChips = buildDateChipsHtml(schedule, isOnce);
-  const editDates = isOnce ? schedule.slice(0, 1) : schedule;
-  const removeMeetingBtn = isOnce
-    ? ''
-    : `<button type="button" class="activity-drawer__date-remove" data-action="remove-meeting" aria-label="הסר מפגש">🗑</button>`;
-  const datePickers = editDates
+  const viewChips = buildDateChipsHtml(schedule, false);
+  const datePickers = schedule
     .map((item, i) => `
       <div class="activity-drawer__date-card" data-meeting-index="${i}">
         <div class="activity-drawer__date-card-top">
           <span class="activity-drawer__meeting-index">מפגש ${i + 1}</span>
           <span class="activity-drawer__date-card-top-aside">
-            ${removeMeetingBtn}
+            <button type="button" class="activity-drawer__date-remove" data-action="remove-meeting" aria-label="הסר מפגש">🗑</button>
             <span class="activity-drawer__weekday">${escapeHtml(fmtWeekdayShort(item?.date || ''))}</span>
           </span>
         </div>
@@ -576,19 +637,7 @@ function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
       </div>
     `)
     .join('');
-  const chainToggle = isOnce
-    ? ''
-    : `
-      <div class="activity-drawer__date-mode" data-mode="edit" data-chain-toggle hidden>
-        <button type="button" class="activity-drawer__toggle" data-date-mode="single">בודד</button>
-        <button type="button" class="activity-drawer__toggle is-active" data-date-mode="chain">שרשרת</button>
-      </div>
-    `;
-  const addMeetingBtn = isOnce
-    ? ''
-    : `<button type="button" class="activity-drawer__action activity-drawer__action--ghost" data-action="add-meeting" data-mode="edit" hidden>➕ הוסף מפגש</button>`;
 
-  const loadingAttr = datesLoading ? ' data-dates-loading="true"' : '';
   const progressHtml = datesLoading
     ? `<div class="activity-drawer__progress-row" data-mode="view"><div class="activity-drawer__progress" data-dates-progress>
         <div class="activity-drawer__progress-meta" data-dates-progress-meta>
@@ -634,8 +683,11 @@ function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
       <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit hidden>
         ${datePickers}
       </div>
-      ${chainToggle}
-      ${addMeetingBtn}
+      <div class="activity-drawer__date-mode" data-mode="edit" data-chain-toggle hidden>
+        <button type="button" class="activity-drawer__toggle" data-date-mode="single">בודד</button>
+        <button type="button" class="activity-drawer__toggle is-active" data-date-mode="chain">שרשרת</button>
+      </div>
+      <button type="button" class="activity-drawer__action activity-drawer__action--ghost" data-action="add-meeting" data-mode="edit" hidden>➕ הוסף מפגש</button>
     </section>
   `;
 }
@@ -669,6 +721,18 @@ export function patchDrawerDatesSection(sectionEl, datesData) {
   const schedule = Array.isArray(datesData?.meeting_schedule) ? datesData.meeting_schedule : [];
   const activityType = String(datesData?.activity_type || '').trim();
   const isOnce = ONCE_TYPES.includes(activityType);
+
+  if (isOnce) {
+    const firstMeeting = schedule[0] || {};
+    const dateVal = String(firstMeeting?.date || '').trim();
+    const dateEl = sectionEl.querySelector('[data-oneday-date-display]');
+    if (dateEl) dateEl.textContent = dateVal ? formatDateHe(dateVal) : '—';
+    const weekdayEl = sectionEl.querySelector('[data-oneday-weekday-display]');
+    if (weekdayEl) weekdayEl.textContent = dateVal ? fmtWeekdayShort(dateVal) : '—';
+    sectionEl.removeAttribute('data-dates-loading');
+    return;
+  }
+
   const doneFromSchedule = countDoneMeetings(schedule);
   const doneFallback = numericOrNull(datesData?.meetings_done);
   const done = doneFromSchedule > 0 ? doneFromSchedule : (doneFallback ?? 0);
@@ -688,7 +752,7 @@ export function patchDrawerDatesSection(sectionEl, datesData) {
   if (endDisplay) endDisplay.textContent = formatDateHeWithWeekday(computedEnd) || '—';
 
   const chipsDiv = sectionEl.querySelector('[data-dates-view-chips]');
-  if (chipsDiv) chipsDiv.innerHTML = buildDateChipsHtml(schedule, isOnce);
+  if (chipsDiv) chipsDiv.innerHTML = buildDateChipsHtml(schedule, false);
 
   sectionEl.removeAttribute('data-dates-loading');
 }

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -274,11 +274,16 @@ export function bindActivityEditForm(contentRoot, {
 
     if (hasMeetingDatesChanged(form, initialValues)) {
       const snapshot = buildMeetingDatesSnapshot(form);
+      const isOnce = form.dataset.isOnce === 'yes';
       for (let i = 0; i < 35; i++) {
         changes[`meeting_date_${i}`] = snapshot.dates[i];
       }
       changes.start_date = snapshot.startDate;
-      changes.end_date = snapshot.endDate;
+      changes.end_date = isOnce ? snapshot.startDate : snapshot.endDate;
+      if (isOnce && snapshot.startDate) {
+        changes.date_1 = snapshot.startDate;
+        changes.end_date = snapshot.startDate;
+      }
     }
 
     if (!validateActivityTypeAndName(form, statusEl)) return;

--- a/frontend/src/screens/shared/summer-activity.js
+++ b/frontend/src/screens/shared/summer-activity.js
@@ -3,11 +3,14 @@ const SUMMER_END_DATE = '2026-08-31';
 export const SUMMER_DEFAULT_MONTH_YM = SUMMER_START_DATE.slice(0, 7);
 export const ACTIVITY_SEASON_REGULAR = 'regular';
 export const ACTIVITY_SEASON_SUMMER_2026 = 'summer_2026';
+export const ACTIVITY_SEASON_SCHOOL_2027 = 'school_2027';
 export const ACTIVITY_SEASON_OPTIONS = [
-  { value: ACTIVITY_SEASON_REGULAR, label: 'רגיל' },
-  { value: ACTIVITY_SEASON_SUMMER_2026, label: 'קיץ תשפ״ו' }
+  { value: ACTIVITY_SEASON_REGULAR, label: 'תשפ"ו | 2026' },
+  { value: ACTIVITY_SEASON_SUMMER_2026, label: 'קיץ 2026' },
+  { value: ACTIVITY_SEASON_SCHOOL_2027, label: 'תשפ"ז | 2027' }
 ];
 const SUMMER_SEASON_ALIASES = new Set([ACTIVITY_SEASON_SUMMER_2026, 'summer']);
+const SCHOOL_2027_ALIASES = new Set([ACTIVITY_SEASON_SCHOOL_2027]);
 
 function normalizedDateText(value) {
   const raw = String(value || '').trim();
@@ -20,9 +23,10 @@ function normalizedDateText(value) {
 }
 
 export function normalizeActivitySeason(value) {
-  return SUMMER_SEASON_ALIASES.has(String(value || '').trim())
-    ? ACTIVITY_SEASON_SUMMER_2026
-    : ACTIVITY_SEASON_REGULAR;
+  const v = String(value || '').trim();
+  if (SUMMER_SEASON_ALIASES.has(v)) return ACTIVITY_SEASON_SUMMER_2026;
+  if (SCHOOL_2027_ALIASES.has(v)) return ACTIVITY_SEASON_SCHOOL_2027;
+  return ACTIVITY_SEASON_REGULAR;
 }
 
 export function activitySeasonLabel(value) {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 541;
+const CACHE_VERSION = 542;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
This PR adds dedicated UI and handling for one-time activities (activities that occur only once), separate from recurring activities. Previously, one-time activities were treated similarly to recurring ones with limited customization.

## Key Changes

- **New one-time activity view component** (`buildOneDayViewHtml`): Creates a specialized display for one-time activities showing activity date, weekday, and time range instead of the generic date chips used for recurring activities.

- **Refactored `blockDates` function**: Split logic to handle one-time activities separately from recurring activities:
  - One-time activities now display a single date picker with dedicated labels ("תאריך הפעילות")
  - Removed conditional rendering of edit buttons and chain toggle for one-time activities
  - Recurring activities retain their original multi-meeting interface with add/remove buttons and chain mode toggle

- **Updated `patchDrawerDatesSection` function**: Added early return path for one-time activities to update only the date and weekday display elements, avoiding unnecessary processing of recurring activity logic.

- **Enhanced activity season support** (`summer-activity.js`):
  - Added new `ACTIVITY_SEASON_SCHOOL_2027` season constant
  - Updated season labels for better clarity (e.g., "תשפ"ו | 2026" instead of "רגיל")
  - Extended `normalizeActivitySeason` to handle the new 2027 school season

- **Fixed one-time activity date handling** (`bind-activity-edit-form.js`): When saving one-time activities, `end_date` is now set to match `start_date` (instead of being calculated), and `date_1` field is populated for proper backend synchronization.

- **Cache version bump**: Updated service worker cache version to 542 to ensure fresh assets are loaded.

## Implementation Details

The one-time activity UI provides a cleaner, more intuitive interface with:
- Dedicated field labels in Hebrew for date, weekday, and activity hours
- Loading state support with "טוען..." message
- Consistent styling with the existing activity drawer design
- Proper HTML escaping for all user-facing content

https://claude.ai/code/session_01MnB5WUAsady2oFGNJuvYu1