### PR TITLE
Refine personal reports authentication screen copy and styling

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -164,21 +164,21 @@ function internalEmployeeLoginHtml(message = '') {
   return `
     <div class="pr-screen pr-internal-auth-screen" dir="rtl">
       <div class="pr-body pr-internal-auth-body">
-        ${dsPageHeader('דוחות אישיים', 'הוצאות, נסיעות ודיווח שכר חודשי')}
+        ${dsPageHeader('דוחות אישיים')}
         <section class="pr-card pr-internal-login-card" aria-labelledby="pr-internal-login-title">
           <div class="pr-internal-login-head">
-            <h2 class="pr-internal-login-title" id="pr-internal-login-title">אימות נוסף לדוחות אישיים</h2>
-            <p class="pr-internal-login-subtitle">אזור זה כולל מידע רגיש. יש להזין את קוד ההתחברות האישי כדי להציג את הדוחות.</p>
+            <h2 class="pr-internal-login-title" id="pr-internal-login-title">דוחות אישיים</h2>
+            <p class="pr-internal-login-subtitle">נדרש אימות נוסף כדי להיכנס לאזור זה</p>
           </div>
           ${message ? `<div class="pr-alert pr-alert--danger" role="alert">${escapeHtml(message)}</div>` : ''}
           <form id="pr-internal-login-form" class="pr-form pr-internal-login-form" autocomplete="off">
             <div class="pr-field">
-              <label class="pr-label" for="pr-internal-access-code">קוד התחברות</label>
+              <label class="pr-label" for="pr-internal-access-code">קוד אישי</label>
               <input class="pr-input" id="pr-internal-access-code" name="access_code" type="password" autocomplete="off" required />
             </div>
-            <button class="pr-btn pr-btn--primary pr-btn--full pr-internal-login-submit" type="submit">הצגת הדוחות שלי</button>
+            <button class="pr-btn pr-btn--primary pr-btn--full pr-internal-login-submit" type="submit">כניסה לדוחות</button>
           </form>
-          <button class="pr-btn--link pr-internal-login-back" data-pr-action="back-to-dashboard" type="button">חזרה לדשבורד</button>
+          <button class="pr-btn pr-btn--link pr-internal-login-back" data-pr-action="back-to-dashboard" type="button">חזרה</button>
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Updated the internal employee authentication screen for personal reports with improved Hebrew copy and minor styling adjustments for better clarity and consistency.

## Key Changes
- **Page header**: Removed subtitle from `dsPageHeader()` call, simplifying the header display
- **Login title**: Changed from "אימות נוסף לדוחות אישיים" to "דוחות אישיים" for more direct messaging
- **Subtitle text**: Simplified from detailed explanation to concise "נדרש אימות נוסף כדי להיכנס לאזור זה"
- **Input label**: Updated from "קוד התחברות" to "קוד אישי" for clearer terminology
- **Submit button**: Changed text from "הצגת הדוחות שלי" to "כניסה לדוחות" for consistency
- **Back button**: 
  - Simplified text from "חזרה לדשבורד" to "חזרה"
  - Added missing `pr-btn` class alongside `pr-btn--link` for proper styling

## Implementation Details
All changes are text/copy updates and minor CSS class additions. No functional logic was modified. The changes improve UX by using more concise, consistent Hebrew terminology throughout the authentication flow.

https://claude.ai/code/session_01K5NPkNpVA8Cu8EURudAEM6