### PR TITLE
Migration: grant personal reports access only to explicit whitelist

### DIFF
--- a/supabase/migrations/20260609_profiles_personal_reports_access.sql
+++ b/supabase/migrations/20260609_profiles_personal_reports_access.sql
@@ -1,17 +1,25 @@
 -- Personal reports access: source of truth is public.profiles, not users.permissions.
+-- Grant is explicit-only; new/active employees do not receive access by default.
 
 ALTER TABLE public.profiles
-  ADD COLUMN IF NOT EXISTS can_access_personal_reports boolean NOT NULL DEFAULT true;
+  ADD COLUMN IF NOT EXISTS can_access_personal_reports boolean NOT NULL DEFAULT false;
 
--- Seed profile flags: all active profiles except Yael Aviv.
+ALTER TABLE public.profiles
+  ALTER COLUMN can_access_personal_reports SET DEFAULT false;
+
+UPDATE public.profiles
+SET can_access_personal_reports = false;
+
 UPDATE public.profiles
 SET can_access_personal_reports = true
-WHERE is_active = true
-  AND lower(trim(coalesce(email, ''))) <> 'yael_aviv@think.org.il';
-
-UPDATE public.profiles
-SET can_access_personal_reports = false
-WHERE lower(trim(coalesce(email, ''))) = 'yael_aviv@think.org.il';
+WHERE lower(trim(coalesce(email, ''))) IN (
+  'esraas@think.org.il',
+  'gilneeman@think.org.il',
+  'hilar@think.org.il',
+  'toni@think.org.il',
+  'edenc@think.org.il',
+  'idann@think.org.il'
+);
 
 CREATE OR REPLACE FUNCTION private.dashboard_user_can_access_personal_reports()
 RETURNS boolean

--- a/tests/personal-reports-access-permission.test.mjs
+++ b/tests/personal-reports-access-permission.test.mjs
@@ -59,11 +59,17 @@ test('main syncs can_access_personal_reports from bootstrap', async () => {
   assert.match(source, /state\.user\.profile_is_active = bootstrap\.profile_is_active !== false/);
 });
 
-test('migration seeds Yael Aviv without personal reports access on profiles', async () => {
+test('migration grants personal reports access only to explicit profile whitelist', async () => {
   const sql = await readFile(MIGRATION_FILE, 'utf8');
-  assert.match(sql, /yael_aviv@think\.org\.il/);
+  assert.match(sql, /DEFAULT false/);
+  assert.match(sql, /SET can_access_personal_reports = false/);
+  assert.match(sql, /idann@think\.org\.il/);
+  assert.match(sql, /esraas@think\.org\.il/);
+  assert.match(sql, /gilneeman@think\.org\.il/);
+  assert.match(sql, /hilar@think\.org\.il/);
+  assert.match(sql, /toni@think\.org\.il/);
+  assert.match(sql, /edenc@think\.org\.il/);
+  assert.doesNotMatch(sql, /WHERE is_active = true[\s\S]*SET can_access_personal_reports = true/);
   assert.match(sql, /public\.profiles/);
-  assert.match(sql, /can_access_personal_reports/);
   assert.match(sql, /dashboard_user_can_access_personal_reports/);
-  assert.match(sql, /p\.can_access_personal_reports = true/);
 });


### PR DESCRIPTION
Set profiles.can_access_personal_reports default to false, reset all rows to false, then enable only the six approved emails. New active employees no longer receive access automatically.