### PR TITLE
Lock personal reports behind re-authentication

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 562;
+const CACHE_VERSION = 563;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Dlb7c7pR.js",
+  "./assets/index-CRGbycjY.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Dlb7c7pR.js"></script>
+  <script type="module" crossorigin src="./assets/index-CRGbycjY.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DY1gahrU.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 562;
+const CACHE_VERSION = 563;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Dlb7c7pR.js",
+  "./assets/index-CRGbycjY.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -42,6 +42,7 @@ let prSession        = null;
 let prSelectedReport = null;
 let prViewAsEmployee = null;
 let prAdminMode      = 'my';
+let isPersonalReportsUnlocked = false;
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -136,6 +137,29 @@ function sessionFromDashboardState(appState) {
   return { user: { id: profile.id }, profile, needsInternalAuth: !profile.id };
 }
 
+function personalReportsLoginIdentifier(user) {
+  return String(user?.user_id || user?.email || user?.work_email || user?.emp_id || user?.employee_id || '').trim();
+}
+
+function sameDashboardUser(userRow, dashboardUser) {
+  const expected = [dashboardUser?.user_id, dashboardUser?.email, dashboardUser?.work_email, dashboardUser?.emp_id, dashboardUser?.employee_id]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+  const actual = [userRow?.user_id, userRow?.email, userRow?.emp_id]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+  if (!expected.length || !actual.length) return false;
+  return expected.some((value) => actual.includes(value));
+}
+
+function resetPersonalReportsAuth() {
+  prSession        = null;
+  prSelectedReport = null;
+  prViewAsEmployee = null;
+  prAdminMode      = 'my';
+  isPersonalReportsUnlocked = false;
+}
+
 function internalEmployeeLoginHtml(message = '') {
   return `
     <div class="pr-screen pr-internal-auth-screen" dir="rtl">
@@ -143,20 +167,16 @@ function internalEmployeeLoginHtml(message = '') {
         ${dsPageHeader('דוחות אישיים', 'הוצאות, נסיעות ודיווח שכר חודשי')}
         <section class="pr-card pr-internal-login-card" aria-labelledby="pr-internal-login-title">
           <div class="pr-internal-login-head">
-            <h2 class="pr-internal-login-title" id="pr-internal-login-title">התחברות פנימית לעובדים</h2>
-            <p class="pr-internal-login-subtitle">כניסה מאובטחת לצפייה בדוחות האישיים שלך.</p>
+            <h2 class="pr-internal-login-title" id="pr-internal-login-title">אימות נוסף לדוחות אישיים</h2>
+            <p class="pr-internal-login-subtitle">אזור זה כולל מידע רגיש. יש להזין את קוד ההתחברות האישי כדי להציג את הדוחות.</p>
           </div>
           ${message ? `<div class="pr-alert pr-alert--danger" role="alert">${escapeHtml(message)}</div>` : ''}
           <form id="pr-internal-login-form" class="pr-form pr-internal-login-form" autocomplete="off">
             <div class="pr-field">
-              <label class="pr-label" for="pr-employee-code">קוד עובד</label>
-              <input class="pr-input" id="pr-employee-code" name="employee_code" type="text" inputmode="numeric" autocomplete="username" required />
+              <label class="pr-label" for="pr-internal-access-code">קוד התחברות</label>
+              <input class="pr-input" id="pr-internal-access-code" name="access_code" type="password" autocomplete="off" required />
             </div>
-            <div class="pr-field">
-              <label class="pr-label" for="pr-internal-access-code">קוד גישה / סיסמה פנימית</label>
-              <input class="pr-input" id="pr-internal-access-code" name="access_code" type="password" autocomplete="current-password" required />
-            </div>
-            <button class="pr-btn pr-btn--primary pr-btn--full pr-internal-login-submit" type="submit">כניסה לדוחות האישיים</button>
+            <button class="pr-btn pr-btn--primary pr-btn--full pr-internal-login-submit" type="submit">הצגת הדוחות שלי</button>
           </form>
           <button class="pr-btn--link pr-internal-login-back" data-pr-action="back-to-dashboard" type="button">חזרה לדשבורד</button>
         </section>
@@ -182,15 +202,15 @@ function authUnavailableHtml(message = 'לא נמצא משתמש מחובר במ
 
 // ─── supabase API ─────────────────────────────────────────────────────────────
 
-async function authenticateInternalEmployee(employeeCode, accessCode) {
-  const code = String(employeeCode || '').trim();
+async function authenticateInternalEmployee(dashboardUser, accessCode) {
+  const login = personalReportsLoginIdentifier(dashboardUser);
   const password = String(accessCode || '').trim();
-  if (!code || !password) {
+  if (!login || !password) {
     throw new Error('invalid_credentials');
   }
 
   const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
-    email: buildInternalAuthEmail(code),
+    email: buildInternalAuthEmail(login),
     password
   });
   if (authError || !authData?.user?.id) {
@@ -205,20 +225,20 @@ async function authenticateInternalEmployee(employeeCode, accessCode) {
     .eq('is_active', true)
     .maybeSingle();
 
-  if (userError || !userRow) {
+  if (userError || !userRow || !sameDashboardUser(userRow, dashboardUser)) {
     throw new Error('invalid_credentials');
   }
 
   const profile = {
     id: authUserId,
     email: String(userRow.email || authData.user.email || '').trim(),
-    full_name: String(userRow.name || userRow.email || code).trim(),
+    full_name: String(userRow.name || userRow.email || login).trim(),
     role: isAdminRole(userRow.role) ? 'admin' : 'employee',
     display_role: String(userRow.display_role || userRow.role || '').trim(),
-    emp_id: String(userRow.emp_id || userRow.user_id || code).trim()
+    emp_id: String(userRow.emp_id || userRow.user_id || login).trim()
   };
 
-  return { user: { id: authUserId }, profile, internalEmployeeCode: code, needsInternalAuth: false };
+  return { user: { id: authUserId }, profile, needsInternalAuth: false };
 }
 
 function assertEmployeeUuid(employeeId) {
@@ -1815,44 +1835,47 @@ function bindEmployeeSelector(root) {
 }
 
 function dispatchBackToDashboard() {
+  resetPersonalReportsAuth();
   document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: 'dashboard' } }));
 }
 
-function bindInternalEmployeeLogin(root) {
+function bindInternalEmployeeLogin(root, dashboardUser) {
   root.querySelector('[data-pr-action="back-to-dashboard"]')?.addEventListener('click', dispatchBackToDashboard);
   root.querySelector('#pr-internal-login-form')?.addEventListener('submit', async (event) => {
     event.preventDefault();
     const form = event.currentTarget;
     const submit = form.querySelector('button[type="submit"]');
     const fd = new FormData(form);
-    const employeeCode = fd.get('employee_code');
     const accessCode = fd.get('access_code');
     if (submit) {
       submit.disabled = true;
-      submit.textContent = 'בודק פרטי התחברות…';
+      submit.textContent = 'בודק אימות…';
     }
     try {
-      prSession = await authenticateInternalEmployee(employeeCode, accessCode);
+      prSession = await authenticateInternalEmployee(dashboardUser, accessCode);
       prSelectedReport = null;
       prViewAsEmployee = null;
       prAdminMode = 'my';
-      await rerender(root);
+      isPersonalReportsUnlocked = true;
+      await rerender(root, dashboardUser);
     } catch (err) {
-      renderInto(root, internalEmployeeLoginHtml(friendlyPersonalReportsError(err, 'פרטי ההתחברות אינם תקינים. יש לבדוק את קוד העובד ולנסות שוב.')));
-      bindInternalEmployeeLogin(root);
+      isPersonalReportsUnlocked = false;
+      renderInto(root, internalEmployeeLoginHtml('הקוד שהוזן אינו תקין. יש לבדוק ולנסות שוב.'));
+      bindInternalEmployeeLogin(root, dashboardUser);
     }
   });
 }
 
-async function rerender(root) {
-  if (!prSession) {
+async function rerender(root, dashboardUser) {
+  if (!isPersonalReportsUnlocked) {
     renderInto(root, internalEmployeeLoginHtml());
-    bindInternalEmployeeLogin(root);
+    bindInternalEmployeeLogin(root, dashboardUser);
     return;
   }
-  if (!prSession.user?.id) {
-    renderInto(root, internalEmployeeLoginHtml('נדרשת התחברות פנימית כדי לפתוח את הדוחות האישיים.'));
-    bindInternalEmployeeLogin(root);
+  if (!prSession || !prSession.user?.id) {
+    isPersonalReportsUnlocked = false;
+    renderInto(root, internalEmployeeLoginHtml('הקוד שהוזן אינו תקין. יש לבדוק ולנסות שוב.'));
+    bindInternalEmployeeLogin(root, dashboardUser);
     return;
   }
   if (isAdminRole(prSession.profile.role) && prAdminMode === 'my' && !prViewAsEmployee) {
@@ -1889,21 +1912,31 @@ export const personalReportsScreen = {
 
   bind({ root, state } = {}) {
     const prRoot = (root && root.querySelector('#pr-root')) || root;
+    const dashboardUser = state?.user || null;
+    const view = prRoot?.ownerDocument?.defaultView || globalThis.window;
 
-    prSession        = sessionFromDashboardState(state);
-    prSelectedReport = null;
-    prViewAsEmployee = null;
-    prAdminMode      = 'my';
+    resetPersonalReportsAuth();
+    prSession = sessionFromDashboardState(state);
 
-    rerender(prRoot);
+    rerender(prRoot, dashboardUser);
 
     const onNavigateAway = () => {
-      prSession        = null;
-      prSelectedReport = null;
-      prViewAsEmployee = null;
-      prAdminMode      = 'my';
+      resetPersonalReportsAuth();
       document.removeEventListener('app:navigate', onNavigateAway);
+      view?.removeEventListener('pagehide', onPageHide);
+      view?.removeEventListener('pageshow', onPageShow);
+    };
+    const onPageHide = () => {
+      resetPersonalReportsAuth();
+    };
+    const onPageShow = (event) => {
+      if (!event.persisted) return;
+      resetPersonalReportsAuth();
+      prSession = sessionFromDashboardState(state);
+      rerender(prRoot, dashboardUser);
     };
     document.addEventListener('app:navigate', onNavigateAway);
+    view?.addEventListener('pagehide', onPageHide);
+    view?.addEventListener('pageshow', onPageShow);
   }
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 562;
+const CACHE_VERSION = 563;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 562;
+const SW_ENTRY_VERSION = 563;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -28,47 +28,56 @@ test.after(() => {
   global.fetch = originalFetch;
 });
 
-test('personal reports renders only the internal employee login when no employee UUID exists', () => {
-  const { root } = mountWithUser({ full_name: 'עובד רגיל', display_role: 'instructor', user_id: '8000' });
+test('personal reports always opens locked with only the internal verification card', () => {
+  const { root } = mountWithUser({ full_name: 'עובד רגיל', display_role: 'instructor', user_id: '8000', auth_user_id: EMPLOYEE_UUID });
 
   assert.ok(root.querySelector('#pr-internal-login-form'));
-  assert.ok(root.querySelector('#pr-employee-code'));
   assert.ok(root.querySelector('#pr-internal-access-code'));
+  assert.equal(root.querySelector('#pr-employee-code'), null);
   assert.equal(root.querySelector('#pr-login-form'), null);
   assert.equal(root.querySelector('#pr-email'), null);
   assert.equal(root.querySelector('#pr-pass'), null);
-  assert.match(root.textContent, /התחברות פנימית לעובדים/);
-  assert.match(root.textContent, /כניסה מאובטחת לצפייה בדוחות האישיים שלך/);
+  assert.equal(root.querySelector('.pr-card.pr-month-selector-card'), null);
+  assert.match(root.textContent, /אימות נוסף לדוחות אישיים/);
+  assert.match(root.textContent, /אזור זה כולל מידע רגיש/);
+  assert.match(root.textContent, /קוד התחברות/);
+  assert.match(root.textContent, /הצגת הדוחות שלי/);
 });
 
-test('regular employee with a resolved UUID sees the three compact report tabs inside a card', () => {
-  const { root } = mountWithUser({ full_name: 'עובד רגיל', display_role: 'instructor', user_id: '8000', auth_user_id: EMPLOYEE_UUID });
-
-  const card = root.querySelector('.pr-card.pr-month-selector-card');
-  assert.ok(card, 'employee content should be wrapped in the personal reports card');
-
-  const tabs = [...card.querySelectorAll('.pr-quick-tabs .pr-report-tab')].map((btn) => btn.textContent.trim());
-  assert.deepEqual(tabs, ['הוצאות', 'נסיעות', 'דיווח שכר']);
-});
-
-test('admin with a resolved UUID starts in my reports mode with mode tabs and employee report tabs', () => {
+test('admin also starts locked and does not render personal or management report content before verification', () => {
   const { root } = mountWithUser({ full_name: 'מנהלת מערכת', display_role: 'admin', user_id: 'admin', auth_user_id: ADMIN_UUID });
 
-  const modes = [...root.querySelectorAll('.pr-admin-mode-switch .pr-report-tab')].map((btn) => btn.textContent.trim());
-  assert.deepEqual(modes, ['הדוחות שלי', 'ניהול דוחות עובדים']);
-
-  const quickTabs = [...root.querySelectorAll('.pr-quick-tabs .pr-report-tab')].map((btn) => btn.textContent.trim());
-  assert.deepEqual(quickTabs, ['הוצאות', 'נסיעות', 'דיווח שכר']);
+  assert.ok(root.querySelector('#pr-internal-login-form'));
+  assert.equal(root.querySelector('.pr-admin-mode-switch'), null);
+  assert.equal(root.querySelector('.pr-quick-tabs'), null);
+  assert.doesNotMatch(root.textContent, /ניהול דוחות עובדים/);
 });
 
-test('source keeps internal auth scoped to personal reports and maps code to auth UUID before report queries', async () => {
+test('leaving personal reports resets the unlocked module state so the next bind is locked again', () => {
+  const user = { full_name: 'עובד רגיל', display_role: 'instructor', user_id: '8000', auth_user_id: EMPLOYEE_UUID };
+  const { root } = mountWithUser(user);
+
+  document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: 'dashboard' } }));
+  root.innerHTML = personalReportsScreen.render({}, { state: { user } });
+  personalReportsScreen.bind({ root, state: { user } });
+
+  assert.ok(root.querySelector('#pr-internal-login-form'));
+  assert.equal(root.querySelector('.pr-card.pr-month-selector-card'), null);
+});
+
+test('source keeps personal reports auth temporary and maps verified login to auth UUID before report queries', async () => {
   const source = await readFile(new URL('../frontend/src/screens/personal-reports.js', import.meta.url), 'utf8');
 
-  assert.match(source, /function internalEmployeeLoginHtml/);
+  assert.match(source, /let isPersonalReportsUnlocked = false/);
+  assert.match(source, /function resetPersonalReportsAuth/);
+  assert.match(source, /isPersonalReportsUnlocked = false/);
   assert.match(source, /function authenticateInternalEmployee/);
   assert.match(source, /auth\.signInWithPassword/);
   assert.match(source, /authUserId = authData\.user\.id/);
+  assert.match(source, /sameDashboardUser\(userRow, dashboardUser\)/);
   assert.match(source, /assertEmployeeUuid\(employeeId\)/);
-  assert.match(source, /התחברות פנימית לעובדים/);
+  assert.doesNotMatch(source, /localStorage|sessionStorage/);
+  assert.match(source, /אימות נוסף לדוחות אישיים/);
+  assert.match(source, /הקוד שהוזן אינו תקין\. יש לבדוק ולנסות שוב\./);
   assert.doesNotMatch(source, /id="pr-email"|id="pr-pass"|מייל עבודה|שכחתי סיסמה/);
 });


### PR DESCRIPTION
### Motivation
- Prevent any personal/ sensitive data from being shown or loaded before the currently signed-in dashboard user explicitly re-enters their personal access code for the "דוחות אישיים" screen.
- Keep the unlock state ephemeral (screen/component-level) and ensure it is cleared whenever the user leaves or the page is restored from bfcache so the next entry always requires re-auth.

### Description
- Personal reports now open locked by default and require re-entry of the user’s personal code; a module-only flag `isPersonalReportsUnlocked` controls visibility and is never persisted to `localStorage`/`sessionStorage`.
- Replaced the previous internal-login UI with the requested UX: title `אימות נוסף לדוחות אישיים`, explanatory text, single `קוד התחברות` field and button `הצגת הדוחות שלי` (in `internalEmployeeLoginHtml`).
- Authentication flow changed to validate the entered code against Supabase Auth and verify the returned user row matches the current dashboard user via a `sameDashboardUser` check before mapping to the auth UUID (no numeric code sent as UUID), and `authenticateInternalEmployee` now accepts the dashboard user for scoped verification.
- Added `resetPersonalReportsAuth()` and reset hooks on navigation and on page lifecycle events (`app:navigate`, `pagehide`, `pageshow`) so leaving the screen or restoring from cache clears the unlocked state; `dispatchBackToDashboard()` now triggers the reset.
- Updated focused unit tests (`tests/personal-reports-screen.test.mjs`) to assert the locked-first behavior, temporary state, and absence of storage usage, and bumped Service Worker/PWA cache version (`CACHE_VERSION` / `SW_ENTRY_VERSION`) to avoid serving stale cached screen versions.

### Testing
- Ran `npm run check:changed` and verified syntax checks for changed files completed (passed). 
- Ran `node --test tests/personal-reports-screen.test.mjs` which executed the focused personal-reports tests (4 tests) and they all passed.
- Ran `npm run check:build` (frontend build) and the build completed successfully; Vite emitted unrelated CSS/chunk warnings but the build finished and the generated `dist` SW/index.html were updated to the new cache version (562 → 563).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e2d3519c832bbce58320ac0a69b0)