### PR TITLE
Compact monthly report detail UX pass

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 577;
+const CACHE_VERSION = 578;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BQxV6bBH.js",
+  "./assets/index-Cdbju4ni.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-pA4zeoBV.css",
+  "./assets/style-0KvpvKws.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/dist/index.html
+++ b/dist/index.html
@@ -11,12 +11,12 @@
   <meta name="apple-mobile-web-app-title" content="Dashboard-Taasiyeda" />
   <link rel="manifest" href="./manifest.json" />
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
-  <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
+  <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BQxV6bBH.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-pA4zeoBV.css">
+  <script type="module" crossorigin src="./assets/index-Cdbju4ni.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-0KvpvKws.css">
 </head>
 <body>
-  <main id="app"></main>
+  <main id="app"></main>
 </body>
 </html>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 577;
+const CACHE_VERSION = 578;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BQxV6bBH.js",
+  "./assets/index-Cdbju4ni.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -40,7 +40,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-pA4zeoBV.css",
+  "./assets/style-0KvpvKws.css",
   "./catalog/catalog_programs_tashpaz.json",
   "./catalog/logo-catalog.png",
   "./catalog/summercatalog/activities.json",

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -953,39 +953,34 @@ function reportDetailHtml(report, travel, expenses, absences, attachments, profi
     ? `<div class="pr-entry-list">${absenceRows}</div>`
     : compactEmptyRowHtml('לא דווחו ימי חופש, מחלה או הצהרה לחודש זה.');
 
-  const leaveSection = `
-    ${editable ? `
-      <div class="pr-add-panel pr-absence-panel">
-        <form class="pr-add-form" data-form-type="absence">
-          <input type="hidden" name="id" />
-          <input type="hidden" name="absence_type" />
-          <div class="pr-absence-choice" aria-label="בחירת סוג היעדרות">
-            <button class="pr-btn pr-btn--ghost pr-btn--sm" type="button" data-pr-action="choose-absence-type" data-absence-type="vacation">חופש</button>
-            <button class="pr-btn pr-btn--ghost pr-btn--sm" type="button" data-pr-action="choose-absence-type" data-absence-type="sick">מחלה</button>
-            <button class="pr-btn pr-btn--ghost pr-btn--sm" type="button" data-pr-action="choose-absence-type" data-absence-type="declaration">הצהרה</button>
-          </div>
-          <div class="pr-absence-fields" hidden>
-            <div class="pr-form-row">
-              <div class="pr-field"><label class="pr-label">מתאריך *</label><input class="pr-input pr-absence-date" type="date" name="start_date" /></div>
-              <div class="pr-field"><label class="pr-label">עד תאריך *</label><input class="pr-input pr-absence-date" type="date" name="end_date" /></div>
-              <div class="pr-field"><label class="pr-label">ימים מחושבים</label><input class="pr-input" type="number" name="calculated_days" readonly value="0" /></div>
-            </div>
-            <div class="pr-form-row">
-              <div class="pr-field pr-field--wide"><label class="pr-label">קובץ אסמכתא</label><input class="pr-input" type="file" name="attachment" accept="image/*,.pdf" /></div>
-            </div>
-            <div class="pr-add-form-actions">
-              <button class="pr-btn pr-btn--primary" type="submit">שמירה</button>
-              <button class="pr-btn pr-btn--ghost" type="reset">ביטול</button>
-            </div>
-          </div>
-        </form>
-      </div>` : ''}
-    ${absenceTable}
-  `;
+  const absenceChoiceButtons = editable ? `
+    <button class="pr-btn pr-btn--outline pr-btn--sm pr-absence-type-btn" type="button" data-pr-action="choose-absence-type" data-absence-type="vacation">חופש</button>
+    <button class="pr-btn pr-btn--outline pr-btn--sm pr-absence-type-btn" type="button" data-pr-action="choose-absence-type" data-absence-type="sick">מחלה</button>
+    <button class="pr-btn pr-btn--outline pr-btn--sm pr-absence-type-btn" type="button" data-pr-action="choose-absence-type" data-absence-type="declaration">הצהרה</button>
+  ` : '';
 
-  const financeNotice = report.finance_notes
-    ? `<div class="pr-finance-notes pr-alert-card" role="note"><strong>💬 הערות כספים:</strong> ${escapeHtml(report.finance_notes)}</div>`
-    : '';
+  const addAbsencePanel = editable ? `
+    <div class="pr-add-panel pr-absence-panel" id="pr-add-absence-panel" hidden>
+      <form class="pr-add-form" data-form-type="absence">
+        <input type="hidden" name="id" />
+        <input type="hidden" name="absence_type" />
+        <div class="pr-absence-fields">
+          <div class="pr-form-row">
+            <div class="pr-field"><label class="pr-label">מתאריך *</label><input class="pr-input pr-absence-date" type="date" name="start_date" /></div>
+            <div class="pr-field"><label class="pr-label">עד תאריך *</label><input class="pr-input pr-absence-date" type="date" name="end_date" /></div>
+            <div class="pr-field"><label class="pr-label">ימים מחושבים</label><input class="pr-input" type="number" name="calculated_days" readonly value="0" /></div>
+          </div>
+          <div class="pr-form-row">
+            <div class="pr-field pr-field--wide"><label class="pr-label">קובץ אסמכתא</label><input class="pr-input" type="file" name="attachment" accept="image/*,.pdf" /></div>
+          </div>
+          <div class="pr-add-form-actions">
+            <button class="pr-btn pr-btn--primary" type="submit">שמירה</button>
+            <button class="pr-btn pr-btn--ghost" type="button" data-pr-action="cancel-absence-form">ביטול</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  ` : '';
 
   const travelRows = travel.map((r) => {
     const isPublicTransport = r.travel_type === 'public_transport';
@@ -1136,21 +1131,20 @@ function reportDetailHtml(report, travel, expenses, absences, attachments, profi
     : '';
 
   const submitSection = editable && !isSimulation ? `
-    <div class="pr-submit-card">
-      <p class="pr-signature-text">אני מאשר/ת כי הפרטים בדוח זה נכונים ומלאים עבור חודש השכר הנוכחי.</p>
+    <div class="pr-submit-card pr-submit-card--compact">
       <label class="pr-label pr-signature-field" for="pr-signature-name">
-        <span>שם מלא לחתימה דיגיטלית</span>
+        <span>שם לחתימה</span>
         <input class="pr-input pr-signature-input" id="pr-signature-name" type="text"
           value="${escapeHtml(profile.full_name || '')}" autocomplete="name" />
       </label>
       <label class="pr-confirm-label">
         <input type="checkbox" id="pr-confirm-checkbox" class="pr-confirm-checkbox" />
-        <span>אני מאשר/ת כי החתימה הדיגיטלית ומועד האישור יישמרו בדוח.</span>
+        <span>אני מאשר/ת שהפרטים נכונים ומלאים</span>
       </label>
       <button class="pr-btn pr-btn--primary pr-submit-btn"
         id="pr-submit-btn" data-pr-action="submit-report"
         data-report-id="${escapeHtml(report.id)}" disabled>
-        ${report.status === 'needs_correction' ? 'שליחה מחדש לאישור' : 'אישור ושליחה'}
+        ${report.status === 'needs_correction' ? 'שליחה מחדש' : 'אישור ושליחה'}
       </button>
     </div>
   ` : editable && isSimulation ? `
@@ -1192,18 +1186,10 @@ function reportDetailHtml(report, travel, expenses, absences, attachments, profi
           <div class="pr-report-hero-card__main">
             <span class="pr-eyebrow">דוחות אישיים</span>
             <h1 class="pr-report-hero-card__title">דוח אישי לשכר — ${escapeHtml(monthYearLabel)}</h1>
-            <div class="pr-report-hero-card__meta">
-              <span>${escapeHtml(profile.full_name || '')}</span>
-              <span aria-hidden="true">•</span>
-              <span>תקופת דיווח: ${escapeHtml(reportPeriod.label)}</span>
-              <span aria-hidden="true">•</span>
-              <span>סטטוס: ${statusChip}</span>
-            </div>
+            <p class="pr-report-hero-card__meta">${escapeHtml(profile.full_name || '')}</p>
           </div>
           <button class="pr-btn pr-btn--ghost pr-back-btn" type="button" data-pr-action="back-to-my-reports">← חזרה לדוחות שלי</button>
         </section>
-
-        ${financeNotice}
 
         <nav class="pr-report-tabs" role="tablist" aria-label="אזורי הדוח">
           <button class="pr-report-tab is-active" type="button" role="tab" aria-selected="true" data-pr-action="switch-report-tab" data-tab="status">
@@ -1246,12 +1232,7 @@ function reportDetailHtml(report, travel, expenses, absences, attachments, profi
         </section>
 
         <section class="pr-card pr-section-card pr-tab-panel" data-tab-panel="status" id="pr-report-header">
-          <div class="pr-section-head">
-            <div>
-              <h2 class="pr-section-title">סטטוס הדוח</h2>
-            </div>
-          </div>
-          <div class="pr-info-list">
+          <div class="pr-status-log" aria-label="יומן מצב">
             ${reportInfoRowHtml('סטטוס נוכחי', statusChip, { html: true })}
             ${reportInfoRowHtml('תקופת דיווח', reportPeriod.label)}
             ${reportInfoRowHtml('הערת כספים / סיבת החזרה', report.finance_notes || '')}
@@ -1266,16 +1247,13 @@ function reportDetailHtml(report, travel, expenses, absences, attachments, profi
               <h2 class="pr-section-title">ימי עבודה</h2>
               <p class="pr-section-subtext">מדווחים כאן רק אם היו ימי חופש, מחלה או הצהרה.</p>
             </div>
+            <div class="pr-section-head__actions pr-absence-choice">${absenceChoiceButtons}</div>
           </div>
-          ${leaveSection}
+          ${addAbsencePanel}
+          ${absenceTable}
         </section>
 
         <section class="pr-card pr-section-card pr-tab-panel" data-tab-panel="details">
-          <div class="pr-section-head">
-            <div>
-              <h2 class="pr-section-title">פרטים</h2>
-            </div>
-          </div>
           <section class="pr-summary-bar pr-summary-bar--details" aria-label="סיכום הדוח">
             ${detailsSummary || summaryPillHtml('סטטוס', statusText)}
           </section>
@@ -1797,12 +1775,26 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
     if (!form) return;
     const typeInput = form.querySelector('input[name="absence_type"]');
     if (typeInput) typeInput.value = type || '';
-    form.querySelectorAll('[data-pr-action="choose-absence-type"]').forEach((choice) => {
+    const panel = form.closest('.pr-absence-panel');
+    root.querySelectorAll('[data-pr-action="choose-absence-type"]').forEach((choice) => {
       choice.classList.toggle('is-active', choice.dataset.absenceType === type);
     });
+    if (panel) panel.hidden = !type;
     const fields = form.querySelector('.pr-absence-fields');
     if (fields) fields.hidden = !type;
     fields?.querySelectorAll('input[name="start_date"], input[name="end_date"]').forEach((input) => { input.required = Boolean(type); });
+    updateAbsenceCalculatedDays(form);
+  }
+
+  function resetAbsenceForm(form) {
+    if (!form) return;
+    form.reset();
+    const panel = form.closest('.pr-absence-panel');
+    if (panel) panel.hidden = true;
+    form.querySelector('input[name="id"]') && (form.querySelector('input[name="id"]').value = '');
+    form.querySelector('input[name="absence_type"]') && (form.querySelector('input[name="absence_type"]').value = '');
+    root.querySelectorAll('[data-pr-action="choose-absence-type"]').forEach((choice) => choice.classList.remove('is-active'));
+    form.querySelector('.pr-absence-fields')?.querySelectorAll('input[name="start_date"], input[name="end_date"]').forEach((input) => { input.required = false; });
     updateAbsenceCalculatedDays(form);
   }
 
@@ -1879,9 +1871,15 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
     }
 
     if (action === 'choose-absence-type') {
-      const form = btn.closest('form[data-form-type="absence"]');
+      const panel = showPanel('pr-add-absence-panel');
+      const form = panel?.querySelector('form[data-form-type="absence"]');
       revealAbsenceFields(form, btn.dataset.absenceType || '');
       form?.querySelector('input[name="start_date"]')?.focus();
+      return;
+    }
+
+    if (action === 'cancel-absence-form') {
+      resetAbsenceForm(root.querySelector('form[data-form-type="absence"]'));
       return;
     }
 
@@ -1919,7 +1917,8 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
     }
 
     if (action === 'edit-absence') {
-      const form = root.querySelector('form[data-form-type="absence"]');
+      const panel = showPanel('pr-add-absence-panel');
+      const form = panel?.querySelector('form[data-form-type="absence"]');
       setFormValues(form, {
         id: btn.dataset.entryId,
         start_date: btn.dataset.startDate,
@@ -2054,15 +2053,7 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
   root.addEventListener('reset', (e) => {
     const form = e.target.closest('form[data-form-type="absence"]');
     if (!form) return;
-    setTimeout(() => {
-      const fields = form.querySelector('.pr-absence-fields');
-      if (fields) fields.hidden = true;
-      form.querySelector('input[name="id"]') && (form.querySelector('input[name="id"]').value = '');
-      form.querySelector('input[name="absence_type"]') && (form.querySelector('input[name="absence_type"]').value = '');
-      form.querySelectorAll('[data-pr-action="choose-absence-type"]').forEach((choice) => choice.classList.remove('is-active'));
-      fields?.querySelectorAll('input[name="start_date"], input[name="end_date"]').forEach((input) => { input.required = false; });
-      updateAbsenceCalculatedDays(form);
-    }, 0);
+    setTimeout(() => resetAbsenceForm(form), 0);
   });
 
   // Add entry forms submit

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -13921,3 +13921,136 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     max-width: none;
   }
 }
+
+/* Personal reports monthly detail — status log & compact approval pass */
+.pr-report-detail-body {
+  overflow-x: hidden;
+}
+.pr-report-detail-body .pr-report-hero-card__meta {
+  margin: 0;
+  color: #475569;
+  font-size: 0.84rem;
+}
+.pr-report-detail-body .pr-section-head {
+  border-bottom: none;
+  background: transparent;
+  min-height: auto;
+  padding: 10px 12px 6px;
+}
+.pr-status-log {
+  display: grid;
+  gap: 0;
+  padding: 8px 12px 0;
+}
+.pr-status-log .pr-info-row {
+  grid-template-columns: minmax(120px, 0.38fr) minmax(0, 1fr);
+  gap: 8px;
+  min-height: 30px;
+  padding: 7px 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  border-bottom: 1px solid #edf0f5;
+}
+.pr-status-log .pr-info-row:last-child {
+  border-bottom: none;
+}
+.pr-info-note {
+  margin: 8px 12px 10px;
+  padding: 6px 10px;
+  border: 1px solid #dbeafe;
+  border-radius: 8px;
+  background: #f8fbff;
+  color: #334155;
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+.pr-btn--outline {
+  background: #fff;
+  color: var(--ds-accent, #1a3358);
+  border: 1px solid #cbd5e1;
+}
+.pr-btn--outline:hover {
+  background: #f8fafc;
+  border-color: #94a3b8;
+}
+.pr-absence-type-btn.is-active,
+.pr-absence-choice .pr-btn.is-active {
+  border-color: #6366f1;
+  background: #eef2ff;
+  color: #1e3a8a;
+}
+.pr-section-head__actions.pr-absence-choice {
+  gap: 6px;
+}
+.pr-section-head__actions.pr-absence-choice .pr-btn {
+  min-width: 68px;
+  max-width: 88px;
+}
+.pr-report-detail-body .pr-absence-panel {
+  margin: 0 12px 10px;
+  padding: 10px;
+}
+.pr-report-detail-body .pr-absence-panel .pr-form-row {
+  margin-bottom: 0;
+}
+.pr-report-detail-body .pr-absence-panel .pr-field {
+  flex: 1 1 120px;
+}
+.pr-submit-card--compact {
+  gap: 8px;
+  padding: 8px 10px;
+  align-items: center;
+}
+.pr-submit-card--compact .pr-signature-field {
+  flex: 1 1 180px;
+  min-width: 0;
+}
+.pr-submit-card--compact .pr-signature-field span {
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+.pr-submit-card--compact .pr-signature-input {
+  width: 100%;
+  max-width: 180px;
+  min-height: 34px;
+}
+.pr-submit-card--compact .pr-confirm-label {
+  flex: 1 1 200px;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+.pr-submit-card--compact .pr-submit-btn {
+  flex: 0 0 auto;
+  min-width: 120px;
+  max-width: 150px;
+}
+.pr-summary-bar--details {
+  overflow: hidden;
+}
+.pr-summary-bar--details .pr-sum-item {
+  min-width: 0;
+}
+.pr-report-detail-body .pr-entry-row,
+.pr-report-detail-body .pr-entry-list,
+.pr-report-detail-body .pr-compact-empty {
+  max-width: 100%;
+}
+@media (max-width: 760px) {
+  .pr-submit-card--compact {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .pr-submit-card--compact .pr-signature-input,
+  .pr-submit-card--compact .pr-submit-btn {
+    max-width: none;
+    width: 100%;
+  }
+  .pr-section-head__actions.pr-absence-choice {
+    width: 100%;
+  }
+  .pr-section-head__actions.pr-absence-choice .pr-btn {
+    flex: 1 1 30%;
+    max-width: none;
+  }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 577;
+const CACHE_VERSION = 578;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 577;
+const SW_ENTRY_VERSION = 578;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Focused UX and design pass on the monthly report detail page within **דוחות אישיים**, making the interface lighter, more compact, and easier to scan without changing business logic.

## Changes

### Status tab
- Removed duplicate status/period/finance info from the hero card and the alert above tabs
- Restyled the status tab as a compact **status log** (flat rows with dividers) instead of form-like bordered boxes
- Kept the deadline reminder as a subtle info strip

### Travel & expenses tabs
- No structural changes — already using single header add buttons, compact empty rows, and entry lists (no wide tables / horizontal scroll)

### Work days tab
- Moved **חופש / מחלה / הצהרה** buttons to the section header as compact outline buttons
- Form panel opens only after selecting a type; hidden by default
- Added cancel action to close the form without leaving the tab

### Details tab
- Removed redundant section heading
- Compact green approval bar: signature, checkbox, and submit aligned in one row
- Summary bar unchanged: totals and absence counts only when > 0, single **סה״כ להחזר**

### Service Worker
- Bumped `CACHE_VERSION` / `SW_ENTRY_VERSION` to **578** in `frontend/sw.js` and `sw.js`

## Verification

- [x] `node --check frontend/src/screens/personal-reports.js`
- [x] `node --test tests/personal-reports-screen.test.mjs` (7/7)
- [x] `node --test tests/service-worker-pwa-cache.test.mjs` (5/5)
- [x] `npm run check:build`
- [x] Five tabs preserved: סטטוס, נסיעות, הוצאות, ימי עבודה, פרטים
- [x] No `work_hour_entries`, no new SQL, no Supabase Auth changes
- [x] Save-on-tab behavior preserved via `initialTab: currentReportTab(root)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37b2ff6c-6443-4643-aaa8-d46f1a6a91ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37b2ff6c-6443-4643-aaa8-d46f1a6a91ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

