### PR TITLE
Fix personal reports login identifier and authentication status check

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -138,7 +138,9 @@ function sessionFromDashboardState(appState) {
 }
 
 function personalReportsLoginIdentifier(user) {
-  return String(user?.user_id || user?.email || user?.work_email || user?.emp_id || user?.employee_id || '').trim();
+  // Prefer email (the primary login identifier) so the RPC looks up by the
+  // same credential the user authenticated with, not by an internal ID.
+  return String(user?.email || user?.work_email || user?.user_id || user?.emp_id || user?.employee_id || '').trim();
 }
 
 function sameDashboardUser(userRow, dashboardUser) {
@@ -354,7 +356,7 @@ async function authenticateInternalEmployee(dashboardUser, accessCode) {
   }
 
   const row = Array.isArray(data) ? data[0] : data;
-  if (!row || row.status !== 'ok') {
+  if (!row || row.login_status !== 'ok') {
     throw new Error('invalid_credentials');
   }
 


### PR DESCRIPTION
## Summary
This PR fixes two issues in the personal reports authentication flow:
1. Corrects the login identifier lookup order to prioritize email credentials
2. Fixes the authentication response status field name

## Key Changes
- **Login identifier priority**: Reordered the fallback chain in `personalReportsLoginIdentifier()` to check `email` first, followed by `work_email`, then internal IDs (`user_id`, `emp_id`, `employee_id`). This ensures the RPC lookup uses the same credential the user authenticated with rather than an internal ID.
  
- **Authentication status field**: Fixed `authenticateInternalEmployee()` to check `row.login_status` instead of `row.status` to correctly validate the authentication response from the server.

## Implementation Details
- Added clarifying comments explaining why email should be the primary login identifier
- The change ensures consistency between the authentication method and the credential used for subsequent lookups

https://claude.ai/code/session_01Y2avzGKBe6ubqFK5nJ7sLr