### PR TITLE
Fix activity layout side-drawer: fixed compact column widths and SW cache bump

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 555;
+const CACHE_VERSION = 558;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CnNva74X.js",
+  "./assets/index-BAc-dN2T.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BXRu5CtB.css",
+  "./assets/style-D1yachPS.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CnNva74X.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BXRu5CtB.css">
+  <script type="module" crossorigin src="./assets/index-BAc-dN2T.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-D1yachPS.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 555;
+const CACHE_VERSION = 558;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CnNva74X.js",
+  "./assets/index-BAc-dN2T.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-BXRu5CtB.css",
+  "./assets/style-D1yachPS.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1053,7 +1053,7 @@ function activityLayoutListHtml(groups = []) {
     </tr>`;
   }).join('');
   if (!rows) return '<div class="ds-empty" dir="rtl"><p class="ds-empty__msg">אין בתי ספר מוכנים להפקת פריסת פעילות בשלב זה.</p></div>';
-  return dsTableWrap(`<table class="ds-table ds-table--activity-layout" dir="rtl"><thead><tr><th class="col-al-school">בית ספר</th><th class="col-al-authority">רשות</th><th class="col-al-count">#</th><th class="col-al-status">סטטוס</th><th class="col-al-actions">פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
+  return dsTableWrap(`<table class="ds-table ds-table--activity-layout" dir="rtl"><colgroup><col class="col-al-school"><col class="col-al-authority"><col class="col-al-count"><col class="col-al-status"><col class="col-al-actions"></colgroup><thead><tr><th class="col-al-school">בית ספר</th><th class="col-al-authority">רשות</th><th class="col-al-count">פעילויות</th><th class="col-al-status">סטטוס שליחה</th><th class="col-al-actions">פעולות</th></tr></thead><tbody>${rows}</tbody></table>`);
 }
 
 export const activitiesScreen = {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12159,11 +12159,13 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 /* טבלת פריסת פעילות בחלון הצד — עמודות קומפקטיות עם px קבועים */
 .ds-table-wrap:has(.ds-table--activity-layout) {
   overflow-x: auto;
+  max-width: 100%;
 }
 .ds-table--activity-layout {
   table-layout: fixed;
-  width: 100%;
-  min-width: 490px;
+  width: 475px;
+  min-width: 475px;
+  max-width: 475px;
 }
 .ds-table--activity-layout th,
 .ds-table--activity-layout td {
@@ -12171,28 +12173,36 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
-  padding: 3px 6px;
+  padding: 3px 5px;
 }
 .ds-table--activity-layout .col-al-school {
-  width: 155px;
+  width: 120px;
+  min-width: 120px;
+  max-width: 120px;
 }
 .ds-table--activity-layout .col-al-authority {
   width: 90px;
+  min-width: 90px;
+  max-width: 90px;
 }
 .ds-table--activity-layout .col-al-count {
-  width: 48px;
+  width: 60px;
+  min-width: 60px;
+  max-width: 60px;
   text-align: center;
   overflow: visible;
   text-overflow: clip;
 }
 .ds-table--activity-layout .col-al-status {
-  width: 90px;
+  width: 85px;
+  min-width: 85px;
+  max-width: 85px;
   white-space: nowrap;
-  overflow: visible;
-  text-overflow: clip;
 }
 .ds-table--activity-layout .col-al-actions {
-  /* takes remaining width */
+  width: 120px;
+  min-width: 120px;
+  max-width: 120px;
 }
 .ds-table--activity-layout .col-al-actions-cell {
   white-space: normal;
@@ -12203,7 +12213,13 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   gap: 2px;
   align-items: flex-start;
 }
-/* hide sent metadata — keep status cell to chip only */
+.ds-table--activity-layout .ds-chip--status {
+  font-size: 0.68rem;
+  line-height: 1;
+  padding: 2px 6px;
+  min-height: 18px;
+}
+/* hide sent metadata — keep status cell to compact chip only */
 .ds-activity-layout-sent-meta {
   display: none;
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 557;
+const CACHE_VERSION = 558;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 555;
+const SW_ENTRY_VERSION = 558;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation

- להבטיח שטבלת "פריסת פעילות" בחלון הצד תשתמש ברוחבי עמודות קבועים וקומפקטיים (לא חלוקה שווה, לא `flex: 1`) ותתנהג היטב במצבי רוחב קטנים; לוודא שה־CSS החדש נטען דרך Service Worker.

### Description

- הוספתי `colgroup` וכותרות מפורשות לטבלת הפריסה ב־`frontend/src/screens/activities.js` כדי לקבע את מבנה העמודות במקום לחלק אותן שוות.
- הגדרתי רוחבי px קבועים ב־`frontend/src/styles/main.css` והגבתי אותם עם `min-width`/`max-width` ורוחב טבלה קבוע (`width: 475px`) כך שהעמודות לא יתפרסו מעבר למה שהוגדר; העמודות הראשיות: בית ספר 120px, רשות 90px, פעילויות 60px, סטטוס שליחה 85px.
- וידאתי שעמודת "פעילויות" מציגה את המספר המלא ללא ellipsis/חיתוך (`overflow: visible` / `text-overflow: clip`) ושתגית ה־status קומפקטית (`.ds-chip--status` מותאמת).
- עדכנתי גרסאות Service Worker (`frontend/sw.js` ו־`sw.js`) ובניתי מחדש (`dist`) כדי שהקבצים וה־CSS החדשים יופיעו ויזרימו את רענון הקאש; עדכונים מתאימים נמצאים גם בקבצי `dist` שנוצרו.

### Testing

- הרצתי `npm run check:changed` והבדיקה הממוקדת עברה בהצלחה.
- הרצתי `npm run check:build` (שמפעיל את תהליך ה־build) והבנייה הצליחה; `dist` עודכן עם הקבצים החדשים.
- הרצתי את הבדיקה הממוקדת `node --test tests/activities-screen.test.mjs` וכל המבחנים הממוקדים עברו (`20` בדיקות עברו, `0` נכשלו).
- אימתתי שגרסאות ה־Service Worker תואמות בין `frontend/sw.js`, `sw.js`, `dist/frontend/sw.js` ו־`dist/sw.js` (כולם `558`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218e1eab50832baeb3b51c982fbcfa)