### PR TITLE
Improve error handling and logging for travel entries and reports

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 599;
+const CACHE_VERSION = 602;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 599;
+const CACHE_VERSION = 602;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -550,8 +550,14 @@ function friendlyPersonalReportsError(error, fallback = 'אירעה תקלה ב�
   if (/missing_travel_rate|missing travel rate/i.test(raw)) {
     return 'לא הוגדר תעריף החזר נסיעות לעובד. יש לפנות למנהל המערכת.';
   }
+  if (/report_not_editable/i.test(raw)) {
+    return 'הדוח אינו ניתן לעריכה (אינו בסטטוס טיוטה). יש לפנות למנהל המערכת.';
+  }
   if (/permission denied|row-level security|rls|unauthorized|forbidden/i.test(raw)) {
     return 'אין הרשאה לצפייה בדוחות אלה.';
+  }
+  if (raw) {
+    return `${fallback} (${raw})`;
   }
   return fallback;
 }
@@ -1075,17 +1081,22 @@ async function upsertDeclaredTravel(entry) {
   const { travel_type: travelType = 'km', id, ...baseEntry } = entry;
   const isPublicTransport = travelType === 'public_transport';
   if (!isPublicTransport) {
-    const { data, error } = await supabase.rpc('upsert_declared_travel_entry', {
+    const rpcPayload = {
       p_id: id || null,
       p_report_id: baseEntry.report_id,
       p_employee_id: baseEntry.employee_id,
-      p_travel_date: baseEntry.travel_date,
+      p_travel_date: baseEntry.travel_date || null,
       p_origin: baseEntry.origin || '',
       p_destination: baseEntry.destination || '',
       p_description: baseEntry.description || '',
-      p_roundtrip_km: Number(baseEntry.roundtrip_km || 0)
-    });
-    if (error) throw error;
+      p_roundtrip_km: Number(baseEntry.roundtrip_km) || 0
+    };
+    console.error('[declared_travel] payload before upsert:', JSON.stringify(rpcPayload));
+    const { data, error } = await supabase.rpc('upsert_declared_travel_entry', rpcPayload);
+    if (error) {
+      console.error('[declared_travel] upsert error:', error.message, error.code, error.details, 'payload:', JSON.stringify(rpcPayload));
+      throw error;
+    }
     const row = Array.isArray(data) ? data[0] : data;
     return { ...row, travel_type: 'km', entry_table: 'declared_travel_entries' };
   }
@@ -3121,6 +3132,7 @@ function bindReportDetail(root, { isSimulation = false } = {}) {
       await safeOpenReportDetail(root, reportId, false, { isSimulation, initialTab: currentReportTab(root), forceReload: true });
       showToast('נשמר', 'success');
     } catch (err) {
+      console.error('[personal-reports] save error:', err?.message, err?.code, err?.details, err);
       showToast(friendlyPersonalReportsError(err, 'אירעה תקלה בשמירת הדוח. יש לנסות שוב.'), 'danger');
     } finally {
       savingForms.delete(form);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 601;
+const CACHE_VERSION = 602;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 601;
+const SW_ENTRY_VERSION = 602;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR enhances error handling and debugging capabilities in the personal reports module by adding better error messages, improved logging, and more robust data validation.

## Key Changes
- **Enhanced error messages**: Added a new error handler for `report_not_editable` errors with a user-friendly Hebrew message, and improved the fallback error message to include the raw error details
- **Improved logging**: Added comprehensive console.error logging for:
  - Travel entry upsert operations (before and after RPC calls)
  - Report save operations
- **Better data validation**: Fixed potential issues in the `upsertDeclaredTravel` function:
  - Explicitly handle null `travel_date` values
  - Improved `roundtrip_km` number conversion logic
  - Extracted RPC payload into a variable for better debugging
- **Cache version bump**: Updated service worker cache versions (599→602, 601→602) to ensure clients pick up the latest changes

## Notable Implementation Details
- Error logging includes error message, code, details, and the payload that caused the error for easier debugging
- The fallback error message now appends the raw error to help identify unexpected error types
- The travel entry payload is logged before the RPC call to help diagnose data-related issues

https://claude.ai/code/session_016ztTL5AhC1tetTxmtMWUDk