### PR TITLE
Revert internal-login redesign and restore previous login/personal-reports behavior

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1959,8 +1959,7 @@ function flattenUserRow(userRow = {}) {
     display_role: role,
     display_role_label: customDisplayRole || hebrewRole(role),
     display_role2: String(permissions.display_role2 || ''),
-    emp_id: String(userRow.emp_id || userRow.user_id || ''),
-    auth_user_id: String(userRow.auth_user_id || ''),
+    emp_id: String(userRow.user_id || ''),
     active: userRow.is_active ? 'yes' : 'no',
     ...permissions
   };
@@ -2960,7 +2959,6 @@ export const api = {
         display_role2: flat.display_role2,
         full_name: flat.full_name,
         emp_id: flat.emp_id,
-        auth_user_id: flat.auth_user_id,
         can_add_activity: canDirectManageActivitiesUser(flat) || ACTIVITY_REQUEST_ROLES.has(String(flat.role || '').trim()),
         can_edit_direct: canDirectManageActivitiesUser(flat),
         can_request_edit: canSubmitActivityRequestsUser(flat),

--- a/frontend/src/screens/login.js
+++ b/frontend/src/screens/login.js
@@ -4,7 +4,7 @@ export const loginScreen = {
   render(initialError = '', systemTitle = 'דשבורד תעשיידע') {
     return `
       <div class="login-shell" dir="rtl">
-        <section class="login-card" role="main" aria-labelledby="loginHeading">
+        <section class="login-card">
           <div class="login-brand">
             <img
               class="login-logo"
@@ -15,45 +15,31 @@ export const loginScreen = {
               decoding="async"
             />
           </div>
+          <header class="ds-page-header ds-page-header--login opacity-[0.99] border-t-[0.385723px] border-r-[0.385723px] border-b-[0.385723px] border-l-[0.385723px]" aria-labelledby="loginHeading">
+            <h1 id="loginHeading" class="ds-page-header__title">כניסה למערכת</h1>
+            <p class="ds-page-header__subtitle">${systemTitle}</p>
+          </header>
 
-          <div class="login-header">
-            <h1 id="loginHeading" class="login-header__title">התחברות פנימית לעובדים</h1>
-            <p class="login-header__subtitle">כניסה מאובטחת לצפייה בדוחות האישיים שלך</p>
-          </div>
+          <form id="loginForm" class="login-form">
+            <input
+              id="userId"
+              required
+              placeholder="שם משתמש / מייל (לדוגמה: idann)"
+              autocomplete="username"
+            />
 
-          <form id="loginForm" class="login-form" novalidate>
-            <div class="login-field">
-              <label class="login-label" for="userId">קוד עובד</label>
-              <input
-                id="userId"
-                class="login-input"
-                required
-                placeholder="הזן קוד עובד"
-                autocomplete="username"
-                inputmode="text"
-                dir="ltr"
-              />
-            </div>
+            <input
+              id="entryCode"
+              type="password"
+              required
+              placeholder="קוד כניסה"
+              autocomplete="current-password"
+            />
 
-            <div class="login-field">
-              <label class="login-label" for="entryCode">קוד גישה</label>
-              <input
-                id="entryCode"
-                class="login-input"
-                type="password"
-                required
-                placeholder="הזן קוד גישה"
-                autocomplete="current-password"
-                dir="ltr"
-              />
-            </div>
-
-            <button type="submit" class="login-submit">כניסה לדוחות האישיים</button>
+            <button type="submit" class="login-submit">התחברות</button>
           </form>
 
-          <p id="loginError" class="login-error" role="alert" aria-live="polite">${initialError}</p>
-
-          <p class="login-footer-note">${systemTitle}</p>
+          <p id="loginError" class="error">${initialError}</p>
         </section>
       </div>
     `;
@@ -85,7 +71,7 @@ export const loginScreen = {
       const code = codeInput?.value.trim() ?? '';
 
       if (!userId || !code) {
-        if (errorNode) errorNode.textContent = 'נא למלא קוד עובד וקוד גישה';
+        if (errorNode) errorNode.textContent = 'נא למלא שם משתמש / מייל וקוד כניסה';
         return;
       }
 
@@ -94,7 +80,7 @@ export const loginScreen = {
         await onLogin(userId, code, errorNode);
       } catch (error) {
         if (errorNode && !errorNode.textContent) errorNode.textContent = error.message;
-        if (root.isConnected) setBusy(false, 'כניסה לדוחות האישיים');
+        if (root.isConnected) setBusy(false, 'התחברות');
       }
     });
 

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -83,20 +83,16 @@ function isAdminRole(role) {
   return String(role || '').trim().toLowerCase() === 'admin';
 }
 
-function isValidUuid(value) {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(value || '').trim());
-}
-
 function profileFromDashboardUser(user) {
   if (!user || typeof user !== 'object') return null;
-  const candidateId = (
+  const id = String(
     user.personal_reports_user_id
     || user.supabase_user_id
     || user.auth_user_id
     || user.id
+    || user.user_id
     || ''
-  );
-  const id = isValidUuid(candidateId) ? String(candidateId).trim() : '';
+  ).trim();
   const displayRole = String(user.display_role || user.role || '').trim();
   const role = isAdminRole(displayRole) ? 'admin' : 'employee';
   return {
@@ -128,22 +124,6 @@ function authUnavailableHtml(message = 'לא נמצא משתמש מחובר במ
       </div>
     </div>
   `;
-}
-
-function friendlyErrorMessage(err) {
-  const raw = String(err?.message || err || '');
-  if (raw.includes('invalid input syntax for type uuid')) {
-    console.warn('[personal-reports] UUID error (suppressed from UI):', raw);
-    return 'אירעה תקלה בטעינת הדוחות. יש לנסות שוב או לפנות למנהל המערכת.';
-  }
-  if (raw.includes('not found') || raw.includes('PGRST116')) {
-    return 'לא נמצאו נתונים עבור הבקשה.';
-  }
-  if (raw.includes('JWT') || raw.includes('unauthorized') || raw.includes('permission denied')) {
-    return 'פרטי ההתחברות אינם תקינים. יש לבדוק את קוד העובד ולנסות שוב.';
-  }
-  console.warn('[personal-reports] Supabase error (suppressed from UI):', raw);
-  return 'אירעה תקלה בטעינת הדוחות. יש לנסות שוב.';
 }
 
 // ─── supabase API ─────────────────────────────────────────────────────────────
@@ -1013,13 +993,6 @@ function renderInto(root, html) {
 
 async function loadMyReportsList(root, employeeId) {
   const listEl = root.querySelector('#pr-my-reports-list');
-  if (!isValidUuid(employeeId)) {
-    if (listEl) {
-      listEl.innerHTML = `<div class="pr-alert pr-alert--warning" role="alert">לא ניתן לטעון דוחות — פרטי זיהוי העובד אינם תקינים. יש לנסות להתחבר מחדש.</div>`;
-    }
-    console.warn('[personal-reports] loadMyReportsList: invalid UUID, got:', employeeId);
-    return;
-  }
   try {
     const { data: reports, error } = await supabase
       .from('personal_reports')
@@ -1031,7 +1004,7 @@ async function loadMyReportsList(root, employeeId) {
     if (listEl) listEl.innerHTML = myReportsListHtml(reports || []);
   } catch (err) {
     if (listEl) {
-      listEl.innerHTML = `<div class="pr-alert pr-alert--danger" role="alert">${escapeHtml(friendlyErrorMessage(err))}</div>`;
+      listEl.innerHTML = `<div class="pr-alert pr-alert--danger" role="alert">לא ניתן לטעון דוחות קודמים כרגע. ${escapeHtml(err.message || '')}</div>`;
     }
   }
 }
@@ -1237,10 +1210,6 @@ function bindEmployeeDashboard(root, { isSimulation = false } = {}) {
     if (!statusEl) return;
 
     statusEl.innerHTML = '<span class="pr-checking">בודק…</span>';
-    if (!isValidUuid(employeeId)) {
-      statusEl.innerHTML = `<span class="pr-alert pr-alert--warning">לא ניתן לטעון דוח — נדרשת התחברות מחדש.</span>`;
-      return;
-    }
     try {
       const report = await getReport(employeeId, month, year);
       if (report) {
@@ -1256,7 +1225,7 @@ function bindEmployeeDashboard(root, { isSimulation = false } = {}) {
         statusEl.innerHTML = noReportStateHtml(month, year, isSimulation);
       }
     } catch (err) {
-      statusEl.innerHTML = `<span class="pr-alert pr-alert--danger">${escapeHtml(friendlyErrorMessage(err))}</span>`;
+      statusEl.innerHTML = `<span class="pr-checking" style="color:#991b1b">${escapeHtml(err.message)}</span>`;
     }
   }
 
@@ -1264,10 +1233,6 @@ function bindEmployeeDashboard(root, { isSimulation = false } = {}) {
     const sel = root.querySelector('#pr-month-select');
     const [month, year] = (sel?.value || '').split('-').map(Number);
     if (!month || !year) return;
-    if (!isValidUuid(employeeId)) {
-      showToast('לא ניתן לפתוח דוח — נדרשת התחברות מחדש.', 'danger');
-      return;
-    }
     try {
       let report = await getReport(employeeId, month, year);
       if (!report) {
@@ -1277,7 +1242,7 @@ function bindEmployeeDashboard(root, { isSimulation = false } = {}) {
       }
       await openReportDetail(root, report.id, false, { isSimulation, initialTab: tab });
     } catch (err) {
-      showToast(friendlyErrorMessage(err), 'danger');
+      showToast(err.message || 'שגיאה בפתיחת הדוח', 'danger');
     }
   }
 
@@ -1319,19 +1284,13 @@ function bindEmployeeDashboard(root, { isSimulation = false } = {}) {
       if (!month || !year) return;
       btn.disabled = true;
       btn.textContent = 'יוצר דוח…';
-      if (!isValidUuid(employeeId)) {
-        showToast('לא ניתן ליצור דוח — נדרשת התחברות מחדש.', 'danger');
-        btn.disabled = false;
-        btn.textContent = 'פתיחת דוח לחודש זה';
-        return;
-      }
       try {
         const report = await createReport(employeeId, month, year);
         prSelectedReport = report;
         await openReportDetail(root, report.id, false, { isSimulation: false });
         showToast('טיוטה נוצרה', 'success');
       } catch (err) {
-        showToast(friendlyErrorMessage(err), 'danger');
+        showToast(err.message || 'שגיאה ביצירת הדוח', 'danger');
         btn.disabled = false;
         btn.textContent = 'פתיחת דוח לחודש זה';
       }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3190,12 +3190,14 @@ span.ds-chip {
 }
 
 .login-card {
-  width: min(360px, 100%);
-  background: #fff;
-  border: 1px solid rgba(26, 51, 88, 0.12);
+  width: min(300px, 100%);
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(16px) saturate(1.3);
+  -webkit-backdrop-filter: blur(16px) saturate(1.3);
+  border: 1px solid rgba(26, 51, 88, 0.1);
   border-radius: var(--ds-radius-lg);
-  padding: var(--ds-space-6) var(--ds-space-5);
-  box-shadow: 0 4px 24px rgba(26, 51, 88, 0.12), 0 1px 4px rgba(15, 23, 42, 0.08);
+  padding: var(--ds-space-5) var(--ds-space-4);
+  box-shadow: 0 8px 32px rgba(26, 51, 88, 0.18), 0 2px 8px rgba(15, 23, 42, 0.1), 0 0 0 1px rgba(255, 255, 255, 0.5) inset;
 }
 
 .login-brand {
@@ -3207,118 +3209,95 @@ span.ds-chip {
 .login-logo {
   display: block;
   width: 100%;
-  max-width: 160px;
-  max-height: 64px;
+  max-width: 200px;
+  max-height: 76px;
   height: auto;
   object-fit: contain;
 }
 
-/* כותרת פנימית */
-.login-header {
+/* כותרת מסך התחברות — אותה היררכיה כמו dsPageHeader */
+.ds-page-header--login {
   text-align: center;
-  margin: 0 0 var(--ds-space-5);
-  padding-bottom: var(--ds-space-4);
-  border-bottom: 1px solid var(--ds-border);
+  padding: 0;
+  margin: 0 auto var(--ds-space-3);
+  width: 60%;
+  background: none;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
-.login-header__title {
-  font-size: 1rem;
+.ds-page-header--login .ds-page-header__title {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--ds-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.ds-page-header--login .ds-page-header__subtitle {
+  margin-top: var(--ds-space-1);
+  font-size: 1.08rem;
   font-weight: 700;
   color: var(--ds-text);
-  margin: 0 0 var(--ds-space-1);
-  letter-spacing: -0.01em;
+  display: inline-block;
+  padding-bottom: var(--ds-space-2);
+  position: relative;
 }
 
-.login-header__subtitle {
-  font-size: 0.8rem;
-  color: var(--ds-text-muted);
-  margin: 0;
-  font-weight: 400;
+.ds-page-header--login .ds-page-header__subtitle::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  height: 2px;
+  background: linear-gradient(to left, transparent, var(--ds-accent), transparent);
+  border-radius: 2px;
 }
 
-/* שדות טופס */
 .login-form {
   display: grid;
-  gap: var(--ds-space-4);
+  gap: var(--ds-space-3);
+  justify-items: stretch;
 }
 
-.login-field {
-  display: grid;
-  gap: var(--ds-space-1);
-}
-
-.login-label {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--ds-text-secondary);
-  display: block;
-}
-
-.login-input {
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid var(--ds-border);
-  border-radius: var(--ds-radius-sm);
-  padding: 9px 12px;
-  font-size: 0.9rem;
-  background: var(--ds-surface-raised);
-  color: var(--ds-text);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-.login-input:focus:not(:focus-visible) {
-  outline: none;
-}
-
-.login-input:focus-visible {
-  outline: none;
-  border-color: rgba(26, 51, 88, 0.45);
-  box-shadow: var(--ds-focus-ring);
-}
-
-.login-input:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-  background: var(--ds-surface-subtle);
-}
-
-/* Legacy selectors for post-auth state */
 .login-card .login-form input {
   width: 100%;
-  box-sizing: border-box;
+  max-width: 118px;
+  margin-inline: auto;
   border: 1px solid var(--ds-border);
   border-radius: var(--ds-radius-sm);
   padding: 9px 12px;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   background: var(--ds-surface-raised);
   color: var(--ds-text);
+  text-align: center;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.login-card .login-form input:focus:not(:focus-visible) { outline: none; }
+.login-card .login-form input:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .login-card .login-form input:focus-visible {
   outline: none;
   border-color: rgba(26, 51, 88, 0.45);
   box-shadow: var(--ds-focus-ring);
 }
-.login-card .login-form input:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-  background: var(--ds-surface-subtle);
-}
 
-/* כפתור ראשי */
 .login-submit {
-  width: 100%;
-  margin-top: var(--ds-space-2);
+  width: auto;
+  min-width: 60px;
+  margin-inline: auto;
+  margin-top: var(--ds-space-1);
   border: 1px solid var(--ds-accent);
   background: var(--ds-accent);
   color: #fff;
   font-weight: 700;
   border-radius: var(--ds-radius-sm);
-  padding: 10px 20px;
-  font-size: 0.9rem;
-  cursor: pointer;
+  padding: 4px 9px;
+  font-size: 0.42rem;
   transition: background 0.15s ease, border-color 0.15s ease, filter 0.15s ease,
     transform 0.08s ease, opacity 0.15s ease;
 }
@@ -3362,43 +3341,10 @@ span.ds-chip {
   animation: ds-spin 0.7s linear infinite;
 }
 
-/* שגיאה */
-.login-error {
-  text-align: center;
-  font-size: 0.8rem;
-  margin-top: var(--ds-space-3);
-  color: var(--ds-danger);
-  min-height: 1.2em;
-}
-
-.login-error:empty {
-  display: none;
-  margin-top: 0;
-  min-height: 0;
-}
-
-/* תיאום לגייסי */
-.login-card .error {
-  text-align: center;
-  font-size: 0.8rem;
-  margin-top: var(--ds-space-2);
-  color: var(--ds-danger);
-  min-height: 1.25em;
-}
-
-.login-card .error:empty {
-  display: none;
-  margin-top: 0;
-  min-height: 0;
-}
-
-/* שורת מידע תחתית */
-.login-footer-note {
-  text-align: center;
-  font-size: 0.74rem;
-  color: var(--ds-text-muted);
-  margin-top: var(--ds-space-3);
-  margin-bottom: 0;
+.login-card .login-form input:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  background: var(--ds-surface-subtle);
 }
 
 .login-card--post-auth {
@@ -3419,27 +3365,18 @@ span.ds-chip {
   color: var(--ds-text-muted);
 }
 
-/* ds-page-header--login — kept for backwards compat */
-.ds-page-header--login {
+.login-card .error {
   text-align: center;
-  padding: 0;
-  margin: 0 auto var(--ds-space-3);
-  background: none;
-  border: none;
-  box-shadow: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  font-size: 0.8rem;
+  margin-top: var(--ds-space-2);
+  color: var(--ds-danger);
+  min-height: 1.25em;
 }
-.ds-page-header--login .ds-page-header__title {
-  font-size: 0.72rem;
-  font-weight: 500;
-  color: var(--ds-text-muted);
-}
-.ds-page-header--login .ds-page-header__subtitle {
-  margin-top: var(--ds-space-1);
-  font-size: 1.08rem;
-  font-weight: 700;
-  color: var(--ds-text);
+
+.login-card .error:empty {
+  display: none;
+  margin-top: 0;
+  min-height: 0;
 }
 
 /* ——— Permissions ——— */

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 562;
+const CACHE_VERSION = 561;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 562;
+const SW_ENTRY_VERSION = 561;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Restore the previous, working login screen and personal-reports authentication flow after a recent internal-login redesign replaced the main login and caused the internal auth to appear as a standalone login page.
- The goal was to return the code to the immediately previous working version without manual UI redesigns or adding new logic.

### Description
- Reverted the recent internal-login redesign and restored the original login screen markup and behavior in `frontend/src/screens/login.js` and its styles in `frontend/src/styles/main.css`.
- Restored personal-reports handling to use the dashboard-authenticated user and removed the newly added UUID guard / friendly-error suppression logic in `frontend/src/screens/personal-reports.js` and adjusted the API shaping in `frontend/src/api.js` to match the prior bootstrap behavior.
- Reverted the Service Worker cache bump so `frontend/sw.js` and root `sw.js` use a consistent cache version again.
- Files changed: `frontend/src/api.js`, `frontend/src/screens/login.js`, `frontend/src/screens/personal-reports.js`, `frontend/src/styles/main.css`, `frontend/sw.js`, `sw.js`.

### Testing
- Ran `npm run check:changed` and `node --check` on the modified files and all syntax checks passed.
- Ran focused unit tests `tests/personal-reports-screen.test.mjs` and `tests/dashboard-stage2c-live-ui.test.mjs` and both tests passed.
- Performed `npm run check:build` which completed successfully though the build emitted an existing CSS syntax warning in activity-layout and chunk-size warnings; a login render smoke test also passed and a local dev server served `/sw.js` and `/frontend/sw.js?v=561` confirming SW/cache consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21cb9a6ba0832ba30587be9155117e)