### PR TITLE
Migration: drop verify_personal_reports_entry_code before recreate

### DIFF
--- a/supabase/migrations/20260609_profiles_personal_reports_access.sql
+++ b/supabase/migrations/20260609_profiles_personal_reports_access.sql
@@ -37,6 +37,8 @@ AS $$
   );
 $$;
 
+DROP FUNCTION IF EXISTS public.verify_personal_reports_entry_code(text, text);
+
 CREATE OR REPLACE FUNCTION public.verify_personal_reports_entry_code(
   p_email      text,
   p_entry_code text

--- a/tests/personal-reports-access-permission.test.mjs
+++ b/tests/personal-reports-access-permission.test.mjs
@@ -72,4 +72,5 @@ test('migration grants personal reports access only to explicit profile whitelis
   assert.doesNotMatch(sql, /WHERE is_active = true[\s\S]*SET can_access_personal_reports = true/);
   assert.match(sql, /public\.profiles/);
   assert.match(sql, /dashboard_user_can_access_personal_reports/);
+  assert.match(sql, /DROP FUNCTION IF EXISTS public\.verify_personal_reports_entry_code\(text, text\)/);
 });


### PR DESCRIPTION
PostgreSQL cannot change an existing function return type via CREATE OR REPLACE; drop the prior signature first so the migration is rerunnable.