### PR TITLE
Enhance activity layout document generation with type labels and styling

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -901,6 +901,15 @@ function readyActivityLayoutSchools(rows = [], statuses = []) {
     .sort((a, b) => cleanText(a.authority).localeCompare(cleanText(b.authority), 'he') || cleanText(a.school).localeCompare(cleanText(b.school), 'he'));
 }
 
+function activityLayoutActivityTypeLabel(row = {}) {
+  const raw = String(row.activity_type || row.activity_family || row.type || '').trim();
+  if (['escape_room', 'חדר בריחה', 'חדרי בריחה'].includes(raw)) return 'חדר בריחה';
+  if (['workshop', 'workshops', 'סדנה', 'סדנאות'].includes(raw)) return 'סדנה';
+  if (['tour', 'סיור', 'סיורים'].includes(raw)) return 'סיור';
+  if (['after_school', 'חוג', 'חוגים'].includes(raw)) return 'חוג';
+  return '';
+}
+
 function activityLayoutRowsForDocument(group) {
   return (Array.isArray(group?.rows) ? group.rows : [])
     .map((row) => ({
@@ -909,6 +918,7 @@ function activityLayoutRowsForDocument(group) {
       endTime: activityLayoutEndTime(row),
       classGroup: activityLayoutClassGroup(row),
       activityName: cleanText(row.activity_name),
+      activityTypeLabel: activityLayoutActivityTypeLabel(row),
       instructors: activityLayoutInstructors(row)
     }))
     .sort((a, b) => String(a.date).localeCompare(String(b.date)) || String(a.startTime).localeCompare(String(b.startTime)));
@@ -935,14 +945,19 @@ function stripKitaPrefix(value) {
 function activityLayoutDocumentHtml(group) {
   const rows = activityLayoutRowsForDocument(group);
   const title = activityLayoutDocumentTitle(group);
-  const tableRows = rows.map((row) => `<tr>
-    <td>${escapeHtml(formatActivityLayoutDate(row.date))}</td>
-    <td>${escapeHtml(row.startTime)}</td>
-    <td>${escapeHtml(row.endTime)}</td>
-    <td>${escapeHtml(stripKitaPrefix(row.classGroup))}</td>
-    <td>${escapeHtml(row.activityName)}</td>
+  const tableRows = rows.map((row) => {
+    const activityCell = row.activityTypeLabel
+      ? `${escapeHtml(row.activityName)}<span class="act-type-tag">${escapeHtml(row.activityTypeLabel)}</span>`
+      : escapeHtml(row.activityName);
+    return `<tr>
+    <td class="col-date">${escapeHtml(formatActivityLayoutDate(row.date))}</td>
+    <td class="col-center">${escapeHtml(row.startTime)}</td>
+    <td class="col-center">${escapeHtml(row.endTime)}</td>
+    <td class="col-center">${escapeHtml(stripKitaPrefix(row.classGroup))}</td>
+    <td class="col-activity">${activityCell}</td>
     <td>${escapeHtml(row.instructors)}</td>
-  </tr>`).join('');
+  </tr>`;
+  }).join('');
   return `<!doctype html><html lang="he" dir="rtl"><head><meta charset="utf-8"><title>${escapeHtml(title)}</title><style>
     @page { size: A4; margin: 16mm; }
     * { box-sizing: border-box; }
@@ -956,23 +971,27 @@ function activityLayoutDocumentHtml(group) {
     .meta div { margin: 2px 0; }
     p { margin: 0 0 10px; font-size: 14px; }
     table { width: 100%; border-collapse: collapse; margin-top: 6px; margin-bottom: 12px; font-size: 13px; table-layout: fixed; }
-    col.col-date { width: 72px; }
-    col.col-start { width: 62px; }
-    col.col-end { width: 62px; }
-    col.col-grade { width: 70px; }
-    col.col-activity { width: auto; }
-    col.col-instructor { width: 110px; }
+    col.col-date { width: 88px; }
+    col.col-start { width: 58px; }
+    col.col-end { width: 58px; }
+    col.col-grade { width: 64px; }
+    col.col-activity { width: 130px; }
+    col.col-instructor { width: auto; }
     th, td { border: 1px solid #cbd5e1; padding: 5px 7px; text-align: right; vertical-align: top; word-break: break-word; }
-    th { background: #f1f5f9; font-weight: 700; }
+    th { background: #f1f5f9; font-weight: 700; text-align: center; }
+    td.col-date { white-space: nowrap; text-align: center; }
+    td.col-center { text-align: center; white-space: nowrap; }
+    td.col-activity { overflow-wrap: break-word; }
+    .act-type-tag { display: block; font-size: 11px; color: #64748b; margin-top: 2px; font-weight: 400; }
+    tr { page-break-inside: avoid; }
     .signature { margin-top: 20px; text-align: left; direction: rtl; }
     @media print { body { background: #fff; } .screen-actions { display: none !important; } .doc { width: auto; min-height: auto; margin: 0; padding: 0; box-shadow: none; } }
   </style></head><body><div class="screen-actions"><button class="print-btn" type="button" onclick="window.print()">הדפסה / שמירה כ־PDF</button></div><main class="doc">
     <img class="doc-logo" src="${escapeHtml(taasiyedaLogoSrc)}" alt="תעשיידע">
     <h1>פריסת פעילות</h1>
     <section class="meta" aria-label="פרטי לקוח">
-      <div><strong>לכבוד:</strong> ________</div>
-      <div><strong>בית ספר:</strong> ${escapeHtml(group?.school || '')}</div>
-      <div><strong>רשות:</strong> ${escapeHtml(group?.authority || '')}</div>
+      <div><strong>לכבוד:</strong></div>
+      <div>בית ספר ${escapeHtml(group?.school || '')} | ${escapeHtml(group?.authority || '')}</div>
     </section>
     <p>שלום רב,</p>
     <p>בהמשך לתיאום, מצורפת פריסת הפעילויות המתוכננת במסגרת קיץ תשפ"ו | 2026.</p>

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1040,18 +1040,20 @@ function activityLayoutListHtml(groups = []) {
       ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activity-layout-sent="${key}">עדכן אישור שליחה</button>`
       : `<button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-activity-layout-sent="${key}">סמן כנשלח</button>`;
     return `<tr>
-      <td><button type="button" class="ds-link-btn" data-activity-layout-open="${key}">${escapeHtml(group.school)}</button></td>
-      <td>${escapeHtml(group.authority)}</td>
-      <td>${escapeHtml(String(group.count || 0))}</td>
-      <td class="ds-activity-layout-status-cell">${sentStatusHtml}</td>
-      <td class="ds-actions-cell">
-        <button type="button" class="ds-btn ds-btn--sm" data-activity-layout-open="${key}">הפק מסמך</button>
-        ${sentBtnHtml}
+      <td class="col-al-school"><button type="button" class="ds-link-btn" data-activity-layout-open="${key}">${escapeHtml(group.school)}</button></td>
+      <td class="col-al-authority">${escapeHtml(group.authority)}</td>
+      <td class="col-al-count">${escapeHtml(String(group.count || 0))}</td>
+      <td class="col-al-status ds-activity-layout-status-cell">${sentStatusHtml}</td>
+      <td class="col-al-actions col-al-actions-cell">
+        <div class="ds-al-actions-stack">
+          <button type="button" class="ds-btn ds-btn--sm" data-activity-layout-open="${key}">הפק מסמך</button>
+          ${sentBtnHtml}
+        </div>
       </td>
     </tr>`;
   }).join('');
   if (!rows) return '<div class="ds-empty" dir="rtl"><p class="ds-empty__msg">אין בתי ספר מוכנים להפקת פריסת פעילות בשלב זה.</p></div>';
-  return dsTableWrap(`<table class="ds-table" dir="rtl"><thead><tr><th>בית ספר</th><th>רשות</th><th>מספר פעילויות</th><th>סטטוס שליחה</th><th>פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
+  return dsTableWrap(`<table class="ds-table ds-table--activity-layout" dir="rtl"><thead><tr><th class="col-al-school">בית ספר</th><th class="col-al-authority">רשות</th><th class="col-al-count">#</th><th class="col-al-status">סטטוס</th><th class="col-al-actions">פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
 }
 
 export const activitiesScreen = {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1337,8 +1337,7 @@ span.ds-chip {
 
 /* ——— Tables ——— */
 .ds-table-wrap {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow-x: hidden;
   max-width: 100%;
 }
 
@@ -12155,6 +12154,33 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   font-size: 0.75em;
   color: #64748b;
   margin-top: 2px;
+}
+
+/* טבלת פריסת פעילות בחלון הצד — עמודות קומפקטיות ללא גלילה */
+.ds-table--activity-layout {
+  table-layout: fixed;
+  width: 100%;
+}
+.ds-table--activity-layout th,
+.ds-table--activity-layout td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.ds-table--activity-layout .col-al-school { width: 30%; }
+.ds-table--activity-layout .col-al-authority { width: 22%; }
+.ds-table--activity-layout .col-al-count { width: 28px; text-align: center; }
+.ds-table--activity-layout .col-al-status { width: 20%; }
+.ds-table--activity-layout .col-al-actions { width: 26%; }
+.ds-table--activity-layout .col-al-actions-cell {
+  white-space: normal;
+}
+.ds-table--activity-layout .ds-al-actions-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  align-items: flex-start;
 }
 
 /* Confirm overlay */

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1337,7 +1337,9 @@ span.ds-chip {
 
 /* ——— Tables ——— */
 .ds-table-wrap {
-  overflow-x: hidden;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
 }
 
 .ds-table {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 556;
+const CACHE_VERSION = 557;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
## Summary
This PR improves the activity layout document generation feature by adding activity type categorization, enhancing table styling for better readability, and optimizing the activity layout list view with improved column layouts.

## Key Changes

- **Activity Type Labeling**: Added `activityLayoutActivityTypeLabel()` function to normalize and categorize activity types (escape room, workshop, tour, after-school club) in Hebrew, with support for multiple input formats
- **Document HTML Enhancement**: 
  - Integrated activity type labels as styled tags within activity cells in generated documents
  - Added CSS classes to table cells for better styling control
  - Updated column widths for improved document layout
  - Refined metadata section formatting (removed placeholder line, combined school and authority info)
  - Added visual styling for activity type tags (smaller font, gray color, block display)
  - Implemented page-break-inside: avoid for better print layout
- **Activity Layout List View**:
  - Added column-specific CSS classes to the activity layout table for responsive column sizing
  - Implemented fixed table layout with percentage-based column widths
  - Created a flex-based action stack for better button arrangement
  - Added text truncation with ellipsis for long content
- **CSS Improvements**:
  - New `.ds-table--activity-layout` class with fixed layout and column definitions
  - Added `.ds-al-actions-stack` for vertical button stacking
  - Updated `.ds-table-wrap` with max-width constraint
- **Cache Version**: Bumped service worker cache version from 556 to 557

## Implementation Details
- Activity type normalization handles both English and Hebrew variants (e.g., 'escape_room', 'חדר בריחה')
- Document styling uses RTL (right-to-left) layout for Hebrew text
- Table columns are now fixed-width with proper text overflow handling
- Activity type tags appear as secondary information below activity names in documents

https://claude.ai/code/session_01EGhAdTmGxpaJamawvyvYBM