### PR TITLE
תיקון עיצוב: מסך כניסה וטבלאות בדוחות אישיים

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -302,13 +302,16 @@ function internalEmployeeLoginHtml(message = '') {
         text-align: right;
       }
       .pr-lock-form-inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
         width: 100%;
-        max-width: 260px;
         margin: 0 auto;
       }
       .pr-lock-field {
         display: flex;
         flex-direction: column;
+        align-items: center;
         gap: 6px;
         margin-bottom: 14px;
       }
@@ -322,7 +325,8 @@ function internalEmployeeLoginHtml(message = '') {
         all: unset;
         box-sizing: border-box;
         display: block;
-        width: 100%;
+        width: 260px;
+        max-width: 100%;
         padding: 10px 12px;
         font-size: 1rem;
         font-family: inherit;
@@ -352,6 +356,7 @@ function internalEmployeeLoginHtml(message = '') {
         box-sizing: border-box;
         display: block;
         width: 150px;
+        flex-shrink: 0;
         min-height: 38px;
         padding: 0 16px;
         font-size: 0.92rem;
@@ -371,7 +376,7 @@ function internalEmployeeLoginHtml(message = '') {
       @media (max-width: 480px) {
         .pr-lock-card { width: min(92vw, 420px); padding: 20px; border-radius: 14px; }
         .pr-lock-wrap { padding: 20px 12px; align-items: flex-start; padding-top: 40px; }
-        .pr-lock-form-inner { max-width: 260px; }
+        .pr-lock-input { width: min(260px, 100%); }
       }
     </style>
     <div class="pr-lock-wrap" dir="rtl">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -13122,7 +13122,7 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 .pr-report-detail-body .pr-data-table td {
   background: #fff;
 }
-.pr-report-detail-body .pr-table-scroll {
+.pr-report-detail-body .pr-table-scroll:not(.pr-entries-table-wrap) {
   margin: 0;
 }
 .pr-icon-btn {
@@ -13483,7 +13483,7 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 .pr-report-detail-body .pr-data-table td {
   border-bottom: 1px solid #edf0f5;
 }
-.pr-report-detail-body .pr-table-scroll {
+.pr-report-detail-body .pr-table-scroll:not(.pr-entries-table-wrap) {
   border: 1px solid #edf0f5;
   border-radius: 12px;
   overflow-x: auto;
@@ -13530,8 +13530,9 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   white-space: nowrap;
 }
 .pr-lock-btn {
+  width: 150px;
   max-width: 150px;
-  margin: 0 auto;
+  margin: 0;
 }
 @media (max-width: 760px) {
   .pr-body.pr-landing-body,
@@ -13617,7 +13618,7 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 .pr-report-detail-body .pr-section-card { padding: 0; }
 .pr-report-detail-body .pr-tab-panel[hidden] { display: none !important; }
-.pr-report-detail-body .pr-table-scroll { overflow-x: auto; }
+.pr-report-detail-body .pr-table-scroll:not(.pr-entries-table-wrap) { overflow-x: auto; }
 .pr-report-detail-body .pr-data-table { min-width: 0; table-layout: auto; }
 .pr-compact-empty {
   margin: 10px 12px 12px;
@@ -13734,6 +13735,7 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 .pr-report-detail-body .pr-section-card {
   overflow: visible;
+  padding-bottom: 2px;
 }
 .pr-report-detail-body .pr-section-head {
   min-height: 44px;
@@ -13998,29 +14000,39 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   line-height: 1.4;
 }
 .pr-entries-table-wrap {
-  margin: 0 12px 12px;
+  margin: 0 14px 14px;
   width: fit-content;
-  max-width: 100%;
-  border: 1px solid #e2e8f0;
+  max-width: calc(100% - 28px);
+  border: 1px solid #dce4ed;
   border-radius: 10px;
-  overflow: hidden;
+  overflow: visible;
   background: #fff;
+  box-sizing: border-box;
 }
-.pr-entries-table-wrap.pr-table-scroll {
-  overflow-x: hidden;
+.pr-report-detail-body .pr-entries-table-wrap.pr-table-scroll {
+  overflow: visible;
 }
 .pr-entries-table-wrap .pr-entries-table {
   width: fit-content;
   max-width: 100%;
   table-layout: auto;
+  border-collapse: collapse;
 }
 .pr-entries-table-wrap .pr-data-table th,
 .pr-entries-table-wrap .pr-data-table td {
   padding: 5px 8px;
-  border-bottom: 1px solid #edf0f5;
+  border: 1px solid #dce4ed;
 }
+.pr-entries-table-wrap .pr-data-table th {
+  background: #f8fafc;
+}
+.pr-entries-table-wrap .pr-data-row:last-of-type td,
 .pr-entries-table-wrap .pr-data-table tr:last-child td {
-  border-bottom: none;
+  border-bottom: 1px solid #dce4ed;
+}
+.pr-entries-table-wrap .pr-total-row td {
+  border: 1px solid #dce4ed !important;
+  border-top: 2px solid #bae6fd !important;
 }
 .pr-entries-table .pr-col-date,
 .pr-entries-table .pr-td-date {

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -167,7 +167,8 @@ test('personal reports entry tables use compact fit-content layout', async () =>
   assert.match(css, /\.pr-entries-table-wrap\s*\{[^}]*width:\s*fit-content/);
   assert.match(css, /\.pr-entries-table-wrap \.pr-entries-table\s*\{[^}]*width:\s*fit-content/);
   assert.match(css, /\.pr-entries-table \.pr-col-date[^}]*max-width:\s*110px/);
-  assert.match(css, /\.pr-entries-table-wrap\.pr-table-scroll\s*\{[^}]*overflow-x:\s*hidden/);
+  assert.match(css, /\.pr-report-detail-body \.pr-entries-table-wrap\.pr-table-scroll\s*\{[^}]*overflow:\s*visible/);
+  assert.match(css, /\.pr-entries-table-wrap \.pr-data-table th[^}]*border:\s*1px solid/);
   assert.match(css, /\.pr-report-detail-body \.pr-field\[hidden\]\s*\{[^}]*display:\s*none !important/);
   assert.match(css, /\.pr-th-num, \.pr-td-num\s*\{[^}]*text-align:\s*center/);
   assert.match(css, /\.pr-entries-table-wrap\s*\{[^}]*border:\s*1px solid/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## סיכום

תיקון עיצוב ממוקד בדוחות האישיים — מסך הכניסה וטבלאות הנסיעות, ההוצאות וימי העבודה.

## שינויים

### 1. מסך כניסה לדוחות אישיים
- שדה הקוד וכפתור "כניסה" ממורכזים על אותו ציר (flex column + `align-items: center`)
- רוחב שדה הקוד: 260px (בטווח 240–280px), ללא `width: 100%`
- רוחב כפתור "כניסה": 150px (בטווח 140–160px)
- יישור לפי מרכז התיבה הפנימית, לא לפי רוחב הכרטיס

### 2. גבולות בטבלאות (נסיעות / הוצאות / ימי עבודה)
- כל תא (`th` / `td`) מקבל `border: 1px solid #dce4ed` — קווי עמודות ושורות
- כותרות עם רקע `#f8fafc` למבנה טבלה ברור

### 3. מניעת חיתוך טבלאות
- `overflow: visible` על `.pr-entries-table-wrap` במקום `hidden`
- מרווח פנימי 14px מהכרטיס (`margin: 0 14px 14px`)
- `max-width: calc(100% - 28px)` למניעת חיתוך
- כללי scroll כלליים מוחרגים מ־`.pr-entries-table-wrap` כדי למנוע התנגשויות

### 4. רוחב טבלאות
- נשמר `width: fit-content` — קומפקטי לפי תוכן, ללא מתיחה ל־100%

## בדיקות
- `node --check frontend/src/screens/personal-reports.js`
- `node --test tests/personal-reports-screen.test.mjs` — 14/14 עברו
- `npm run check:changed` — עבר
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed878081-2a84-4977-b40f-678ff4ffd467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed878081-2a84-4977-b40f-678ff4ffd467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

