### PR TITLE
Restore activities month navigation and bump Service Worker cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 603;
+const CACHE_VERSION = 604;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BiYIJRG7.js",
+  "./assets/index-DNcbH8ZK.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BiYIJRG7.js"></script>
+  <script type="module" crossorigin src="./assets/index-DNcbH8ZK.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-Dl2MJDjC.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 603;
+const CACHE_VERSION = 604;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BiYIJRG7.js",
+  "./assets/index-DNcbH8ZK.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -522,6 +522,31 @@ function isEndingInMonth(row = {}, ym = '') {
   return /^\d{4}-\d{2}$/.test(month) && String(row?.end_date || row?.date_end || '').slice(0, 7) === month;
 }
 
+function currentYm() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function shiftYm(ym, delta) {
+  const base = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
+  const d = base ? new Date(Number(base[1]), Number(base[2]) - 1, 1) : new Date();
+  d.setMonth(d.getMonth() + delta);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function monthLabel(ym) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
+  if (!m) return '';
+  return `${m[1]}-${m[2]}`;
+}
+
+const HE_MONTHS = ['ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'];
+function heMonthLabel(ym) {
+  const m = /^(\d{4})-(\d{2})$/.exec(String(ym || '').trim());
+  if (!m) return monthLabel(ym);
+  return HE_MONTHS[Number(m[2]) - 1] || monthLabel(ym);
+}
+
 function applyClientFilters(rows, state, settings) {
   let out = Array.isArray(rows) ? rows.slice() : [];
   const oneDayTypes = resolveOneDayTypes(settings);
@@ -1118,6 +1143,7 @@ function activityLayoutListHtml(groups = []) {
 export const activitiesScreen = {
   async load({ api, state }) {
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
+    if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
     return api.activities({
       activity_type: 'all',
       include_inactive: true
@@ -1127,6 +1153,7 @@ export const activitiesScreen = {
   render(data, { state }) {
     const allRows       = Array.isArray(data?.rows) ? data.rows : [];
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
+    if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
     const periodRows    = activityPeriodRows(allRows, state.activityPeriodTab);
     const filteredRows  = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
 
@@ -1284,9 +1311,11 @@ export const activitiesScreen = {
       </div>
     </div>`;
 
-    const titleNavRow = `<div class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" dir="rtl">
-      <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(activityPeriodLabelForKey(state.activityPeriodTab))} · ${total} פעילויות ${navLoadingChip}</h2>
-    </div>`;
+    const titleNavRow = `<nav class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" aria-label="ניווט חודשי לפעילויות" dir="rtl">
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-prev aria-label="חודש קודם" title="חודש קודם" ${isNavLoading ? 'disabled' : ''}>▶</button>
+      <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(heMonthLabel(state.activitiesMonthYm))} · ${total} פעילויות ${navLoadingChip}</h2>
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-next aria-label="חודש הבא" title="חודש הבא" ${isNavLoading ? 'disabled' : ''}>◀</button>
+    </nav>`;
     const periodTabs = activityPeriodTabsHtml(allRows, state.activityPeriodTab);
 
     const html = dsScreenStack(`<section class="ds-activities-screen">
@@ -1473,6 +1502,22 @@ export const activitiesScreen = {
     };
 
     bindActivitiesViewSwitcher(root, state, rerender);
+
+    const runMonthShift = (delta) => {
+      if (state.activitiesNavLoading) return;
+      const startedAt = Date.now();
+      state.activitiesNavLoading = true;
+      state.activitiesMonthYm = shiftYm(state.activitiesMonthYm || currentYm(), delta);
+      rerenderLocal();
+      const minMs = 420;
+      setTimeout(() => {
+        state.activitiesNavLoading = false;
+        rerenderLocal();
+      }, Math.max(0, minMs - (Date.now() - startedAt)));
+    };
+
+    root.querySelector('[data-activities-month-prev]')?.addEventListener('click', () => runMonthShift(-1));
+    root.querySelector('[data-activities-month-next]')?.addEventListener('click', () => runMonthShift(1));
 
     const upsertLocalRow = (rowId, patch) => {
       const hit = activitiesRows.find((row) => String(row?.RowID || '') === String(rowId || ''));

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 603;
+const CACHE_VERSION = 604;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 603;
+const SW_ENTRY_VERSION = 604;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Restore the missing month navigation header on the Activities screen so users see a centered month selector above the search/filters (RTL Hebrew label and prev/next arrows) without changing table or filter logic.  
- Ensure the change is served to live users by updating Service Worker/cache version to avoid stale cached assets.

### Description
- Reintroduced month helpers (`currentYm`, `shiftYm`, `monthLabel`, `heMonthLabel`) and ensure `state.activitiesMonthYm` is initialized in `activitiesScreen.load` and `render` (`frontend/src/screens/activities.js`).  
- Replaced the title row with a centered `<nav>` containing `data-activities-month-prev` / `data-activities-month-next` buttons and the Hebrew month label, and added `runMonthShift` event handlers that move the month and show a short nav-loading state (`frontend/src/screens/activities.js`).  
- Kept all table rendering and filtering logic unchanged and relied on existing CSS (`.ds-activities-title-row`) to center the control (`frontend/src/styles/main.css`).  
- Bumped Service Worker/cache version to `604` and updated `frontend/sw.js`, `sw.js` and built `dist` references so the new bundle and cache are precached (dist assets updated accordingly).

### Testing
- Ran `node --check frontend/src/screens/activities.js && node --check frontend/sw.js && node --check sw.js` and these checks passed.  
- Ran `npm run check:build` (production `vite build`) and the build completed successfully and produced updated `dist` files.  
- Ran `npm run check:changed` (focused checks) which completed successfully.  
- Performed a jsdom render+bind smoke test that verified the page title shows `ניהול פעילויות · מאי · 2 פעילויות` and that clicking prev/next updates `state.activitiesMonthYm` (`2026-05 → 2026-04 → 2026-05`), which succeeded.  
- Playwright/screenshot capture was blocked by `npm` registry access (`403`), so no browser screenshot was produced; the jsdom check and updated `dist`/SW changes are provided as verification and the SW precache references were updated to ensure the change reaches live users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2552d7a4d4832b9ffa5e7417ad6415)