### PR TITLE
Redesign personal reports lock screen with polished UI

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -164,21 +164,23 @@ function internalEmployeeLoginHtml(message = '') {
   return `
     <div class="pr-screen pr-internal-auth-screen" dir="rtl">
       <div class="pr-body pr-internal-auth-body">
-        ${dsPageHeader('דוחות אישיים')}
-        <section class="pr-card pr-internal-login-card" aria-labelledby="pr-internal-login-title">
-          <div class="pr-internal-login-head">
-            <h2 class="pr-internal-login-title" id="pr-internal-login-title">דוחות אישיים</h2>
-            <p class="pr-internal-login-subtitle">נדרש אימות נוסף כדי להיכנס לאזור זה</p>
+        <section class="pr-internal-lock-card" aria-labelledby="pr-internal-login-title">
+          <div class="pr-internal-lock-icon" aria-hidden="true">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+              <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
           </div>
-          ${message ? `<div class="pr-alert pr-alert--danger" role="alert">${escapeHtml(message)}</div>` : ''}
-          <form id="pr-internal-login-form" class="pr-form pr-internal-login-form" autocomplete="off">
-            <div class="pr-field">
-              <label class="pr-label" for="pr-internal-access-code">קוד אישי</label>
-              <input class="pr-input" id="pr-internal-access-code" name="access_code" type="password" autocomplete="off" required />
+          <h2 class="pr-internal-lock-title" id="pr-internal-login-title">אימות נוסף לדוחות אישיים</h2>
+          <p class="pr-internal-lock-subtitle">אזור זה כולל מידע רגיש. יש להזין את קוד ההתחברות האישי כדי להמשיך.</p>
+          ${message ? `<div class="pr-internal-lock-error" role="alert">${escapeHtml(message)}</div>` : ''}
+          <form id="pr-internal-login-form" autocomplete="off" class="pr-internal-lock-form">
+            <div class="pr-internal-lock-field">
+              <label class="pr-internal-lock-label" for="pr-internal-access-code">קוד התחברות</label>
+              <input class="pr-internal-lock-input" id="pr-internal-access-code" name="access_code" type="password" autocomplete="off" placeholder="הזן קוד אישי" required />
             </div>
-            <button class="pr-btn pr-btn--primary pr-btn--full pr-internal-login-submit" type="submit">כניסה לדוחות</button>
+            <button class="pr-internal-lock-btn" type="submit">כניסה</button>
           </form>
-          <button class="pr-btn pr-btn--link pr-internal-login-back" data-pr-action="back-to-dashboard" type="button">חזרה</button>
         </section>
       </div>
     </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12989,56 +12989,118 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 
 /* Internal employee authentication (personal reports only) */
 .pr-internal-auth-screen {
-  background: #f8fafc;
+  background: #f1f5f9;
+  min-height: 100vh;
 }
 .pr-internal-auth-body {
-  align-items: flex-end;
-  max-width: 860px;
-}
-.pr-internal-login-card {
-  width: min(100%, 420px);
-  border: 1px solid #e2e8f0;
-  border-radius: 16px;
-  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.08);
-  padding: 24px;
-  text-align: right;
-}
-.pr-internal-login-head {
-  margin-bottom: 18px;
-}
-.pr-internal-login-title {
-  margin: 0 0 6px;
-  color: #0f172a;
-  font-size: 1.18rem;
-  font-weight: 700;
-}
-.pr-internal-login-subtitle {
-  margin: 0;
-  color: #64748b;
-  font-size: 0.92rem;
-  line-height: 1.55;
-}
-.pr-internal-login-form {
-  gap: 14px;
-}
-.pr-internal-login-card .pr-input {
-  min-height: 42px;
-}
-.pr-internal-login-submit {
-  min-height: 42px;
-  margin-top: 2px;
-}
-.pr-internal-login-back {
-  display: inline-flex;
-  margin-top: 14px;
-  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 64px);
+  padding: 32px 16px;
 }
 
-@media (max-width: 640px) {
-  .pr-internal-auth-body {
-    align-items: stretch;
-  }
-  .pr-internal-login-card {
-    width: 100%;
+/* Lock card */
+.pr-internal-lock-card {
+  width: min(100%, 400px);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  box-shadow: 0 4px 6px rgba(15,23,42,0.04), 0 16px 40px rgba(15,23,42,0.09);
+  padding: 40px 36px 36px;
+  text-align: right;
+  direction: rtl;
+}
+.pr-internal-lock-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  background: #f0f7ff;
+  border-radius: 14px;
+  margin: 0 auto 24px;
+  color: var(--ds-accent, #1a3358);
+}
+.pr-internal-lock-title {
+  margin: 0 0 8px;
+  color: #0f172a;
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-align: center;
+}
+.pr-internal-lock-subtitle {
+  margin: 0 0 24px;
+  color: #64748b;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  text-align: center;
+}
+.pr-internal-lock-error {
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #991b1b;
+  font-size: 0.875rem;
+  text-align: right;
+}
+.pr-internal-lock-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.pr-internal-lock-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pr-internal-lock-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+}
+.pr-internal-lock-input {
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  color: #0f172a;
+  background: #f8fafc;
+  border: 1.5px solid #cbd5e1;
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
+  direction: ltr;
+  text-align: center;
+  letter-spacing: 0.12em;
+}
+.pr-internal-lock-input:focus {
+  border-color: var(--ds-accent, #1a3358);
+  box-shadow: 0 0 0 3px rgba(26,51,88,0.10);
+  background: #ffffff;
+}
+.pr-internal-lock-btn {
+  width: 100%;
+  padding: 11px 20px;
+  font-size: 0.97rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--ds-accent, #1a3358);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+  margin-top: 2px;
+}
+.pr-internal-lock-btn:hover { opacity: 0.88; }
+.pr-internal-lock-btn:active { transform: scale(0.98); }
+.pr-internal-lock-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+@media (max-width: 480px) {
+  .pr-internal-lock-card {
+    padding: 28px 20px 24px;
+    border-radius: 16px;
   }
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 563;
+const CACHE_VERSION = 564;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 


### PR DESCRIPTION
- Replace raw HTML form with centered lock card (.pr-internal-lock-card)
- Add lock icon, centered title/subtitle in card, styled error block
- Field label: קוד התחברות, submit button: כניסה (only)
- Remove all internal/technical text from the lock screen
- Add full CSS for lock card: shadow, radius, focus ring, RTL, mobile
- Bump SW CACHE_VERSION to 564 to invalidate old cached assets

https://claude.ai/code/session_01K5NPkNpVA8Cu8EURudAEM6