### PR TITLE
Improve activity layout print table

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 558;
+const CACHE_VERSION = 559;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BAc-dN2T.js",
+  "./assets/index-DC1M1lQW.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BAc-dN2T.js"></script>
+  <script type="module" crossorigin src="./assets/index-DC1M1lQW.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-D1yachPS.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 558;
+const CACHE_VERSION = 559;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BAc-dN2T.js",
+  "./assets/index-DC1M1lQW.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -955,7 +955,7 @@ function activityLayoutDocumentHtml(group) {
     <td class="col-center">${escapeHtml(row.endTime)}</td>
     <td class="col-center">${escapeHtml(stripKitaPrefix(row.classGroup))}</td>
     <td class="col-activity">${activityCell}</td>
-    <td>${escapeHtml(row.instructors)}</td>
+    <td class="col-instructor">${escapeHtml(row.instructors)}</td>
   </tr>`;
   }).join('');
   return `<!doctype html><html lang="he" dir="rtl"><head><meta charset="utf-8"><title>${escapeHtml(title)}</title><style>
@@ -970,19 +970,77 @@ function activityLayoutDocumentHtml(group) {
     .meta { margin: 0 0 12px; font-size: 15px; }
     .meta div { margin: 2px 0; }
     p { margin: 0 0 10px; font-size: 14px; }
-    table { width: 100%; border-collapse: collapse; margin-top: 6px; margin-bottom: 12px; font-size: 13px; table-layout: fixed; }
-    col.col-date { width: 88px; }
-    col.col-start { width: 58px; }
-    col.col-end { width: 58px; }
-    col.col-grade { width: 64px; }
-    col.col-activity { width: 130px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 6px;
+      margin-bottom: 12px;
+      font-size: 12.5px;
+      line-height: 1.25;
+      table-layout: fixed;
+    }
+
+    col.col-date { width: 96px; }
+    col.col-start { width: 70px; }
+    col.col-end { width: 70px; }
+    col.col-grade { width: 50px; }
+    col.col-activity { width: 190px; }
     col.col-instructor { width: auto; }
-    th, td { border: 1px solid #cbd5e1; padding: 5px 7px; text-align: right; vertical-align: top; word-break: break-word; }
-    th { background: #f1f5f9; font-weight: 700; text-align: center; }
-    td.col-date { white-space: nowrap; text-align: center; }
-    td.col-center { text-align: center; white-space: nowrap; }
-    td.col-activity { overflow-wrap: break-word; }
-    .act-type-tag { display: block; font-size: 11px; color: #64748b; margin-top: 2px; font-weight: 400; }
+
+    th,
+    td {
+      border: 1px solid #cbd5e1;
+      padding: 4px 6px;
+      text-align: right;
+      vertical-align: middle;
+      word-break: normal;
+      overflow-wrap: anywhere;
+    }
+
+    th {
+      background: #f1f5f9;
+      font-weight: 700;
+      text-align: center;
+      white-space: nowrap;
+      line-height: 1.15;
+    }
+
+    td.col-date {
+      white-space: nowrap;
+      text-align: center;
+    }
+
+    td.col-center {
+      text-align: center;
+      white-space: nowrap;
+    }
+
+    td.col-activity {
+      text-align: right;
+      overflow-wrap: anywhere;
+    }
+
+    td.col-instructor {
+      text-align: center;
+      white-space: normal;
+    }
+
+    .act-type-tag {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-inline-start: 5px;
+      padding: 0 6px;
+      border: 1px solid #cbd5e1;
+      border-radius: 999px;
+      background: #f8fafc;
+      color: #475569;
+      font-size: 10.5px;
+      line-height: 1.45;
+      font-weight: 600;
+      white-space: nowrap;
+      vertical-align: middle;
+    }
     tr { page-break-inside: avoid; }
     .signature { margin-top: 20px; text-align: left; direction: rtl; }
     @media print { body { background: #fff; } .screen-actions { display: none !important; } .doc { width: auto; min-height: auto; margin: 0; padding: 0; box-shadow: none; } }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 558;
+const CACHE_VERSION = 559;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 558;
+const SW_ENTRY_VERSION = 559;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Improve the printed/PDF activity layout so rows are more compact and the activity-type tag doesn’t increase row height while keeping all data and table structure unchanged. 
- Allow instructor cells to be styled/centered via a dedicated class without touching business logic or field names. 
- Ensure the frontend update is picked up after deploy by bumping the Service Worker cache version to avoid serving a stale cache. 

### Description
- Add `class="col-instructor"` to the instructor cell in the activity layout row in `frontend/src/screens/activities.js` so instructor `<td>` can be targeted. 
- Replace the table CSS inside the `activityLayoutDocumentHtml` template to reduce font/padding, adjust column widths, set vertical alignment to middle, make the activity-type tag an inline pill, and tune wrapping behavior for compact rows. 
- Bump the Service Worker cache/version to `559` in `frontend/sw.js` and `sw.js` and update generated `dist` artifacts so the new bundle and precache entries are used after deployment. 

### Testing
- Ran `node --check frontend/src/screens/activities.js`, which completed successfully. 
- Ran `npm run check:changed`, which completed focused checks without failures. 
- Ran `node --test tests/activities-screen.test.mjs`, which passed (`20` tests passed, `0` failed). 
- Ran `npm run check:build` (build + postbuild), which completed successfully and updated `dist` precache entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a035ed6c832b86ce3e4d920a4dfc)