### PR TITLE
Fix personal reports permissions: wait for Supabase auth session

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 598;
+const CACHE_VERSION = 599;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 598;
+const CACHE_VERSION = 599;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,7 +4,7 @@ import { hebrewRole } from './screens/shared/ui-hebrew.js';
 import { cleanActivityManagerName, NO_ACTIVITY_MANAGER_LABEL, normalizeOneDayActivityType, resolveActivityInstructorName } from './screens/shared/activity-options.js';
 import { EXCEPTION_TYPE_ORDER, normalizedExceptionTypes } from './screens/shared/exceptions-metrics.js';
 import { isSummerActivity, normalizeActivitySeason } from './screens/shared/summer-activity.js';
-import { supabase, supabaseConfig } from './supabase-client.js';
+import { supabase, supabaseConfig, waitForSupabaseAuthSession } from './supabase-client.js';
 import { isEmptyValue, nonEmptyString } from './utils/empty-value.js';
 
 /**
@@ -1914,6 +1914,11 @@ function profileCanAccessPersonalReports(profileRow) {
 async function readPersonalReportsProfile(authUserId) {
   const id = String(authUserId || '').trim();
   if (!supabase || !id) return null;
+  const session = await waitForSupabaseAuthSession();
+  if (!session?.user?.id) {
+    try { console.warn('[personal-reports-profile] skipped: no supabase auth session'); } catch { /* ignore */ }
+    return null;
+  }
   const { data, error } = await supabase
     .from('profiles')
     .select(PROFILE_PERSONAL_REPORTS_COLUMNS)
@@ -1929,6 +1934,11 @@ async function readPersonalReportsProfile(authUserId) {
 async function readPersonalReportsProfilesByAuthIds(authUserIds = []) {
   const ids = [...new Set(authUserIds.map((id) => String(id || '').trim()).filter(Boolean))];
   if (!supabase || !ids.length) return new Map();
+  const session = await waitForSupabaseAuthSession();
+  if (!session?.user?.id) {
+    try { console.warn('[personal-reports-profiles] skipped: no supabase auth session'); } catch { /* ignore */ }
+    return new Map();
+  }
   const { data, error } = await supabase
     .from('profiles')
     .select(`${PROFILE_PERSONAL_REPORTS_COLUMNS},email`)
@@ -2164,6 +2174,8 @@ async function readCurrentUserBySession() {
   if (!supabase) throw new Error('no_supabase_client');
   const userId = String(state?.user?.user_id || '').trim();
   if (!userId) throw new Error('unauthorized');
+  const session = await waitForSupabaseAuthSession();
+  if (!session?.user?.id) throw new Error('unauthorized');
   const { data, error } = await supabase
     .from('users')
     .select(USER_PUBLIC_COLUMNS)
@@ -3048,6 +3060,7 @@ export const api = {
     };
   },
   bootstrap: async () => {
+    await waitForSupabaseAuthSession();
     const [{ userRow: user, profileRow }, listsData, settingsRows] = await Promise.all([
       readCurrentUserBySession(),
       readListsFromSupabase().catch(() => null),

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,7 @@ import { uniqueExceptionActivityCount } from './screens/shared/exceptions-metric
 import { loginScreen } from './screens/login.js';
 import { clearFinancePrefsIfUserChanged } from './screens/shared/finance-prefs-storage.js';
 import { applyGlobalAccent, accentNameFromStorage, bindAccentPickerOnce as bindAccentPickerListenerOnce } from './accent-picker.js';
+import { waitForSupabaseAuthSession } from './supabase-client.js';
 
 const app = document.getElementById('app');
 const loginLogoSrc  = new URL('../assets/logo1.png',      import.meta.url).href;
@@ -1434,6 +1435,55 @@ function tryRestoreRoutesInstant() {
   } catch { return false; }
 }
 
+function applyBootstrapUserFlags(bootstrap) {
+  if (!bootstrap?.profile || !state.user) return;
+  const fn = bootstrap.profile.full_name != null ? String(bootstrap.profile.full_name).trim() : '';
+  if (fn) state.user.full_name = fn;
+  state.user.display_role2 =
+    bootstrap.profile.display_role2 != null ? String(bootstrap.profile.display_role2) : '';
+  if (bootstrap.profile.display_role_label != null) {
+    state.user.display_role_label = String(bootstrap.profile.display_role_label);
+  }
+  state.user.can_add_activity = permissionEnabled(bootstrap.can_add_activity);
+  state.user.can_edit_direct = permissionEnabled(bootstrap.can_edit_direct);
+  state.user.can_request_edit = permissionEnabled(bootstrap.can_request_edit);
+  state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
+  state.user.finance_access = !!bootstrap.has_finance_access;
+  state.user.profile_is_active = bootstrap.profile_is_active !== false;
+  state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
+  state.user.personal_reports_manager = !!bootstrap.has_personal_reports_manager;
+  localStorage.setItem('dashboard_user', JSON.stringify(state.user));
+}
+
+async function prepareAuthenticatedSupabaseSession() {
+  if (!state.token) {
+    state.authSessionReady = false;
+    state.permissionsReady = true;
+    return null;
+  }
+  state.permissionsReady = false;
+  const session = await waitForSupabaseAuthSession();
+  state.authSessionReady = !!session?.user?.id;
+  return session;
+}
+
+function applyBootstrapRoutes(bootstrap) {
+  const prevRouteSet = new Set(state.effectiveRoutes || []);
+  if (bootstrap.client_settings && typeof bootstrap.client_settings === 'object') {
+    state.clientSettings = { ...defaultClientSettings(), ...bootstrap.client_settings };
+  }
+  const normalizedRoutes = applySettingsToRoutes(bootstrap.routes || [], state.clientSettings);
+  state.routes = normalizedRoutes;
+  state.effectiveRoutes = normalizedRoutes;
+  const newDefault = resolveAllowedDefaultRoute(bootstrap.default_route, normalizedRoutes);
+  saveRoutesToStorage(state.routes, newDefault, state.clientSettings);
+  applyBootstrapUserFlags(bootstrap);
+  state.permissionsReady = true;
+  const routesChanged = normalizedRoutes.length !== prevRouteSet.size ||
+    normalizedRoutes.some((r) => !prevRouteSet.has(r));
+  return { routesChanged, newDefault };
+}
+
 /**
  * Fetches a fresh bootstrap in the background and silently updates state.
  * Called after instant-restore so permissions/profile stay up to date.
@@ -1441,46 +1491,24 @@ function tryRestoreRoutesInstant() {
  */
 function backgroundSyncBootstrap() {
   if (!state.token) return;
-  api.bootstrap().then((bootstrap) => {
-    const prevRouteSet = new Set(state.effectiveRoutes || []);
-    if (bootstrap.client_settings && typeof bootstrap.client_settings === 'object') {
-      state.clientSettings = { ...defaultClientSettings(), ...bootstrap.client_settings };
-    }
-    const normalizedRoutes = applySettingsToRoutes(bootstrap.routes || [], state.clientSettings);
-    state.routes = normalizedRoutes;
-    state.effectiveRoutes = normalizedRoutes;
-    const newDefault = resolveAllowedDefaultRoute(bootstrap.default_route, normalizedRoutes);
-    saveRoutesToStorage(state.routes, newDefault, state.clientSettings);
-    if (bootstrap.profile && state.user) {
-      const fn = bootstrap.profile.full_name != null ? String(bootstrap.profile.full_name).trim() : '';
-      if (fn) state.user.full_name = fn;
-      state.user.display_role2 =
-        bootstrap.profile.display_role2 != null ? String(bootstrap.profile.display_role2) : '';
-      if (bootstrap.profile.display_role_label != null) {
-        state.user.display_role_label = String(bootstrap.profile.display_role_label);
+  prepareAuthenticatedSupabaseSession()
+    .then(() => api.bootstrap())
+    .then((bootstrap) => {
+      const { routesChanged, newDefault } = applyBootstrapRoutes(bootstrap);
+      if (!isAllowedRoute(state.route)) {
+        state.route = newDefault;
+        render().catch(() => {});
+      } else if (routesChanged) {
+        render().catch(() => {});
+      } else {
+        updateNavActiveClasses();
+        if (state.route === 'personal-reports') render().catch(() => {});
       }
-      state.user.can_add_activity = permissionEnabled(bootstrap.can_add_activity);
-      state.user.can_edit_direct = permissionEnabled(bootstrap.can_edit_direct);
-      state.user.can_request_edit = permissionEnabled(bootstrap.can_request_edit);
-      state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
-      state.user.finance_access = !!bootstrap.has_finance_access;
-      state.user.profile_is_active = bootstrap.profile_is_active !== false;
-      state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
-      state.user.personal_reports_manager = !!bootstrap.has_personal_reports_manager;
-      localStorage.setItem('dashboard_user', JSON.stringify(state.user));
-    }
-    const routesChanged = normalizedRoutes.length !== prevRouteSet.size ||
-      normalizedRoutes.some((r) => !prevRouteSet.has(r));
-    if (!isAllowedRoute(state.route)) {
-      state.route = newDefault;
-      render().catch(() => {});
-    } else if (routesChanged) {
-      render().catch(() => {});
-    } else {
-      updateNavActiveClasses();
-    }
-    refreshOpenEditRequestsCount().catch(() => {});
-  }).catch(() => {});
+      refreshOpenEditRequestsCount().catch(() => {});
+    })
+    .catch(() => {
+      state.permissionsReady = true;
+    });
 }
 
 async function restoreSession() {
@@ -1488,34 +1516,13 @@ async function restoreSession() {
   if (state.routes.length) return;
 
   restoreScreenCacheFromStorage();
+  await prepareAuthenticatedSupabaseSession();
   const bootstrap = await api.bootstrap();
-  if (bootstrap.client_settings && typeof bootstrap.client_settings === 'object') {
-    state.clientSettings = { ...defaultClientSettings(), ...bootstrap.client_settings };
-  }
-  const normalizedRoutes = applySettingsToRoutes(bootstrap.routes || [], state.clientSettings);
-  state.routes = normalizedRoutes;
-  state.effectiveRoutes = normalizedRoutes;
-  state.route = resolveAllowedDefaultRoute(bootstrap.default_route, normalizedRoutes);
+  applyBootstrapRoutes(bootstrap);
+  state.route = resolveAllowedDefaultRoute(bootstrap.default_route, state.effectiveRoutes);
   saveRoutesToStorage(state.routes, state.route, state.clientSettings);
   consumePendingRouteFromUrlOrSession();
   clearFinancePrefsIfUserChanged(state.user?.user_id);
-  if (bootstrap.profile && state.user) {
-    const fn = bootstrap.profile.full_name != null ? String(bootstrap.profile.full_name).trim() : '';
-    if (fn) state.user.full_name = fn;
-    state.user.display_role2 =
-      bootstrap.profile.display_role2 != null ? String(bootstrap.profile.display_role2) : '';
-    if (bootstrap.profile.display_role_label != null) {
-      state.user.display_role_label = String(bootstrap.profile.display_role_label);
-    }
-    state.user.can_add_activity = permissionEnabled(bootstrap.can_add_activity);
-    state.user.can_edit_direct = permissionEnabled(bootstrap.can_edit_direct);
-    state.user.can_request_edit = permissionEnabled(bootstrap.can_request_edit);
-    state.user.can_review_requests = permissionEnabled(bootstrap.can_review_requests);
-    state.user.finance_access = !!bootstrap.has_finance_access;
-    state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
-    state.user.personal_reports_manager = !!bootstrap.has_personal_reports_manager;
-    localStorage.setItem('dashboard_user', JSON.stringify(state.user));
-  }
   refreshOpenEditRequestsCount().catch(() => {});
 }
 
@@ -1863,6 +1870,8 @@ async function render() {
             firstPrefetchTimerStarted = false;
             beginPerfTimer('login:setSession');
             setSession({ token: data.token, user: data.user });
+            state.authSessionReady = true;
+            state.permissionsReady = true;
             clearFinancePrefsIfUserChanged(data.user?.user_id);
             endPerfTimer('login:setSession');
             beginPerfTimer('login:applyBootstrap');

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -10,7 +10,7 @@
  *   manager  — admin or personal_reports_manager=yes: sees all reports, can approve / return / mark paid
  */
 
-import { supabase } from '../supabase-client.js';
+import { supabase, waitForSupabaseAuthSession } from '../supabase-client.js';
 import { escapeHtml } from './shared/html.js';
 import { dsPageHeader, dsEmptyState, dsStatusChip, dsScreenStack } from './shared/layout.js';
 
@@ -42,6 +42,14 @@ function profileCanManagePersonalReports(profile = {}) {
 
 function personalReportsAccessDeniedHtml() {
   return dsScreenStack(`${dsPageHeader('דוחות אישיים', 'גישה מוגבלת')} ${dsEmptyState('אין הרשאה לצפייה בדוחות אישיים.')}`);
+}
+
+function personalReportsPermissionsPending(appState) {
+  return !!(appState?.token && appState?.permissionsReady === false);
+}
+
+function personalReportsPermissionsLoadingHtml() {
+  return dsScreenStack(`${dsPageHeader('דוחות אישיים', 'טוען הרשאות…')} <div class="pr-loading-placeholder">טוען…</div>`);
 }
 
 // ─── constants ────────────────────────────────────────────────────────────────
@@ -1133,6 +1141,8 @@ async function deleteAttachment(attachment) {
 }
 
 async function fetchReportEligibleEmployees() {
+  const session = await waitForSupabaseAuthSession();
+  if (!session?.user?.id) throw new Error('unauthorized');
   const { data, error } = await supabase
     .from('profiles')
     .select('id, full_name, email, role, is_active, can_access_personal_reports')
@@ -3414,6 +3424,9 @@ export const personalReportsScreen = {
   load: () => Promise.resolve({}),
 
   render(_data, ctx) {
+    if (personalReportsPermissionsPending(ctx?.state)) {
+      return personalReportsPermissionsLoadingHtml();
+    }
     if (!canAccessPersonalReports(ctx?.state?.user)) {
       return personalReportsAccessDeniedHtml();
     }
@@ -3422,6 +3435,7 @@ export const personalReportsScreen = {
 
   bind({ root, state } = {}) {
     const prRoot = (root && root.querySelector('#pr-root')) || root;
+    if (personalReportsPermissionsPending(state)) return;
     if (!canAccessPersonalReports(state?.user)) return;
     _dashboardUser = state?.user || _dashboardUser || null;
     const view = prRoot?.ownerDocument?.defaultView || globalThis.window;

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -1,3 +1,5 @@
+import { resetSupabaseAuthSessionWait } from './supabase-client.js';
+
 function defaultClientSettings() {
   return {
     system_name: 'Dashboard Taasiyeda',
@@ -105,7 +107,11 @@ export const state = {
   /** @type {Record<string, { data: unknown, t: number }>} */
   screenDataCache: {},
   /** Sidebar badge for open approval requests (null = not loaded yet). */
-  openEditRequestsCount: null
+  openEditRequestsCount: null,
+  /** True once Supabase Auth session is available on the shared client. */
+  authSessionReady: false,
+  /** False while bootstrap/profile permission sync is in flight after reload. */
+  permissionsReady: false
 };
 
 function parseTokenPayloadClaims(token) {
@@ -167,6 +173,9 @@ export function setSession(session) {
     state.clientSettings = defaultClientSettings();
     state.screenDataCache = {};
     state.openEditRequestsCount = null;
+    state.authSessionReady = false;
+    state.permissionsReady = false;
+    resetSupabaseAuthSessionWait();
     localStorage.removeItem('dashboard_token');
     localStorage.removeItem('dashboard_user');
     cleanupLegacyCalendarMonthLocalStorage(state.user?.user_id);

--- a/frontend/src/supabase-client.js
+++ b/frontend/src/supabase-client.js
@@ -11,6 +11,7 @@ const supabaseAnonKey =
   FALLBACK_SUPABASE_PUBLISHABLE_KEY;
 
 let supabase = null;
+let authSessionWaitPromise = null;
 
 if (supabaseUrl && supabaseAnonKey) {
   supabase = createClient(supabaseUrl, supabaseAnonKey);
@@ -27,5 +28,62 @@ export const supabaseConfig = {
   usesFallbackUrl: supabaseUrl === FALLBACK_SUPABASE_URL,
   usesFallbackAnonKey: supabaseAnonKey === FALLBACK_SUPABASE_PUBLISHABLE_KEY
 };
+
+export function resetSupabaseAuthSessionWait() {
+  authSessionWaitPromise = null;
+}
+
+/**
+ * Resolves when Supabase Auth has restored the persisted session (or timeout).
+ * Personal reports RLS and profile reads require auth.uid() on the shared client.
+ */
+export function waitForSupabaseAuthSession(options = {}) {
+  if (!supabase) return Promise.resolve(null);
+  if (authSessionWaitPromise) return authSessionWaitPromise;
+
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : 8000;
+
+  authSessionWaitPromise = new Promise((resolve) => {
+    let settled = false;
+    let subscription = null;
+    let timer = null;
+
+    const finish = (session) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      try {
+        subscription?.unsubscribe();
+      } catch {
+        /* ignore */
+      }
+      resolve(session?.user?.id ? session : null);
+    };
+
+    timer = setTimeout(() => {
+      supabase.auth
+        .getSession()
+        .then(({ data }) => finish(data?.session || null))
+        .catch(() => finish(null));
+    }, timeoutMs);
+
+    supabase.auth
+      .getSession()
+      .then(({ data, error }) => {
+        if (!error && data?.session?.user?.id) finish(data.session);
+      })
+      .catch(() => {});
+
+    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!session?.user?.id) return;
+      if (event === 'INITIAL_SESSION' || event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        finish(session);
+      }
+    });
+    subscription = listener?.subscription;
+  });
+
+  return authSessionWaitPromise;
+}
 
 export { supabase };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 598;
+const CACHE_VERSION = 599;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 598;
+const SW_ENTRY_VERSION = 599;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/personal-reports-access-permission.test.mjs
+++ b/tests/personal-reports-access-permission.test.mjs
@@ -60,6 +60,28 @@ test('main syncs can_access_personal_reports from bootstrap', async () => {
   assert.match(source, /state\.user\.profile_is_active = bootstrap\.profile_is_active !== false/);
 });
 
+test('main waits for Supabase auth session before bootstrap permission sync', async () => {
+  const mainSource = await readFile(MAIN_FILE, 'utf8');
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const clientSource = await readFile(new URL('../frontend/src/supabase-client.js', import.meta.url), 'utf8');
+  assert.match(clientSource, /function waitForSupabaseAuthSession/);
+  assert.match(mainSource, /waitForSupabaseAuthSession/);
+  assert.match(mainSource, /permissionsReady/);
+  assert.match(mainSource, /authSessionReady/);
+  assert.match(apiSource, /await waitForSupabaseAuthSession\(\)/);
+  assert.match(apiSource, /skipped: no supabase auth session/);
+});
+
+test('personal reports screen shows loading until permissions sync completes', async () => {
+  const source = await readFile(PR_FILE, 'utf8');
+  assert.match(source, /function personalReportsPermissionsPending/);
+  assert.match(source, /permissionsReady === false/);
+  assert.match(source, /personalReportsPermissionsLoadingHtml/);
+  assert.match(source, /if \(personalReportsPermissionsPending\(ctx\?\.state\)\)/);
+  assert.match(source, /if \(personalReportsPermissionsPending\(state\)\) return/);
+  assert.match(source, /waitForSupabaseAuthSession/);
+});
+
 test('login and bootstrap expose personal_reports_manager without granting admin routes', async () => {
   const apiSource = await readFile(API_FILE, 'utf8');
   const routesBlock = apiSource.match(/const SUPABASE_ROLE_ROUTES = \{[\s\S]*?\};/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Personal reports access was denied in the app even when Supabase RLS functions returned `true` for users like עידן נחום. The root cause was application-side timing: profile/permission reads ran before the shared Supabase client had restored the authenticated JWT, so `auth.uid()` was empty during bootstrap and profile queries.

## Solution

- Added `waitForSupabaseAuthSession()` on the shared Supabase client and use it before bootstrap/profile reads.
- Track `authSessionReady` and `permissionsReady` in app state so permission checks are not treated as final until bootstrap completes with a valid session.
- Personal reports screen now shows a loading state while permissions sync is pending, instead of immediately rendering "no access".
- Re-render personal reports after background bootstrap sync when already on that route.
- Admin employee listing queries also wait for Supabase session before hitting RLS-protected tables.
- Bumped service worker cache version to **599** in both `frontend/sw.js` and root `sw.js`.

## Out of scope (per request)

- No SQL function changes
- No database permission/RLS changes

## Verification

- `node --check` on all changed JS files
- `node --test tests/personal-reports-access-permission.test.mjs` — pass
- `npm run check:build` not run (vite missing in environment); SW versions bumped consistently in source files

## Expected outcome

Active admin users with `can_access_personal_reports=true` (e.g. עידן נחום / `idann@think.org.il`) should receive personal reports access and manager capabilities in the app after session restore, without false "no permission" states during page load.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1f3d346-ae5e-4a37-b244-698236528a7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1f3d346-ae5e-4a37-b244-698236528a7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

