### PR TITLE
Filter activities table by selected month and bump SW cache version

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 604;
+const CACHE_VERSION = 605;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 604;
+const CACHE_VERSION = 605;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -522,6 +522,55 @@ function isEndingInMonth(row = {}, ym = '') {
   return /^\d{4}-\d{2}$/.test(month) && String(row?.end_date || row?.date_end || '').slice(0, 7) === month;
 }
 
+function selectedMonthRange(ym = '') {
+  const month = String(ym || '').trim().slice(0, 7);
+  if (!/^\d{4}-\d{2}$/.test(month)) return null;
+  const [year, monthNumber] = month.split('-').map(Number);
+  const lastDay = new Date(year, monthNumber, 0).getDate();
+  return {
+    month,
+    start: `${month}-01`,
+    end: `${month}-${String(lastDay).padStart(2, '0')}`
+  };
+}
+
+function normalizedActivityDateValue(value) {
+  const date = String(value || '').trim().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : '';
+}
+
+function activityMeetingDates(row = {}) {
+  const dates = [];
+  const addDate = (value) => {
+    const date = normalizedActivityDateValue(value);
+    if (date && !dates.includes(date)) dates.push(date);
+  };
+  const cols = Array.isArray(row?.meeting_dates) ? row.meeting_dates
+    : Array.isArray(row?.date_cols) ? row.date_cols : [];
+  cols.forEach(addDate);
+  for (let i = 1; i <= 35; i++) {
+    addDate(row?.[`date_${i}`]);
+    addDate(row?.[`Date${i}`]);
+  }
+  return dates;
+}
+
+function activityOccursInSelectedMonth(row = {}, ym = '') {
+  const range = selectedMonthRange(ym);
+  if (!range) return true;
+  const dates = activityMeetingDates(row);
+  if (dates.length > 0) return dates.some((date) => date >= range.start && date <= range.end);
+
+  const start = normalizedActivityDateValue(row?.start_date ?? row?.date_start);
+  if (!start) return false;
+  const end = normalizedActivityDateValue(row?.end_date ?? row?.date_end) || start;
+  return start <= range.end && end >= range.start;
+}
+
+function applySelectedActivitiesMonth(rows, state) {
+  return (Array.isArray(rows) ? rows : []).filter((row) => activityOccursInSelectedMonth(row, state?.activitiesMonthYm));
+}
+
 function currentYm() {
   const d = new Date();
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
@@ -1155,7 +1204,8 @@ export const activitiesScreen = {
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
     if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
     const periodRows    = activityPeriodRows(allRows, state.activityPeriodTab);
-    const filteredRows  = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
+    const monthRows     = applySelectedActivitiesMonth(periodRows, state);
+    const filteredRows  = applyActivitiesLocalFilters(monthRows, state, state?.clientSettings);
 
     const listFilters   = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
     const { visible: safeRows, hasMore, total, nextCount } = splitVisibleRows(filteredRows, listFilters);
@@ -1291,7 +1341,9 @@ export const activitiesScreen = {
       safeRows.length === 0
         ? dsEmptyState(periodRows.length === 0
             ? 'אין פעילויות להצגה בתקופה זו'
-            : 'לא נמצאו פעילויות התואמות לסינון הנוכחי')
+            : monthRows.length === 0
+              ? 'אין פעילויות להצגה בחודש הנבחר'
+              : 'לא נמצאו פעילויות התואמות לסינון הנוכחי')
         : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--activities-list" dir="rtl">
                 ${tableColsHtml}
                 <tbody>${tableRows}</tbody>
@@ -1354,7 +1406,7 @@ export const activitiesScreen = {
       const canViewExceptions = userRoutes.includes('exceptions');
 
       const exceptionsBtn = canViewExceptions
-        ? `<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-overdue-exceptions>מעבר לתיקון החריגה</button>`
+        ? `<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-overdue-exceptions>מעבר לעמוד החריגות</button>`
         : '';
 
       const el = document.createElement('div');

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 604;
+const CACHE_VERSION = 605;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 604;
+const SW_ENTRY_VERSION = 605;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
 
 if (!globalThis.sessionStorage) {
   const sessionStore = new Map();
@@ -186,6 +187,7 @@ test('activities quick filters include one-day summer rows by family and distric
 
 test('activities period tabs split rows by start_date and default to school 2026', () => {
   const state = baseState();
+  state.activitiesMonthYm = '2026-06';
   delete state.activityPeriodTab;
   const data = {
     rows: [
@@ -207,6 +209,86 @@ test('activities period tabs split rows by start_date and default to school 2026
   assert.doesNotMatch(html, /פעילות ספטמבר/);
   assert.doesNotMatch(html, /פעילות סגורה/);
   assert.doesNotMatch(html, /כל הפעילויות/);
+});
+
+test('activities selected month drives title, count and table rows', () => {
+  const state = baseState();
+  state.activitiesMonthYm = '2026-05';
+  const data = {
+    rows: [
+      { RowID: 'MAY-1', activity_name: 'פעילות מאי', activity_type: 'workshop', authority: 'רשות א', school: 'בית ספר א', start_date: '2026-05-10', end_date: '2026-05-10' },
+      { RowID: 'JUNE-1', activity_name: 'פעילות יוני', activity_type: 'workshop', authority: 'רשות ב', school: 'בית ספר ב', start_date: '2026-06-12', end_date: '2026-06-12' },
+      { RowID: 'SPAN-MAY-JUNE', activity_name: 'פעילות חוצה חודשים', activity_type: 'course', authority: 'רשות ג', school: 'בית ספר ג', start_date: '2026-05-20', end_date: '2026-06-10' },
+      { RowID: 'DATES-JUNE', activity_name: 'מפגש יוני', activity_type: 'course', authority: 'רשות ד', school: 'בית ספר ד', start_date: '2026-05-01', end_date: '2026-05-31', date_1: '2026-06-03' }
+    ]
+  };
+
+  const mayHtml = activitiesScreen.render(data, { state });
+  assert.match(mayHtml, /ניהול פעילויות · מאי · 2 פעילויות/);
+  assert.match(mayHtml, /פעילות מאי/);
+  assert.match(mayHtml, /פעילות חוצה חודשים/);
+  assert.doesNotMatch(mayHtml, /פעילות יוני/);
+  assert.doesNotMatch(mayHtml, /מפגש יוני/);
+
+  state.activitiesMonthYm = '2026-06';
+  const juneHtml = activitiesScreen.render(data, { state });
+  assert.match(juneHtml, /ניהול פעילויות · יוני · 3 פעילויות/);
+  assert.doesNotMatch(juneHtml, /פעילות מאי/);
+  assert.match(juneHtml, /פעילות יוני/);
+  assert.match(juneHtml, /פעילות חוצה חודשים/);
+  assert.match(juneHtml, /מפגש יוני/);
+});
+
+test('activities month navigation updates the single selected month state and rerenders RTL title/table', async () => {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousAbortController = globalThis.AbortController;
+  const dom = new JSDOM('<main id="root"></main>', { url: 'https://example.test/dashboard?route=activities' });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.AbortController = dom.window.AbortController;
+  try {
+    const state = baseState();
+    state.activitiesMonthYm = '2026-05';
+    const data = {
+      rows: [
+        { RowID: 'MAY-1', activity_name: 'פעילות מאי', activity_type: 'workshop', authority: 'רשות א', school: 'בית ספר א', start_date: '2026-05-10', end_date: '2026-05-10' },
+        { RowID: 'JUNE-1', activity_name: 'פעילות יוני', activity_type: 'workshop', authority: 'רשות ב', school: 'בית ספר ב', start_date: '2026-06-12', end_date: '2026-06-12' }
+      ]
+    };
+    const root = dom.window.document.querySelector('#root');
+    const rerender = () => {
+      root.innerHTML = activitiesScreen.render(data, { state });
+      activitiesScreen.bind({ root, data, state, rerender, api: {}, ui: { bindInteractiveCards() {} } });
+    };
+
+    rerender();
+    assert.match(root.querySelector('.ds-activities-title-row')?.getAttribute('dir') || '', /rtl/);
+    assert.match(root.textContent, /ניהול פעילויות · מאי · 1 פעילויות/);
+    assert.match(root.textContent, /פעילות מאי/);
+    assert.doesNotMatch(root.textContent, /פעילות יוני/);
+
+    root.querySelector('[data-activities-month-next]').click();
+    assert.equal(state.activitiesMonthYm, '2026-06');
+    assert.match(root.textContent, /ניהול פעילויות · יוני · 1 פעילויות/);
+    assert.doesNotMatch(root.textContent, /פעילות מאי/);
+    assert.match(root.textContent, /פעילות יוני/);
+
+    await new Promise((resolve) => setTimeout(resolve, 450));
+    root.querySelector('[data-activities-month-prev]').click();
+    assert.equal(state.activitiesMonthYm, '2026-05');
+    assert.match(root.textContent, /ניהול פעילויות · מאי · 1 פעילויות/);
+    assert.match(root.textContent, /פעילות מאי/);
+    assert.doesNotMatch(root.textContent, /פעילות יוני/);
+    await new Promise((resolve) => setTimeout(resolve, 450));
+  } finally {
+    if (previousWindow === undefined) delete globalThis.window;
+    else globalThis.window = previousWindow;
+    if (previousDocument === undefined) delete globalThis.document;
+    else globalThis.document = previousDocument;
+    if (previousAbortController === undefined) delete globalThis.AbortController;
+    else globalThis.AbortController = previousAbortController;
+  }
 });
 
 test('activities view switcher keeps week and month routes without an all/summer mixing button', () => {
@@ -364,7 +446,6 @@ test('all-activities Excel filename keeps Hebrew base and date stamp', async () 
   }
 });
 
-const { JSDOM } = await import('jsdom');
 const { getActivityNamesForType } = await import('../frontend/src/screens/shared/activity-options.js');
 const { activityWorkDrawerHtml } = await import('../frontend/src/screens/shared/activity-detail-html.js');
 const { bindActivityEditForm } = await import('../frontend/src/screens/shared/bind-activity-edit-form.js');


### PR DESCRIPTION
### Motivation
- The activities month navigator updated the page title but did not drive the table rows or count, leaving the page inconsistent; the selected month must be the single source of truth for title, count and table contents.
- Preserve existing filter semantics and table layout while ensuring meeting dates (`date_1..date_35` / `Date1..Date35`) and multi-day activities are considered when filtering by month.
- Make sure the deployed site sees the change by invalidating Service Worker caches.

### Description
- Added month-aware helpers to `frontend/src/screens/activities.js`: `selectedMonthRange`, `normalizedActivityDateValue`, `activityMeetingDates`, `activityOccursInSelectedMonth`, and `applySelectedActivitiesMonth` to compute whether an activity occurs in the chosen month.
- Applied month filtering in `render()` by running `applySelectedActivitiesMonth(periodRows, state)` before the existing local filters so the title, visible count and table rows share `state.activitiesMonthYm` as the single source of truth.
- Adjusted the empty-state message to show a dedicated message when there are no activities in the selected month without changing table layout or filter structure, and updated the overdue button label text to match test expectations (`מעבר לעמוד החריגות`).
- Bumped Service Worker/cache versions from `604` to `605` in `frontend/sw.js`, `sw.js` (and the built `dist` SW files) to invalidate old caches so the change reaches live clients.
- Added focused tests and test adjustments in `tests/activities-screen.test.mjs` to cover month-selected title/count/table behavior and navigation (RTL/Hebrew), and minor test harness adjustments for JSDOM/AbortController compatibility.

### Testing
- Ran syntax checks with `node --check` and `npm run check:changed` on modified files with no syntax errors reported.
- Ran the focused unit tests with `node --test tests/activities-screen.test.mjs` and `node --test tests/service-worker-pwa-cache.test.mjs`, and all tests passed after the fixes.
- Performed a frontend build via `npm run check:build` (Vite build) which completed successfully and updated `dist` precache entries.
- Verified SW/cache version consistency and PWA SW tests passed to ensure clients will pick up the new deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2561f397b0832b934d581948471ccd)