### PR TITLE
Require re-authentication on each personal reports visit

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -1098,27 +1098,21 @@ export const personalReportsScreen = {
   bind({ root } = {}) {
     const prRoot = (root && root.querySelector('#pr-root')) || root;
 
-    // Try restoring existing Supabase session
-    supabase.auth.getSession().then(async ({ data: { session } }) => {
-      if (session?.user) {
-        try {
-          const profile = await getProfile(session.user.id);
-          prSession = { user: session.user, profile };
-          prView = profile.role === 'admin' ? 'admin' : 'employee';
-          await rerender(prRoot);
-        } catch {
-          prSession = null;
-          renderInto(prRoot, loginHtml());
-          bindLoginForm(prRoot);
-        }
-      } else {
-        renderInto(prRoot, loginHtml());
-        bindLoginForm(prRoot);
-      }
-    }).catch(() => {
-      renderInto(prRoot, loginHtml());
-      bindLoginForm(prRoot);
-    });
+    // Always reset internal auth on every entry — module requires re-authentication each visit.
+    prSession = null;
+    prView = 'login';
+    prSelectedReport = null;
 
+    renderInto(prRoot, loginHtml());
+    bindLoginForm(prRoot);
+
+    // Clear internal auth when the user navigates away to another route.
+    const onNavigateAway = () => {
+      prSession = null;
+      prView = 'login';
+      prSelectedReport = null;
+      document.removeEventListener('app:navigate', onNavigateAway);
+    };
+    document.addEventListener('app:navigate', onNavigateAway);
   }
 };

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12230,9 +12230,9 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 .pr-auth-card {
   background: #fff;
   border-radius: 14px;
-  padding: 36px 32px;
+  padding: 28px 20px;
   width: 100%;
-  max-width: 380px;
+  max-width: 228px;
   box-shadow: 0 4px 24px rgba(0,0,0,0.09);
 }
 .pr-auth-title {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 553;
+const CACHE_VERSION = 554;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 553;
+const SW_ENTRY_VERSION = 554;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
Modified the personal reports module to require users to re-authenticate each time they visit, rather than restoring previous Supabase sessions. This enhances security by ensuring fresh authentication on every entry to the module.

## Key Changes
- **Authentication flow**: Removed automatic session restoration logic that checked for existing Supabase sessions. Now the module always resets internal auth state and displays the login form on entry.
- **State cleanup**: Added event listener for `app:navigate` to clear internal auth state (`prSession`, `prView`, `prSelectedReport`) when users navigate away from the personal reports module.
- **UI adjustments**: Reduced padding and max-width of the auth card (`.pr-auth-card`) for a more compact login form presentation.
- **Cache version bump**: Incremented service worker cache versions (553 → 554) to ensure clients pick up the updated module behavior.

## Implementation Details
- The `bind()` method now unconditionally initializes the login view without attempting to restore previous sessions
- A cleanup listener is registered on each bind to handle navigation away, preventing stale auth state
- The auth card styling changes make the login interface more compact while maintaining visual hierarchy

https://claude.ai/code/session_01F1XCFrmFBXswETKW2ux6dh