### PR TITLE
fix(auth): expose email in state.user so personal-reports can verify …

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2955,6 +2955,7 @@ export const api = {
       token,
       user: {
         user_id: flat.user_id,
+        email: String(user.email || '').trim(),
         display_role: flat.role,
         display_role_label: flat.display_role_label,
         display_role2: flat.display_role2,


### PR DESCRIPTION
…by email

api.login now includes email: String(user.email || '').trim() in the returned user object. setSession() spreads session.user into state.user and persists it to localStorage, so state.user.email is available both immediately after login and after a page refresh.

Without this, dashboardUserEmail() in personal-reports returned '' (no @ field on state.user), causing authenticateInternalEmployee to throw before the RPC call — so verify_personal_reports_entry_code was never reached.

https://claude.ai/code/session_01BwZj2Wd5wuR7wh9CpNzcDL