### PR TITLE
Update login to accept username/email instead of employee ID

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2052,7 +2052,7 @@ async function loginWithSupabaseAuth(user_id, entry_code) {
   const code = String(entry_code || '').trim();
   if (!uid || !code) throwLoginError('missing_user_id_or_entry_code');
 
-  const authEmail = `${uid}@taasiyeda.local`;
+  const authEmail = uid.includes('@') ? uid : `${uid}@think.org.il`;
 
   const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
     email: authEmail,

--- a/frontend/src/screens/login.js
+++ b/frontend/src/screens/login.js
@@ -24,7 +24,7 @@ export const loginScreen = {
             <input
               id="userId"
               required
-              placeholder="מספר עובד"
+              placeholder="שם משתמש / מייל (לדוגמה: idann)"
               autocomplete="username"
             />
 
@@ -71,7 +71,7 @@ export const loginScreen = {
       const code = codeInput?.value.trim() ?? '';
 
       if (!userId || !code) {
-        if (errorNode) errorNode.textContent = 'נא למלא מספר עובד וקוד כניסה';
+        if (errorNode) errorNode.textContent = 'נא למלא שם משתמש / מייל וקוד כניסה';
         return;
       }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 551;
+const CACHE_VERSION = 552;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
Updated the login flow to accept username or email addresses instead of employee IDs, with automatic domain handling for non-email inputs.

## Key Changes
- **Login placeholder text**: Changed from "מספר עובד" (employee number) to "שם משתמש / מייל (לדוגמה: idann)" (username/email with example)
- **Error message**: Updated validation error message to reference username/email instead of employee number
- **Email domain handling**: Modified authentication logic to:
  - Accept inputs that already contain `@` as complete email addresses
  - Automatically append `@think.org.il` domain to inputs without `@`
  - Replaced hardcoded `@taasiyeda.local` domain with the new domain
- **Cache version**: Bumped service worker cache version from 551 to 552 to ensure clients pick up the updated assets

## Implementation Details
The authentication email construction now intelligently handles both formats:
- Direct email input: `user@example.com` → used as-is
- Username input: `idann` → converted to `idann@think.org.il`

This provides flexibility for users while maintaining backward compatibility with the authentication system.

https://claude.ai/code/session_01RMR1FVMV8PsHAs3XR3BAmM