### PR TITLE
Remove overdue popup count

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 563;
+const CACHE_VERSION = 566;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CRGbycjY.js",
+  "./assets/index-DoVahJNY.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DY1gahrU.css",
+  "./assets/style-BqrWDX1w.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CRGbycjY.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DY1gahrU.css">
+  <script type="module" crossorigin src="./assets/index-DoVahJNY.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BqrWDX1w.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 563;
+const CACHE_VERSION = 566;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CRGbycjY.js",
+  "./assets/index-DoVahJNY.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-DY1gahrU.css",
+  "./assets/style-BqrWDX1w.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1327,12 +1327,17 @@ export const activitiesScreen = {
       el.innerHTML = `
         <div class="ds-overdue-dialog">
           <div class="ds-overdue-icon" aria-hidden="true">⚠️</div>
-          <h3 class="ds-overdue-title">פעילויות פתוחות שתאריך הסיום שלהן חלף</h3>
-          <p class="ds-overdue-body">קיימות <strong>${overdue.length}</strong> פעילויות בסטטוס <strong>פתוח</strong> שתאריך הסיום שלהן כבר עבר.<br>מומלץ לבדוק ולעדכן את הסטטוס שלהן.</p>
-          <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-overdue-close>הבנתי</button>
+          <h3 class="ds-overdue-title">יש תוכניות שהסתיימו ועדיין לא נסגרו</h3>
+          <p class="ds-overdue-body">מומלץ לעבור לעמוד החריגות, לבדוק את הרשומות הרלוונטיות ולעדכן סטטוס לפי הצורך.</p>
+          <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-overdue-exceptions>מעבר לעמוד החריגות</button>
         </div>`;
       el.addEventListener('click', (e) => {
-        if (e.target.closest('[data-overdue-close]') || e.target === el) el.remove();
+        if (e.target.closest('[data-overdue-exceptions]')) {
+          el.remove();
+          document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: 'exceptions' } }));
+          return;
+        }
+        if (e.target === el) el.remove();
       });
       document.addEventListener('keydown', function onKey(e) {
         if (e.key === 'Escape') { el.remove(); document.removeEventListener('keydown', onKey); }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 565;
+const CACHE_VERSION = 566;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 565;
+const SW_ENTRY_VERSION = 566;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -227,6 +227,16 @@ test('activities source no longer wires the admin summary drawer into the activi
   assert.doesNotMatch(source, /querySelector\('\[data-activities-admin-summary\]'\)/);
 });
 
+test('activities overdue popup shows general exceptions message without count', async () => {
+  const fs = await import('node:fs/promises');
+  const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
+  assert.match(source, /יש תוכניות שהסתיימו ועדיין לא נסגרו/);
+  assert.match(source, /מומלץ לעבור לעמוד החריגות, לבדוק את הרשומות הרלוונטיות ולעדכן סטטוס לפי הצורך/);
+  assert.match(source, /מעבר לעמוד החריגות/);
+  assert.doesNotMatch(source, /<strong>\$\{overdue\.length\}<\/strong>/);
+  assert.doesNotMatch(source, /קיימות\s*<strong>\$\{overdue\.length\}<\/strong>/);
+});
+
 test('admin activities summary renders one total summary without district sections', async () => {
   const { renderAdminActivitiesSummary } = await import('../frontend/src/screens/activities.js');
   const rows = [


### PR DESCRIPTION
### Motivation
- The overdue/ended-open overlay should continue to alert when at least one `end_date_passed` activity exists but must not display the numeric count in the message or title. 

### Description
- Replaced the overlay HTML in `frontend/src/screens/activities.js` to remove `${overdue.length}` and show the generic title `יש תוכניות שהסתיימו ועדיין לא נסגרו` with the requested guidance text and CTA. 
- The overlay CTA now dispatches the existing navigation event to go to the exceptions screen instead of showing a numeric count. 
- Bumped the Service Worker cache version to `566` in `frontend/sw.js` and `sw.js` and refreshed built `dist` entries so the new bundle/cache is picked up by deployments. 
- Added a focused test in `tests/activities-screen.test.mjs` that asserts the popup copy is generic and that no `${overdue.length}` or equivalent count is present. 

### Testing
- Ran `node --check frontend/src/screens/activities.js && node --check frontend/sw.js && node --check sw.js && node --test tests/activities-screen.test.mjs` and the focused test suite passed. 
- Ran the project checks via `npm run check:changed` which completed successfully. 
- Ran `npm run check:build` (production build completed); Vite emitted an existing CSS minify warning and chunk-size warning but the build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f0281730832b9b43dec19c2b38ac)