### PR TITLE
הרשאת personal_reports_manager לניהול דוחות אישיים

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 597;
+const CACHE_VERSION = 598;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CBnIk7s8.js",
+  "./assets/index-BiYIJRG7.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CBnIk7s8.js"></script>
+  <script type="module" crossorigin src="./assets/index-BiYIJRG7.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-Dl2MJDjC.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 597;
+const CACHE_VERSION = 598;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CBnIk7s8.js",
+  "./assets/index-BiYIJRG7.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1893,6 +1893,12 @@ function permissionFlagYes(value) {
   return ['yes', 'true', '1'].includes(String(value || '').trim().toLowerCase());
 }
 
+function canManagePersonalReportsUser(user = {}) {
+  const role = String(user?.display_role || user?.role || '').trim().toLowerCase();
+  if (role === 'admin') return true;
+  return permissionFlagYes(user?.personal_reports_manager);
+}
+
 function personalReportsProfileFlagYes(value) {
   if (value === true) return true;
   if (value === false) return false;
@@ -2040,6 +2046,7 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
     allowedRoutes.push('edit-requests');
   }
   const hasPersonalReportsAccess = profileCanAccessPersonalReports(profileRow);
+  const hasPersonalReportsManager = canManagePersonalReportsUser(flat);
   const personalReportsIdx = allowedRoutes.indexOf('personal-reports');
   if (hasPersonalReportsAccess && personalReportsIdx === -1) allowedRoutes.push('personal-reports');
   if (!hasPersonalReportsAccess && personalReportsIdx >= 0) allowedRoutes.splice(personalReportsIdx, 1);
@@ -2048,6 +2055,7 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
     default_route: allowedRoutes[0] || 'my-data',
     has_finance_access: hasFinanceAccess,
     has_personal_reports_access: hasPersonalReportsAccess,
+    has_personal_reports_manager: hasPersonalReportsManager,
     profile_is_active: profileRow?.is_active !== false,
     profile: {
       full_name: flat.full_name,
@@ -3032,7 +3040,8 @@ export const api = {
         can_review_requests: canDirectManageActivitiesUser(flat),
         finance_access: (flat.role === 'finance' || permissionFlagYes(flat.finance_access) || permissionFlagYes(flat.view_finance)),
         profile_is_active: profileRow?.is_active !== false,
-        can_access_personal_reports: hasPersonalReportsAccess
+        can_access_personal_reports: hasPersonalReportsAccess,
+        personal_reports_manager: permissionFlagYes(flat.personal_reports_manager) ? 'yes' : 'no'
       },
       ...buildBootstrapFromUser(user, profileRow),
       client_settings: buildClientSettingsFromLists(listsData, settingsRows)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1466,6 +1466,7 @@ function backgroundSyncBootstrap() {
       state.user.finance_access = !!bootstrap.has_finance_access;
       state.user.profile_is_active = bootstrap.profile_is_active !== false;
       state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
+      state.user.personal_reports_manager = !!bootstrap.has_personal_reports_manager;
       localStorage.setItem('dashboard_user', JSON.stringify(state.user));
     }
     const routesChanged = normalizedRoutes.length !== prevRouteSet.size ||
@@ -1512,6 +1513,7 @@ async function restoreSession() {
     state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
     state.user.finance_access = !!bootstrap.has_finance_access;
     state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
+    state.user.personal_reports_manager = !!bootstrap.has_personal_reports_manager;
     localStorage.setItem('dashboard_user', JSON.stringify(state.user));
   }
   refreshOpenEditRequestsCount().catch(() => {});

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -7,7 +7,7 @@
  *
  * Roles:
  *   employee — sees only their own reports
- *   admin    — sees all reports, can approve / return / mark paid
+ *   manager  — admin or personal_reports_manager=yes: sees all reports, can approve / return / mark paid
  */
 
 import { supabase } from '../supabase-client.js';
@@ -23,6 +23,21 @@ function permissionYes(value) {
 function canAccessPersonalReports(user = {}) {
   if (user?.profile_is_active === false) return false;
   return permissionYes(user?.can_access_personal_reports);
+}
+
+function isAdminRole(role) {
+  return String(role || '').trim().toLowerCase() === 'admin';
+}
+
+function canManagePersonalReports(user = {}) {
+  if (isAdminRole(user?.display_role || user?.role)) return true;
+  return permissionYes(user?.personal_reports_manager);
+}
+
+function profileCanManagePersonalReports(profile = {}) {
+  if (profile?.can_manage_personal_reports === true) return true;
+  if (isAdminRole(profile?.role)) return true;
+  return permissionYes(profile?.personal_reports_manager);
 }
 
 function personalReportsAccessDeniedHtml() {
@@ -454,10 +469,6 @@ function canEdit(report) {
   return !report || report.status === 'draft' || report.status === 'needs_correction';
 }
 
-function isAdminRole(role) {
-  return String(role || '').trim().toLowerCase() === 'admin';
-}
-
 function isUuid(value) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || '').trim());
 }
@@ -548,13 +559,16 @@ function profileFromDashboardUser(user) {
   );
   const displayRole = String(user.display_role || user.role || '').trim();
   const role = isAdminRole(displayRole) ? 'admin' : 'employee';
+  const canManage = canManagePersonalReports(user);
   return {
     id,
     email: String(user.email || user.work_email || '').trim(),
     full_name: String(user.full_name || user.name || user.user_id || 'משתמש מחובר').trim(),
     role,
     display_role: displayRole,
-    emp_id: String(user.emp_id || user.employee_id || '').trim()
+    emp_id: String(user.emp_id || user.employee_id || '').trim(),
+    personal_reports_manager: permissionYes(user?.personal_reports_manager) ? 'yes' : 'no',
+    can_manage_personal_reports: canManage
   };
 }
 
@@ -809,7 +823,9 @@ async function authenticateInternalEmployee(dashboardUser, accessCode) {
     full_name: String(user?.full_name || sessionEmail).trim(),
     role: isAdminRole(user?.display_role || user?.role) ? 'admin' : 'employee',
     display_role: String(user?.display_role || user?.role || '').trim(),
-    emp_id: String(user?.emp_id || user?.employee_id || '').trim()
+    emp_id: String(user?.emp_id || user?.employee_id || '').trim(),
+    personal_reports_manager: permissionYes(user?.personal_reports_manager) ? 'yes' : 'no',
+    can_manage_personal_reports: canManagePersonalReports(user)
   };
 
   return { user: { id: authUserId }, profile, needsInternalAuth: false };
@@ -2235,7 +2251,7 @@ async function returnToEmployeeDashboard(root, { isSimulation = false } = {}) {
   }
   prSelectedReport = null;
 
-  const showModeTabs = isAdminRole(profile.role) && !isSimulation;
+  const showModeTabs = profileCanManagePersonalReports(profile) && !isSimulation;
   await renderMyReportsDashboard(root, {
     profile,
     employeeId,
@@ -2634,7 +2650,7 @@ function bindMyReportsDashboard(root, { isSimulation = false } = {}) {
     const selectedMonth = clampMyReportsMonthValue(e.target.value);
     _prMyReportsSelectedMonth = selectedMonth;
     e.target.value = selectedMonth;
-    const showModeTabs = isAdminRole(profile.role) && !isSimulation;
+    const showModeTabs = profileCanManagePersonalReports(profile) && !isSimulation;
     await renderMyReportsDashboard(root, {
       profile,
       employeeId,
@@ -3349,7 +3365,7 @@ async function rerender(root, dashboardUser = dashboardUserForAuth(), { forceRel
     bindInternalEmployeeLogin(root);
     return;
   }
-  if (isAdminRole(prSession.profile.role) && prScreenMode === PR_SCREEN_MODES.MY_REPORTS && !prViewAsEmployee) {
+  if (profileCanManagePersonalReports(prSession.profile) && prScreenMode === PR_SCREEN_MODES.MY_REPORTS && !prViewAsEmployee) {
     await renderMyReportsDashboard(root, {
       profile: prSession.profile,
       employeeId: prSession.user.id,
@@ -3357,7 +3373,7 @@ async function rerender(root, dashboardUser = dashboardUserForAuth(), { forceRel
       selectedMonth: resolveMyReportsSelectedMonth(),
       force: forceReload
     });
-  } else if (isAdminRole(prSession.profile.role) && prViewAsEmployee) {
+  } else if (profileCanManagePersonalReports(prSession.profile) && prViewAsEmployee) {
     await renderMyReportsDashboard(root, {
       profile: prViewAsEmployee,
       employeeId: prViewAsEmployee.id,
@@ -3365,7 +3381,7 @@ async function rerender(root, dashboardUser = dashboardUserForAuth(), { forceRel
       selectedMonth: resolveMyReportsSelectedMonth(),
       force: forceReload
     });
-  } else if (isAdminRole(prSession.profile.role)) {
+  } else if (profileCanManagePersonalReports(prSession.profile)) {
     try {
       const filters = {
         month: _prLastAdminFilters.month || defaultMonthFilterValue(),

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -67,7 +67,8 @@ function normalizeStoredUserFlags(user) {
     can_edit_direct: normalizeBoolPermission(user.can_edit_direct),
     can_request_edit: normalizeBoolPermission(user.can_request_edit),
     finance_access: normalizeBoolPermission(user.finance_access),
-    can_access_personal_reports: normalizeBoolPermission(user.can_access_personal_reports)
+    can_access_personal_reports: normalizeBoolPermission(user.can_access_personal_reports),
+    personal_reports_manager: normalizeBoolPermission(user.personal_reports_manager)
   };
 }
 
@@ -194,6 +195,7 @@ export function setSession(session) {
   state.user.can_request_edit = normalizeBoolPermission(state.user.can_request_edit);
   state.user.finance_access = normalizeBoolPermission(state.user.finance_access);
   state.user.can_access_personal_reports = normalizeBoolPermission(state.user.can_access_personal_reports);
+  state.user.personal_reports_manager = normalizeBoolPermission(state.user.personal_reports_manager);
   const newCalKey = calendarMonthSessionKey(state.user.user_id);
   state.monthYm = (newCalKey && sessionStorage.getItem(newCalKey)) || '';
   cleanupLegacyCalendarMonthLocalStorage(state.user.user_id);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 597;
+const CACHE_VERSION = 598;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260610_personal_reports_manager_permission.sql
+++ b/supabase/migrations/20260610_personal_reports_manager_permission.sql
@@ -1,0 +1,105 @@
+-- Personal reports management: admin OR users.permissions.personal_reports_manager = yes.
+-- Scoped to personal reports tables only; does not grant general admin access.
+
+CREATE OR REPLACE FUNCTION private.dashboard_user_can_manage_personal_reports()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT private.dashboard_user_can_access_personal_reports()
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM public.profiles
+        WHERE id = auth.uid()
+          AND role = 'admin'
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.users u
+        WHERE u.auth_user_id = auth.uid()
+          AND u.is_active = true
+          AND lower(trim(coalesce(u.permissions->>'personal_reports_manager', ''))) IN ('yes', 'true', '1')
+      )
+    );
+$$;
+
+-- personal_reports
+DROP POLICY IF EXISTS "reports_select_admin" ON public.personal_reports;
+CREATE POLICY "reports_select_admin" ON public.personal_reports
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "reports_update_admin" ON public.personal_reports;
+CREATE POLICY "reports_update_admin" ON public.personal_reports
+  FOR UPDATE USING (private.dashboard_user_can_manage_personal_reports());
+
+-- declared_travel_entries
+DROP POLICY IF EXISTS "dte_select_admin" ON public.declared_travel_entries;
+CREATE POLICY "dte_select_admin" ON public.declared_travel_entries
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "dte_admin_all" ON public.declared_travel_entries;
+CREATE POLICY "dte_admin_all" ON public.declared_travel_entries
+  FOR ALL USING (private.dashboard_user_can_manage_personal_reports());
+
+-- public_transport_entries
+DROP POLICY IF EXISTS "pte_select_admin" ON public.public_transport_entries;
+CREATE POLICY "pte_select_admin" ON public.public_transport_entries
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "pte_admin_all" ON public.public_transport_entries;
+CREATE POLICY "pte_admin_all" ON public.public_transport_entries
+  FOR ALL USING (private.dashboard_user_can_manage_personal_reports());
+
+-- expense_entries
+DROP POLICY IF EXISTS "ee_select_admin" ON public.expense_entries;
+CREATE POLICY "ee_select_admin" ON public.expense_entries
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "ee_admin_all" ON public.expense_entries;
+CREATE POLICY "ee_admin_all" ON public.expense_entries
+  FOR ALL USING (private.dashboard_user_can_manage_personal_reports());
+
+-- report_attachments
+DROP POLICY IF EXISTS "ra_select_admin" ON public.report_attachments;
+CREATE POLICY "ra_select_admin" ON public.report_attachments
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "ra_admin_all" ON public.report_attachments;
+CREATE POLICY "ra_admin_all" ON public.report_attachments
+  FOR ALL USING (private.dashboard_user_can_manage_personal_reports());
+
+-- absence_entries
+DROP POLICY IF EXISTS "ae_select_admin" ON public.absence_entries;
+CREATE POLICY "ae_select_admin" ON public.absence_entries
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "ae_admin_all" ON public.absence_entries;
+CREATE POLICY "ae_admin_all" ON public.absence_entries
+  FOR ALL USING (private.dashboard_user_can_manage_personal_reports());
+
+-- profiles listing for personal reports management
+DROP POLICY IF EXISTS "profiles_select_admin" ON public.profiles;
+CREATE POLICY "profiles_select_admin" ON public.profiles
+  FOR SELECT USING (private.dashboard_user_can_manage_personal_reports());
+
+DROP POLICY IF EXISTS "profiles_update_admin" ON public.profiles;
+CREATE POLICY "profiles_update_admin" ON public.profiles
+  FOR UPDATE USING (private.dashboard_user_can_manage_personal_reports());
+
+-- storage bucket policies
+DROP POLICY IF EXISTS "storage_select_admin" ON storage.objects;
+CREATE POLICY "storage_select_admin" ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_manage_personal_reports()
+  );
+
+DROP POLICY IF EXISTS "storage_delete_admin" ON storage.objects;
+CREATE POLICY "storage_delete_admin" ON storage.objects
+  FOR DELETE USING (
+    bucket_id = 'personal-report-attachments'
+    AND private.dashboard_user_can_manage_personal_reports()
+  );

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 597;
+const SW_ENTRY_VERSION = 598;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/personal-reports-access-permission.test.mjs
+++ b/tests/personal-reports-access-permission.test.mjs
@@ -7,6 +7,7 @@ const PR_FILE = new URL('../frontend/src/screens/personal-reports.js', import.me
 const PERM_FILE = new URL('../frontend/src/screens/permissions.js', import.meta.url);
 const MAIN_FILE = new URL('../frontend/src/main.js', import.meta.url);
 const MIGRATION_FILE = new URL('../supabase/migrations/20260609_profiles_personal_reports_access.sql', import.meta.url);
+const MANAGER_MIGRATION_FILE = new URL('../supabase/migrations/20260610_personal_reports_manager_permission.sql', import.meta.url);
 
 test('personal-reports route is not granted by role alone', async () => {
   const source = await readFile(API_FILE, 'utf8');
@@ -57,6 +58,32 @@ test('main syncs can_access_personal_reports from bootstrap', async () => {
   const source = await readFile(MAIN_FILE, 'utf8');
   assert.match(source, /state\.user\.can_access_personal_reports = !!bootstrap\.has_personal_reports_access/);
   assert.match(source, /state\.user\.profile_is_active = bootstrap\.profile_is_active !== false/);
+});
+
+test('login and bootstrap expose personal_reports_manager without granting admin routes', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const routesBlock = apiSource.match(/const SUPABASE_ROLE_ROUTES = \{[\s\S]*?\};/);
+  assert.ok(routesBlock, 'SUPABASE_ROLE_ROUTES should exist');
+  assert.doesNotMatch(routesBlock[0], /personal_reports_manager/);
+  assert.match(apiSource, /function canManagePersonalReportsUser\(/);
+  assert.match(apiSource, /has_personal_reports_manager: hasPersonalReportsManager/);
+  assert.match(apiSource, /personal_reports_manager: permissionFlagYes\(flat\.personal_reports_manager\)/);
+});
+
+test('main syncs personal_reports_manager from bootstrap', async () => {
+  const source = await readFile(MAIN_FILE, 'utf8');
+  assert.match(source, /state\.user\.personal_reports_manager = !!bootstrap\.has_personal_reports_manager/);
+});
+
+test('migration scopes personal reports manager to personal reports RLS only', async () => {
+  const sql = await readFile(MANAGER_MIGRATION_FILE, 'utf8');
+  assert.match(sql, /dashboard_user_can_manage_personal_reports/);
+  assert.match(sql, /personal_reports_manager/);
+  assert.match(sql, /reports_select_admin/);
+  assert.match(sql, /reports_update_admin/);
+  assert.match(sql, /profiles_select_admin/);
+  assert.doesNotMatch(sql, /view_admin/);
+  assert.doesNotMatch(sql, /view_permissions/);
 });
 
 test('migration grants personal reports access only to explicit profile whitelist', async () => {

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -187,8 +187,8 @@ test('service worker cache version bumped for personal reports deploy', async ()
   const rootSw = await readFile(new URL('../sw.js', import.meta.url), 'utf8');
   const css = await readFile(new URL('../frontend/src/styles/main.css', import.meta.url), 'utf8');
 
-  assert.match(frontendSw, /const CACHE_VERSION = 597;/);
-  assert.match(rootSw, /const SW_ENTRY_VERSION = 597;/);
+  assert.match(frontendSw, /const CACHE_VERSION = 598;/);
+  assert.match(rootSw, /const SW_ENTRY_VERSION = 598;/);
   assert.match(css, /\.pr-input--month-compact/);
 });
 
@@ -429,4 +429,22 @@ test('migration keeps travel rates private and exposes only RPC entry points', a
   assert.match(sql, /public\.upsert_declared_travel_entry/);
   assert.match(sql, /public\.manage_employee_travel_rate/);
   assert.match(sql, /REVOKE ALL ON SCHEMA private/);
+});
+
+test('personal reports manager permission gates management UI without requiring admin role', async () => {
+  const source = await readFile(new URL('../frontend/src/screens/personal-reports.js', import.meta.url), 'utf8');
+
+  assert.match(source, /function canManagePersonalReports\(/);
+  assert.match(source, /personal_reports_manager/);
+  assert.match(source, /function profileCanManagePersonalReports\(/);
+  assert.match(source, /profileCanManagePersonalReports\(prSession\.profile\)/);
+  assert.match(source, /profileCanManagePersonalReports\(profile\)/);
+  assert.doesNotMatch(source, /if \(isAdminRole\(prSession\.profile\.role\)\)/);
+});
+
+test('finance personal reports manager does not get admin role in profile mapping', async () => {
+  const source = await readFile(new URL('../frontend/src/screens/personal-reports.js', import.meta.url), 'utf8');
+
+  assert.match(source, /can_manage_personal_reports: canManage/);
+  assert.match(source, /role = isAdminRole\(displayRole\) \? 'admin' : 'employee'/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## סיכום

מוסיף הרשאה ייעודית `personal_reports_manager` לניהול דוחות אישיים — ללא הפיכת המשתמש לאדמין.

משתמש מורשה לנהל דוחות אישיים אם מתקיים אחד מהתנאים:
- `role === "admin"`
- `permissions.personal_reports_manager === "yes"`

## שינויים עיקריים

### Frontend (`personal-reports.js`)
- פונקציה מרכזית `canManagePersonalReports(user)` + `profileCanManagePersonalReports(profile)`
- כל בדיקות ניהול הדוחות (טאבים, רשימת עובדים, אישור/החזרה, PDF, CSV) משתמשות בהרשאה החדשה במקום `role === admin` בלבד
- טוני (`finance` + `personal_reports_manager=yes`) תראה "הדוחות שלי" **וגם** "ניהול דוחות עובדים"

### API / State
- `personal_reports_manager` נחשף ב-login וב-bootstrap (`has_personal_reports_manager`)
- `main.js` מסנכרן את ההרשאה ב-refresh — **ללא** הוספת מסכי אדמין ל-`SUPABASE_ROLE_ROUTES`

### SQL (`20260610_personal_reports_manager_permission.sql`)
- פונקציה `dashboard_user_can_manage_personal_reports()` ל-RLS
- עדכון policies של דוחות אישיים, profiles, storage — **רק** בתחום דוחות אישיים

### Service Worker
- `CACHE_VERSION` / `SW_ENTRY_VERSION` עודכנו ל-**598** כדי למנוע cache ישן

## בדיקות שבוצעו
- `node --check` על הקבצים ששונו
- `node --test tests/personal-reports-screen.test.mjs`
- `node --test tests/personal-reports-access-permission.test.mjs`
- `npm run check:build` — עבר

## לאחר deploy
1. להריץ את migration `20260610_personal_reports_manager_permission.sql` ב-Supabase
2. טוני צריכה לצאת ולהיכנס מחדש (או refresh מלא) כדי לטעון את ההרשאה
3. לוודא ש-SW התעדכן לגרסה 598
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10166445-851c-4b60-b7e9-21844bb3875f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10166445-851c-4b60-b7e9-21844bb3875f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

