### PR TITLE
Add can_access_personal_reports permission for personal reports tab

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1872,15 +1872,15 @@ const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_
 const ROLES_WITH_DIRECT_EDIT = new Set(['admin', 'operation_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
-  admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists', 'personal-reports'],
-  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'personal-reports'],
-  authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
-  finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
-  activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
-  domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
-  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
-  instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'personal-reports'],
-  instructor: ['my-data', 'week', 'month', 'personal-reports']
+  admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
+  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  instructor: ['my-data', 'week', 'month']
 };
 
 function normalizeSupabaseRole(role) {
@@ -1890,6 +1890,11 @@ function normalizeSupabaseRole(role) {
 
 function permissionFlagYes(value) {
   return ['yes', 'true', '1'].includes(String(value || '').trim().toLowerCase());
+}
+
+function userCanAccessPersonalReports(userRow = {}) {
+  if (!userRow?.is_active) return false;
+  return permissionFlagYes(parsePermissions(userRow?.permissions).can_access_personal_reports);
 }
 
 const ACTIVITY_DIRECT_MANAGE_ROLES = new Set(['admin', 'operation_manager']);
@@ -1985,10 +1990,15 @@ function buildBootstrapFromUser(userRow) {
   if (canReviewRequests && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
+  const hasPersonalReportsAccess = userCanAccessPersonalReports(userRow);
+  const personalReportsIdx = allowedRoutes.indexOf('personal-reports');
+  if (hasPersonalReportsAccess && personalReportsIdx === -1) allowedRoutes.push('personal-reports');
+  if (!hasPersonalReportsAccess && personalReportsIdx >= 0) allowedRoutes.splice(personalReportsIdx, 1);
   return {
     routes: [...allowedRoutes],
     default_route: allowedRoutes[0] || 'my-data',
     has_finance_access: hasFinanceAccess,
+    has_personal_reports_access: hasPersonalReportsAccess,
     profile: {
       full_name: flat.full_name,
       display_role2: flat.display_role2 || '',
@@ -2967,7 +2977,8 @@ export const api = {
         can_edit_direct: canDirectManageActivitiesUser(flat),
         can_request_edit: canSubmitActivityRequestsUser(flat),
         can_review_requests: canDirectManageActivitiesUser(flat),
-        finance_access: (flat.role === 'finance' || permissionFlagYes(flat.finance_access) || permissionFlagYes(flat.view_finance))
+        finance_access: (flat.role === 'finance' || permissionFlagYes(flat.finance_access) || permissionFlagYes(flat.view_finance)),
+        can_access_personal_reports: userCanAccessPersonalReports(user)
       },
       ...buildBootstrapFromUser(user),
       client_settings: buildClientSettingsFromLists(listsData, settingsRows)
@@ -3173,15 +3184,15 @@ export const api = {
     return {
       rows,
       roleDefaults: {
-        admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes', view_catalog: 'yes', view_orders: 'yes' },
-        operation_manager: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
-        authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
-        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes' },
-        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
-        domain_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes' },
-        business_development_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no' },
-        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' },
-        instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no' }
+        admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
+        operation_manager: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
+        authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
+        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes', can_access_personal_reports: 'yes' },
+        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
+        domain_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
+        business_development_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no', can_access_personal_reports: 'yes' },
+        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
+        instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' }
       }
     };
   },

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1464,6 +1464,7 @@ function backgroundSyncBootstrap() {
       state.user.can_request_edit = permissionEnabled(bootstrap.can_request_edit);
       state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
       state.user.finance_access = !!bootstrap.has_finance_access;
+      state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
       localStorage.setItem('dashboard_user', JSON.stringify(state.user));
     }
     const routesChanged = normalizedRoutes.length !== prevRouteSet.size ||
@@ -1509,6 +1510,7 @@ async function restoreSession() {
     state.user.can_request_edit = permissionEnabled(bootstrap.can_request_edit);
     state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
     state.user.finance_access = !!bootstrap.has_finance_access;
+    state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
     localStorage.setItem('dashboard_user', JSON.stringify(state.user));
   }
   refreshOpenEditRequestsCount().catch(() => {});

--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -13,7 +13,8 @@ const KEY_PERM_FLAGS = [
   'view_permissions',
   'view_catalog',
   'view_orders',
-  'finance_access'
+  'finance_access',
+  'can_access_personal_reports'
 ];
 
 const PERMISSION_ROLE_OPTIONS = [

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -12,7 +12,21 @@
 
 import { supabase } from '../supabase-client.js';
 import { escapeHtml } from './shared/html.js';
-import { dsPageHeader, dsEmptyState, dsStatusChip } from './shared/layout.js';
+import { dsPageHeader, dsEmptyState, dsStatusChip, dsScreenStack } from './shared/layout.js';
+
+// ─── permission ────────────────────────────────────────────────────────────────
+
+function permissionYes(value) {
+  return value === true || ['yes', 'true', '1'].includes(String(value || '').trim().toLowerCase());
+}
+
+function canAccessPersonalReports(user = {}) {
+  return permissionYes(user?.can_access_personal_reports);
+}
+
+function personalReportsAccessDeniedHtml() {
+  return dsScreenStack(`${dsPageHeader('דוחות אישיים', 'גישה מוגבלת')} ${dsEmptyState('אין הרשאה לצפייה בדוחות אישיים.')}`);
+}
 
 // ─── constants ────────────────────────────────────────────────────────────────
 
@@ -2506,12 +2520,16 @@ async function rerender(root, dashboardUser) {
 export const personalReportsScreen = {
   load: () => Promise.resolve({}),
 
-  render(_data, _ctx) {
+  render(_data, ctx) {
+    if (!canAccessPersonalReports(ctx?.state?.user)) {
+      return personalReportsAccessDeniedHtml();
+    }
     return `<div id="pr-root" class="pr-module-root" dir="rtl"><div class="pr-loading-placeholder">טוען…</div></div>`;
   },
 
   bind({ root, state } = {}) {
     const prRoot = (root && root.querySelector('#pr-root')) || root;
+    if (!canAccessPersonalReports(state?.user)) return;
     _dashboardUser = state?.user || null;
     const view = prRoot?.ownerDocument?.defaultView || globalThis.window;
 

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -159,6 +159,7 @@ const PERMISSION_FIELD_LABELS = {
   view_my_data: 'צפייה — הנתונים שלי',
   view_operations_data: 'צפייה — נתוני תפעול',
   finance_access: 'גישה — כספים / גבייה',
+  can_access_personal_reports: 'גישה — דוחות אישיים',
   view_contacts_instructors: 'צפייה — אנשי קשר מדריכים',
   'view_contacts_instructors 2': 'צפייה — אנשי קשר מדריכים (2)',
   view_permissions: 'צפייה — הרשאות',

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -66,7 +66,8 @@ function normalizeStoredUserFlags(user) {
     can_add_activity: normalizeBoolPermission(user.can_add_activity),
     can_edit_direct: normalizeBoolPermission(user.can_edit_direct),
     can_request_edit: normalizeBoolPermission(user.can_request_edit),
-    finance_access: normalizeBoolPermission(user.finance_access)
+    finance_access: normalizeBoolPermission(user.finance_access),
+    can_access_personal_reports: normalizeBoolPermission(user.can_access_personal_reports)
   };
 }
 
@@ -192,6 +193,7 @@ export function setSession(session) {
   state.user.can_edit_direct = normalizeBoolPermission(state.user.can_edit_direct);
   state.user.can_request_edit = normalizeBoolPermission(state.user.can_request_edit);
   state.user.finance_access = normalizeBoolPermission(state.user.finance_access);
+  state.user.can_access_personal_reports = normalizeBoolPermission(state.user.can_access_personal_reports);
   const newCalKey = calendarMonthSessionKey(state.user.user_id);
   state.monthYm = (newCalKey && sessionStorage.getItem(newCalKey)) || '';
   cleanupLegacyCalendarMonthLocalStorage(state.user.user_id);

--- a/supabase/migrations/20260608_personal_reports_access_permission.sql
+++ b/supabase/migrations/20260608_personal_reports_access_permission.sql
@@ -1,0 +1,553 @@
+-- Gate personal reports behind users.permissions.can_access_personal_reports.
+-- Active users no longer see the tab by role alone; Yael Aviv is explicitly excluded.
+
+CREATE OR REPLACE FUNCTION private.dashboard_user_can_access_personal_reports()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.auth_user_id = auth.uid()
+      AND u.is_active = true
+      AND lower(trim(coalesce(u.permissions->>'can_access_personal_reports', ''))) IN ('yes', 'true', '1')
+  );
+$$;
+
+-- Seed permission for existing users: grant all active users except Yael Aviv.
+UPDATE public.users
+SET permissions = jsonb_set(
+  COALESCE(permissions, '{}'::jsonb),
+  '{can_access_personal_reports}',
+  '"yes"'::jsonb,
+  true
+)
+WHERE is_active = true
+  AND lower(trim(coalesce(email, ''))) <> 'yael_aviv@think.org.il';
+
+UPDATE public.users
+SET permissions = jsonb_set(
+  COALESCE(permissions, '{}'::jsonb),
+  '{can_access_personal_reports}',
+  '"no"'::jsonb,
+  true
+)
+WHERE lower(trim(coalesce(email, ''))) = 'yael_aviv@think.org.il';
+
+-- personal_reports
+DROP POLICY IF EXISTS "reports_select_own" ON public.personal_reports;
+CREATE POLICY "reports_select_own" ON public.personal_reports
+  FOR SELECT USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "reports_select_admin" ON public.personal_reports;
+CREATE POLICY "reports_select_admin" ON public.personal_reports
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "reports_insert_own" ON public.personal_reports;
+CREATE POLICY "reports_insert_own" ON public.personal_reports
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "reports_update_own_draft" ON public.personal_reports;
+CREATE POLICY "reports_update_own_draft" ON public.personal_reports
+  FOR UPDATE USING (
+    auth.uid() = employee_id
+    AND status IN ('draft','needs_correction')
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "reports_update_admin" ON public.personal_reports;
+CREATE POLICY "reports_update_admin" ON public.personal_reports
+  FOR UPDATE USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- declared_travel_entries
+DROP POLICY IF EXISTS "dte_select_own" ON public.declared_travel_entries;
+CREATE POLICY "dte_select_own" ON public.declared_travel_entries
+  FOR SELECT USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "dte_select_admin" ON public.declared_travel_entries;
+CREATE POLICY "dte_select_admin" ON public.declared_travel_entries
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "dte_insert_own" ON public.declared_travel_entries;
+CREATE POLICY "dte_insert_own" ON public.declared_travel_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "dte_update_own_draft" ON public.declared_travel_entries;
+CREATE POLICY "dte_update_own_draft" ON public.declared_travel_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "dte_delete_own_draft" ON public.declared_travel_entries;
+CREATE POLICY "dte_delete_own_draft" ON public.declared_travel_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "dte_admin_all" ON public.declared_travel_entries;
+CREATE POLICY "dte_admin_all" ON public.declared_travel_entries
+  FOR ALL USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- public_transport_entries
+DROP POLICY IF EXISTS "pte_select_own" ON public.public_transport_entries;
+CREATE POLICY "pte_select_own" ON public.public_transport_entries
+  FOR SELECT USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "pte_select_admin" ON public.public_transport_entries;
+CREATE POLICY "pte_select_admin" ON public.public_transport_entries
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "pte_insert_own" ON public.public_transport_entries;
+CREATE POLICY "pte_insert_own" ON public.public_transport_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "pte_update_own_draft" ON public.public_transport_entries;
+CREATE POLICY "pte_update_own_draft" ON public.public_transport_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "pte_delete_own_draft" ON public.public_transport_entries;
+CREATE POLICY "pte_delete_own_draft" ON public.public_transport_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "pte_admin_all" ON public.public_transport_entries;
+CREATE POLICY "pte_admin_all" ON public.public_transport_entries
+  FOR ALL USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- expense_entries
+DROP POLICY IF EXISTS "ee_select_own" ON public.expense_entries;
+CREATE POLICY "ee_select_own" ON public.expense_entries
+  FOR SELECT USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "ee_select_admin" ON public.expense_entries;
+CREATE POLICY "ee_select_admin" ON public.expense_entries
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "ee_insert_own" ON public.expense_entries;
+CREATE POLICY "ee_insert_own" ON public.expense_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ee_update_own_draft" ON public.expense_entries;
+CREATE POLICY "ee_update_own_draft" ON public.expense_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ee_delete_own_draft" ON public.expense_entries;
+CREATE POLICY "ee_delete_own_draft" ON public.expense_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ee_admin_all" ON public.expense_entries;
+CREATE POLICY "ee_admin_all" ON public.expense_entries
+  FOR ALL USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- report_attachments
+DROP POLICY IF EXISTS "ra_select_own" ON public.report_attachments;
+CREATE POLICY "ra_select_own" ON public.report_attachments
+  FOR SELECT USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "ra_select_admin" ON public.report_attachments;
+CREATE POLICY "ra_select_admin" ON public.report_attachments
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "ra_insert_own" ON public.report_attachments;
+CREATE POLICY "ra_insert_own" ON public.report_attachments
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ra_delete_own_draft" ON public.report_attachments;
+CREATE POLICY "ra_delete_own_draft" ON public.report_attachments
+  FOR DELETE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ra_admin_all" ON public.report_attachments;
+CREATE POLICY "ra_admin_all" ON public.report_attachments
+  FOR ALL USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- absence_entries
+DROP POLICY IF EXISTS "ae_select_own" ON public.absence_entries;
+CREATE POLICY "ae_select_own" ON public.absence_entries
+  FOR SELECT USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "ae_select_admin" ON public.absence_entries;
+CREATE POLICY "ae_select_admin" ON public.absence_entries
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "ae_insert_own" ON public.absence_entries;
+CREATE POLICY "ae_insert_own" ON public.absence_entries
+  FOR INSERT WITH CHECK (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ae_update_own_draft" ON public.absence_entries;
+CREATE POLICY "ae_update_own_draft" ON public.absence_entries
+  FOR UPDATE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ae_delete_own_draft" ON public.absence_entries;
+CREATE POLICY "ae_delete_own_draft" ON public.absence_entries
+  FOR DELETE USING (
+    auth.uid() = employee_id
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.personal_reports
+      WHERE id = report_id AND employee_id = auth.uid() AND status IN ('draft','needs_correction')
+    )
+  );
+
+DROP POLICY IF EXISTS "ae_admin_all" ON public.absence_entries;
+CREATE POLICY "ae_admin_all" ON public.absence_entries
+  FOR ALL USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- profiles admin listing for personal reports management
+DROP POLICY IF EXISTS "profiles_select_admin" ON public.profiles;
+CREATE POLICY "profiles_select_admin" ON public.profiles
+  FOR SELECT USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.profiles p2
+      WHERE p2.id = auth.uid() AND p2.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "profiles_update_admin" ON public.profiles;
+CREATE POLICY "profiles_update_admin" ON public.profiles
+  FOR UPDATE USING (
+    private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1 FROM public.profiles p2
+      WHERE p2.id = auth.uid() AND p2.role = 'admin'
+    )
+  );
+
+-- storage bucket policies
+DROP POLICY IF EXISTS "storage_insert_own" ON storage.objects;
+CREATE POLICY "storage_insert_own" ON storage.objects
+  FOR INSERT WITH CHECK (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_access_personal_reports()
+    AND auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+DROP POLICY IF EXISTS "storage_select_own" ON storage.objects;
+CREATE POLICY "storage_select_own" ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_access_personal_reports()
+    AND auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+DROP POLICY IF EXISTS "storage_delete_own" ON storage.objects;
+CREATE POLICY "storage_delete_own" ON storage.objects
+  FOR DELETE USING (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_access_personal_reports()
+    AND auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+DROP POLICY IF EXISTS "storage_select_admin" ON storage.objects;
+CREATE POLICY "storage_select_admin" ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+DROP POLICY IF EXISTS "storage_delete_admin" ON storage.objects;
+CREATE POLICY "storage_delete_admin" ON storage.objects
+  FOR DELETE USING (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- RPC hardening
+CREATE OR REPLACE FUNCTION private.personal_reports_can_manage_travel_rates()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT private.dashboard_user_can_access_personal_reports()
+    AND EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE id = auth.uid()
+        AND role = 'admin'
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.upsert_declared_travel_entry(
+  p_id uuid DEFAULT NULL,
+  p_report_id uuid DEFAULT NULL,
+  p_employee_id uuid DEFAULT NULL,
+  p_travel_date date DEFAULT NULL,
+  p_origin text DEFAULT '',
+  p_destination text DEFAULT '',
+  p_description text DEFAULT '',
+  p_roundtrip_km numeric DEFAULT 0
+)
+RETURNS public.declared_travel_entries
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, private
+AS $$
+DECLARE
+  v_row public.declared_travel_entries;
+BEGIN
+  IF auth.uid() IS NULL OR auth.uid() <> p_employee_id THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  IF NOT private.dashboard_user_can_access_personal_reports() THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  IF NOT private.personal_report_is_editable(p_report_id) THEN
+    RAISE EXCEPTION 'report_not_editable';
+  END IF;
+
+  IF p_id IS NOT NULL THEN
+    UPDATE public.declared_travel_entries
+    SET
+      report_id = p_report_id,
+      employee_id = p_employee_id,
+      travel_date = p_travel_date,
+      origin = COALESCE(p_origin, ''),
+      destination = COALESCE(p_destination, ''),
+      description = COALESCE(p_description, ''),
+      roundtrip_km = COALESCE(p_roundtrip_km, 0),
+      updated_at = now()
+    WHERE id = p_id
+      AND employee_id = p_employee_id
+    RETURNING * INTO v_row;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'not_found';
+    END IF;
+  ELSE
+    INSERT INTO public.declared_travel_entries (
+      report_id,
+      employee_id,
+      travel_date,
+      origin,
+      destination,
+      description,
+      roundtrip_km
+    ) VALUES (
+      p_report_id,
+      p_employee_id,
+      p_travel_date,
+      COALESCE(p_origin, ''),
+      COALESCE(p_destination, ''),
+      COALESCE(p_description, ''),
+      COALESCE(p_roundtrip_km, 0)
+    )
+    RETURNING * INTO v_row;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.verify_personal_reports_entry_code(
+  p_email      text,
+  p_entry_code text
+)
+RETURNS TABLE (
+  verify_status text,
+  email         text,
+  name          text,
+  role          text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, private
+AS $$
+  WITH input AS (
+    SELECT
+      lower(trim(coalesce(p_email, '')))  AS email,
+      trim(coalesce(p_entry_code, ''))    AS code
+  ),
+  guard AS (
+    SELECT
+      CASE
+        WHEN (SELECT i.email FROM input i) = ''                          THEN 'invalid_input'
+        WHEN (SELECT i.code  FROM input i) = ''                          THEN 'invalid_input'
+        WHEN position('@' IN (SELECT i.email FROM input i)) = 0          THEN 'invalid_input'
+        ELSE 'pass'
+      END AS result
+  ),
+  candidate AS (
+    SELECT
+      u.email      AS c_email,
+      u.name       AS c_name,
+      u.role       AS c_role,
+      u.is_active  AS c_is_active,
+      u.entry_code AS c_entry_code,
+      lower(trim(coalesce(u.permissions->>'can_access_personal_reports', ''))) AS c_pr_access
+    FROM public.users u
+    CROSS JOIN input i
+    WHERE lower(trim(u.email)) = i.email
+    LIMIT 1
+  ),
+  diagnostic AS (
+    SELECT
+      CASE
+        WHEN (SELECT g.result FROM guard g) <> 'pass'                    THEN (SELECT g.result FROM guard g)
+        WHEN NOT EXISTS (SELECT 1 FROM candidate)                        THEN 'user_not_found'
+        WHEN NOT (SELECT c.c_is_active FROM candidate c)               THEN 'inactive_user'
+        WHEN (SELECT c.c_pr_access FROM candidate c) NOT IN ('yes', 'true', '1') THEN 'permission_denied'
+        WHEN trim(coalesce((SELECT c.c_entry_code FROM candidate c), ''))
+             <> (SELECT i.code FROM input i)                             THEN 'entry_code_mismatch'
+        ELSE 'ok'
+      END AS status
+  )
+  SELECT
+    d.status                                                AS verify_status,
+    CASE WHEN d.status = 'ok' THEN c.c_email END            AS email,
+    CASE WHEN d.status = 'ok' THEN c.c_name  END            AS name,
+    CASE WHEN d.status = 'ok' THEN c.c_role  END            AS role
+  FROM diagnostic d
+  LEFT JOIN candidate c ON true;
+$$;

--- a/tests/personal-reports-access-permission.test.mjs
+++ b/tests/personal-reports-access-permission.test.mjs
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
+const PR_FILE = new URL('../frontend/src/screens/personal-reports.js', import.meta.url);
+const PERM_FILE = new URL('../frontend/src/screens/permissions.js', import.meta.url);
+const MAIN_FILE = new URL('../frontend/src/main.js', import.meta.url);
+const MIGRATION_FILE = new URL('../supabase/migrations/20260608_personal_reports_access_permission.sql', import.meta.url);
+
+test('personal-reports route is not granted by role alone', async () => {
+  const source = await readFile(API_FILE, 'utf8');
+  const routesBlock = source.match(/const SUPABASE_ROLE_ROUTES = \{[\s\S]*?\};/);
+  assert.ok(routesBlock, 'SUPABASE_ROLE_ROUTES should exist');
+  assert.doesNotMatch(routesBlock[0], /'personal-reports'/);
+});
+
+test('buildBootstrapFromUser gates personal-reports on can_access_personal_reports and is_active', async () => {
+  const source = await readFile(API_FILE, 'utf8');
+  assert.match(source, /function userCanAccessPersonalReports\(/);
+  assert.match(source, /if \(!userRow\?\.is_active\) return false;/);
+  assert.match(source, /can_access_personal_reports/);
+  assert.match(source, /hasPersonalReportsAccess/);
+  assert.match(source, /has_personal_reports_access: hasPersonalReportsAccess/);
+});
+
+test('login exposes can_access_personal_reports on session user', async () => {
+  const source = await readFile(API_FILE, 'utf8');
+  assert.match(source, /can_access_personal_reports: userCanAccessPersonalReports\(user\)/);
+});
+
+test('permissions editor includes can_access_personal_reports key flag', async () => {
+  const source = await readFile(PERM_FILE, 'utf8');
+  assert.match(source, /'can_access_personal_reports'/);
+});
+
+test('personal reports screen blocks users without can_access_personal_reports', async () => {
+  const source = await readFile(PR_FILE, 'utf8');
+  assert.match(source, /function canAccessPersonalReports\(/);
+  assert.match(source, /if \(!canAccessPersonalReports\(ctx\?\.state\?\.user\)\)/);
+  assert.match(source, /if \(!canAccessPersonalReports\(state\?\.user\)\) return;/);
+});
+
+test('main syncs can_access_personal_reports from bootstrap', async () => {
+  const source = await readFile(MAIN_FILE, 'utf8');
+  assert.match(source, /state\.user\.can_access_personal_reports = !!bootstrap\.has_personal_reports_access/);
+});
+
+test('migration seeds Yael Aviv without personal reports access and adds RLS guard', async () => {
+  const sql = await readFile(MIGRATION_FILE, 'utf8');
+  assert.match(sql, /yael_aviv@think\.org\.il/);
+  assert.match(sql, /dashboard_user_can_access_personal_reports/);
+  assert.match(sql, /can_access_personal_reports/);
+  assert.match(sql, /permission_denied/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a dedicated `can_access_personal_reports` permission so the **דוחות אישיים** tab is no longer shown to every active user by role alone.
- Users see the tab only when `is_active = true` **and** `can_access_personal_reports = yes`.
- **יעל אביב** (`yael_aviv@think.org.il`) remains active but is explicitly excluded from personal reports access.
- Server-side RLS and RPC checks enforce the same rule even if the UI tab is bypassed.

## Changes

### Frontend
- Removed `personal-reports` from default role route lists in `SUPABASE_ROLE_ROUTES`.
- Added `userCanAccessPersonalReports()` in `buildBootstrapFromUser()` to grant/revoke the route based on the permission flag and active status.
- Exposed `can_access_personal_reports` on the session user and synced via bootstrap (`has_personal_reports_access`).
- Added the flag to the permissions editor (`KEY_PERM_FLAGS`) with Hebrew label **גישה — דוחות אישיים**.
- Added a screen-level access guard in `personal-reports.js` (same pattern as finance).

### Database migration (`20260608_personal_reports_access_permission.sql`)
- Seeds `can_access_personal_reports = yes` for all active users except `yael_aviv@think.org.il`.
- Sets `can_access_personal_reports = no` for Yael Aviv.
- Adds `private.dashboard_user_can_access_personal_reports()` and applies it to all personal-reports RLS policies, storage policies, travel-rate RPC, upsert RPC, and entry-code verification RPC.

## Verification

- `node --check` on all changed JS files
- `node --test tests/personal-reports-access-permission.test.mjs` — 7/7 passed

## Deployment note

Apply the Supabase migration before or with the frontend deploy so RLS enforcement matches the UI gating.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebe46dfc-7f48-470d-b369-2499ff41dbc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebe46dfc-7f48-470d-b369-2499ff41dbc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

