### PR TITLE
Add permission check and dismiss button to overdue warning dialog

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 566;
+const CACHE_VERSION = 567;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 566;
+const CACHE_VERSION = 567;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1318,6 +1318,15 @@ export const activitiesScreen = {
       if (!overdue.length) return;
       const existing = root.querySelector('[data-overdue-warning]');
       if (existing) return;
+
+      const userRoutes = Array.isArray(state?.effectiveRoutes) ? state.effectiveRoutes
+        : (Array.isArray(state?.routes) ? state.routes : []);
+      const canViewExceptions = userRoutes.includes('exceptions');
+
+      const exceptionsBtn = canViewExceptions
+        ? `<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-overdue-exceptions>מעבר לתיקון החריגה</button>`
+        : '';
+
       const el = document.createElement('div');
       el.setAttribute('data-overdue-warning', '');
       el.setAttribute('role', 'alertdialog');
@@ -1329,15 +1338,30 @@ export const activitiesScreen = {
           <div class="ds-overdue-icon" aria-hidden="true">⚠️</div>
           <h3 class="ds-overdue-title">יש תוכניות שהסתיימו ועדיין לא נסגרו</h3>
           <p class="ds-overdue-body">מומלץ לעבור לעמוד החריגות, לבדוק את הרשומות הרלוונטיות ולעדכן סטטוס לפי הצורך.</p>
-          <button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-overdue-exceptions>מעבר לעמוד החריגות</button>
+          <div class="ds-overdue-actions">
+            ${exceptionsBtn}
+            <button type="button" class="ds-btn ds-btn--secondary ds-btn--sm" data-overdue-dismiss>אישור והמשך עבודה בדשבורד</button>
+          </div>
         </div>`;
       el.addEventListener('click', (e) => {
         if (e.target.closest('[data-overdue-exceptions]')) {
           el.remove();
+          state.listFilters = state.listFilters || {};
+          state.listFilters.exceptions = {
+            ...(state.listFilters.exceptions || {}),
+            q: '',
+            district: '',
+            activity_manager: '',
+            exception_type: 'end_date_passed',
+            visibleCount: 200
+          };
           document.dispatchEvent(new CustomEvent('app:navigate', { detail: { route: 'exceptions' } }));
           return;
         }
-        if (e.target === el) el.remove();
+        if (e.target.closest('[data-overdue-dismiss]') || e.target === el) {
+          el.remove();
+          return;
+        }
       });
       document.addEventListener('keydown', function onKey(e) {
         if (e.key === 'Escape') { el.remove(); document.removeEventListener('keydown', onKey); }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10612,6 +10612,14 @@ select.ds-input {
   line-height: 1.6;
 }
 
+.ds-overdue-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
 .ds-pa-records-shell { border:1px solid var(--ds-border); border-radius:14px; box-shadow: var(--ds-shadow-sm); overflow:hidden; background:var(--ds-surface); }
 .ds-pa-records-shell .ds-table-wrap { margin:0; border:none; border-radius:0; box-shadow:none; }
 .ds-pa-records-shell .ds-pa-table thead th { background:var(--ds-surface-2); }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 566;
+const CACHE_VERSION = 567;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 566;
+const SW_ENTRY_VERSION = 567;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
Enhanced the overdue warning dialog in the activities screen with permission-based visibility and improved user interaction options.

## Key Changes
- **Permission-based button visibility**: The "Go to exceptions" button now only displays for users with the 'exceptions' route permission, checking both `effectiveRoutes` and `routes` from the application state
- **Improved dialog actions**: Restructured the button layout into a dedicated `.ds-overdue-actions` container with flexbox styling for better organization
- **Dismiss functionality**: Added a secondary "Acknowledge and continue" button that allows users to dismiss the warning without navigating away
- **Pre-filtered exceptions view**: When navigating to exceptions from the warning, the view is now pre-filtered to show only `end_date_passed` exceptions with a limit of 200 visible items
- **Cache version bump**: Updated service worker cache versions (566 → 567) across all entry points to ensure new assets are fetched

## Implementation Details
- The exceptions button is conditionally rendered as an empty string if the user lacks permissions, preventing unauthorized access
- The dialog's click handler now distinguishes between the exceptions navigation action and the dismiss action
- Filter state is properly initialized in `state.listFilters.exceptions` before navigation to ensure the exceptions view displays the correct filtered data
- Added CSS styling for the new actions container with vertical flex layout and 8px gap between buttons

https://claude.ai/code/session_01DBUMa6qHyekypWb7nB88Fv