### PR TITLE
Add activity creation requests and align activity permissions by role

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 547;
+const CACHE_VERSION = 548;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CFv-cvSb.js",
+  "./assets/index-_Ta33XgJ.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CFv-cvSb.js"></script>
+  <script type="module" crossorigin src="./assets/index-_Ta33XgJ.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-RaaXqnQU.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 547;
+const CACHE_VERSION = 548;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CFv-cvSb.js",
+  "./assets/index-_Ta33XgJ.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -28,6 +28,7 @@ const MUTATING_ACTIONS = {
   addContact: true,
   saveContact: true,
   submitEditRequest: true,
+  submitCreateActivityRequest: true,
   reviewEditRequest: true,
   savePermission: true,
   addUser: true,
@@ -1383,6 +1384,7 @@ function invalidateScreenDataByAction(action) {
     addActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'exceptions:', 'end-dates'],
     deleteActivity: ['activities:', 'activityDetail:', 'activityDates:', 'week:', 'month:', 'dashboard:', 'archive', 'end-dates', 'exceptions:'],
     submitEditRequest: ['activities:', 'edit-requests'],
+    submitCreateActivityRequest: ['activities:', 'edit-requests'],
     reviewEditRequest: ['edit-requests', 'activities:', 'activityDetail:', 'dashboard:', 'exceptions:', 'activityDates:', 'archive', 'archiveDetail:', 'archiveDates:', 'week:', 'month:'],
     addUser: ['permissions', 'dashboard:'],
     deactivateUser: ['permissions', 'dashboard:'],
@@ -1890,9 +1892,24 @@ function permissionFlagYes(value) {
   return ['yes', 'true', '1'].includes(String(value || '').trim().toLowerCase());
 }
 
+const ACTIVITY_DIRECT_MANAGE_ROLES = new Set(['admin', 'operation_manager']);
+const ACTIVITY_REQUEST_ROLES = new Set(['activities_manager', 'instructor_manager', 'business_development_manager']);
+
+function currentActivityRole(user = state?.user || {}) {
+  return String(user?.display_role || user?.role || '').trim();
+}
+
+function canDirectManageActivitiesUser(user = state?.user || {}) {
+  return ACTIVITY_DIRECT_MANAGE_ROLES.has(currentActivityRole(user));
+}
+
+function canSubmitActivityRequestsUser(user = state?.user || {}) {
+  return canDirectManageActivitiesUser(user) || ACTIVITY_REQUEST_ROLES.has(currentActivityRole(user));
+}
+
 function canReviewEditRequestsUser(user = state?.user || {}) {
-  const role = String(user?.display_role || user?.role || '').trim();
-  return ['admin', 'operation_manager'].includes(role) || permissionFlagYes(user?.can_review_requests);
+  // Legacy permissionFlagYes(user?.can_review_requests) is intentionally not enough for activity request review.
+  return canDirectManageActivitiesUser(user);
 }
 
 function getLoginStatus(row) {
@@ -1953,16 +1970,18 @@ function buildBootstrapFromUser(userRow) {
   const role = normalizeSupabaseRole(flat.role);
   const allowedRoutes = [...(SUPABASE_ROLE_ROUTES[role] || SUPABASE_ROLE_ROUTES.authorized_user)];
   const isBusinessDevelopmentManager = role === 'business_development_manager';
+  const canDirectManageActivities = ACTIVITY_DIRECT_MANAGE_ROLES.has(role);
+  const canRequestActivities = ACTIVITY_REQUEST_ROLES.has(role);
   const hasFinanceAccess = isBusinessDevelopmentManager ? false : (role === 'finance' || permissionFlagYes(parsePermissions(userRow?.permissions).finance_access) || permissionFlagYes(parsePermissions(userRow?.permissions).view_finance));
   const financeIdx = allowedRoutes.indexOf('finance');
   if (hasFinanceAccess && financeIdx === -1) allowedRoutes.push('finance');
   if (!hasFinanceAccess && financeIdx >= 0) allowedRoutes.splice(financeIdx, 1);
   if (permissionFlagYes(flat.view_catalog) && !allowedRoutes.includes('catalog')) allowedRoutes.push('catalog');
   if ((permissionFlagYes(flat.view_orders) || permissionFlagYes(flat.view_invitations)) && !allowedRoutes.includes('orders')) allowedRoutes.push('orders');
-  const canEditDirect = isBusinessDevelopmentManager ? false : permissionFlagYes(flat.can_edit_direct);
-  const canRequestEdit = isBusinessDevelopmentManager ? false : (canEditDirect || permissionFlagYes(flat.can_request_edit));
-  const canReviewRequests = isBusinessDevelopmentManager ? false : (['admin', 'operation_manager'].includes(role) || permissionFlagYes(flat.can_review_requests));
-  if (!isBusinessDevelopmentManager && (canRequestEdit || canReviewRequests || permissionFlagYes(flat.view_edit_requests)) && !allowedRoutes.includes('edit-requests')) {
+  const canEditDirect = canDirectManageActivities;
+  const canRequestEdit = canDirectManageActivities || canRequestActivities;
+  const canReviewRequests = canDirectManageActivities;
+  if (canReviewRequests && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
   return {
@@ -1974,7 +1993,7 @@ function buildBootstrapFromUser(userRow) {
       display_role2: flat.display_role2 || '',
       display_role_label: flat.display_role_label || hebrewRole(role)
     },
-    can_add_activity: permissionFlagYes(flat.can_add_activity),
+    can_add_activity: canDirectManageActivities || canRequestActivities,
     can_edit_direct: canEditDirect,
     can_request_edit: canRequestEdit,
     can_review_requests: canReviewRequests,
@@ -2543,52 +2562,77 @@ function filterOperationsRows(rows, params = {}) {
   });
 }
 
+function parseJsonishObject(value, fallback = {}) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+  try {
+    const parsed = JSON.parse(String(value || ''));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function parseJsonishArray(value, fallback = []) {
+  if (Array.isArray(value)) return value;
+  try {
+    const parsed = JSON.parse(String(value || ''));
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function normalizeEditRequestType(value) {
+  const type = String(value || '').trim();
+  return type === 'create_activity' ? 'create_activity' : 'edit_activity';
+}
+
 function buildEditRequestGroups(rows = [], canReview = false, activityByRowId = {}) {
   const groups = rows.map((row) => {
+    const requestType = normalizeEditRequestType(row?.request_type);
     const sourceRowId = String(row?.source_row_id || '').trim();
     const activityRow = sourceRowId && activityByRowId[sourceRowId] ? activityByRowId[sourceRowId] : null;
 
-    const changedFields =
-      Array.isArray(row?.changed_fields) ? row.changed_fields
-        : (() => {
-            try { return JSON.parse(String(row?.changed_fields || '[]')); } catch { return []; }
-          })();
-    const requestedValues =
-      row?.requested_values && typeof row.requested_values === 'object'
-        ? row.requested_values
-        : (() => {
-            try { return JSON.parse(String(row?.requested_values || '{}')); } catch { return {}; }
-          })();
-    const originalValues =
-      row?.original_values && typeof row.original_values === 'object'
-        ? row.original_values
-        : (() => {
-            try { return JSON.parse(String(row?.original_values || '{}')); } catch { return {}; }
-          })();
+    const changedFields = parseJsonishArray(row?.changed_fields);
+    const requestedValues = parseJsonishObject(row?.requested_values);
+    const originalValues = parseJsonishObject(row?.original_values);
+    const requestedPayload = sanitizeActivityPayloadForSupabase(
+      synchronizeStartDateAndFirstMeeting(parseJsonishObject(row?.requested_payload)),
+      { includeRowId: true }
+    );
 
-    const fields = (Array.isArray(changedFields) ? changedFields : []).map((fieldName) => {
-      const fn = String(fieldName || '');
-      if (!fn) return null;
-      const hasOriginalKey = Object.prototype.hasOwnProperty.call(originalValues, fn);
-      const oldFromSnapshot = hasOriginalKey
-        ? String(originalValues[fn] ?? '').trim()
-        : (activityRow ? String(activityRow[fn] ?? '').trim() : '');
-      const newVal = String(requestedValues?.[fn] ?? '').trim();
-      return {
-        field_name: fn,
-        old_value: oldFromSnapshot,
-        new_value: newVal
-      };
-    }).filter(Boolean);
+    const fields = requestType === 'create_activity'
+      ? Object.keys(requestedPayload).map((fieldName) => ({
+          field_name: fieldName,
+          old_value: '',
+          new_value: requestedPayload[fieldName]
+        }))
+      : (Array.isArray(changedFields) ? changedFields : []).map((fieldName) => {
+          const fn = String(fieldName || '');
+          if (!fn) return null;
+          const hasOriginalKey = Object.prototype.hasOwnProperty.call(originalValues, fn);
+          const oldFromSnapshot = hasOriginalKey
+            ? String(originalValues[fn] ?? '').trim()
+            : (activityRow ? String(activityRow[fn] ?? '').trim() : '');
+          const newVal = String(requestedValues?.[fn] ?? '').trim();
+          return {
+            field_name: fn,
+            old_value: oldFromSnapshot,
+            new_value: newVal
+          };
+        }).filter(Boolean);
 
     const activityName =
       String(row?.activity_name || '').trim() ||
+      String(requestedPayload?.activity_name || '').trim() ||
       String(activityRow?.activity_name || '').trim();
     const authority =
       String(row?.authority || '').trim() ||
+      String(requestedPayload?.authority || '').trim() ||
       String(activityRow?.authority || '').trim();
     const school =
       String(row?.school || '').trim() ||
+      String(requestedPayload?.school || '').trim() ||
       String(activityRow?.school || '').trim();
 
     return {
@@ -2600,12 +2644,13 @@ function buildEditRequestGroups(rows = [], canReview = false, activityByRowId = 
       review_note: String(row?.review_note || ''),
       source_row_id: sourceRowId,
       source_sheet: String(row?.source_sheet || 'activities'),
+      request_type: requestType,
+      requested_payload: requestedPayload,
       activity_name: activityName,
       authority,
       school,
       activity: activityRow,
-      /** אישור מותר רק כשיש שורת פעילות נטענת מה־DB — אחרת חסר הקשר לפני/אחרי */
-      can_approve: Boolean(activityRow),
+      can_approve: requestType === 'create_activity' ? Object.keys(requestedPayload).length > 0 : Boolean(activityRow),
       fields
     };
   });
@@ -2914,10 +2959,10 @@ export const api = {
         display_role2: flat.display_role2,
         full_name: flat.full_name,
         emp_id: flat.emp_id,
-        can_add_activity: permissionFlagYes(flat.can_add_activity),
-        can_edit_direct: permissionFlagYes(flat.can_edit_direct),
-        can_request_edit: (permissionFlagYes(flat.can_edit_direct) || permissionFlagYes(flat.can_request_edit)),
-        can_review_requests: (['admin', 'operation_manager'].includes(flat.role) || permissionFlagYes(flat.can_review_requests)),
+        can_add_activity: canDirectManageActivitiesUser(flat) || ACTIVITY_REQUEST_ROLES.has(String(flat.role || '').trim()),
+        can_edit_direct: canDirectManageActivitiesUser(flat),
+        can_request_edit: canSubmitActivityRequestsUser(flat),
+        can_review_requests: canDirectManageActivitiesUser(flat),
         finance_access: (flat.role === 'finance' || permissionFlagYes(flat.finance_access) || permissionFlagYes(flat.view_finance))
       },
       ...buildBootstrapFromUser(user),
@@ -3125,14 +3170,14 @@ export const api = {
       rows,
       roleDefaults: {
         admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes', view_catalog: 'yes', view_orders: 'yes' },
-        operation_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
+        operation_manager: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
         authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
-        finance: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes' },
+        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes' },
         activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
-        domain_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
-        business_development_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' },
+        domain_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
+        business_development_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' },
         instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
-        instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' }
+        instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' }
       }
     };
   },
@@ -3364,10 +3409,42 @@ export const api = {
     throw new Error('invalid_contact_kind');
   },
   addActivity: async (target, data) => {
+    if (!canDirectManageActivitiesUser()) throw new Error('forbidden_add_activity');
     const payload = (typeof target === 'object' && target !== null && data === undefined)
       ? { activity: target }
       : { activity: { ...(data || {}), source: target } };
     return upsertActivityToSupabase(payload);
+  },
+  submitCreateActivityRequest: async (activity) => {
+    if (!canSubmitActivityRequestsUser()) throw new Error('forbidden_create_activity_request');
+    const currentUser = state?.user || {};
+    const requestedPayload = sanitizeActivityPayloadForSupabase(
+      synchronizeStartDateAndFirstMeeting(sanitizeActivityPayload(activity || {})),
+      { includeRowId: true }
+    );
+    if (!Object.keys(requestedPayload).length) throw new Error('missing_activity_request_payload');
+    const row = {
+      request_id: `REQ-${Date.now()}`,
+      source_row_id: '',
+      source_sheet: 'activities',
+      request_type: 'create_activity',
+      requested_payload: requestedPayload,
+      activity_name: String(requestedPayload.activity_name || '').trim(),
+      school: String(requestedPayload.school || '').trim(),
+      authority: String(requestedPayload.authority || '').trim(),
+      changed_fields: JSON.stringify([]),
+      original_values: JSON.stringify({}),
+      requested_values: JSON.stringify({}),
+      status: 'pending',
+      active: 'yes',
+      requested_by_user_id: String(currentUser?.user_id || '').trim(),
+      requested_by_name: String(currentUser?.full_name || currentUser?.profile?.full_name || '').trim(),
+      requested_at: new Date().toISOString()
+    };
+    const { error } = await supabase.from('edit_requests').insert(row);
+    if (error) throw buildSupabaseMutationError('submitCreateActivityRequest', error, 'submit_create_activity_request_failed');
+    logActivityMutationDebug('success', 'submitCreateActivityRequest', { source_sheet: 'activities', source_row_id: '', changes: requestedPayload }, { table: 'edit_requests', request_id: row.request_id });
+    return { request_id: row.request_id, status: 'pending', request_type: 'create_activity' };
   },
   /** מקבל אובייקט מלא (כולל source_sheet, changes) או חתימה ישנה (id, changes). */
   saveActivity: async (a, b) => {
@@ -3375,8 +3452,8 @@ export const api = {
       ? { source_row_id: a, changes: b }
       : a;
     const userRole = String(state?.user?.display_role || state?.user?.role || '').trim();
-    const canEditDirect = permissionFlagYes(state?.user?.can_edit_direct);
-    if (userRole === 'activities_manager' && !canEditDirect) {
+    const canEditDirect = canDirectManageActivitiesUser();
+    if (!canEditDirect && canSubmitActivityRequestsUser()) {
       // eslint-disable-next-line no-console
       console.warn('wrong_flow: activities_manager attempted saveActivity; using submitEditRequest instead', {
         action: 'saveActivity',
@@ -3385,6 +3462,7 @@ export const api = {
       });
       return api.submitEditRequest(payload);
     }
+    if (!canEditDirect) throw new Error('forbidden_save_activity');
     return updateActivityInSupabase(payload);
   },
   deleteActivity: async (source_row_id) => {
@@ -3405,6 +3483,7 @@ export const api = {
   },
   submitEditRequest: async (source_row_id, changes, source_sheet = 'activities') => {
     const requestPayload = (source_row_id && typeof source_row_id === 'object') ? source_row_id : null;
+    if (!canSubmitActivityRequestsUser()) throw new Error('forbidden_submit_edit_request');
     const rowId = String(requestPayload?.source_row_id || source_row_id || '').trim();
     const sourceSheet = String(requestPayload?.source_sheet || source_sheet || 'activities').trim() || 'activities';
     const rawChanges = requestPayload?.changes || changes || {};
@@ -3452,6 +3531,7 @@ export const api = {
       changed_fields: JSON.stringify(changedKeys),
       original_values: JSON.stringify(originalValuesMap),
       requested_values: JSON.stringify(normalizedChanges),
+      request_type: 'edit_activity',
       status: 'pending',
       active: 'yes',
       requested_by_user_id: String(currentUser?.user_id || '').trim(),
@@ -3497,25 +3577,29 @@ export const api = {
     const reqRow = reqRes.data;
     if (String(reqRow?.status || '').trim() !== 'pending') throw new Error('edit_request_already_reviewed');
     if (nextStatus === 'approved') {
+      const requestType = normalizeEditRequestType(reqRow?.request_type);
       const sourceRowId = String(reqRow?.source_row_id || '').trim();
-      const requestedValues =
-        reqRow?.requested_values && typeof reqRow.requested_values === 'object'
-          ? reqRow.requested_values
-          : (() => {
-              try { return JSON.parse(String(reqRow?.requested_values || '{}')); } catch { return {}; }
-            })();
-      if (sourceRowId && requestedValues && Object.keys(requestedValues).length) {
-        const sanitizedRequestedValues = sanitizeActivityPayloadForSupabase(
-          mapMeetingDateFieldNamesToSupabase(requestedValues),
-          { includeRowId: false }
+      if (requestType === 'create_activity') {
+        const requestedPayload = sanitizeActivityPayloadForSupabase(
+          synchronizeStartDateAndFirstMeeting(parseJsonishObject(reqRow?.requested_payload)),
+          { includeRowId: true }
         );
-        const { data: appliedRow, error: applyErr } = await supabase
-          .from('activities')
-          .update(sanitizedRequestedValues)
-          .eq('row_id', sourceRowId)
-          .select('row_id')
-          .maybeSingle();
-        if (applyErr || !appliedRow) {
+        if (!Object.keys(requestedPayload).length) throw new Error('missing_create_activity_payload');
+        await upsertActivityToSupabase({ activity: requestedPayload });
+      } else {
+        const requestedValues = parseJsonishObject(reqRow?.requested_values);
+        if (sourceRowId && requestedValues && Object.keys(requestedValues).length) {
+          const sanitizedRequestedValues = sanitizeActivityPayloadForSupabase(
+            mapMeetingDateFieldNamesToSupabase(requestedValues),
+            { includeRowId: false }
+          );
+          const { data: appliedRow, error: applyErr } = await supabase
+            .from('activities')
+            .update(sanitizedRequestedValues)
+            .eq('row_id', sourceRowId)
+            .select('row_id')
+            .maybeSingle();
+          if (applyErr || !appliedRow) {
           const authContext = await buildActivityMutationAuthContext();
           // eslint-disable-next-line no-console
           console.error('[activity-save-error]', {
@@ -3538,6 +3622,7 @@ export const api = {
             error: applyErr
           });
           throw buildSupabaseMutationError('reviewEditRequest', applyErr || new Error('activity_not_found_or_forbidden'), 'review_edit_request_apply_failed');
+          }
         }
       }
     }
@@ -3567,9 +3652,9 @@ export const api = {
     const nextRole = row.role || existing.data.role;
     if (nextRole === 'business_development_manager') {
       Object.assign(permissions, {
-        can_add_activity: 'no',
+        can_add_activity: 'yes',
         can_edit_direct: 'no',
-        can_request_edit: 'no',
+        can_request_edit: 'yes',
         can_review_requests: 'no',
         view_admin: 'no',
         view_permissions: 'no',
@@ -3595,7 +3680,7 @@ export const api = {
   addUser: async (row) => {
     const role = String(row?.role || 'instructor').trim();
     const permissions = role === 'business_development_manager'
-      ? { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' }
+      ? { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' }
       : { can_request_edit: 'yes' };
     const insert = {
       user_id: String(row?.user_id || '').trim(),

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -56,6 +56,24 @@ const DEFAULT_ACTIVITY_PERIOD_TAB = 'school_2026';
 const INACTIVE_ACTIVITY_STATUSES = new Set(['סגור', 'נמחק', 'closed', 'deleted', 'inactive']);
 const ACTIVITY_LAYOUT_SEASON = 'summer_2026';
 const ACTIVITY_LAYOUT_ALLOWED_ROLES = new Set(['admin', 'operation_manager']);
+const ACTIVITY_DIRECT_MANAGE_ROLES = new Set(['admin', 'operation_manager']);
+const ACTIVITY_REQUEST_ROLES = new Set(['activities_manager', 'instructor_manager', 'business_development_manager']);
+
+function activityRole(state) {
+  return String(state?.user?.display_role || state?.user?.role || '').trim();
+}
+
+function canDirectManageActivities(state) {
+  return ACTIVITY_DIRECT_MANAGE_ROLES.has(activityRole(state));
+}
+
+function canRequestActivityChanges(state) {
+  return canDirectManageActivities(state) || ACTIVITY_REQUEST_ROLES.has(activityRole(state));
+}
+
+function canOpenCreateActivity(state) {
+  return canDirectManageActivities(state) || ACTIVITY_REQUEST_ROLES.has(activityRole(state));
+}
 
 function normalizeActivityPeriodTab(value) {
   const key = String(value || '').trim();
@@ -1013,8 +1031,9 @@ export const activitiesScreen = {
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
     const role = String(state?.user?.display_role || state?.user?.role || '').trim();
-    const canDeleteActivity = ['admin', 'operation_manager'].includes(role);
-    const canAddActivity = !!state?.user?.can_add_activity || role === 'operation_manager' || role === 'admin';
+    const canDeleteActivity = canDirectManageActivities(state);
+    const canAddActivity = canOpenCreateActivity(state);
+    const isCreateRequestOnly = canAddActivity && !canDirectManageActivities(state);
     const isAdmin = isAdminUser(state);
     const canUseLayout = canUseActivityLayout(state) && state.activityPeriodTab === ACTIVITY_LAYOUT_SEASON;
 
@@ -1155,7 +1174,7 @@ export const activitiesScreen = {
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
         ${canUseLayout ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn ds-activities-toolbar-btn--layout" data-activity-layout-list title="פריסת פעילות לבתי ספר עם שיבוץ מלא">פריסת פעילות</button>` : ''}
         ${isAdmin ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-activities-toolbar-btn" data-activities-export-all title="ייצוא הפעילויות בלשונית הפעילה לאקסל">ייצוא לאקסל</button>` : ''}
-        ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-activities-add-btn aria-label="הוספת פעילות" title="הוספת פעילות">+</button>` : ''}
+        ${canAddActivity ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ${isCreateRequestOnly ? 'ds-activities-toolbar-btn' : 'ds-btn--icon-only'}" data-activities-add-btn aria-label="${isCreateRequestOnly ? 'בקשה להוספת פעילות' : 'הוספת פעילות'}" title="${isCreateRequestOnly ? 'בקשה להוספת פעילות' : 'הוספת פעילות'}">${isCreateRequestOnly ? 'בקשה להוספת פעילות' : '+'}</button>` : ''}
       </div>
     </div>`;
 
@@ -1274,15 +1293,14 @@ export const activitiesScreen = {
     }
     const filteredRows      = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
     const canSeePrivateNotes = ['operation_manager', 'admin'].includes(state?.user?.display_role);
-    const canEditActivity   = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);
+    const canEditActivity   = canRequestActivityChanges(state);
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
     const role = String(state?.user?.display_role || state?.user?.role || '').trim();
-    const canDeleteActivity = ['admin', 'operation_manager'].includes(
-      String(state?.user?.display_role || state?.user?.role || '').trim()
-    );
-    const canAddActivity = !!state?.user?.can_add_activity || role === 'operation_manager' || role === 'admin';
+    const canDeleteActivity = canDirectManageActivities(state);
+    const canAddActivity = canOpenCreateActivity(state);
+    const isCreateRequestOnly = canAddActivity && !canDirectManageActivities(state);
     const isAdmin = isAdminUser(state);
 
     const rerenderLocal = () => {
@@ -1345,7 +1363,7 @@ export const activitiesScreen = {
             if (freshRow && contentRoot) {
               putCachedActivityDetail({ RowID: sourceRowId, source_sheet: sourceSheet || 'activities' }, freshRow, state);
               contentRoot.innerHTML = activityDrawerContent(
-                freshRow, canSeePrivateNotes, canEditActivity, !!state?.user?.can_edit_direct, !!state?.user?.can_request_edit,
+                freshRow, canSeePrivateNotes, canEditActivity, canDirectManageActivities(state), canRequestActivityChanges(state),
                 canDeleteActivity,
                 hideEmpIds, hideRowId, hideActivityNo,
                 mergeSettingsWithFallback(state?.clientSettings || {}, buildFallbackOptionsFromRows(activitiesRows)),
@@ -1401,8 +1419,8 @@ export const activitiesScreen = {
       if (!summaryRow || !ui) return;
       const cachedDetail = getCachedActivityDetail(summaryRow, state);
       const cachedDates  = getCachedActivityDates(summaryRow, state);
-      const canDirectEdit = !!state?.user?.can_edit_direct;
-      const canRequestEdit = !!state?.user?.can_request_edit;
+      const canDirectEdit = canDirectManageActivities(state);
+      const canRequestEdit = canRequestActivityChanges(state);
       const settings = mergeSettingsWithFallback(
         state?.clientSettings || {},
         buildFallbackOptionsFromRows(activitiesRows)
@@ -1800,15 +1818,26 @@ export const activitiesScreen = {
         return;
       }
 
-      const originalText = submitBtn?.textContent || 'שמור';
+      const originalText = submitBtn?.textContent || (isCreateRequestOnly ? 'שליחת בקשה' : 'שמור');
       try {
         if (submitBtn) {
           submitBtn.disabled = true;
-          submitBtn.textContent = 'שומר...';
+          submitBtn.textContent = isCreateRequestOnly ? 'שולח בקשה...' : 'שומר...';
         }
-        if (statusEl) statusEl.textContent = 'שומר...';
-        console.info('[addActivity] submit fired');
+        if (statusEl) statusEl.textContent = isCreateRequestOnly ? 'שולח בקשה לאישור...' : 'שומר...';
+        console.info('[addActivity] submit fired', { requestOnly: isCreateRequestOnly });
         console.info('[addActivity] payload', payload);
+        if (isCreateRequestOnly) {
+          const rsp = await api.submitCreateActivityRequest(payload);
+          console.info('[addActivity] request success', rsp);
+          clearScreenDataCache?.();
+          try { document.dispatchEvent(new CustomEvent('app:edit-requests-updated')); } catch (_) { /* ignore */ }
+          const requestId = String(rsp?.request_id || '').trim();
+          if (statusEl) statusEl.textContent = requestId ? `הבקשה נשלחה לאישור · מזהה בקשה: ${requestId}` : 'הבקשה נשלחה לאישור';
+          showToast('הבקשה להוספת פעילות נשלחה לאישור', 'success', 3200);
+          ui?.closeModal?.();
+          return;
+        }
         const rsp = await api.addActivity(payload);
         console.info('[addActivity] success', rsp);
         clearScreenDataCache?.();
@@ -1872,12 +1901,12 @@ export const activitiesScreen = {
     if (canAddActivity && ui && addBtn) {
       addBtn.addEventListener('click', () => {
         ui.openModal({
-          title: 'הוספת פעילות',
+          title: isCreateRequestOnly ? 'בקשה להוספת פעילות' : 'הוספת פעילות',
           // חשוב: חלון הוספת פעילות חייב להשתמש ב-client settings האחידים
           // (כמו admin), ללא בניית רשימות fallback מתוך rows חלקיים של המסך.
           content: addActivityModalHtml(state?.clientSettings || {}),
           actions: `
-            <button type="button" class="ds-btn ds-btn--primary" data-add-activity-submit>שמור</button>
+            <button type="button" class="ds-btn ds-btn--primary" data-add-activity-submit>${isCreateRequestOnly ? 'שליחת בקשה לאישור' : 'שמור'}</button>
             <button type="button" class="ds-btn" data-ui-close-modal>ביטול</button>
           `
         });

--- a/frontend/src/screens/edit-requests.js
+++ b/frontend/src/screens/edit-requests.js
@@ -90,26 +90,31 @@ function instructorLine(activity) {
   return parts.length ? parts.join(' · ') : '—';
 }
 
+function requestTypeLabel(type) {
+  return String(type || '') === 'create_activity' ? 'בקשה להוספת פעילות' : 'בקשת עריכה';
+}
+
 function renderGroup(group, canReview) {
   const activity = group.activity || null;
+  const isCreateRequest = String(group.request_type || '') === 'create_activity';
   const hasActivity = Boolean(activity);
   const titleName = String(group.activity_name || activity?.activity_name || '').trim() || 'פעילות ללא שם';
   const rowId = String(group.source_row_id || '').trim();
-  const activityType = activity
+  const activityTypeRaw = String((isCreateRequest ? group?.requested_payload?.activity_type : activity?.activity_type) || '').trim();
+  const activityType = activityTypeRaw
     ? (() => {
-        const t = String(activity.activity_type || '').trim();
-        const he = hebrewActivityType(t);
-        return he && he !== 'לא מסווג' ? he : (t || '—');
+        const he = hebrewActivityType(activityTypeRaw);
+        return he && he !== 'לא מסווג' ? he : activityTypeRaw;
       })()
     : '—';
   const authority = String(group.authority || activity?.authority || '').trim() || '—';
   const school = String(group.school || activity?.school || '').trim() || '—';
-  const manager = String(activity?.activity_manager || '').trim() || '—';
-  const startD = activity ? formatDateDisplay(String(activity.start_date || '').trim()) : '';
-  const endD = activity ? formatDateDisplay(String(activity.end_date || '').trim()) : '';
+  const manager = String((isCreateRequest ? group?.requested_payload?.activity_manager : activity?.activity_manager) || '').trim() || '—';
+  const startD = formatDateDisplay(String((isCreateRequest ? group?.requested_payload?.start_date : activity?.start_date) || '').trim());
+  const endD = formatDateDisplay(String((isCreateRequest ? group?.requested_payload?.end_date : activity?.end_date) || '').trim());
   const startEnd = [startD, endD].filter(Boolean).join(' — ') || '—';
 
-  const warnIncomplete = !hasActivity
+  const warnIncomplete = (!hasActivity && !isCreateRequest)
     ? `<div class="ds-er-warn" role="alert">לא נמצאו פרטי פעילות מלאים לבדיקה — לא ניתן לאשר עד שנטענת הפעילות מהמערכת.</div>`
     : '';
 
@@ -139,16 +144,17 @@ function renderGroup(group, canReview) {
   return `
     <article class="ds-er-group" data-status="${escapeHtml(group.status || '')}" data-request-id="${escapeHtml(group.request_id)}">
       <header class="ds-er-card-head">
-        <h3 class="ds-er-card-title">בקשת עריכה לפעילות: ${escapeHtml(titleName)}</h3>
+        <h3 class="ds-er-card-title">${escapeHtml(requestTypeLabel(group.request_type))}: ${escapeHtml(titleName)}</h3>
         <div>${dsStatusChip(statusLabel(group.status), statusVariant(group.status))}</div>
       </header>
       <div class="ds-er-meta-grid" dir="rtl">
-        <p><span class="ds-muted">מזהה:</span> <strong>${escapeHtml(rowId || '—')}</strong></p>
-        <p><span class="ds-muted">סוג:</span> ${escapeHtml(activityType)}</p>
+        <p><span class="ds-muted">מזהה:</span> <strong>${escapeHtml(rowId || (isCreateRequest ? 'ייווצר באישור' : '—'))}</strong></p>
+        <p><span class="ds-muted">סוג בקשה:</span> ${escapeHtml(requestTypeLabel(group.request_type))}</p>
+        <p><span class="ds-muted">סוג פעילות:</span> ${escapeHtml(activityType)}</p>
         <p><span class="ds-muted">רשות:</span> ${escapeHtml(authority)}</p>
         <p><span class="ds-muted">בית ספר:</span> ${escapeHtml(school)}</p>
         <p><span class="ds-muted">מנהל פעילות:</span> ${escapeHtml(manager)}</p>
-        <p><span class="ds-muted">מדריך:</span> ${escapeHtml(instructorLine(activity))}</p>
+        <p><span class="ds-muted">מדריך:</span> ${escapeHtml(isCreateRequest ? instructorLine(group.requested_payload || {}) : instructorLine(activity))}</p>
         <p><span class="ds-muted">תאריכי התחלה–סיום:</span> ${escapeHtml(startEnd)}</p>
       </div>
       <p class="ds-er-requester-line" dir="rtl">
@@ -158,15 +164,15 @@ function renderGroup(group, canReview) {
         ${escapeHtml(formatDateDisplay(group.requested_at) || String(group.requested_at || '—'))}
       </p>
       ${warnIncomplete}
-      <h4 class="ds-er-section-title">מה השתנה?</h4>
+      <h4 class="ds-er-section-title">${isCreateRequest ? 'פרטי הפעילות המבוקשת' : 'מה השתנה?'}</h4>
       <div class="ds-table-wrap ds-er-fields-wrap">
         <table class="ds-table ds-er-fields-table">
           <thead>
             <tr>
               <th>שדה</th>
-              <th>ערך נוכחי</th>
+              <th>${isCreateRequest ? 'פרט' : 'ערך נוכחי'}</th>
               <th></th>
-              <th>ערך מבוקש</th>
+              <th>${isCreateRequest ? 'ערך' : 'ערך מבוקש'}</th>
             </tr>
           </thead>
           <tbody>${fieldsRows}</tbody>
@@ -188,7 +194,7 @@ export const editRequestsScreen = {
   load: ({ api }) => api.editRequests(),
   render(data) {
     const groups = Array.isArray(data?.groups) ? data.groups : [];
-    const validGroups = groups.filter((group) => Array.isArray(group?.fields) && group.fields.length > 0);
+    const validGroups = groups.filter((group) => String(group?.request_type || '') === 'create_activity' || (Array.isArray(group?.fields) && group.fields.length > 0));
     const canReview = !!data?.canReview;
 
     const openGroups = validGroups.filter(isOpen);
@@ -197,10 +203,10 @@ export const editRequestsScreen = {
       ? dsEmptyState('אין בקשות פתוחות כרגע')
       : openGroups.map((g) => renderGroup(g, canReview)).join('');
 
-    const subtitle = canReview ? 'בקשות עריכה הממתינות לאישורך' : 'בקשות עריכה שהגשת';
+    const subtitle = canReview ? 'בקשות פעילות הממתינות לאישורך' : 'בקשות פעילות שהגשת';
 
     return dsScreenStack(`
-      ${dsPageHeader('בקשות עריכה', subtitle)}
+      ${dsPageHeader('בקשות פעילות', subtitle)}
       ${dsCard({
         title: `בקשות פתוחות (${openGroups.length})`,
         padded: false,

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -585,7 +585,7 @@ function buildOneDayViewHtml(schedule, row, datesLoading) {
   </div>`;
 }
 
-function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
+function blockDates(row, { canEdit = false, canDirectEdit = false, datesLoading = false } = {}) {
   const schedule = Array.isArray(row?.meeting_schedule) ? row.meeting_schedule : [];
   const activityType = String(row.activity_type || '').trim();
   const isOnce = ONCE_TYPES.includes(activityType);
@@ -615,7 +615,7 @@ function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
       <section class="activity-drawer__section" data-dates-section${loadingAttr}>
         <div class="activity-drawer__section-head">
           <h3 class="activity-drawer__section-title">תאריך ושעות פעילות</h3>
-          ${canEdit ? '<button type="button" class="activity-drawer__action" data-action="start-edit" data-mode="view">✏️ עריכה</button>' : ''}
+          ${canEdit ? `<button type="button" class="activity-drawer__action" data-action="start-edit" data-mode="view">✏️ ${canDirectEdit ? 'עריכה' : 'בקשת שינוי'}</button>` : ''}
         </div>
         ${buildOneDayViewHtml(schedule, row, datesLoading)}
         <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit hidden>
@@ -692,7 +692,7 @@ function blockDates(row, { canEdit = false, datesLoading = false } = {}) {
     <section class="activity-drawer__section" data-dates-section${loadingAttr}>
       <div class="activity-drawer__section-head">
         <h3 class="activity-drawer__section-title">מפגשים ותאריכים</h3>
-        ${canEdit ? '<button type="button" class="activity-drawer__action" data-action="start-edit" data-mode="view">✏️ עריכה</button>' : ''}
+        ${canEdit ? `<button type="button" class="activity-drawer__action" data-action="start-edit" data-mode="view">✏️ ${canDirectEdit ? 'עריכה' : 'בקשת שינוי'}</button>` : ''}
       </div>
       ${progressHtml}
       <div class="activity-drawer__dates activity-drawer__dates--edit" data-mode="edit" data-meeting-dates-edit hidden>
@@ -849,7 +849,7 @@ function singleForm(row, { settings = {}, privateNote = null, canEdit = false, c
       ${blockActivityDetails(row, { settings })}
       ${blockAssignment(row, { settings })}
       ${blockTeamTimes(row, { settings })}
-      ${blockDates(row, { canEdit, datesLoading })}
+      ${blockDates(row, { canEdit, canDirectEdit, datesLoading })}
       ${instructorLimited ? '' : blockExtraEditInfo(row, { settings })}
       ${blockNotes(row, { hidden: instructorLimited })}
       ${blockSupplementalView(row, { settings, hideFunding: instructorLimited })}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 547;
+const CACHE_VERSION = 548;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 547;
+const SW_ENTRY_VERSION = 548;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activity-request-permissions.test.mjs
+++ b/tests/activity-request-permissions.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
+const ACTIVITIES_FILE = new URL('../frontend/src/screens/activities.js', import.meta.url);
+const EDIT_REQUESTS_FILE = new URL('../frontend/src/screens/edit-requests.js', import.meta.url);
+
+test('activity roles split direct managers, request-only managers, and read-only users', async () => {
+  const apiSource = await fs.readFile(API_FILE, 'utf8');
+  const activitiesSource = await fs.readFile(ACTIVITIES_FILE, 'utf8');
+
+  assert.match(apiSource, /ACTIVITY_DIRECT_MANAGE_ROLES = new Set\(\['admin', 'operation_manager'\]\)/);
+  assert.match(apiSource, /ACTIVITY_REQUEST_ROLES = new Set\(\['activities_manager', 'instructor_manager', 'business_development_manager'\]\)/);
+  assert.match(apiSource, /domain_manager: \{ can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no'/);
+  assert.match(apiSource, /finance: \{ can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no'/);
+  assert.match(apiSource, /instructor: \{ can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no'/);
+  assert.match(activitiesSource, /function canDirectManageActivities\(state\)/);
+  assert.match(activitiesSource, /function canOpenCreateActivity\(state\)/);
+  assert.match(activitiesSource, /בקשה להוספת פעילות/);
+  assert.match(activitiesSource, /submitCreateActivityRequest\(payload\)/);
+});
+
+test('create activity requests use edit_requests request_type and requested_payload', async () => {
+  const apiSource = await fs.readFile(API_FILE, 'utf8');
+  const editRequestsSource = await fs.readFile(EDIT_REQUESTS_FILE, 'utf8');
+
+  assert.match(apiSource, /submitCreateActivityRequest: async/);
+  assert.match(apiSource, /request_type: 'create_activity'/);
+  assert.match(apiSource, /requested_payload: requestedPayload/);
+  assert.match(apiSource, /status: 'pending'/);
+  assert.match(apiSource, /requested_by_user_id/);
+  assert.match(apiSource, /request_type: 'edit_activity'/);
+  assert.match(apiSource, /normalizeEditRequestType/);
+  assert.match(apiSource, /requestType === 'create_activity'/);
+  assert.match(apiSource, /await upsertActivityToSupabase\(\{ activity: requestedPayload \}\)/);
+  assert.match(editRequestsSource, /סוג בקשה/);
+  assert.match(editRequestsSource, /פרטי הפעילות המבוקשת/);
+});


### PR DESCRIPTION
### Motivation
- לאפשר למנהלי פעילויות שאינם מורשים לערוך/ליצור ישירות להגיש בקשה להוספת פעילות או בקשת שינוי, ולשמור על אפשרות אישור/דחייה על ידי `admin`/`operation_manager` בלבד.
- לשמור עקביות DB ו־API באמצעות שדה `request_type` (`'create_activity'` / `'edit_activity'`) ו־`requested_payload` כדי לאחסן בקשות יצירה בצורה קריאה ובטוחה.

### Description
- פיצלתי הרשאות פעילות לפי תפקידים והוספתי פונקציות בדיקה: `ACTIVITY_DIRECT_MANAGE_ROLES`, `ACTIVITY_REQUEST_ROLES`, `canDirectManageActivitiesUser`, `canSubmitActivityRequestsUser` ו־UI-level helpers ב־`activities.js` (`canDirectManageActivities`, `canOpenCreateActivity`, `canRequestActivityChanges`).
- הוספתי תהליך יצירת בקשת פעילות חדש ב־API: `submitCreateActivityRequest` ששומר שורה ב־`edit_requests` עם `request_type = 'create_activity'` ו־`requested_payload` ברור; ואיפוס הזרימה כך שאישור ב־`reviewEditRequest` עבור `create_activity` מבצע `upsertActivityToSupabase` ליצירת הפעילות.
- עדכנתי את עמוד ה־Activities: כפתור ההוספה מציג יצירה ישירה למנהלים ישירים, ו"בקשה להוספת פעילות" (או טקסט דומה) לתפקידי בקשות בלבד; במודאל ההוספה המשתמשים מבקשים ישלחו ל־`submitCreateActivityRequest` במקום `addActivity` כאשר הם רק מבקשים.
- עדכנתי את המודאל/מגירת עריכת פעילות כך שכפתור עריכה מציג "בקשת שינוי" למשתמשים שאינם מורשים לעריכה ישירה, והונחה המנגנון הקיים לשמירת בקשות עריכה דרך `submitEditRequest`.
- שיפרתי את מסך הבקשות (`edit-requests.js`) להצגת `request_type`, הצגה קריאה של `requested_payload` עבור בקשות יצירה, וטקסטים מתאימים בעברית; ובניתי group building מותאם הכולל `requested_payload` ו־`can_approve` מותאמת.
- עדכנתי ה־Service Worker (`frontend/sw.js`, `sw.js` ו־dist) להעלות `CACHE_VERSION`/`SW_ENTRY_VERSION` כדי לנקות cache ישן לאחר הפריסה.
- נוספו בדיקות ממוקדות: `tests/activity-request-permissions.test.mjs` וגם עדכונים/התאמות ל־`tests/edit-requests-feedback-regression.test.mjs` כדי לכסות ההרשאות והזרימה החדשה.

### Testing
- הרצת המבחנים הממוקדים: `node --test tests/edit-requests-feedback-regression.test.mjs tests/activity-request-permissions.test.mjs` — כל המבחנים עברו בהצלחה (4 + 2 tests passed).
- בדיקות סטטיות/תיקון: `npm run check:changed` — עבר ללא שגיאות סינטקס על הקבצים ששונו.
- בניית frontend: `npm run check:build` — build הצליח ו־dist עודכן (SW cache version הועלה).
- הוספתי ומיד הרצתי `tests/activity-request-permissions.test.mjs` שמוודא את חלוקת התפקידים, שמירת `create_activity` ב־`edit_requests` עם `requested_payload`, ואת הנראות במסך הבקשות; הבדיקה עברה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203ddf3b58832bb2ef5759894aaebb)