### PR TITLE
Fix personal reports tab: read access from profiles table

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1868,6 +1868,7 @@ async function readProposalsAgreementsFromSupabase() {
 }
 
 const USER_PUBLIC_COLUMNS = 'user_id,email,name,role,display_role,is_active,permissions,auth_user_id';
+const PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_reports';
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 const ROLES_WITH_DIRECT_EDIT = new Set(['admin', 'operation_manager']);
 
@@ -1892,9 +1893,57 @@ function permissionFlagYes(value) {
   return ['yes', 'true', '1'].includes(String(value || '').trim().toLowerCase());
 }
 
-function userCanAccessPersonalReports(userRow = {}) {
-  if (!userRow?.is_active) return false;
-  return permissionFlagYes(parsePermissions(userRow?.permissions).can_access_personal_reports);
+function personalReportsProfileFlagYes(value) {
+  if (value === true) return true;
+  if (value === false) return false;
+  return permissionFlagYes(value);
+}
+
+function profileCanAccessPersonalReports(profileRow) {
+  if (!profileRow || profileRow.can_access_personal_reports === undefined) return false;
+  if (profileRow.is_active === false) return false;
+  return personalReportsProfileFlagYes(profileRow.can_access_personal_reports);
+}
+
+async function readPersonalReportsProfile(authUserId) {
+  const id = String(authUserId || '').trim();
+  if (!supabase || !id) return null;
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(PROFILE_PERSONAL_REPORTS_COLUMNS)
+    .eq('id', id)
+    .maybeSingle();
+  if (error) {
+    try { console.warn('[personal-reports-profile]', error.message); } catch { /* ignore */ }
+    return null;
+  }
+  return data;
+}
+
+async function readPersonalReportsProfilesByAuthIds(authUserIds = []) {
+  const ids = [...new Set(authUserIds.map((id) => String(id || '').trim()).filter(Boolean))];
+  if (!supabase || !ids.length) return new Map();
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(`${PROFILE_PERSONAL_REPORTS_COLUMNS},email`)
+    .in('id', ids);
+  if (error) {
+    try { console.warn('[personal-reports-profiles]', error.message); } catch { /* ignore */ }
+    return new Map();
+  }
+  const map = new Map();
+  (Array.isArray(data) ? data : []).forEach((row) => {
+    if (row?.id) map.set(String(row.id), row);
+  });
+  return map;
+}
+
+function mergePersonalReportsProfileIntoFlatUser(flat, profileRow) {
+  if (!flat || !profileRow) return flat;
+  return {
+    ...flat,
+    can_access_personal_reports: profileCanAccessPersonalReports(profileRow) ? 'yes' : 'no'
+  };
 }
 
 const ACTIVITY_DIRECT_MANAGE_ROLES = new Set(['admin', 'operation_manager']);
@@ -1971,7 +2020,7 @@ function flattenUserRow(userRow = {}) {
   };
 }
 
-function buildBootstrapFromUser(userRow) {
+function buildBootstrapFromUser(userRow, profileRow = null) {
   const flat = flattenUserRow(userRow);
   const role = normalizeSupabaseRole(flat.role);
   const allowedRoutes = [...(SUPABASE_ROLE_ROUTES[role] || SUPABASE_ROLE_ROUTES.authorized_user)];
@@ -1990,7 +2039,7 @@ function buildBootstrapFromUser(userRow) {
   if (canReviewRequests && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
-  const hasPersonalReportsAccess = userCanAccessPersonalReports(userRow);
+  const hasPersonalReportsAccess = profileCanAccessPersonalReports(profileRow);
   const personalReportsIdx = allowedRoutes.indexOf('personal-reports');
   if (hasPersonalReportsAccess && personalReportsIdx === -1) allowedRoutes.push('personal-reports');
   if (!hasPersonalReportsAccess && personalReportsIdx >= 0) allowedRoutes.splice(personalReportsIdx, 1);
@@ -1999,6 +2048,7 @@ function buildBootstrapFromUser(userRow) {
     default_route: allowedRoutes[0] || 'my-data',
     has_finance_access: hasFinanceAccess,
     has_personal_reports_access: hasPersonalReportsAccess,
+    profile_is_active: profileRow?.is_active !== false,
     profile: {
       full_name: flat.full_name,
       display_role2: flat.display_role2 || '',
@@ -2088,7 +2138,8 @@ async function loginWithSupabaseAuth(user_id, entry_code) {
   }
 
   assertValidLoginUserRow(userRow);
-  return userRow;
+  const profileRow = await readPersonalReportsProfile(authUserId);
+  return { userRow, profileRow };
 }
 
 function makeSessionToken(userRow) {
@@ -2112,7 +2163,8 @@ async function readCurrentUserBySession() {
     .single();
   if (error || !data) throw new Error('unauthorized');
   if (!data.is_active) throw new Error('unauthorized');
-  return data;
+  const profileRow = await readPersonalReportsProfile(data.auth_user_id);
+  return { userRow: data, profileRow };
 }
 
 function buildSupabaseMutationError(operation, error, fallback = 'server_error') {
@@ -2954,13 +3006,14 @@ async function readCatalogProgramsFromSupabase() {
 }
 export const api = {
   login: async (user_id, entry_code) => {
-    const [user, listsData, settingsRows] = await Promise.all([
+    const [{ userRow: user, profileRow }, listsData, settingsRows] = await Promise.all([
       loginWithSupabaseAuth(user_id, entry_code),
       readListsFromSupabase().catch(() => null),
       readSettingsRowsFromSupabase().catch(() => [])
     ]);
     const token = makeSessionToken(user);
     const flat = flattenUserRow(user);
+    const hasPersonalReportsAccess = profileCanAccessPersonalReports(profileRow);
     return {
       token,
       user: {
@@ -2978,20 +3031,21 @@ export const api = {
         can_request_edit: canSubmitActivityRequestsUser(flat),
         can_review_requests: canDirectManageActivitiesUser(flat),
         finance_access: (flat.role === 'finance' || permissionFlagYes(flat.finance_access) || permissionFlagYes(flat.view_finance)),
-        can_access_personal_reports: userCanAccessPersonalReports(user)
+        profile_is_active: profileRow?.is_active !== false,
+        can_access_personal_reports: hasPersonalReportsAccess
       },
-      ...buildBootstrapFromUser(user),
+      ...buildBootstrapFromUser(user, profileRow),
       client_settings: buildClientSettingsFromLists(listsData, settingsRows)
     };
   },
   bootstrap: async () => {
-    const [user, listsData, settingsRows] = await Promise.all([
+    const [{ userRow: user, profileRow }, listsData, settingsRows] = await Promise.all([
       readCurrentUserBySession(),
       readListsFromSupabase().catch(() => null),
       readSettingsRowsFromSupabase().catch(() => [])
     ]);
     return {
-      ...buildBootstrapFromUser(user),
+      ...buildBootstrapFromUser(user, profileRow),
       client_settings: buildClientSettingsFromLists(listsData, settingsRows)
     };
   },
@@ -3180,7 +3234,14 @@ export const api = {
       console.error('[permissions] Supabase error:', error.code, error.message, error.details, error.hint);
       throw new Error(error.message || 'permissions_read_failed');
     }
-    const rows = (Array.isArray(data) ? data : []).map(flattenUserRow);
+    const profileMap = await readPersonalReportsProfilesByAuthIds(
+      (Array.isArray(data) ? data : []).map((row) => row?.auth_user_id)
+    );
+    const rows = (Array.isArray(data) ? data : []).map((row) => {
+      const flat = flattenUserRow(row);
+      const profileRow = profileMap.get(String(row?.auth_user_id || '').trim()) || null;
+      return mergePersonalReportsProfileIntoFlatUser(flat, profileRow);
+    });
     return {
       rows,
       roleDefaults: {
@@ -3661,7 +3722,7 @@ export const api = {
     if (existing.error || !existing.data) throw new Error('user_not_found');
     const permissions = { ...(existing.data.permissions || {}) };
     Object.entries(row || {}).forEach(([k, v]) => {
-      if (['user_id', 'role', 'active', 'full_name', 'entry_code', 'emp_id', 'display_role2'].includes(k)) return;
+      if (['user_id', 'role', 'active', 'full_name', 'entry_code', 'emp_id', 'display_role2', 'can_access_personal_reports'].includes(k)) return;
       permissions[k] = v;
     });
     const nextRole = row.role || existing.data.role;
@@ -3690,6 +3751,17 @@ export const api = {
     };
     const { error } = await supabase.from('users').update(patch).eq('user_id', userId);
     if (error) throw new Error(error.message || 'save_permission_failed');
+    const authUserId = String(existing.data.auth_user_id || '').trim();
+    if (authUserId && Object.prototype.hasOwnProperty.call(row || {}, 'can_access_personal_reports')) {
+      const profilePatch = {
+        can_access_personal_reports: personalReportsProfileFlagYes(row.can_access_personal_reports)
+      };
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .update(profilePatch)
+        .eq('id', authUserId);
+      if (profileError) throw new Error(profileError.message || 'save_personal_reports_profile_failed');
+    }
     return { ok: true };
   },
   addUser: async (row) => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1464,6 +1464,7 @@ function backgroundSyncBootstrap() {
       state.user.can_request_edit = permissionEnabled(bootstrap.can_request_edit);
       state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
       state.user.finance_access = !!bootstrap.has_finance_access;
+      state.user.profile_is_active = bootstrap.profile_is_active !== false;
       state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
       localStorage.setItem('dashboard_user', JSON.stringify(state.user));
     }

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -21,6 +21,7 @@ function permissionYes(value) {
 }
 
 function canAccessPersonalReports(user = {}) {
+  if (user?.profile_is_active === false) return false;
   return permissionYes(user?.can_access_personal_reports);
 }
 
@@ -699,7 +700,7 @@ async function deleteAttachment(attachment) {
 
 async function fetchActiveEmployees() {
   const { data, error } = await supabase
-    .from('profiles').select('id, full_name, email, role, is_active').order('full_name');
+    .from('profiles').select('id, full_name, email, role, is_active, can_access_personal_reports').order('full_name');
   if (error) throw error;
   return (data || []).filter(p => p.role !== 'admin' && p.is_active !== false);
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 588;
+const CACHE_VERSION = 589;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260609_profiles_personal_reports_access.sql
+++ b/supabase/migrations/20260609_profiles_personal_reports_access.sql
@@ -1,0 +1,93 @@
+-- Personal reports access: source of truth is public.profiles, not users.permissions.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS can_access_personal_reports boolean NOT NULL DEFAULT true;
+
+-- Seed profile flags: all active profiles except Yael Aviv.
+UPDATE public.profiles
+SET can_access_personal_reports = true
+WHERE is_active = true
+  AND lower(trim(coalesce(email, ''))) <> 'yael_aviv@think.org.il';
+
+UPDATE public.profiles
+SET can_access_personal_reports = false
+WHERE lower(trim(coalesce(email, ''))) = 'yael_aviv@think.org.il';
+
+CREATE OR REPLACE FUNCTION private.dashboard_user_can_access_personal_reports()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.is_active = true
+      AND p.can_access_personal_reports = true
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.verify_personal_reports_entry_code(
+  p_email      text,
+  p_entry_code text
+)
+RETURNS TABLE (
+  verify_status text,
+  email         text,
+  name          text,
+  role          text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, private
+AS $$
+  WITH input AS (
+    SELECT
+      lower(trim(coalesce(p_email, '')))  AS email,
+      trim(coalesce(p_entry_code, ''))    AS code
+  ),
+  guard AS (
+    SELECT
+      CASE
+        WHEN (SELECT i.email FROM input i) = ''                          THEN 'invalid_input'
+        WHEN (SELECT i.code  FROM input i) = ''                          THEN 'invalid_input'
+        WHEN position('@' IN (SELECT i.email FROM input i)) = 0          THEN 'invalid_input'
+        ELSE 'pass'
+      END AS result
+  ),
+  candidate AS (
+    SELECT
+      u.email      AS c_email,
+      u.name       AS c_name,
+      u.role       AS c_role,
+      p.is_active  AS c_is_active,
+      u.entry_code AS c_entry_code,
+      p.can_access_personal_reports AS c_pr_access
+    FROM public.users u
+    INNER JOIN public.profiles p ON p.id = u.auth_user_id
+    CROSS JOIN input i
+    WHERE lower(trim(u.email)) = i.email
+    LIMIT 1
+  ),
+  diagnostic AS (
+    SELECT
+      CASE
+        WHEN (SELECT g.result FROM guard g) <> 'pass'                    THEN (SELECT g.result FROM guard g)
+        WHEN NOT EXISTS (SELECT 1 FROM candidate)                        THEN 'user_not_found'
+        WHEN NOT (SELECT c.c_is_active FROM candidate c)                 THEN 'inactive_user'
+        WHEN NOT COALESCE((SELECT c.c_pr_access FROM candidate c), false) THEN 'permission_denied'
+        WHEN trim(coalesce((SELECT c.c_entry_code FROM candidate c), ''))
+             <> (SELECT i.code FROM input i)                             THEN 'entry_code_mismatch'
+        ELSE 'ok'
+      END AS status
+  )
+  SELECT
+    d.status                                                AS verify_status,
+    CASE WHEN d.status = 'ok' THEN c.c_email END            AS email,
+    CASE WHEN d.status = 'ok' THEN c.c_name  END            AS name,
+    CASE WHEN d.status = 'ok' THEN c.c_role  END            AS role
+  FROM diagnostic d
+  LEFT JOIN candidate c ON true;
+$$;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 588;
+const SW_ENTRY_VERSION = 589;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/personal-reports-access-permission.test.mjs
+++ b/tests/personal-reports-access-permission.test.mjs
@@ -6,7 +6,7 @@ const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
 const PR_FILE = new URL('../frontend/src/screens/personal-reports.js', import.meta.url);
 const PERM_FILE = new URL('../frontend/src/screens/permissions.js', import.meta.url);
 const MAIN_FILE = new URL('../frontend/src/main.js', import.meta.url);
-const MIGRATION_FILE = new URL('../supabase/migrations/20260608_personal_reports_access_permission.sql', import.meta.url);
+const MIGRATION_FILE = new URL('../supabase/migrations/20260609_profiles_personal_reports_access.sql', import.meta.url);
 
 test('personal-reports route is not granted by role alone', async () => {
   const source = await readFile(API_FILE, 'utf8');
@@ -15,18 +15,22 @@ test('personal-reports route is not granted by role alone', async () => {
   assert.doesNotMatch(routesBlock[0], /'personal-reports'/);
 });
 
-test('buildBootstrapFromUser gates personal-reports on can_access_personal_reports and is_active', async () => {
+test('buildBootstrapFromUser gates personal-reports on profiles.can_access_personal_reports and is_active', async () => {
   const source = await readFile(API_FILE, 'utf8');
-  assert.match(source, /function userCanAccessPersonalReports\(/);
-  assert.match(source, /if \(!userRow\?\.is_active\) return false;/);
-  assert.match(source, /can_access_personal_reports/);
+  assert.match(source, /function profileCanAccessPersonalReports\(/);
+  assert.match(source, /PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_reports'/);
+  assert.match(source, /if \(profileRow\.is_active === false\) return false;/);
+  assert.match(source, /if \(!profileRow \|\| profileRow\.can_access_personal_reports === undefined\) return false;/);
+  assert.match(source, /readPersonalReportsProfile\(/);
   assert.match(source, /hasPersonalReportsAccess/);
   assert.match(source, /has_personal_reports_access: hasPersonalReportsAccess/);
+  assert.doesNotMatch(source, /parsePermissions\(userRow\?\.permissions\)\.can_access_personal_reports/);
 });
 
-test('login exposes can_access_personal_reports on session user', async () => {
+test('login exposes can_access_personal_reports from profiles on session user', async () => {
   const source = await readFile(API_FILE, 'utf8');
-  assert.match(source, /can_access_personal_reports: userCanAccessPersonalReports\(user\)/);
+  assert.match(source, /can_access_personal_reports: hasPersonalReportsAccess/);
+  assert.match(source, /profile_is_active: profileRow\?\.is_active !== false/);
 });
 
 test('permissions editor includes can_access_personal_reports key flag', async () => {
@@ -34,22 +38,32 @@ test('permissions editor includes can_access_personal_reports key flag', async (
   assert.match(source, /'can_access_personal_reports'/);
 });
 
-test('personal reports screen blocks users without can_access_personal_reports', async () => {
+test('savePermission writes can_access_personal_reports to profiles not users.permissions', async () => {
+  const source = await readFile(API_FILE, 'utf8');
+  assert.match(source, /'can_access_personal_reports'\]\.includes\(k\)/);
+  assert.match(source, /\.from\('profiles'\)\s*\n\s*\.update\(profilePatch\)/);
+});
+
+test('personal reports screen blocks users without profile personal reports access', async () => {
   const source = await readFile(PR_FILE, 'utf8');
   assert.match(source, /function canAccessPersonalReports\(/);
+  assert.match(source, /if \(user\?\.profile_is_active === false\) return false;/);
   assert.match(source, /if \(!canAccessPersonalReports\(ctx\?\.state\?\.user\)\)/);
   assert.match(source, /if \(!canAccessPersonalReports\(state\?\.user\)\) return;/);
+  assert.match(source, /can_access_personal_reports/);
 });
 
 test('main syncs can_access_personal_reports from bootstrap', async () => {
   const source = await readFile(MAIN_FILE, 'utf8');
   assert.match(source, /state\.user\.can_access_personal_reports = !!bootstrap\.has_personal_reports_access/);
+  assert.match(source, /state\.user\.profile_is_active = bootstrap\.profile_is_active !== false/);
 });
 
-test('migration seeds Yael Aviv without personal reports access and adds RLS guard', async () => {
+test('migration seeds Yael Aviv without personal reports access on profiles', async () => {
   const sql = await readFile(MIGRATION_FILE, 'utf8');
   assert.match(sql, /yael_aviv@think\.org\.il/);
-  assert.match(sql, /dashboard_user_can_access_personal_reports/);
+  assert.match(sql, /public\.profiles/);
   assert.match(sql, /can_access_personal_reports/);
-  assert.match(sql, /permission_denied/);
+  assert.match(sql, /dashboard_user_can_access_personal_reports/);
+  assert.match(sql, /p\.can_access_personal_reports = true/);
 });

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -178,8 +178,8 @@ test('service worker cache version bumped for personal reports deploy', async ()
   const frontendSw = await readFile(new URL('../frontend/sw.js', import.meta.url), 'utf8');
   const rootSw = await readFile(new URL('../sw.js', import.meta.url), 'utf8');
 
-  assert.match(frontendSw, /const CACHE_VERSION = 588;/);
-  assert.match(rootSw, /const SW_ENTRY_VERSION = 588;/);
+  assert.match(frontendSw, /const CACHE_VERSION = 589;/);
+  assert.match(rootSw, /const SW_ENTRY_VERSION = 589;/);
 });
 
 test('bindReportDetail uses bindScreenListeners, AbortController, and savingForms', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "דוחות אישיים" tab was hidden for users like Idan Nahum (`idann@think.org.il`) even when `profiles.can_access_personal_reports = true`, because the frontend gated visibility on `users.permissions.can_access_personal_reports` instead of the `profiles` table.

## Fix

- **Profile fetch on login/bootstrap:** load `profiles.id, is_active, can_access_personal_reports` via `auth_user_id`
- **Tab visibility:** show `personal-reports` only when `profile.is_active === true && profile.can_access_personal_reports === true`
- **No role-only grant:** route remains excluded from default role routes
- **Permissions editor:** reads/writes `can_access_personal_reports` on `profiles`, not `users.permissions`
- **Migration:** `20260609_profiles_personal_reports_access.sql` adds the column (if missing), seeds Yael Aviv as excluded, and updates RLS/RPC + verify RPC to use profiles
- **Service Worker:** cache version bumped to **589** in `frontend/sw.js` and root `sw.js`

## Expected behavior after deploy + migration

| User | Sees "דוחות אישיים" |
|------|---------------------|
| עידן נחום (admin, `can_access_personal_reports=true`) | Yes |
| יעל אביב (`can_access_personal_reports=false`) | No |
| איסראא / גיל / הילה / טוני / עדן (active + flag true) | Yes |
| Other users without flag | No |

## Verification

- `node --check` on changed JS files
- `node --test tests/personal-reports-access-permission.test.mjs` — pass (8/8)
- `node --test tests/service-worker-pwa-cache.test.mjs` — pass
- `npm run check:build` — pass

## Deploy notes

1. Apply migration `20260609_profiles_personal_reports_access.sql` in Supabase
2. Deploy frontend; users may need one hard refresh for SW cache 589
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b03d59fd-4367-47a6-ae28-829cb18b7d49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b03d59fd-4367-47a6-ae28-829cb18b7d49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

