### PR TITLE
Add Personal Reports Module styling

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 549;
+const CACHE_VERSION = 551;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CT00ijXz.js",
+  "./assets/index-DEOAi4EO.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DeJf2Vd1.css",
+  "./assets/style-ChsrbNT5.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CT00ijXz.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DeJf2Vd1.css">
+  <script type="module" crossorigin src="./assets/index-DEOAi4EO.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-ChsrbNT5.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 549;
+const CACHE_VERSION = 551;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CT00ijXz.js",
+  "./assets/index-DEOAi4EO.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DeJf2Vd1.css",
+  "./assets/style-ChsrbNT5.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12148,3 +12148,366 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   gap: 10px;
   justify-content: flex-end;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Personal Reports Module  (pr-*)
+   ═══════════════════════════════════════════════════════════════ */
+
+.pr-module-root {
+  min-height: 100%;
+  background: var(--ds-bg, #f8fafc);
+}
+
+/* Toast */
+.pr-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(80px);
+  opacity: 0;
+  background: #1e293b;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  z-index: 9999;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  pointer-events: none;
+  white-space: nowrap;
+}
+.pr-toast--visible {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+.pr-toast--success { background: #166534; }
+.pr-toast--danger  { background: #991b1b; }
+.pr-toast--warning { background: #92400e; }
+
+/* Auth card */
+.pr-auth-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80vh;
+  padding: 24px;
+}
+.pr-auth-card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 36px 32px;
+  width: 100%;
+  max-width: 380px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.09);
+}
+.pr-auth-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+  text-align: center;
+}
+.pr-auth-sub {
+  color: #64748b;
+  text-align: center;
+  margin: 0 0 20px;
+  font-size: 0.9rem;
+}
+
+/* Alert */
+.pr-alert {
+  padding: 10px 14px;
+  border-radius: 8px;
+  margin-bottom: 14px;
+  font-size: 0.88rem;
+}
+.pr-alert--danger { background: #fee2e2; color: #991b1b; }
+
+/* Topbar */
+.pr-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+.pr-topbar__title {
+  font-weight: 600;
+  font-size: 1rem;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Screen / body */
+.pr-screen {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+.pr-body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 860px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* Cards */
+.pr-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+.pr-card--highlight {
+  border-right: 4px solid var(--ds-accent, #1a3358);
+}
+.pr-card--summary {
+  border-top: 2px solid #e2e8f0;
+}
+.pr-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.pr-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+.pr-card__total {
+  font-weight: 700;
+  color: var(--ds-accent, #1a3358);
+}
+
+/* Form elements */
+.pr-form { display: flex; flex-direction: column; gap: 12px; }
+.pr-field { display: flex; flex-direction: column; gap: 4px; flex: 1; }
+.pr-field--wide { flex: 2; }
+.pr-form-row { display: flex; gap: 10px; flex-wrap: wrap; }
+.pr-label { font-size: 0.82rem; font-weight: 500; color: #475569; }
+.pr-input {
+  padding: 8px 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  font-size: 0.9rem;
+  background: #fff;
+  color: #1e293b;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+.pr-input:focus { outline: none; border-color: var(--ds-accent, #1a3358); }
+.pr-input--select { cursor: pointer; }
+
+/* Buttons */
+.pr-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 7px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+}
+.pr-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+.pr-btn--primary {
+  background: var(--ds-accent, #1a3358);
+  color: #fff;
+}
+.pr-btn--primary:hover { opacity: 0.88; }
+.pr-btn--ghost {
+  background: transparent;
+  color: var(--ds-accent, #1a3358);
+  border: 1px solid #cbd5e1;
+}
+.pr-btn--ghost:hover { background: #f1f5f9; }
+.pr-btn--warning { background: #d97706; color: #fff; }
+.pr-btn--success { background: #166534; color: #fff; }
+.pr-btn--danger  { color: #991b1b; }
+.pr-btn--sm { padding: 4px 10px; font-size: 0.78rem; }
+.pr-btn--large { padding: 11px 28px; font-size: 1rem; }
+.pr-btn--full { width: 100%; }
+.pr-btn--link {
+  background: transparent;
+  border: none;
+  color: #64748b;
+  font-size: 0.82rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.pr-back-btn { padding: 6px 10px; }
+
+/* Entry rows */
+.pr-entry-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid #f1f5f9;
+}
+.pr-entry-row:last-of-type { border-bottom: none; }
+.pr-entry-main {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  font-size: 0.88rem;
+}
+.pr-entry-date { color: #64748b; white-space: nowrap; }
+.pr-entry-desc { font-weight: 500; }
+.pr-entry-note { color: #64748b; font-size: 0.82rem; }
+.pr-entry-detail { color: #64748b; font-size: 0.82rem; }
+.pr-entry-doc-type {
+  background: #e2e8f0;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.78rem;
+}
+.pr-entry-amount { font-weight: 600; white-space: nowrap; }
+.pr-entry-del {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.pr-entry-del:hover { color: #991b1b; }
+.pr-entry-attach-btn {
+  cursor: pointer;
+  font-size: 1.1rem;
+  opacity: 0.6;
+}
+.pr-entry-attach-btn:hover { opacity: 1; }
+.pr-file-input { display: none; }
+
+/* Add-form accordion */
+.pr-add-form-wrap {
+  margin-top: 10px;
+  border-top: 1px dashed #e2e8f0;
+  padding-top: 8px;
+}
+.pr-add-summary {
+  cursor: pointer;
+  font-size: 0.88rem;
+  color: var(--ds-accent, #1a3358);
+  font-weight: 500;
+  user-select: none;
+  padding: 4px 0;
+}
+.pr-add-form { margin-top: 12px; }
+
+/* Attachments */
+.pr-attachment-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid #f1f5f9;
+  font-size: 0.88rem;
+}
+.pr-attachment-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Summary rows */
+.pr-summary-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  font-size: 0.92rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+.pr-summary-row--total {
+  font-size: 1rem;
+  font-weight: 700;
+  border-bottom: none;
+  padding-top: 10px;
+  margin-top: 4px;
+  border-top: 2px solid #e2e8f0;
+}
+.pr-summary-status { margin-top: 8px; font-size: 0.88rem; color: #64748b; }
+.pr-finance-notes {
+  background: #fef9c3;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 0.88rem;
+}
+
+/* Actions bar */
+.pr-actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }
+.pr-actions-cell { white-space: nowrap; }
+
+/* Admin table */
+.pr-table-scroll { overflow-x: auto; }
+.pr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.pr-table th {
+  text-align: right;
+  padding: 8px 10px;
+  background: #f8fafc;
+  border-bottom: 2px solid #e2e8f0;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.pr-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+.pr-table tr:hover td { background: #f8fafc; }
+
+/* Report cards list */
+.pr-reports-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.pr-report-card {
+  background: #fff;
+  border-radius: 10px;
+  padding: 14px 16px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: box-shadow 0.15s;
+}
+.pr-report-card:hover { box-shadow: 0 3px 10px rgba(0,0,0,0.1); }
+.pr-report-card__title { font-weight: 600; font-size: 0.95rem; }
+.pr-report-card__meta { display: flex; align-items: center; gap: 8px; }
+.pr-report-card__date { font-size: 0.8rem; color: #64748b; }
+
+/* Loading */
+.pr-loading-placeholder {
+  padding: 24px;
+  text-align: center;
+  color: #94a3b8;
+}
+.pr-loading { opacity: 0.5; pointer-events: none; }
+.pr-empty-msg { color: #94a3b8; font-size: 0.9rem; padding: 12px 0; }
+
+/* Mobile tweaks */
+@media (max-width: 600px) {
+  .pr-body { padding: 12px; }
+  .pr-form-row { flex-direction: column; }
+  .pr-table th, .pr-table td { padding: 6px 6px; font-size: 0.8rem; }
+  .pr-topbar { padding: 10px 12px; }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 550;
+const CACHE_VERSION = 551;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 550;
+const SW_ENTRY_VERSION = 551;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR adds comprehensive CSS styling for a new Personal Reports module (pr-*) to the frontend application. The styles support a complete reporting interface with authentication, data entry, file attachments, and administrative features.

## Key Changes
- **New Personal Reports Module Styles**: Added 366 lines of CSS covering:
  - Module root container and layout structure
  - Toast notifications with success/warning/danger variants
  - Authentication card UI for login/signup flows
  - Sticky topbar with title display
  - Card-based layouts with highlight and summary variants
  - Form elements (inputs, labels, fields) with focus states
  - Button styles (primary, ghost, warning, success, danger, link variants)
  - Entry row components for displaying report items with dates, descriptions, amounts
  - File attachment handling and display
  - Summary rows and financial notes sections
  - Admin table styling with hover effects
  - Report card list with interactive elements
  - Loading and empty states
  - Mobile responsive adjustments for screens ≤600px

- **Cache Version Bumps**: Updated service worker cache versions (549→551) and asset references to reflect the new CSS additions

## Implementation Details
- Uses CSS custom properties (--ds-bg, --ds-accent) for theme consistency
- Implements smooth transitions (0.15s-0.25s) for interactive elements
- Follows a consistent color palette with slate/gray tones and accent colors
- Includes accessibility considerations (disabled states, focus indicators)
- Mobile-first responsive design with breakpoint at 600px
- Organized with clear section comments for maintainability

https://claude.ai/code/session_01KWaVz9nzcv3VPYcRHWnbi4