### PR TITLE
Fix back-to-my-reports button on submit success screen

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -1668,7 +1668,7 @@ function reportDetailHtml(report, travel, expenses, absences, attachments, profi
 
 function reportSubmittedSuccessHtml(reportId, message = 'הדוח אושר ונשלח לשכר בהצלחה') {
   return `
-    <div class="pr-screen pr-report-form" dir="rtl">
+    <div class="pr-screen pr-submit-success-screen" dir="rtl">
       <div class="pr-body pr-report-detail-body">
         <section class="pr-card pr-submit-success-card" role="status">
           <span class="pr-submit-success-card__icon" aria-hidden="true">✓</span>
@@ -1848,6 +1848,30 @@ function renderInto(root, html) {
     <div id="pr-toast" class="pr-toast" role="alert" aria-live="assertive"></div>
     ${html}
   `;
+}
+
+function showReportSubmittedSuccess(root, reportId, message, { isSimulation = false } = {}) {
+  _prActiveView = { kind: 'submit-success', reportId, isSimulation };
+  invalidatePersonalReportsLoadCache({ reportId });
+  renderInto(root, reportSubmittedSuccessHtml(reportId, message));
+}
+
+async function returnToEmployeeDashboard(root, { isSimulation = false } = {}) {
+  const employeeId = isSimulation ? prViewAsEmployee?.id : prSession?.user?.id;
+  const profile = isSimulation ? prViewAsEmployee : prSession?.profile;
+  if (!employeeId || !profile) return;
+
+  const submittedReportId = _prActiveView?.reportId || prSelectedReport?.id;
+  if (submittedReportId) invalidatePersonalReportsLoadCache({ reportId: submittedReportId });
+
+  abortPersonalReportsScreenListeners(root);
+  prSelectedReport = null;
+  _prActiveView = { kind: 'employee-dashboard', isSimulation };
+
+  const { month, year } = currentMonthYear();
+  const currentReport = await loadCurrentMonthReport(employeeId, month, year, { force: true });
+  renderInto(root, employeeDashboardHtml(profile, { isSimulation, currentReport }));
+  bindEmployeeDashboard(root, { isSimulation });
 }
 
 async function loadMyReportsList(root, employeeId) {
@@ -2325,12 +2349,7 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
       await rerender(root, _dashboardUser); return;
     }
     if (action === 'back-to-my-reports') {
-      if (isSimulation) {
-        renderInto(root, employeeDashboardHtml(prViewAsEmployee, { isSimulation: true }));
-        bindEmployeeDashboard(root, { isSimulation: true });
-      } else {
-        await rerender(root, _dashboardUser);
-      }
+      await returnToEmployeeDashboard(root, { isSimulation });
       return;
     }
     if (action === 'back-to-dashboard') { dispatchBackToDashboard(); return; }
@@ -2447,10 +2466,7 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
         const wasCorrection = prSelectedReport.status === 'needs_correction';
         await submitReport(prSelectedReport.id, signatureFullName);
         await openMonthlyReportPdf(prSelectedReport.id, 'נשלח לשכר');
-        renderInto(root, reportSubmittedSuccessHtml(
-          prSelectedReport.id,
-          wasCorrection ? 'הדוח נשלח מחדש בהצלחה' : 'הדוח אושר ונשלח לשכר בהצלחה'
-        ));
+        showReportSubmittedSuccess(root, prSelectedReport.id, wasCorrection ? 'הדוח נשלח מחדש בהצלחה' : 'הדוח אושר ונשלח לשכר בהצלחה', { isSimulation });
         showToast(wasCorrection ? 'הדוח נשלח מחדש בהצלחה' : 'הדוח אושר ונשלח לשכר בהצלחה', 'success');
       } catch (err) { showToast(friendlyPersonalReportsError(err), 'danger'); }
       return;

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -269,6 +269,20 @@ test('source computes km reimbursement server-side without exposing travel rates
   assert.match(source, /setReportTab\(root, 'expenses'\)/);
 });
 
+test('submit success back button returns to employee dashboard with a single refreshed load', async () => {
+  const source = await readFile(new URL('../frontend/src/screens/personal-reports.js', import.meta.url), 'utf8');
+
+  assert.match(source, /function showReportSubmittedSuccess/);
+  assert.match(source, /kind: 'submit-success'/);
+  assert.match(source, /function returnToEmployeeDashboard/);
+  assert.match(source, /await returnToEmployeeDashboard\(root, \{ isSimulation \}\)/);
+  assert.match(source, /showReportSubmittedSuccess\(root, prSelectedReport\.id/);
+  assert.match(source, /pr-submit-success-screen/);
+  assert.doesNotMatch(source, /pr-submit-success-screen[\s\S]{0,120}pr-report-form/);
+  assert.match(source, /loadCurrentMonthReport\(employeeId, month, year, \{ force: true \}\)/);
+  assert.doesNotMatch(source, /if \(action === 'back-to-my-reports'\)[\s\S]{0,220}await rerender\(root, _dashboardUser\)/);
+});
+
 test('migration keeps travel rates private and exposes only RPC entry points', async () => {
   const sql = await readFile(new URL('../supabase/migrations/20260607_personal_reports_employee_travel_rates.sql', import.meta.url), 'utf8');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the non-responsive "חזרה לדוחות שלי" button on the personal report submit/resubmit success screen.

## Root cause

After submit, the success view was rendered via `innerHTML` while `_prActiveView` still pointed at `employee-report`. The success markup also reused the `pr-report-form` class, so `personalReportsReportAlreadyRendered()` treated it as the already-open report detail. Clicking back called `rerender()`, which tried to reopen the report and no-op'd.

## Fix

- Track the success screen as `_prActiveView.kind = 'submit-success'`.
- Use a dedicated `returnToEmployeeDashboard()` helper that aborts detail listeners, clears selection, and loads the current month report once with `force: true`.
- Rename the success wrapper class to `pr-submit-success-screen` so report-detail skip logic does not apply.
- Keep PDF download handling on the existing detail listener (still active after success render).

## Verification

- `node --check frontend/src/screens/personal-reports.js`
- `node --check tests/personal-reports-screen.test.mjs`
- `npm run check:changed`

## Acceptance criteria

- [x] Back button returns to "הדוחות שלי"
- [x] Updated report status shown after single reload
- [x] No auth reset, no SQL/RLS changes, no duplicate fetch loops
- [x] PDF download button unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54433fd3-0cd2-461a-81ee-cb9b197f75f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54433fd3-0cd2-461a-81ee-cb9b197f75f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

