### PR TITLE
Refactor Personal Reports second-factor verification to use dedicated RPC

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -106,10 +106,6 @@ function friendlyPersonalReportsError(error, fallback = 'אירעה תקלה ב�
   return fallback;
 }
 
-function buildInternalAuthEmail(employeeCode) {
-  const code = String(employeeCode || '').trim();
-  return code.includes('@') ? code : `${code}@think.org.il`;
-}
 
 function profileFromDashboardUser(user) {
   if (!user || typeof user !== 'object') return null;
@@ -137,21 +133,12 @@ function sessionFromDashboardState(appState) {
   return { user: { id: profile.id }, profile, needsInternalAuth: !profile.id };
 }
 
-function personalReportsLoginIdentifier(user) {
-  // Prefer email (the primary login identifier) so the RPC looks up by the
-  // same credential the user authenticated with, not by an internal ID.
-  return String(user?.email || user?.work_email || user?.user_id || user?.emp_id || user?.employee_id || '').trim();
-}
-
-function sameDashboardUser(userRow, dashboardUser) {
-  const expected = [dashboardUser?.user_id, dashboardUser?.email, dashboardUser?.work_email, dashboardUser?.emp_id, dashboardUser?.employee_id]
-    .map((value) => String(value || '').trim())
-    .filter(Boolean);
-  const actual = [userRow?.user_id, userRow?.email, userRow?.emp_id]
-    .map((value) => String(value || '').trim())
-    .filter(Boolean);
-  if (!expected.length || !actual.length) return false;
-  return expected.some((value) => actual.includes(value));
+function dashboardUserEmail(user) {
+  // Returns the email of the currently logged-in dashboard user.
+  // We accept only a real email (contains @) — internal IDs (user_id, emp_id)
+  // must NOT be used as a lookup key for the second-factor verification.
+  const raw = String(user?.email || user?.work_email || '').trim();
+  return raw.includes('@') ? raw.toLowerCase() : '';
 }
 
 function resetPersonalReportsAuth() {
@@ -338,34 +325,41 @@ function authUnavailableHtml(message = 'לא נמצא משתמש מחובר במ
 // ─── supabase API ─────────────────────────────────────────────────────────────
 
 async function authenticateInternalEmployee(dashboardUser, accessCode) {
-  const login = personalReportsLoginIdentifier(dashboardUser);
-  const password = String(accessCode || '').trim();
-  if (!login || !password) {
+  // Step 1: resolve the email of the already-authenticated user.
+  // We refuse to fall back to internal IDs — only a real email is accepted.
+  const userEmail = dashboardUserEmail(dashboardUser);
+  const enteredCode = String(accessCode || '').trim();
+  if (!userEmail || !enteredCode) {
     throw new Error('invalid_credentials');
   }
 
-  // Use the DB-level RPC that compares entry_code directly — avoids Supabase Auth
-  // email-format mismatches (user_id vs actual auth email).
-  const { data, error } = await supabase.rpc('login_user_by_entry_code', {
-    p_login: login,
-    p_entry_code: password
+  // Step 2: verify the entered code against that specific user's record.
+  // The RPC looks up by email only and compares entry_code — it never
+  // treats the code as a user_id, emp_id, or UUID.
+  const { data, error } = await supabase.rpc('verify_personal_reports_entry_code', {
+    p_email: userEmail,
+    p_entry_code: enteredCode
   });
   if (error) {
-    console.error('[personal-reports] RPC login_user_by_entry_code error:', error.message);
+    console.error('[personal-reports] RPC verify_personal_reports_entry_code error:', error.message);
     throw new Error('invalid_credentials');
   }
 
   const row = Array.isArray(data) ? data[0] : data;
-  if (!row || row.login_status !== 'ok') {
+  if (!row || row.verify_status !== 'ok') {
+    throw new Error(row?.verify_status || 'invalid_credentials');
+  }
+
+  // Step 3: confirm the email returned by the DB matches the logged-in user.
+  // This guards against any unexpected row mismatch.
+  const returnedEmail = String(row.email || '').trim().toLowerCase();
+  if (!returnedEmail || returnedEmail !== userEmail) {
+    console.error('[personal-reports] email mismatch after verify RPC');
     throw new Error('invalid_credentials');
   }
 
-  if (!sameDashboardUser(row, dashboardUser)) {
-    throw new Error('invalid_credentials');
-  }
-
-  // The UUID for report queries comes from the already-authenticated session —
-  // never from the numeric entry code.
+  // Step 4: the UUID for report queries comes exclusively from the
+  // already-authenticated dashboard session — never from the code.
   const authUserId = String(
     dashboardUser?.auth_user_id ||
     dashboardUser?.personal_reports_user_id ||
@@ -377,11 +371,11 @@ async function authenticateInternalEmployee(dashboardUser, accessCode) {
 
   const profile = {
     id: authUserId,
-    email: String(row.email || '').trim(),
-    full_name: String(row.name || row.email || login).trim(),
+    email: returnedEmail,
+    full_name: String(row.name || returnedEmail).trim(),
     role: isAdminRole(row.role) ? 'admin' : 'employee',
     display_role: String(row.role || '').trim(),
-    emp_id: String(row.emp_id || row.user_id || login).trim()
+    emp_id: String(row.emp_id || '').trim()
   };
 
   return { user: { id: authUserId }, profile, needsInternalAuth: false };

--- a/supabase/migrations/20260604b_personal_reports_verify_entry_code.sql
+++ b/supabase/migrations/20260604b_personal_reports_verify_entry_code.sql
@@ -1,0 +1,69 @@
+-- Dedicated second-factor verification for the Personal Reports screen.
+-- Unlike login_user_by_entry_code (which is a general login RPC), this function
+-- is designed for an ALREADY-AUTHENTICATED user: it receives the email of the
+-- logged-in session and verifies that the supplied entry_code belongs to that
+-- exact user record — no fallback to user_id / emp_id lookups.
+
+drop function if exists public.verify_personal_reports_entry_code(text, text);
+
+create function public.verify_personal_reports_entry_code(
+  p_email      text,   -- email of the already-authenticated dashboard user
+  p_entry_code text    -- code typed on the Personal Reports lock screen
+)
+returns table (
+  verify_status text,   -- 'ok' | 'user_not_found' | 'inactive_user' | 'entry_code_mismatch' | 'invalid_input'
+  email         text,
+  name          text,
+  role          text,
+  emp_id        text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  with input as (
+    select
+      lower(trim(coalesce(p_email, '')))      as email,
+      trim(coalesce(p_entry_code, ''))        as code
+  ),
+  -- Require a real email (must contain @) so internal IDs cannot be passed.
+  guard as (
+    select
+      case
+        when (select i.email from input i) = ''           then 'invalid_input'
+        when (select i.code  from input i) = ''           then 'invalid_input'
+        when position('@' in (select i.email from input i)) = 0 then 'invalid_input'
+        else 'pass'
+      end as result
+  ),
+  candidate as (
+    select u.*
+    from public.users u
+    cross join input i
+    where lower(trim(u.email)) = i.email   -- email-only lookup, no user_id/emp_id fallback
+    limit 1
+  ),
+  diagnostic as (
+    select
+      case
+        when (select g.result from guard g) <> 'pass'           then (select g.result from guard g)
+        when not exists (select 1 from candidate)               then 'user_not_found'
+        when not (select c.is_active from candidate c)          then 'inactive_user'
+        when trim(coalesce((select c.entry_code from candidate c), ''))
+             <> (select i.code from input i)                    then 'entry_code_mismatch'
+        else 'ok'
+      end as status
+  )
+  select
+    d.status                                            as verify_status,
+    case when d.status = 'ok' then c.email  end         as email,
+    case when d.status = 'ok' then c.name   end         as name,
+    case when d.status = 'ok' then c.role   end         as role,
+    case when d.status = 'ok' then c.emp_id end         as emp_id
+  from diagnostic d
+  left join candidate c on true;
+$$;
+
+-- Only authenticated users (already signed-in dashboard sessions) may call this.
+revoke all on function public.verify_personal_reports_entry_code(text, text) from public;
+grant execute on function public.verify_personal_reports_entry_code(text, text) to authenticated;


### PR DESCRIPTION
## Summary
Replaced the generic `login_user_by_entry_code` RPC with a new dedicated `verify_personal_reports_entry_code` function designed specifically for second-factor verification of already-authenticated users. This improves security by eliminating fallback lookups to internal IDs and ensuring strict email-based verification.

## Key Changes

- **New Database Function**: Added `verify_personal_reports_entry_code(p_email, p_entry_code)` migration that:
  - Accepts only the email of the authenticated user (no user_id/emp_id fallbacks)
  - Validates input strictly (requires @ in email, non-empty code)
  - Returns detailed status codes: `ok`, `user_not_found`, `inactive_user`, `entry_code_mismatch`, `invalid_input`
  - Grants execute permission only to authenticated users via RLS

- **Frontend Refactoring**:
  - Removed `buildInternalAuthEmail()` helper (no longer needed)
  - Removed `personalReportsLoginIdentifier()` and `sameDashboardUser()` functions
  - Added `dashboardUserEmail()` to extract and validate the logged-in user's email (rejects internal IDs)
  - Updated `authenticateInternalEmployee()` to:
    - Call the new RPC with email + code parameters
    - Validate returned email matches the authenticated session
    - Use only the authenticated session's UUID for report queries (never derive from code)
    - Provide clearer step-by-step verification flow with comments

## Implementation Details

- The new RPC uses a CTE-based approach with input validation, user lookup, and diagnostic status determination
- Email comparison is case-insensitive and trimmed at both DB and frontend levels
- The function explicitly prevents using internal identifiers (user_id, emp_id) as lookup keys for the second factor
- Error handling now distinguishes between different failure modes (user not found vs. code mismatch vs. inactive user)

https://claude.ai/code/session_01BwZj2Wd5wuR7wh9CpNzcDL