### PR TITLE
Add Personal Reports module for expense and travel tracking

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 548;
+const CACHE_VERSION = 549;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-_Ta33XgJ.js",
+  "./assets/index-CT00ijXz.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-RaaXqnQU.css",
+  "./assets/style-DeJf2Vd1.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-_Ta33XgJ.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-RaaXqnQU.css">
+  <script type="module" crossorigin src="./assets/index-CT00ijXz.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-DeJf2Vd1.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 548;
+const CACHE_VERSION = 549;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-_Ta33XgJ.js",
+  "./assets/index-CT00ijXz.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-RaaXqnQU.css",
+  "./assets/style-DeJf2Vd1.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1872,15 +1872,15 @@ const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_
 const ROLES_WITH_DIRECT_EDIT = new Set(['admin', 'operation_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
-  admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
-  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
-  authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  instructor: ['my-data', 'week', 'month']
+  admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists', 'personal-reports'],
+  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'personal-reports'],
+  authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
+  finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
+  domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
+  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
+  instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
+  instructor: ['my-data', 'week', 'month', 'personal-reports']
 };
 
 function normalizeSupabaseRole(role) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -516,7 +516,8 @@ const screenLabels = {
   finance: 'כספים / גבייה',
   invitations: 'הזמנות',
   orders: 'הזמנות',
-  catalog: 'קטלוג'
+  catalog: 'קטלוג',
+  'personal-reports': 'דוחות אישיים'
 };
 
 function navLabelForRoute(route) {
@@ -563,7 +564,8 @@ const screenLoaders = {
   finance: () => import('./screens/finance.js').then((m) => m.financeScreen),
   invitations: () => import('./screens/invitations.js').then((m) => m.invitationsScreen),
   orders: () => import('./screens/orders.js').then((m) => m.ordersScreen),
-  catalog: () => import('./screens/catalog.js').then((m) => m.catalogScreen)
+  catalog: () => import('./screens/catalog.js').then((m) => m.catalogScreen),
+  'personal-reports': () => import('./screens/personal-reports.js').then((m) => m.personalReportsScreen)
 };
 const loadedScreens = new Map();
 const loadingScreens = new Map();

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -1,0 +1,1124 @@
+/**
+ * Personal Reports Screen — דוחות אישיים
+ *
+ * Handles its own Supabase Auth session (separate from the main dashboard session).
+ * Uses the shared supabase client (anon key only — no service_role exposure).
+ *
+ * Roles:
+ *   employee — sees only their own reports
+ *   admin    — sees all reports, can approve / return / mark paid
+ */
+
+import { supabase } from '../supabase-client.js';
+import { escapeHtml } from './shared/html.js';
+import { dsPageHeader, dsCard, dsScreenStack, dsEmptyState, dsStatusChip } from './shared/layout.js';
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const MONTHS_HE = ['ינואר','פברואר','מרץ','אפריל','מאי','יוני','יולי','אוגוסט','ספטמבר','אוקטובר','נובמבר','דצמבר'];
+
+const STATUS_LABELS = {
+  draft:            'טיוטה',
+  submitted:        'נשלח לכספים',
+  needs_correction: 'נדרש תיקון',
+  approved:         'אושר',
+  paid:             'שולם'
+};
+
+const STATUS_KIND = {
+  draft:            'neutral',
+  submitted:        'warning',
+  needs_correction: 'danger',
+  approved:         'success',
+  paid:             'success'
+};
+
+const DOC_TYPE_LABELS = { receipt: 'קבלה', invoice: 'חשבונית', other: 'אחר' };
+
+// ─── module state ─────────────────────────────────────────────────────────────
+
+let prSession = null;   // { user, profile }
+let prView = 'login';   // login | employee | admin | report-detail | employee-report
+let prSelectedReport = null;
+let prSelectedMonth = null;  // { month, year }
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function fmt(n) { return Number(n || 0).toLocaleString('he-IL', { minimumFractionDigits: 2, maximumFractionDigits: 2 }); }
+
+function fmtDate(d) {
+  if (!d) return '';
+  try { return new Date(d).toLocaleDateString('he-IL'); } catch { return d; }
+}
+
+function currentMonthYear() {
+  const now = new Date();
+  return { month: now.getMonth() + 1, year: now.getFullYear() };
+}
+
+function monthLabel(month, year) {
+  return `${MONTHS_HE[month - 1]} ${year}`;
+}
+
+function canEditReport(report) {
+  return !report || report.status === 'draft' || report.status === 'needs_correction';
+}
+
+// ─── supabase API calls ───────────────────────────────────────────────────────
+
+async function signIn(email, password) {
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) throw error;
+  return data;
+}
+
+async function signOut() {
+  await supabase.auth.signOut();
+}
+
+async function resetPassword(email) {
+  const { error } = await supabase.auth.resetPasswordForEmail(email);
+  if (error) throw error;
+}
+
+async function getProfile(userId) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', userId)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function getOrCreateReport(employeeId, month, year) {
+  const { data: existing } = await supabase
+    .from('personal_reports')
+    .select('*')
+    .eq('employee_id', employeeId)
+    .eq('report_month', month)
+    .eq('report_year', year)
+    .single();
+  if (existing) return existing;
+
+  const { data: created, error } = await supabase
+    .from('personal_reports')
+    .insert({ employee_id: employeeId, report_month: month, report_year: year, status: 'draft' })
+    .select()
+    .single();
+  if (error) throw error;
+  return created;
+}
+
+async function fetchReport(reportId) {
+  const { data, error } = await supabase
+    .from('personal_reports')
+    .select('*')
+    .eq('id', reportId)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function fetchAllReports() {
+  const { data, error } = await supabase
+    .from('personal_reports')
+    .select(`
+      *,
+      profiles!personal_reports_employee_id_fkey(full_name, email)
+    `)
+    .order('report_year', { ascending: false })
+    .order('report_month', { ascending: false });
+  if (error) throw error;
+  return data || [];
+}
+
+async function fetchDeclaredTravel(reportId) {
+  const { data, error } = await supabase
+    .from('declared_travel_entries')
+    .select('*')
+    .eq('report_id', reportId)
+    .order('travel_date');
+  if (error) throw error;
+  return data || [];
+}
+
+async function fetchPublicTransport(reportId) {
+  const { data, error } = await supabase
+    .from('public_transport_entries')
+    .select('*')
+    .eq('report_id', reportId)
+    .order('travel_date');
+  if (error) throw error;
+  return data || [];
+}
+
+async function fetchExpenses(reportId) {
+  const { data, error } = await supabase
+    .from('expense_entries')
+    .select('*')
+    .eq('report_id', reportId)
+    .order('expense_date');
+  if (error) throw error;
+  return data || [];
+}
+
+async function fetchAttachments(reportId) {
+  const { data, error } = await supabase
+    .from('report_attachments')
+    .select('*')
+    .eq('report_id', reportId)
+    .order('uploaded_at');
+  if (error) throw error;
+  return data || [];
+}
+
+async function upsertDeclaredTravel(entry) {
+  if (entry.id) {
+    const { error } = await supabase.from('declared_travel_entries').update(entry).eq('id', entry.id);
+    if (error) throw error;
+  } else {
+    const { error } = await supabase.from('declared_travel_entries').insert(entry);
+    if (error) throw error;
+  }
+}
+
+async function upsertPublicTransport(entry) {
+  if (entry.id) {
+    const { error } = await supabase.from('public_transport_entries').update(entry).eq('id', entry.id);
+    if (error) throw error;
+  } else {
+    const { error } = await supabase.from('public_transport_entries').insert(entry);
+    if (error) throw error;
+  }
+}
+
+async function upsertExpense(entry) {
+  if (entry.id) {
+    const { error } = await supabase.from('expense_entries').update(entry).eq('id', entry.id);
+    if (error) throw error;
+  } else {
+    const { error } = await supabase.from('expense_entries').insert(entry);
+    if (error) throw error;
+  }
+}
+
+async function deleteEntry(table, id) {
+  const { error } = await supabase.from(table).delete().eq('id', id);
+  if (error) throw error;
+}
+
+async function submitReport(reportId) {
+  const { error } = await supabase
+    .from('personal_reports')
+    .update({ status: 'submitted', submitted_at: new Date().toISOString() })
+    .eq('id', reportId);
+  if (error) throw error;
+}
+
+async function adminUpdateReport(reportId, fields) {
+  const { error } = await supabase
+    .from('personal_reports')
+    .update(fields)
+    .eq('id', reportId);
+  if (error) throw error;
+}
+
+async function uploadAttachment(reportId, employeeId, expenseEntryId, file) {
+  const ext = file.name.split('.').pop();
+  const path = `${employeeId}/${reportId}/${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`;
+  const { error: uploadError } = await supabase.storage
+    .from('personal-report-attachments')
+    .upload(path, file, { upsert: false });
+  if (uploadError) throw uploadError;
+
+  const { error: dbError } = await supabase.from('report_attachments').insert({
+    report_id: reportId,
+    employee_id: employeeId,
+    expense_entry_id: expenseEntryId || null,
+    storage_path: path,
+    file_name: file.name,
+    file_type: file.type,
+    file_size: file.size
+  });
+  if (dbError) throw dbError;
+}
+
+async function getSignedUrl(storagePath) {
+  const { data, error } = await supabase.storage
+    .from('personal-report-attachments')
+    .createSignedUrl(storagePath, 60);
+  if (error) throw error;
+  return data.signedUrl;
+}
+
+async function deleteAttachment(attachment) {
+  await supabase.storage.from('personal-report-attachments').remove([attachment.storage_path]);
+  await supabase.from('report_attachments').delete().eq('id', attachment.id);
+}
+
+// ─── render helpers ───────────────────────────────────────────────────────────
+
+function showToast(msg, kind = 'info') {
+  const el = document.getElementById('pr-toast');
+  if (!el) return;
+  el.textContent = msg;
+  el.className = `pr-toast pr-toast--${kind} pr-toast--visible`;
+  clearTimeout(el._t);
+  el._t = setTimeout(() => el.classList.remove('pr-toast--visible'), 3500);
+}
+
+function setLoading(id, on) {
+  const el = document.getElementById(id);
+  if (el) el.classList.toggle('pr-loading', on);
+}
+
+// ─── HTML builders ────────────────────────────────────────────────────────────
+
+function loginHtml(errorMsg = '') {
+  return `
+    <div class="pr-auth-wrap" dir="rtl">
+      <div class="pr-auth-card">
+        <h1 class="pr-auth-title">דוחות אישיים</h1>
+        <p class="pr-auth-sub">הוצאות, נסיעות וקבלות</p>
+        ${errorMsg ? `<div class="pr-alert pr-alert--danger" role="alert">${escapeHtml(errorMsg)}</div>` : ''}
+        <form id="pr-login-form" class="pr-form" novalidate>
+          <div class="pr-field">
+            <label class="pr-label" for="pr-email">מייל עבודה</label>
+            <input class="pr-input" id="pr-email" type="email" autocomplete="email" required placeholder="your@email.com" />
+          </div>
+          <div class="pr-field">
+            <label class="pr-label" for="pr-pass">סיסמה</label>
+            <input class="pr-input" id="pr-pass" type="password" autocomplete="current-password" required placeholder="••••••••" />
+          </div>
+          <button class="pr-btn pr-btn--primary pr-btn--full" type="submit" id="pr-login-btn">התחברות</button>
+          <button class="pr-btn pr-btn--link" type="button" id="pr-forgot-btn">שכחתי סיסמה</button>
+        </form>
+      </div>
+    </div>
+  `;
+}
+
+function employeeDashboardHtml(profile) {
+  const { month, year } = currentMonthYear();
+  let monthOptions = '';
+  for (let i = 0; i < 12; i++) {
+    const m = month - i <= 0 ? month - i + 12 : month - i;
+    const y = month - i <= 0 ? year - 1 : year;
+    monthOptions += `<option value="${m}-${y}" ${i === 0 ? 'selected' : ''}>${monthLabel(m, y)}</option>`;
+  }
+
+  return `
+    <div class="pr-screen" dir="rtl">
+      <div class="pr-topbar">
+        <button class="pr-btn pr-btn--ghost pr-back-btn" data-pr-action="back-to-dashboard">← חזרה לדשבורד</button>
+        <span class="pr-topbar__title">דוחות אישיים</span>
+        <button class="pr-btn pr-btn--ghost pr-btn--sm" data-pr-action="sign-out">יציאה</button>
+      </div>
+
+      <div class="pr-body">
+        ${dsPageHeader('הדוחות האישיים שלי', `שלום ${escapeHtml(profile.full_name)}`)}
+
+        <div class="pr-card pr-card--highlight">
+          <label class="pr-label" for="pr-month-select">בחר חודש דיווח</label>
+          <select class="pr-input pr-input--select" id="pr-month-select">
+            ${monthOptions}
+          </select>
+          <button class="pr-btn pr-btn--primary" id="pr-open-report-btn" data-pr-action="open-report" style="margin-top:12px">
+            פתח / צפה בדוח
+          </button>
+        </div>
+
+        <div id="pr-my-reports-list" class="pr-reports-list">
+          <div class="pr-loading-placeholder">טוען דוחות…</div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function reportDetailHtml(report, travel, transport, expenses, attachments, profile) {
+  const editable = canEditReport(report);
+  const monthYearLabel = monthLabel(report.report_month, report.report_year);
+  const statusChip = dsStatusChip(STATUS_LABELS[report.status] || report.status, STATUS_KIND[report.status] || 'neutral');
+
+  const totalTravel = travel.reduce((s, r) => s + Number(r.amount || 0), 0);
+  const totalTransport = transport.reduce((s, r) => s + Number(r.amount || 0), 0);
+  const totalExpenses = expenses.reduce((s, r) => s + Number(r.amount || 0), 0);
+  const totalAll = totalTravel + totalTransport + totalExpenses;
+
+  const travelRows = travel.map(r => `
+    <div class="pr-entry-row" data-entry-id="${escapeHtml(r.id)}" data-entry-type="declared_travel">
+      <div class="pr-entry-main">
+        <span class="pr-entry-date">${fmtDate(r.travel_date)}</span>
+        <span class="pr-entry-desc">${escapeHtml(r.origin)} → ${escapeHtml(r.destination)}</span>
+        ${r.description ? `<span class="pr-entry-note">${escapeHtml(r.description)}</span>` : ''}
+        <span class="pr-entry-detail">${escapeHtml(String(r.roundtrip_km))} ק"מ</span>
+      </div>
+      <div class="pr-entry-amount">₪${fmt(r.amount)}</div>
+      ${editable ? `<button class="pr-entry-del" data-pr-action="delete-entry" data-entry-id="${escapeHtml(r.id)}" data-entry-table="declared_travel_entries" aria-label="מחק">✕</button>` : ''}
+    </div>
+  `).join('');
+
+  const transportRows = transport.map(r => `
+    <div class="pr-entry-row" data-entry-id="${escapeHtml(r.id)}" data-entry-type="public_transport">
+      <div class="pr-entry-main">
+        <span class="pr-entry-date">${fmtDate(r.travel_date)}</span>
+        <span class="pr-entry-desc">${escapeHtml(r.origin)} → ${escapeHtml(r.destination)}</span>
+        ${r.description ? `<span class="pr-entry-note">${escapeHtml(r.description)}</span>` : ''}
+      </div>
+      <div class="pr-entry-amount">₪${fmt(r.amount)}</div>
+      ${editable ? `<button class="pr-entry-del" data-pr-action="delete-entry" data-entry-id="${escapeHtml(r.id)}" data-entry-table="public_transport_entries" aria-label="מחק">✕</button>` : ''}
+    </div>
+  `).join('');
+
+  const expenseRows = expenses.map(r => `
+    <div class="pr-entry-row" data-entry-id="${escapeHtml(r.id)}" data-entry-type="expense">
+      <div class="pr-entry-main">
+        <span class="pr-entry-date">${fmtDate(r.expense_date)}</span>
+        <span class="pr-entry-doc-type">${escapeHtml(DOC_TYPE_LABELS[r.document_type] || r.document_type)}</span>
+        <span class="pr-entry-desc">${escapeHtml(r.description)}</span>
+      </div>
+      <div class="pr-entry-amount">₪${fmt(r.amount)}</div>
+      ${editable ? `
+        <label class="pr-entry-attach-btn" title="צרף קובץ">
+          📎
+          <input type="file" class="pr-file-input" accept="image/*,.pdf" data-expense-id="${escapeHtml(r.id)}" />
+        </label>
+        <button class="pr-entry-del" data-pr-action="delete-entry" data-entry-id="${escapeHtml(r.id)}" data-entry-table="expense_entries" aria-label="מחק">✕</button>
+      ` : ''}
+    </div>
+  `).join('');
+
+  const attachRows = attachments.map(a => `
+    <div class="pr-attachment-row">
+      <span class="pr-attachment-name">${escapeHtml(a.file_name)}</span>
+      <button class="pr-btn pr-btn--ghost pr-btn--sm" data-pr-action="view-attachment" data-storage-path="${escapeHtml(a.storage_path)}">צפה</button>
+      ${editable ? `<button class="pr-btn pr-btn--ghost pr-btn--sm pr-btn--danger" data-pr-action="delete-attachment" data-attachment-id="${escapeHtml(a.id)}" data-storage-path="${escapeHtml(a.storage_path)}">מחק</button>` : ''}
+    </div>
+  `).join('');
+
+  const addTravelForm = editable ? `
+    <details class="pr-add-form-wrap" id="pr-add-travel-wrap">
+      <summary class="pr-add-summary">+ הוסף נסיעה בהצהרה</summary>
+      <form class="pr-add-form" id="pr-add-travel-form" data-form-type="declared_travel">
+        <div class="pr-form-row">
+          <div class="pr-field"><label class="pr-label">תאריך</label><input class="pr-input" type="date" name="travel_date" required /></div>
+          <div class="pr-field"><label class="pr-label">נקודת התחלה</label><input class="pr-input" type="text" name="origin" required placeholder="מ..." /></div>
+          <div class="pr-field"><label class="pr-label">יעד</label><input class="pr-input" type="text" name="destination" required placeholder="ל..." /></div>
+        </div>
+        <div class="pr-form-row">
+          <div class="pr-field"><label class="pr-label">פירוט</label><input class="pr-input" type="text" name="description" placeholder="תיאור הנסיעה" /></div>
+          <div class="pr-field"><label class="pr-label">ק"מ הלוך-חזור</label><input class="pr-input" type="number" name="roundtrip_km" min="0" step="0.1" required placeholder="0" /></div>
+          <div class="pr-field"><label class="pr-label">סכום ₪</label><input class="pr-input" type="number" name="amount" min="0" step="0.01" required placeholder="0.00" /></div>
+        </div>
+        <button class="pr-btn pr-btn--primary" type="submit">הוסף</button>
+      </form>
+    </details>
+  ` : '';
+
+  const addTransportForm = editable ? `
+    <details class="pr-add-form-wrap" id="pr-add-transport-wrap">
+      <summary class="pr-add-summary">+ הוסף נסיעה בתחבורה ציבורית</summary>
+      <form class="pr-add-form" id="pr-add-transport-form" data-form-type="public_transport">
+        <div class="pr-form-row">
+          <div class="pr-field"><label class="pr-label">תאריך</label><input class="pr-input" type="date" name="travel_date" required /></div>
+          <div class="pr-field"><label class="pr-label">ממקום</label><input class="pr-input" type="text" name="origin" required placeholder="מ..." /></div>
+          <div class="pr-field"><label class="pr-label">למקום</label><input class="pr-input" type="text" name="destination" required placeholder="ל..." /></div>
+        </div>
+        <div class="pr-form-row">
+          <div class="pr-field"><label class="pr-label">פירוט</label><input class="pr-input" type="text" name="description" placeholder="תיאור" /></div>
+          <div class="pr-field"><label class="pr-label">סכום ₪</label><input class="pr-input" type="number" name="amount" min="0" step="0.01" required placeholder="0.00" /></div>
+        </div>
+        <button class="pr-btn pr-btn--primary" type="submit">הוסף</button>
+      </form>
+    </details>
+  ` : '';
+
+  const addExpenseForm = editable ? `
+    <details class="pr-add-form-wrap" id="pr-add-expense-wrap">
+      <summary class="pr-add-summary">+ הוסף הוצאה</summary>
+      <form class="pr-add-form" id="pr-add-expense-form" data-form-type="expense">
+        <div class="pr-form-row">
+          <div class="pr-field"><label class="pr-label">תאריך</label><input class="pr-input" type="date" name="expense_date" required /></div>
+          <div class="pr-field">
+            <label class="pr-label">סוג מסמך</label>
+            <select class="pr-input pr-input--select" name="document_type" required>
+              <option value="receipt">קבלה</option>
+              <option value="invoice">חשבונית</option>
+              <option value="other">אחר</option>
+            </select>
+          </div>
+        </div>
+        <div class="pr-form-row">
+          <div class="pr-field pr-field--wide"><label class="pr-label">פירוט</label><input class="pr-input" type="text" name="description" required placeholder="תיאור ההוצאה" /></div>
+          <div class="pr-field"><label class="pr-label">סכום ₪</label><input class="pr-input" type="number" name="amount" min="0" step="0.01" required placeholder="0.00" /></div>
+        </div>
+        <button class="pr-btn pr-btn--primary" type="submit">הוסף</button>
+      </form>
+    </details>
+  ` : '';
+
+  const financeNotes = report.finance_notes
+    ? `<div class="pr-finance-notes"><strong>הערות כספים:</strong> ${escapeHtml(report.finance_notes)}</div>`
+    : '';
+
+  const submitBtn = editable
+    ? `<button class="pr-btn pr-btn--primary pr-btn--large" data-pr-action="submit-report" data-report-id="${escapeHtml(report.id)}">שליחה לכספים</button>`
+    : '';
+
+  return `
+    <div class="pr-screen" dir="rtl">
+      <div class="pr-topbar">
+        <button class="pr-btn pr-btn--ghost pr-back-btn" data-pr-action="back-to-my-reports">← חזרה לדוחות שלי</button>
+        <span class="pr-topbar__title">דוח ${escapeHtml(monthYearLabel)}</span>
+        ${statusChip}
+      </div>
+
+      <div class="pr-body">
+        ${financeNotes}
+
+        <div class="pr-card">
+          <div class="pr-card__head">
+            <h2 class="pr-card__title">נסיעות בהצהרה</h2>
+            <span class="pr-card__total">₪${fmt(totalTravel)}</span>
+          </div>
+          ${travel.length === 0 && !editable ? dsEmptyState('אין רשומות') : ''}
+          ${travelRows}
+          ${addTravelForm}
+        </div>
+
+        <div class="pr-card">
+          <div class="pr-card__head">
+            <h2 class="pr-card__title">תחבורה ציבורית</h2>
+            <span class="pr-card__total">₪${fmt(totalTransport)}</span>
+          </div>
+          ${transport.length === 0 && !editable ? dsEmptyState('אין רשומות') : ''}
+          ${transportRows}
+          ${addTransportForm}
+        </div>
+
+        <div class="pr-card">
+          <div class="pr-card__head">
+            <h2 class="pr-card__title">הוצאות</h2>
+            <span class="pr-card__total">₪${fmt(totalExpenses)}</span>
+          </div>
+          ${expenses.length === 0 && !editable ? dsEmptyState('אין רשומות') : ''}
+          ${expenseRows}
+          ${addExpenseForm}
+        </div>
+
+        ${attachments.length > 0 ? `
+          <div class="pr-card">
+            <div class="pr-card__head"><h2 class="pr-card__title">קבצים מצורפים</h2></div>
+            ${attachRows}
+          </div>
+        ` : ''}
+
+        <div class="pr-card pr-card--summary">
+          <h2 class="pr-card__title">סיכום חודשי</h2>
+          <div class="pr-summary-row"><span>נסיעות בהצהרה</span><strong>₪${fmt(totalTravel)}</strong></div>
+          <div class="pr-summary-row"><span>תחבורה ציבורית</span><strong>₪${fmt(totalTransport)}</strong></div>
+          <div class="pr-summary-row"><span>הוצאות</span><strong>₪${fmt(totalExpenses)}</strong></div>
+          <div class="pr-summary-row pr-summary-row--total"><span>סה"כ לתשלום / החזר</span><strong>₪${fmt(totalAll)}</strong></div>
+          <div class="pr-summary-status">סטטוס: ${statusChip}</div>
+        </div>
+
+        <div class="pr-actions">
+          ${submitBtn}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function adminDashboardHtml(reports) {
+  const rows = reports.map(r => {
+    const profile = r.profiles || {};
+    return `
+      <tr>
+        <td>${escapeHtml(profile.full_name || '—')}</td>
+        <td>${escapeHtml(profile.email || '—')}</td>
+        <td>${escapeHtml(monthLabel(r.report_month, r.report_year))}</td>
+        <td>${dsStatusChip(STATUS_LABELS[r.status] || r.status, STATUS_KIND[r.status] || 'neutral')}</td>
+        <td>${r.submitted_at ? fmtDate(r.submitted_at) : '—'}</td>
+        <td>${r.finance_notes ? escapeHtml(r.finance_notes.slice(0, 40)) : '—'}</td>
+        <td class="pr-actions-cell">
+          <button class="pr-btn pr-btn--ghost pr-btn--sm" data-pr-action="admin-view-report" data-report-id="${escapeHtml(r.id)}">צפה</button>
+          ${r.status === 'submitted' ? `
+            <button class="pr-btn pr-btn--ghost pr-btn--sm pr-btn--success" data-pr-action="admin-approve" data-report-id="${escapeHtml(r.id)}">אשר</button>
+            <button class="pr-btn pr-btn--ghost pr-btn--sm pr-btn--warning" data-pr-action="admin-return" data-report-id="${escapeHtml(r.id)}">החזר לתיקון</button>
+          ` : ''}
+          ${r.status === 'approved' ? `
+            <button class="pr-btn pr-btn--ghost pr-btn--sm pr-btn--success" data-pr-action="admin-mark-paid" data-report-id="${escapeHtml(r.id)}">סמן כשולם</button>
+          ` : ''}
+        </td>
+      </tr>
+    `;
+  });
+
+  return `
+    <div class="pr-screen" dir="rtl">
+      <div class="pr-topbar">
+        <button class="pr-btn pr-btn--ghost pr-back-btn" data-pr-action="back-to-dashboard">← חזרה לדשבורד</button>
+        <span class="pr-topbar__title">דוחות אישיים — ניהול</span>
+        <button class="pr-btn pr-btn--ghost pr-btn--sm" data-pr-action="sign-out">יציאה</button>
+      </div>
+      <div class="pr-body">
+        ${dsPageHeader('ניהול דוחות אישיים', 'כל הדוחות של כל העובדים')}
+        ${reports.length === 0 ? dsEmptyState('אין דוחות להצגה') : `
+          <div class="pr-table-scroll">
+            <table class="pr-table">
+              <thead>
+                <tr>
+                  <th>שם עובד</th>
+                  <th>מייל</th>
+                  <th>חודש</th>
+                  <th>סטטוס</th>
+                  <th>תאריך שליחה</th>
+                  <th>הערות כספים</th>
+                  <th>פעולות</th>
+                </tr>
+              </thead>
+              <tbody>${rows.join('')}</tbody>
+            </table>
+          </div>
+        `}
+      </div>
+    </div>
+  `;
+}
+
+function adminReportViewHtml(report, travel, transport, expenses, attachments) {
+  const profile = report.profiles || {};
+  const totalTravel = travel.reduce((s, r) => s + Number(r.amount || 0), 0);
+  const totalTransport = transport.reduce((s, r) => s + Number(r.amount || 0), 0);
+  const totalExpenses = expenses.reduce((s, r) => s + Number(r.amount || 0), 0);
+  const totalAll = totalTravel + totalTransport + totalExpenses;
+
+  const travelRows = travel.map(r => `
+    <tr><td>${fmtDate(r.travel_date)}</td><td>${escapeHtml(r.origin)}</td><td>${escapeHtml(r.destination)}</td>
+    <td>${escapeHtml(r.description)}</td><td>${r.roundtrip_km}</td><td>₪${fmt(r.amount)}</td></tr>
+  `).join('');
+
+  const transportRows = transport.map(r => `
+    <tr><td>${fmtDate(r.travel_date)}</td><td>${escapeHtml(r.origin)}</td><td>${escapeHtml(r.destination)}</td>
+    <td>${escapeHtml(r.description)}</td><td>₪${fmt(r.amount)}</td></tr>
+  `).join('');
+
+  const expenseRows = expenses.map(r => `
+    <tr><td>${fmtDate(r.expense_date)}</td><td>${escapeHtml(DOC_TYPE_LABELS[r.document_type] || r.document_type)}</td>
+    <td>${escapeHtml(r.description)}</td><td>₪${fmt(r.amount)}</td></tr>
+  `).join('');
+
+  const attachRows = attachments.map(a => `
+    <div class="pr-attachment-row">
+      <span class="pr-attachment-name">${escapeHtml(a.file_name)}</span>
+      <button class="pr-btn pr-btn--ghost pr-btn--sm" data-pr-action="view-attachment" data-storage-path="${escapeHtml(a.storage_path)}">הורד / צפה</button>
+    </div>
+  `).join('');
+
+  const notesForm = `
+    <div class="pr-card" style="margin-top:16px">
+      <h2 class="pr-card__title">הערות כספים</h2>
+      <textarea class="pr-input" id="pr-admin-notes" rows="3" placeholder="הוסף הערה…">${escapeHtml(report.finance_notes || '')}</textarea>
+      <button class="pr-btn pr-btn--primary" data-pr-action="admin-save-notes" data-report-id="${escapeHtml(report.id)}" style="margin-top:8px">שמור הערות</button>
+    </div>
+  `;
+
+  const adminActions = `
+    <div class="pr-actions">
+      ${report.status === 'submitted' ? `
+        <button class="pr-btn pr-btn--primary" data-pr-action="admin-approve" data-report-id="${escapeHtml(report.id)}">אשר דוח</button>
+        <button class="pr-btn pr-btn--warning" data-pr-action="admin-return" data-report-id="${escapeHtml(report.id)}">החזר לתיקון</button>
+      ` : ''}
+      ${report.status === 'approved' ? `
+        <button class="pr-btn pr-btn--primary" data-pr-action="admin-mark-paid" data-report-id="${escapeHtml(report.id)}">סמן כשולם</button>
+      ` : ''}
+    </div>
+  `;
+
+  return `
+    <div class="pr-screen" dir="rtl">
+      <div class="pr-topbar">
+        <button class="pr-btn pr-btn--ghost pr-back-btn" data-pr-action="back-to-admin">← חזרה לרשימה</button>
+        <span class="pr-topbar__title">דוח ${escapeHtml(monthLabel(report.report_month, report.report_year))} — ${escapeHtml(profile.full_name || profile.email || '')}</span>
+        ${dsStatusChip(STATUS_LABELS[report.status] || report.status, STATUS_KIND[report.status] || 'neutral')}
+      </div>
+      <div class="pr-body">
+        ${travel.length > 0 ? `
+          <div class="pr-card">
+            <div class="pr-card__head"><h2 class="pr-card__title">נסיעות בהצהרה</h2><span class="pr-card__total">₪${fmt(totalTravel)}</span></div>
+            <div class="pr-table-scroll">
+              <table class="pr-table"><thead><tr><th>תאריך</th><th>מ</th><th>ל</th><th>פירוט</th><th>ק"מ</th><th>סכום</th></tr></thead>
+              <tbody>${travelRows}</tbody></table>
+            </div>
+          </div>
+        ` : ''}
+        ${transport.length > 0 ? `
+          <div class="pr-card">
+            <div class="pr-card__head"><h2 class="pr-card__title">תחבורה ציבורית</h2><span class="pr-card__total">₪${fmt(totalTransport)}</span></div>
+            <div class="pr-table-scroll">
+              <table class="pr-table"><thead><tr><th>תאריך</th><th>מ</th><th>ל</th><th>פירוט</th><th>סכום</th></tr></thead>
+              <tbody>${transportRows}</tbody></table>
+            </div>
+          </div>
+        ` : ''}
+        ${expenses.length > 0 ? `
+          <div class="pr-card">
+            <div class="pr-card__head"><h2 class="pr-card__title">הוצאות</h2><span class="pr-card__total">₪${fmt(totalExpenses)}</span></div>
+            <div class="pr-table-scroll">
+              <table class="pr-table"><thead><tr><th>תאריך</th><th>סוג</th><th>פירוט</th><th>סכום</th></tr></thead>
+              <tbody>${expenseRows}</tbody></table>
+            </div>
+          </div>
+        ` : ''}
+        ${attachments.length > 0 ? `
+          <div class="pr-card">
+            <div class="pr-card__head"><h2 class="pr-card__title">קבצים מצורפים</h2></div>
+            ${attachRows}
+          </div>
+        ` : ''}
+        <div class="pr-card pr-card--summary">
+          <h2 class="pr-card__title">סיכום</h2>
+          <div class="pr-summary-row"><span>נסיעות בהצהרה</span><strong>₪${fmt(totalTravel)}</strong></div>
+          <div class="pr-summary-row"><span>תחבורה ציבורית</span><strong>₪${fmt(totalTransport)}</strong></div>
+          <div class="pr-summary-row"><span>הוצאות</span><strong>₪${fmt(totalExpenses)}</strong></div>
+          <div class="pr-summary-row pr-summary-row--total"><span>סה"כ</span><strong>₪${fmt(totalAll)}</strong></div>
+        </div>
+        ${notesForm}
+        ${adminActions}
+      </div>
+    </div>
+  `;
+}
+
+function myReportsListHtml(reports) {
+  if (!reports || reports.length === 0) {
+    return `<p class="pr-empty-msg">עדיין לא קיימים דוחות. פתח חודש חדש למעלה כדי להתחיל.</p>`;
+  }
+  return reports.map(r => `
+    <div class="pr-report-card" data-pr-action="open-existing-report" data-report-id="${escapeHtml(r.id)}">
+      <div class="pr-report-card__title">${escapeHtml(monthLabel(r.report_month, r.report_year))}</div>
+      <div class="pr-report-card__meta">
+        ${dsStatusChip(STATUS_LABELS[r.status] || r.status, STATUS_KIND[r.status] || 'neutral')}
+        ${r.submitted_at ? `<span class="pr-report-card__date">נשלח: ${fmtDate(r.submitted_at)}</span>` : ''}
+      </div>
+    </div>
+  `).join('');
+}
+
+// ─── main render & bind ───────────────────────────────────────────────────────
+
+function renderInto(root, html) {
+  root.innerHTML = `
+    <div id="pr-toast" class="pr-toast" role="alert" aria-live="assertive"></div>
+    ${html}
+  `;
+}
+
+async function loadMyReportsList(root, employeeId) {
+  const { data: reports } = await supabase
+    .from('personal_reports')
+    .select('*')
+    .eq('employee_id', employeeId)
+    .order('report_year', { ascending: false })
+    .order('report_month', { ascending: false });
+  const listEl = root.querySelector('#pr-my-reports-list');
+  if (listEl) listEl.innerHTML = myReportsListHtml(reports || []);
+}
+
+async function openReportDetail(root, reportId, isAdmin = false) {
+  const report = await fetchReport(reportId);
+  // For admin view, get profile info too
+  if (isAdmin) {
+    const { data: profileData } = await supabase
+      .from('profiles')
+      .select('full_name, email')
+      .eq('id', report.employee_id)
+      .single();
+    report.profiles = profileData;
+  }
+  const [travel, transport, expenses, attachments] = await Promise.all([
+    fetchDeclaredTravel(reportId),
+    fetchPublicTransport(reportId),
+    fetchExpenses(reportId),
+    fetchAttachments(reportId)
+  ]);
+  prSelectedReport = report;
+
+  if (isAdmin) {
+    renderInto(root, adminReportViewHtml(report, travel, transport, expenses, attachments));
+    bindAdminReportView(root);
+  } else {
+    renderInto(root, reportDetailHtml(report, travel, transport, expenses, attachments, prSession.profile));
+    bindReportDetail(root);
+  }
+}
+
+function bindLoginForm(root) {
+  const form = root.querySelector('#pr-login-form');
+  const forgotBtn = root.querySelector('#pr-forgot-btn');
+
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = root.querySelector('#pr-email')?.value?.trim();
+      const pass = root.querySelector('#pr-pass')?.value;
+      if (!email || !pass) return;
+      const btn = root.querySelector('#pr-login-btn');
+      btn.disabled = true;
+      btn.textContent = 'מתחבר…';
+      try {
+        const { user } = await signIn(email, pass);
+        const profile = await getProfile(user.id);
+        prSession = { user, profile };
+        prView = profile.role === 'admin' ? 'admin' : 'employee';
+        await rerender(root);
+      } catch (err) {
+        renderInto(root, loginHtml(err.message || 'שגיאה בהתחברות. בדוק פרטים ונסה שוב.'));
+        bindLoginForm(root);
+      }
+    });
+  }
+
+  if (forgotBtn) {
+    forgotBtn.addEventListener('click', async () => {
+      const email = root.querySelector('#pr-email')?.value?.trim();
+      if (!email) { showToast('הכנס מייל עבודה תחילה', 'warning'); return; }
+      try {
+        await resetPassword(email);
+        showToast('קישור לאיפוס סיסמה נשלח למייל', 'success');
+      } catch (err) {
+        showToast(err.message || 'שגיאה בשליחת האיפוס', 'danger');
+      }
+    });
+  }
+}
+
+function bindEmployeeDashboard(root) {
+  root.querySelector('[data-pr-action="open-report"]')?.addEventListener('click', async () => {
+    const sel = root.querySelector('#pr-month-select');
+    const [month, year] = (sel?.value || '').split('-').map(Number);
+    if (!month || !year) return;
+    try {
+      const report = await getOrCreateReport(prSession.user.id, month, year);
+      prSelectedReport = report;
+      await openReportDetail(root, report.id, false);
+    } catch (err) {
+      showToast(err.message || 'שגיאה בפתיחת הדוח', 'danger');
+    }
+  });
+
+  root.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-pr-action]');
+    if (!btn) return;
+    const action = btn.dataset.prAction;
+    if (action === 'back-to-dashboard') {
+      dispatchBackToDashboard();
+    } else if (action === 'sign-out') {
+      handleSignOut(root);
+    } else if (action === 'open-existing-report') {
+      const rid = btn.dataset.reportId;
+      if (rid) openReportDetail(root, rid, false);
+    }
+  });
+
+  if (prSession?.user?.id) {
+    loadMyReportsList(root, prSession.user.id);
+  }
+}
+
+function bindReportDetail(root) {
+  root.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-pr-action]');
+    if (!btn) return;
+    const action = btn.dataset.prAction;
+
+    if (action === 'back-to-my-reports') {
+      prView = 'employee';
+      await rerender(root);
+      return;
+    }
+    if (action === 'back-to-dashboard') {
+      dispatchBackToDashboard(); return;
+    }
+    if (action === 'sign-out') {
+      await handleSignOut(root); return;
+    }
+
+    if (action === 'delete-entry') {
+      if (!confirm('למחוק רשומה זו?')) return;
+      try {
+        await deleteEntry(btn.dataset.entryTable, btn.dataset.entryId);
+        await openReportDetail(root, prSelectedReport.id, false);
+        showToast('נמחק', 'success');
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+
+    if (action === 'submit-report') {
+      if (!confirm('לשלוח את הדוח לכספים? לאחר שליחה לא ניתן לערוך.')) return;
+      try {
+        await submitReport(prSelectedReport.id);
+        await openReportDetail(root, prSelectedReport.id, false);
+        showToast('הדוח נשלח לכספים', 'success');
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+
+    if (action === 'view-attachment') {
+      try {
+        const url = await getSignedUrl(btn.dataset.storagePath);
+        window.open(url, '_blank', 'noopener');
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+
+    if (action === 'delete-attachment') {
+      if (!confirm('למחוק קובץ זה?')) return;
+      try {
+        await deleteAttachment({ id: btn.dataset.attachmentId, storage_path: btn.dataset.storagePath });
+        await openReportDetail(root, prSelectedReport.id, false);
+        showToast('קובץ נמחק', 'success');
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+  });
+
+  // File upload handlers
+  root.addEventListener('change', async (e) => {
+    const fileInput = e.target.closest('input[type="file"].pr-file-input');
+    if (!fileInput || !fileInput.files?.[0]) return;
+    const file = fileInput.files[0];
+    const expenseEntryId = fileInput.dataset.expenseId || null;
+    try {
+      await uploadAttachment(prSelectedReport.id, prSession.user.id, expenseEntryId, file);
+      await openReportDetail(root, prSelectedReport.id, false);
+      showToast('הקובץ הועלה', 'success');
+    } catch (err) { showToast(err.message || 'שגיאה בהעלאה', 'danger'); }
+  });
+
+  // Add entry forms
+  root.addEventListener('submit', async (e) => {
+    const form = e.target.closest('.pr-add-form');
+    if (!form) return;
+    e.preventDefault();
+    const formType = form.dataset.formType;
+    const fd = new FormData(form);
+    const reportId = prSelectedReport.id;
+    const employeeId = prSession.user.id;
+    try {
+      if (formType === 'declared_travel') {
+        await upsertDeclaredTravel({
+          report_id: reportId,
+          employee_id: employeeId,
+          travel_date: fd.get('travel_date'),
+          origin: fd.get('origin') || '',
+          destination: fd.get('destination') || '',
+          description: fd.get('description') || '',
+          roundtrip_km: Number(fd.get('roundtrip_km') || 0),
+          amount: Number(fd.get('amount') || 0)
+        });
+      } else if (formType === 'public_transport') {
+        await upsertPublicTransport({
+          report_id: reportId,
+          employee_id: employeeId,
+          travel_date: fd.get('travel_date'),
+          origin: fd.get('origin') || '',
+          destination: fd.get('destination') || '',
+          description: fd.get('description') || '',
+          amount: Number(fd.get('amount') || 0)
+        });
+      } else if (formType === 'expense') {
+        await upsertExpense({
+          report_id: reportId,
+          employee_id: employeeId,
+          expense_date: fd.get('expense_date'),
+          document_type: fd.get('document_type') || 'receipt',
+          description: fd.get('description') || '',
+          amount: Number(fd.get('amount') || 0)
+        });
+      }
+      await openReportDetail(root, reportId, false);
+      showToast('נשמר', 'success');
+    } catch (err) {
+      showToast(err.message || 'שגיאה בשמירה', 'danger');
+    }
+  });
+}
+
+function bindAdminDashboard(root) {
+  root.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-pr-action]');
+    if (!btn) return;
+    const action = btn.dataset.prAction;
+    const reportId = btn.dataset.reportId;
+
+    if (action === 'back-to-dashboard') { dispatchBackToDashboard(); return; }
+    if (action === 'sign-out') { await handleSignOut(root); return; }
+
+    if (action === 'admin-view-report' && reportId) {
+      await openReportDetail(root, reportId, true);
+      return;
+    }
+    if (action === 'admin-approve' && reportId) {
+      if (!confirm('לאשר דוח זה?')) return;
+      try {
+        await adminUpdateReport(reportId, { status: 'approved', approved_at: new Date().toISOString() });
+        showToast('הדוח אושר', 'success');
+        await rerender(root);
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+    if (action === 'admin-return' && reportId) {
+      const notes = prompt('הסבר לעובד (יופיע כהערת כספים):');
+      if (notes === null) return;
+      try {
+        await adminUpdateReport(reportId, { status: 'needs_correction', finance_notes: notes });
+        showToast('הדוח הוחזר לתיקון', 'success');
+        await rerender(root);
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+    if (action === 'admin-mark-paid' && reportId) {
+      if (!confirm('לסמן כשולם?')) return;
+      try {
+        await adminUpdateReport(reportId, { status: 'paid', paid_at: new Date().toISOString() });
+        showToast('סומן כשולם', 'success');
+        await rerender(root);
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+  });
+}
+
+function bindAdminReportView(root) {
+  root.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-pr-action]');
+    if (!btn) return;
+    const action = btn.dataset.prAction;
+    const reportId = btn.dataset.reportId;
+
+    if (action === 'back-to-admin') {
+      prView = 'admin';
+      await rerender(root);
+      return;
+    }
+    if (action === 'admin-approve' && reportId) {
+      if (!confirm('לאשר דוח זה?')) return;
+      try {
+        await adminUpdateReport(reportId, { status: 'approved', approved_at: new Date().toISOString() });
+        showToast('הדוח אושר', 'success');
+        await openReportDetail(root, reportId, true);
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+    if (action === 'admin-return' && reportId) {
+      const notes = prompt('הסבר לעובד:');
+      if (notes === null) return;
+      try {
+        await adminUpdateReport(reportId, { status: 'needs_correction', finance_notes: notes });
+        showToast('הדוח הוחזר לתיקון', 'success');
+        await openReportDetail(root, reportId, true);
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+    if (action === 'admin-mark-paid' && reportId) {
+      if (!confirm('לסמן כשולם?')) return;
+      try {
+        await adminUpdateReport(reportId, { status: 'paid', paid_at: new Date().toISOString() });
+        showToast('סומן כשולם', 'success');
+        await openReportDetail(root, reportId, true);
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+    if (action === 'admin-save-notes' && reportId) {
+      const notes = root.querySelector('#pr-admin-notes')?.value || '';
+      try {
+        await adminUpdateReport(reportId, { finance_notes: notes });
+        showToast('הערות נשמרו', 'success');
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+    if (action === 'view-attachment') {
+      try {
+        const url = await getSignedUrl(btn.dataset.storagePath);
+        window.open(url, '_blank', 'noopener');
+      } catch (err) { showToast(err.message, 'danger'); }
+      return;
+    }
+  });
+}
+
+function dispatchBackToDashboard() {
+  document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: 'dashboard' } }));
+}
+
+async function handleSignOut(root) {
+  await signOut();
+  prSession = null;
+  prView = 'login';
+  prSelectedReport = null;
+  renderInto(root, loginHtml());
+  bindLoginForm(root);
+}
+
+async function rerender(root) {
+  if (!prSession) {
+    renderInto(root, loginHtml());
+    bindLoginForm(root);
+    return;
+  }
+  if (prSession.profile.role === 'admin') {
+    try {
+      const reports = await fetchAllReports();
+      renderInto(root, adminDashboardHtml(reports));
+      bindAdminDashboard(root);
+    } catch (err) {
+      renderInto(root, loginHtml(err.message));
+      bindLoginForm(root);
+    }
+  } else {
+    renderInto(root, employeeDashboardHtml(prSession.profile));
+    bindEmployeeDashboard(root);
+  }
+}
+
+// ─── exported screen object ───────────────────────────────────────────────────
+
+export const personalReportsScreen = {
+  /** Called by main.js routing — no data fetch needed, screen manages its own auth */
+  load: () => ({}),
+
+  render(_data, _ctx) {
+    return `<div id="pr-root" class="pr-module-root" dir="rtl"><div class="pr-loading-placeholder">טוען…</div></div>`;
+  },
+
+  bind({ root } = {}) {
+    const prRoot = (root && root.querySelector('#pr-root')) || root;
+
+    // Try restoring existing Supabase session
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (session?.user) {
+        try {
+          const profile = await getProfile(session.user.id);
+          prSession = { user: session.user, profile };
+          prView = profile.role === 'admin' ? 'admin' : 'employee';
+          await rerender(prRoot);
+        } catch {
+          prSession = null;
+          renderInto(prRoot, loginHtml());
+          bindLoginForm(prRoot);
+        }
+      } else {
+        renderInto(prRoot, loginHtml());
+        bindLoginForm(prRoot);
+      }
+    }).catch(() => {
+      renderInto(prRoot, loginHtml());
+      bindLoginForm(prRoot);
+    });
+
+  }
+};

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11923,3 +11923,433 @@ select.ds-input {
   background: color-mix(in srgb, currentColor 12%, transparent);
   font-variant-numeric: tabular-nums;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Personal Reports Module — דוחות אישיים
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Module root */
+.pr-module-root {
+  min-height: 100%;
+  background: var(--ds-bg, #f4f6fa);
+}
+
+/* Topbar */
+.pr-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--ds-shell, #0b0d12);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  flex-wrap: wrap;
+}
+.pr-topbar__title {
+  font-weight: 600;
+  font-size: 1rem;
+  flex: 1;
+  text-align: center;
+}
+
+/* Body */
+.pr-body {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 16px 16px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Cards */
+.pr-card {
+  background: #fff;
+  border-radius: var(--ds-radius-md, 14px);
+  box-shadow: var(--ds-shadow-sm, 0 1px 4px rgba(0,0,0,.08));
+  padding: 16px;
+}
+.pr-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.pr-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--ds-text, #1a1a2e);
+}
+.pr-card__total {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--ds-accent, #1a3358);
+}
+.pr-card--highlight {
+  border: 2px solid var(--ds-accent, #1a3358);
+}
+.pr-card--summary {
+  background: color-mix(in srgb, var(--ds-accent, #1a3358) 6%, #fff);
+}
+
+/* Summary rows */
+.pr-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(0,0,0,.06);
+  font-size: .95rem;
+}
+.pr-summary-row--total {
+  border-bottom: none;
+  font-size: 1.1rem;
+  font-weight: 700;
+  padding-top: 10px;
+}
+.pr-summary-status { margin-top: 10px; }
+
+/* Entry rows */
+.pr-entry-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(0,0,0,.06);
+}
+.pr-entry-row:last-of-type { border-bottom: none; }
+.pr-entry-main {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  align-items: baseline;
+}
+.pr-entry-date { font-size: .82rem; color: #666; }
+.pr-entry-desc { font-size: .92rem; font-weight: 500; }
+.pr-entry-note, .pr-entry-detail { font-size: .82rem; color: #555; }
+.pr-entry-doc-type {
+  font-size: .78rem;
+  background: #eef;
+  border-radius: 999px;
+  padding: 1px 7px;
+  color: #334;
+}
+.pr-entry-amount {
+  font-weight: 600;
+  font-size: .95rem;
+  white-space: nowrap;
+  color: var(--ds-accent, #1a3358);
+}
+.pr-entry-del {
+  background: none;
+  border: none;
+  color: var(--ds-danger, #b91c1c);
+  cursor: pointer;
+  font-size: .9rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.pr-entry-del:hover { background: rgba(185,28,28,.1); }
+.pr-entry-attach-btn {
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 2px 4px;
+}
+.pr-file-input { display: none; }
+
+/* Add-form details/summary */
+.pr-add-form-wrap {
+  margin-top: 10px;
+  border-top: 1px dashed rgba(0,0,0,.12);
+  padding-top: 8px;
+}
+.pr-add-summary {
+  font-size: .9rem;
+  color: var(--ds-accent, #1a3358);
+  cursor: pointer;
+  font-weight: 600;
+  padding: 4px 0;
+}
+.pr-add-form {
+  padding: 12px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.pr-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+/* Form fields */
+.pr-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 120px;
+}
+.pr-field--wide { flex: 2; min-width: 200px; }
+.pr-label {
+  font-size: .82rem;
+  font-weight: 600;
+  color: #444;
+}
+.pr-input {
+  padding: 9px 12px;
+  border: 1.5px solid #d0d5e0;
+  border-radius: var(--ds-radius-sm, 9px);
+  font-size: .95rem;
+  background: #fff;
+  color: #1a1a2e;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color .15s;
+  font-family: inherit;
+}
+.pr-input:focus {
+  outline: none;
+  border-color: var(--ds-accent, #1a3358);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ds-accent, #1a3358) 15%, transparent);
+}
+.pr-input--select { appearance: auto; cursor: pointer; }
+
+/* Buttons */
+.pr-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 9px 18px;
+  border-radius: var(--ds-radius-sm, 9px);
+  font-size: .92rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background .15s, opacity .15s;
+  font-family: inherit;
+}
+.pr-btn:disabled { opacity: .55; cursor: not-allowed; }
+.pr-btn--primary {
+  background: var(--ds-accent, #1a3358);
+  color: #fff;
+}
+.pr-btn--primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--ds-accent, #1a3358) 80%, #000);
+}
+.pr-btn--ghost {
+  background: transparent;
+  color: #fff;
+  border: 1.5px solid rgba(255,255,255,.35);
+}
+.pr-btn--ghost:hover { background: rgba(255,255,255,.12); }
+.pr-btn--sm { padding: 5px 11px; font-size: .82rem; }
+.pr-btn--full { width: 100%; }
+.pr-btn--link {
+  background: none;
+  color: var(--ds-accent, #1a3358);
+  text-decoration: underline;
+  padding: 6px;
+  font-size: .88rem;
+  font-weight: 500;
+  border: none;
+}
+.pr-btn--large { padding: 13px 24px; font-size: 1rem; width: 100%; }
+.pr-btn--success { color: var(--ds-success, #15803d); border-color: var(--ds-success, #15803d); }
+.pr-btn--warning { color: var(--ds-warning, #b45309); border-color: var(--ds-warning, #b45309); }
+.pr-btn--danger  { color: var(--ds-danger,  #b91c1c); border-color: var(--ds-danger,  #b91c1c); }
+
+/* Actions bar */
+.pr-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 8px 0;
+}
+
+/* Back button (in topbar) */
+.pr-back-btn {
+  font-size: .88rem;
+  padding: 5px 10px;
+}
+
+/* Finance notes box */
+.pr-finance-notes {
+  background: color-mix(in srgb, var(--ds-warning, #b45309) 10%, #fff);
+  border: 1.5px solid var(--ds-warning, #b45309);
+  border-radius: var(--ds-radius-sm, 9px);
+  padding: 10px 14px;
+  font-size: .9rem;
+  color: #5c3a00;
+}
+
+/* Attachments */
+.pr-attachment-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(0,0,0,.06);
+}
+.pr-attachment-row:last-child { border-bottom: none; }
+.pr-attachment-name {
+  flex: 1;
+  font-size: .9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Toast */
+.pr-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(80px);
+  background: #1a1a2e;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 999px;
+  font-size: .92rem;
+  font-weight: 500;
+  z-index: 9999;
+  opacity: 0;
+  transition: transform .25s ease, opacity .25s ease;
+  pointer-events: none;
+  white-space: nowrap;
+  max-width: 90vw;
+}
+.pr-toast--visible { transform: translateX(-50%) translateY(0); opacity: 1; }
+.pr-toast--success { background: var(--ds-success, #15803d); }
+.pr-toast--danger  { background: var(--ds-danger,  #b91c1c); }
+.pr-toast--warning { background: var(--ds-warning, #b45309); }
+
+/* Auth */
+.pr-auth-wrap {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--ds-shell, #0b0d12);
+}
+.pr-auth-card {
+  background: #fff;
+  border-radius: var(--ds-radius-lg, 20px);
+  padding: 32px 28px;
+  width: 100%;
+  max-width: 380px;
+  box-shadow: var(--ds-shadow-float, 0 12px 40px rgba(0,0,0,.25));
+}
+.pr-auth-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--ds-accent, #1a3358);
+  text-align: center;
+  margin: 0 0 4px;
+}
+.pr-auth-sub {
+  font-size: .9rem;
+  color: #666;
+  text-align: center;
+  margin: 0 0 20px;
+}
+.pr-form { display: flex; flex-direction: column; gap: 14px; }
+
+/* Alert */
+.pr-alert {
+  padding: 10px 14px;
+  border-radius: var(--ds-radius-sm, 9px);
+  font-size: .9rem;
+}
+.pr-alert--danger { background: #fee2e2; color: #7f1d1d; border: 1px solid #fca5a5; }
+
+/* Reports list (employee dashboard) */
+.pr-reports-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.pr-report-card {
+  background: #fff;
+  border-radius: var(--ds-radius-sm, 9px);
+  padding: 14px 16px;
+  box-shadow: var(--ds-shadow-sm);
+  cursor: pointer;
+  transition: box-shadow .15s;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.pr-report-card:hover { box-shadow: var(--ds-shadow-md, 0 4px 12px rgba(0,0,0,.12)); }
+.pr-report-card__title { font-weight: 600; font-size: 1rem; }
+.pr-report-card__meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.pr-report-card__date { font-size: .82rem; color: #666; }
+
+/* Empty message */
+.pr-empty-msg {
+  text-align: center;
+  color: #888;
+  font-size: .9rem;
+  padding: 16px 0;
+}
+
+/* Loading placeholder */
+.pr-loading-placeholder {
+  text-align: center;
+  padding: 24px;
+  color: #888;
+  font-size: .9rem;
+}
+
+/* Admin table */
+.pr-table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.pr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .88rem;
+  min-width: 600px;
+}
+.pr-table th, .pr-table td {
+  text-align: right;
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(0,0,0,.07);
+}
+.pr-table th {
+  background: #f5f7fa;
+  font-weight: 600;
+  font-size: .82rem;
+  color: #555;
+  position: sticky;
+  top: 0;
+}
+.pr-table tr:hover td { background: #f8faff; }
+.pr-actions-cell {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .pr-body { padding: 12px 10px 80px; gap: 12px; }
+  .pr-topbar { padding: 8px 12px; gap: 8px; }
+  .pr-form-row { flex-direction: column; gap: 8px; }
+  .pr-card { padding: 12px; }
+  .pr-auth-card { padding: 24px 18px; }
+  .pr-table { min-width: 480px; }
+  .pr-actions-cell { flex-direction: column; }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 548;
+const CACHE_VERSION = 549;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260603_personal_reports_module.sql
+++ b/supabase/migrations/20260603_personal_reports_module.sql
@@ -1,0 +1,378 @@
+-- Personal Reports Module
+-- Tables: profiles, personal_reports, declared_travel_entries, public_transport_entries, expense_entries, report_attachments
+-- Storage bucket: personal-report-attachments
+-- RLS policies enforced on all tables
+
+-- ─────────────────────────────────────────────
+-- 1. profiles
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id           uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email        text NOT NULL,
+  full_name    text NOT NULL DEFAULT '',
+  role         text NOT NULL DEFAULT 'employee' CHECK (role IN ('employee', 'admin')),
+  is_active    boolean NOT NULL DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "profiles_select_own" ON public.profiles
+  FOR SELECT USING (auth.uid() = id);
+
+CREATE POLICY "profiles_select_admin" ON public.profiles
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p2
+      WHERE p2.id = auth.uid() AND p2.role = 'admin'
+    )
+  );
+
+CREATE POLICY "profiles_insert_own" ON public.profiles
+  FOR INSERT WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "profiles_update_own" ON public.profiles
+  FOR UPDATE USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "profiles_update_admin" ON public.profiles
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p2
+      WHERE p2.id = auth.uid() AND p2.role = 'admin'
+    )
+  );
+
+-- Auto-create profile on signup
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, full_name)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', split_part(NEW.email, '@', 1))
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ─────────────────────────────────────────────
+-- 2. personal_reports
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.personal_reports (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  employee_id    uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  report_month   int  NOT NULL CHECK (report_month BETWEEN 1 AND 12),
+  report_year    int  NOT NULL CHECK (report_year >= 2020),
+  status         text NOT NULL DEFAULT 'draft'
+                   CHECK (status IN ('draft','submitted','needs_correction','approved','paid')),
+  submitted_at   timestamptz,
+  approved_at    timestamptz,
+  paid_at        timestamptz,
+  finance_notes  text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (employee_id, report_month, report_year)
+);
+
+ALTER TABLE public.personal_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "reports_select_own" ON public.personal_reports
+  FOR SELECT USING (auth.uid() = employee_id);
+
+CREATE POLICY "reports_select_admin" ON public.personal_reports
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "reports_insert_own" ON public.personal_reports
+  FOR INSERT WITH CHECK (auth.uid() = employee_id);
+
+CREATE POLICY "reports_update_own_draft" ON public.personal_reports
+  FOR UPDATE USING (
+    auth.uid() = employee_id AND status IN ('draft','needs_correction')
+  );
+
+CREATE POLICY "reports_update_admin" ON public.personal_reports
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- ─────────────────────────────────────────────
+-- 3. declared_travel_entries  (נסיעות בהצהרה)
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.declared_travel_entries (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id     uuid NOT NULL REFERENCES public.personal_reports(id) ON DELETE CASCADE,
+  employee_id   uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  travel_date   date NOT NULL,
+  origin        text NOT NULL DEFAULT '',
+  destination   text NOT NULL DEFAULT '',
+  description   text NOT NULL DEFAULT '',
+  roundtrip_km  numeric(10,2) NOT NULL DEFAULT 0,
+  amount        numeric(10,2) NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.declared_travel_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "dte_select_own" ON public.declared_travel_entries
+  FOR SELECT USING (auth.uid() = employee_id);
+
+CREATE POLICY "dte_select_admin" ON public.declared_travel_entries
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "dte_insert_own" ON public.declared_travel_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "dte_update_own_draft" ON public.declared_travel_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "dte_delete_own_draft" ON public.declared_travel_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "dte_admin_all" ON public.declared_travel_entries
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- ─────────────────────────────────────────────
+-- 4. public_transport_entries  (תחבורה ציבורית)
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.public_transport_entries (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id     uuid NOT NULL REFERENCES public.personal_reports(id) ON DELETE CASCADE,
+  employee_id   uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  travel_date   date NOT NULL,
+  origin        text NOT NULL DEFAULT '',
+  destination   text NOT NULL DEFAULT '',
+  description   text NOT NULL DEFAULT '',
+  amount        numeric(10,2) NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.public_transport_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "pte_select_own" ON public.public_transport_entries
+  FOR SELECT USING (auth.uid() = employee_id);
+
+CREATE POLICY "pte_select_admin" ON public.public_transport_entries
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "pte_insert_own" ON public.public_transport_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "pte_update_own_draft" ON public.public_transport_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "pte_delete_own_draft" ON public.public_transport_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "pte_admin_all" ON public.public_transport_entries
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- ─────────────────────────────────────────────
+-- 5. expense_entries  (הוצאות)
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.expense_entries (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id       uuid NOT NULL REFERENCES public.personal_reports(id) ON DELETE CASCADE,
+  employee_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  expense_date    date NOT NULL,
+  document_type   text NOT NULL DEFAULT 'receipt'
+                    CHECK (document_type IN ('receipt','invoice','other')),
+  description     text NOT NULL DEFAULT '',
+  amount          numeric(10,2) NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.expense_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ee_select_own" ON public.expense_entries
+  FOR SELECT USING (auth.uid() = employee_id);
+
+CREATE POLICY "ee_select_admin" ON public.expense_entries
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "ee_insert_own" ON public.expense_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "ee_update_own_draft" ON public.expense_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "ee_delete_own_draft" ON public.expense_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "ee_admin_all" ON public.expense_entries
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- ─────────────────────────────────────────────
+-- 6. report_attachments  (קבצים מצורפים)
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.report_attachments (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id        uuid NOT NULL REFERENCES public.personal_reports(id) ON DELETE CASCADE,
+  employee_id      uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  expense_entry_id uuid REFERENCES public.expense_entries(id) ON DELETE SET NULL,
+  storage_path     text NOT NULL,
+  file_name        text NOT NULL DEFAULT '',
+  file_type        text NOT NULL DEFAULT '',
+  file_size        bigint NOT NULL DEFAULT 0,
+  uploaded_at      timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.report_attachments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ra_select_own" ON public.report_attachments
+  FOR SELECT USING (auth.uid() = employee_id);
+
+CREATE POLICY "ra_select_admin" ON public.report_attachments
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "ra_insert_own" ON public.report_attachments
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "ra_delete_own_draft" ON public.report_attachments
+  FOR DELETE USING (
+    auth.uid() = employee_id AND
+    EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+CREATE POLICY "ra_admin_all" ON public.report_attachments
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- ─────────────────────────────────────────────
+-- Storage bucket RLS policies
+-- (bucket must be created manually in Supabase Dashboard as private bucket named: personal-report-attachments)
+-- ─────────────────────────────────────────────
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'personal-report-attachments',
+  'personal-report-attachments',
+  false,
+  10485760,
+  ARRAY['image/jpeg','image/png','image/webp','image/gif','application/pdf','image/heic','image/heif']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Employees can upload to their own folder: {user_id}/...
+CREATE POLICY "storage_insert_own" ON storage.objects
+  FOR INSERT WITH CHECK (
+    bucket_id = 'personal-report-attachments' AND
+    auth.uid()::text = split_part(name, '/', 1)
+  );
+
+-- Employees can read their own files
+CREATE POLICY "storage_select_own" ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'personal-report-attachments' AND
+    auth.uid()::text = split_part(name, '/', 1)
+  );
+
+-- Employees can delete their own files
+CREATE POLICY "storage_delete_own" ON storage.objects
+  FOR DELETE USING (
+    bucket_id = 'personal-report-attachments' AND
+    auth.uid()::text = split_part(name, '/', 1)
+  );
+
+-- Admins can read all files
+CREATE POLICY "storage_select_admin" ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'personal-report-attachments' AND
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Admins can delete all files
+CREATE POLICY "storage_delete_admin" ON storage.objects
+  FOR DELETE USING (
+    bucket_id = 'personal-report-attachments' AND
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );


### PR DESCRIPTION
## Summary
Introduces a complete Personal Reports module (דוחות אישיים) that enables employees to track and submit expense reports, travel declarations, and public transport costs, with admin approval workflows.

## Key Changes

### New Module: Personal Reports (`frontend/src/screens/personal-reports.js`)
- **Authentication**: Separate Supabase Auth session from main dashboard, supporting employee and admin roles
- **Employee Features**:
  - Create and manage monthly expense reports (draft → submitted → approved → paid)
  - Track three expense categories: declared travel (הצהרה), public transport (תחבורה ציבורית), and general expenses (הוצאות)
  - Add/edit/delete entries with automatic amount calculations
  - Attach supporting documents (receipts, invoices) to expenses
  - Submit reports to finance team
  - View report status and finance team notes

- **Admin Features**:
  - View all employee reports in a centralized dashboard
  - Approve or return reports for correction
  - Mark approved reports as paid
  - Add finance notes visible to employees
  - Full audit trail with timestamps

- **UI Components**:
  - Login screen with password reset
  - Employee dashboard with month selector
  - Detailed report view with collapsible entry forms
  - Admin management table with bulk actions
  - Real-time form validation and error handling
  - Toast notifications for user feedback

### Database Schema (`supabase/migrations/20260603_personal_reports_module.sql`)
- **Tables**:
  - `profiles`: User profiles with role-based access (employee/admin)
  - `personal_reports`: Monthly report headers with status tracking
  - `declared_travel_entries`: Vehicle mileage-based travel claims
  - `public_transport_entries`: Public transit expenses
  - `expense_entries`: General expenses with document type classification
  - `report_attachments`: File metadata for uploaded receipts/invoices

- **Security**:
  - Row-level security (RLS) policies enforcing employee/admin access boundaries
  - Employees can only edit draft/correction-needed reports
  - Admins have full visibility and approval authority
  - Auto-profile creation on user signup

- **Storage**:
  - `personal-report-attachments` bucket for secure file uploads with signed URLs

### Styling (`frontend/src/styles/main.css`)
- Comprehensive RTL-ready design system for Hebrew UI
- Responsive layout with mobile-first approach
- Status chips, form fields, buttons, and data tables
- Toast notifications and loading states
- ~430 lines of new CSS

### Integration
- Added route registration in `frontend/src/main.js` with Hebrew label
- Updated service worker cache version for deployment

## Notable Implementation Details
- **Stateless Design**: Module manages its own session separately from main dashboard
- **Offline-Safe**: Uses Supabase client with anonymous key only (no service_role exposure)
- **Accessibility**: Proper ARIA labels, semantic HTML, keyboard navigation support
- **Localization**: Full Hebrew support with RTL layout, Hebrew month names, and localized currency formatting
- **Data Integrity**: Unique constraints on (employee_id, month, year) prevent duplicate reports

https://claude.ai/code/session_016a1kvaKre5EuYBrkHCDd75