### PR TITLE
Refactor activity layout table styling with fixed column widths

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12156,10 +12156,14 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   margin-top: 2px;
 }
 
-/* טבלת פריסת פעילות בחלון הצד — עמודות קומפקטיות ללא גלילה */
+/* טבלת פריסת פעילות בחלון הצד — עמודות קומפקטיות עם px קבועים */
+.ds-table-wrap:has(.ds-table--activity-layout) {
+  overflow-x: auto;
+}
 .ds-table--activity-layout {
   table-layout: fixed;
   width: 100%;
+  min-width: 490px;
 }
 .ds-table--activity-layout th,
 .ds-table--activity-layout td {
@@ -12167,20 +12171,41 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
+  padding: 3px 6px;
 }
-.ds-table--activity-layout .col-al-school { width: 30%; }
-.ds-table--activity-layout .col-al-authority { width: 22%; }
-.ds-table--activity-layout .col-al-count { width: 28px; text-align: center; }
-.ds-table--activity-layout .col-al-status { width: 20%; }
-.ds-table--activity-layout .col-al-actions { width: 26%; }
+.ds-table--activity-layout .col-al-school {
+  width: 155px;
+}
+.ds-table--activity-layout .col-al-authority {
+  width: 90px;
+}
+.ds-table--activity-layout .col-al-count {
+  width: 48px;
+  text-align: center;
+  overflow: visible;
+  text-overflow: clip;
+}
+.ds-table--activity-layout .col-al-status {
+  width: 90px;
+  white-space: nowrap;
+  overflow: visible;
+  text-overflow: clip;
+}
+.ds-table--activity-layout .col-al-actions {
+  /* takes remaining width */
+}
 .ds-table--activity-layout .col-al-actions-cell {
   white-space: normal;
 }
 .ds-table--activity-layout .ds-al-actions-stack {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   align-items: flex-start;
+}
+/* hide sent metadata — keep status cell to chip only */
+.ds-activity-layout-sent-meta {
+  display: none;
 }
 
 /* Confirm overlay */


### PR DESCRIPTION
## Summary
Refactored the activity layout table styling to use fixed pixel-based column widths instead of percentage-based widths, improving layout consistency and preventing unwanted text wrapping in compact views.

## Key Changes
- Changed from percentage-based column widths to fixed pixel widths for better control:
  - School column: 30% → 155px
  - Authority column: 22% → 90px
  - Count column: 28px → 48px (centered)
  - Status column: 20% → 90px
  - Actions column: 26% → flexible (remaining width)
- Added `min-width: 490px` to the table for minimum layout constraints
- Added horizontal scrolling container (`.ds-table-wrap:has(.ds-table--activity-layout)`) with `overflow-x: auto`
- Standardized cell padding to `3px 6px` across all table cells
- Set `overflow: visible` and `text-overflow: clip` for count and status columns to prevent ellipsis
- Reduced gap in action stack from 3px to 2px
- Hidden sent metadata display (`.ds-activity-layout-sent-meta`) to keep status cell focused on chip display only
- Updated comment to reflect "fixed px" approach instead of "no scrolling"

## Implementation Details
The refactoring prioritizes fixed column widths for predictable layout behavior while maintaining text truncation where needed. The table now scrolls horizontally on smaller viewports rather than forcing content to wrap, improving readability in the sidebar activity panel.

https://claude.ai/code/session_012sbMkSmJXTZLUpkhHrfotD