### PR TITLE
Add activity hours display and fix incomplete row tracking

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 543;
+const CACHE_VERSION = 545;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DAZWIqUJ.js",
+  "./assets/index-DfLIi5aX.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DAZWIqUJ.js"></script>
+  <script type="module" crossorigin src="./assets/index-DfLIi5aX.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-RaaXqnQU.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 543;
+const CACHE_VERSION = 545;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DAZWIqUJ.js",
+  "./assets/index-DfLIi5aX.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -854,11 +854,13 @@ function activityLayoutStatusesMap(rows = []) {
 
 function readyActivityLayoutSchools(rows = [], statuses = []) {
   const groups = new Map();
-  const schoolsWithIncompleteRows = new Set();
+  const authoritySchoolsWithIncompleteRows = new Set();
   (Array.isArray(rows) ? rows : []).forEach((row) => {
     const authority = cleanText(row.authority);
     const school = cleanText(row.school);
-    if (school && !isActivityLayoutRowComplete(row)) schoolsWithIncompleteRows.add(school);
+    if (authority && school && !isActivityLayoutRowComplete(row)) {
+      authoritySchoolsWithIncompleteRows.add(activityLayoutStatusKey({ authority, school }));
+    }
     if (!authority || !school) return;
     const key = activityLayoutStatusKey({ authority, school });
     if (!groups.has(key)) groups.set(key, { season: ACTIVITY_LAYOUT_SEASON, authority, school, rows: [], dates: [] });
@@ -869,7 +871,7 @@ function readyActivityLayoutSchools(rows = [], statuses = []) {
   });
   const statusMap = activityLayoutStatusesMap(statuses);
   return [...groups.values()]
-    .filter((group) => group.rows.length && !schoolsWithIncompleteRows.has(group.school) && group.rows.every(isActivityLayoutRowComplete))
+    .filter((group) => group.rows.length && !authoritySchoolsWithIncompleteRows.has(activityLayoutStatusKey(group)) && group.rows.every(isActivityLayoutRowComplete))
     .map((group) => ({
       ...group,
       count: group.rows.length,
@@ -1060,6 +1062,9 @@ export const activitiesScreen = {
           const activityDateRaw = String(row.date_1 || row.start_date || '').trim();
           const activityDateHe = activityDateRaw ? (formatDateHe(activityDateRaw) || activityDateRaw) : '—';
           const gradeDisplay = escapeHtml(String(row.grade || '—'));
+          const startTime = activityLayoutStartTime(row);
+          const endTime = activityLayoutEndTime(row);
+          const hoursDisplay = (startTime && endTime) ? `${escapeHtml(startTime)}–${escapeHtml(endTime)}` : (startTime || endTime ? escapeHtml(startTime || endTime) : '—');
           return `
       <tr class="ds-data-row ds-activities-row" data-list-item data-search="${escapeHtml(rowSearch)}" data-filter="" data-row-id="${escapeHtml(row.RowID)}">
         <td class="ds-activities-col ds-activities-col--program"><div class="ds-activities-program-cell"><strong class="ds-activities-program-name" title="${activityName}">${activityName}</strong><span class="ds-activities-program-type" title="${activityTypeLabel}">${activityTypeLabel}</span>${editStatusBadge}</div></td>
@@ -1068,6 +1073,7 @@ export const activitiesScreen = {
         <td class="ds-activities-col ds-activities-col--grade" style="text-align:center">${gradeDisplay}</td>
         <td class="ds-activities-col ds-activities-col--instructor"><div class="ds-activities-instructor-wrap">${instructorDisplay}<span class="ds-activities-manager-line" title="${escapeHtml(managerLabel || '—')}">מנהל: ${escapeHtml(managerLabel || '—')}</span></div></td>
         <td class="ds-activities-col ds-activities-col--date" style="text-align:center"><time class="ds-activities-date">${escapeHtml(activityDateHe)}</time></td>
+        <td class="ds-activities-col ds-activities-col--hours" style="text-align:center"><span class="ds-activities-hours">${hoursDisplay}</span></td>
         <td class="ds-activities-col ds-activities-col--notes"><span class="ds-activities-cell-ellipsis" title="${escapeHtml(String(row.notes || '—'))}">${escapeHtml(String(row.notes || '—'))}</span></td>
       </tr>
     `;
@@ -1113,9 +1119,10 @@ export const activitiesScreen = {
                   <col class="ds-activities-col--grade">
                   <col class="ds-activities-col--instructor">
                   <col class="ds-activities-col--date">
+                  <col class="ds-activities-col--hours">
                   <col class="ds-activities-col--notes">
                 </colgroup>
-                <thead><tr><th>תוכנית / סוג</th><th>רשות</th><th>בית ספר</th><th style="text-align:center">כיתה</th><th>מדריך</th><th style="text-align:center">תאריך פעילות</th><th>הערות</th></tr></thead>`
+                <thead><tr><th>תוכנית / סוג</th><th>רשות</th><th>בית ספר</th><th style="text-align:center">כיתה</th><th>מדריך</th><th style="text-align:center">תאריך פעילות</th><th style="text-align:center">שעות</th><th>הערות</th></tr></thead>`
       : `<colgroup>
                   <col class="ds-activities-col--program">
                   <col class="ds-activities-col--authority">

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 544;
+const CACHE_VERSION = 545;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
This PR adds a new hours column to the activities table display and fixes a bug in the activity layout validation logic where incomplete rows were not being properly tracked by authority-school combination.

## Key Changes
- **Fixed incomplete row tracking**: Changed `schoolsWithIncompleteRows` to `authoritySchoolsWithIncompleteRows` to properly track incomplete rows by the combination of authority and school (using `activityLayoutStatusKey`), rather than just by school name alone. This prevents false positives when the same school name exists under different authorities.

- **Added hours column to activities table**: 
  - Extracted start and end times from activity rows using `activityLayoutStartTime()` and `activityLayoutEndTime()` functions
  - Display hours as a formatted range (e.g., "09:00–17:00") or single time if only one is available
  - Added new table column with proper HTML structure, styling, and column group definition
  - Added Hebrew header "שעות" (hours) to the table

- **Updated cache version**: Bumped service worker cache version from 543/544 to 545 to ensure clients pick up the new assets

## Implementation Details
- The hours display uses the same `escapeHtml()` sanitization as other table cells for security
- The hours column is positioned between the date and notes columns in the table layout
- The fix to incomplete row tracking ensures that the filter correctly excludes groups with incomplete rows when the same school name appears under multiple authorities

https://claude.ai/code/session_01TTRfb7qiiJrSsTo9ZwKcx6