### PR TITLE
Expose catalog + edit-requests routes for manager/requester roles; preserve review guard; bump SW cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 605;
+const CACHE_VERSION = 606;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DNcbH8ZK.js",
+  "./assets/index-DQAzjYv4.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DNcbH8ZK.js"></script>
+  <script type="module" crossorigin src="./assets/index-DQAzjYv4.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-Dl2MJDjC.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 605;
+const CACHE_VERSION = 606;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DNcbH8ZK.js",
+  "./assets/index-DQAzjYv4.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1876,11 +1876,11 @@ const SUPABASE_ROLE_ROUTES = {
   admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
   operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  finance: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  activities_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  finance: ['dashboard', 'activities', 'archive', 'catalog', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  instructor_manager: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
+  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  instructor_manager: ['dashboard', 'activities', 'archive', 'catalog', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   instructor: ['my-data', 'week', 'month']
 };
 
@@ -2052,7 +2052,7 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
   const canEditDirect = canDirectManageActivities;
   const canRequestEdit = canDirectManageActivities || canRequestActivities;
   const canReviewRequests = canDirectManageActivities;
-  if (canReviewRequests && !allowedRoutes.includes('edit-requests')) {
+  if (canRequestEdit && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
   const hasPersonalReportsAccess = profileCanAccessPersonalReports(profileRow);
@@ -3270,11 +3270,11 @@ export const api = {
         admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         operation_manager: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
-        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes', can_access_personal_reports: 'yes' },
-        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
+        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes', view_catalog: 'yes', can_access_personal_reports: 'yes' },
+        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', can_access_personal_reports: 'yes' },
         domain_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         business_development_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no', can_access_personal_reports: 'yes' },
-        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
+        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', can_access_personal_reports: 'yes' },
         instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' }
       }
     };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 605;
+const CACHE_VERSION = 606;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 605;
+const SW_ENTRY_VERSION = 606;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/edit-requests-screen.test.mjs
+++ b/tests/edit-requests-screen.test.mjs
@@ -24,5 +24,23 @@ test('edit requests screen hides empty requests and keeps non-empty field rows',
   assert.match(html, /הערות/);
   assert.match(html, /ישן/);
   assert.match(html, /חדש/);
-  assert.match(html, /בקשות \(1\)/);
+  assert.match(html, /בקשות פתוחות \(1\)/);
+});
+
+
+test('edit requests screen hides review actions for non-reviewers', () => {
+  const html = editRequestsScreen.render({
+    canReview: false,
+    groups: [
+      {
+        request_id: 'REQ-MINE',
+        status: 'pending',
+        fields: [{ field_name: 'notes', old_value: 'ישן', new_value: 'חדש' }]
+      }
+    ]
+  });
+
+  assert.match(html, /בקשות פעילות שהגשת/);
+  assert.doesNotMatch(html, /data-action="approve"/);
+  assert.doesNotMatch(html, /data-action="reject"/);
 });

--- a/tests/navigation-permissions-routes.test.mjs
+++ b/tests/navigation-permissions-routes.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const API_FILE = new URL('../frontend/src/api.js', import.meta.url).pathname;
+
+async function readApiSource() {
+  return readFile(API_FILE, 'utf8');
+}
+
+function extractRoleRoutes(src, role) {
+  const pattern = new RegExp(`${role}: \\[([^\\]]*)\\]`);
+  const match = src.match(pattern);
+  assert.ok(match, `missing routes for role ${role}`);
+  return match[1];
+}
+
+function extractDefaultPermission(src, role) {
+  const pattern = new RegExp(`${role}: \\{([^\\}]*)\\}`);
+  const match = src.match(pattern);
+  assert.ok(match, `missing default permissions for role ${role}`);
+  return match[1];
+}
+
+test('catalog is a default route for requested manager and finance roles without adding orders', async () => {
+  const src = await readApiSource();
+
+  for (const role of ['activities_manager', 'instructor_manager', 'finance']) {
+    const routes = extractRoleRoutes(src, role);
+    assert.match(routes, /'catalog'/, `${role} should see catalog by default`);
+  }
+
+  assert.doesNotMatch(extractRoleRoutes(src, 'activities_manager'), /'orders'/, 'activities_manager should not gain orders by default');
+  assert.doesNotMatch(extractRoleRoutes(src, 'instructor_manager'), /'orders'/, 'instructor_manager should not gain orders by default');
+  assert.doesNotMatch(extractRoleRoutes(src, 'finance'), /'orders'/, 'finance should not gain orders by default');
+});
+
+test('edit requests route is available to request submitters while review remains direct-manager only', async () => {
+  const src = await readApiSource();
+
+  for (const role of ['activities_manager', 'instructor_manager', 'business_development_manager', 'finance']) {
+    assert.match(extractRoleRoutes(src, role), /'edit-requests'/, `${role} should have edit-requests route for its badge/screen`);
+  }
+
+  assert.match(src, /const canReviewRequests = canDirectManageActivities;/, 'review permission should stay limited to admin and operation_manager');
+  assert.match(src, /if \(canRequestEdit && !allowedRoutes\.includes\('edit-requests'\)\)/, 'bootstrap should expose edit-requests to users who can request edits');
+  assert.match(src, /if \(!canReviewEditRequestsUser\(\)\) throw new Error\('forbidden_review_edit_request'\);/, 'review action should keep the server-side non-reviewer guard');
+});
+
+test('default permissions grant catalog but not edit-review to requested roles', async () => {
+  const src = await readApiSource();
+
+  for (const role of ['activities_manager', 'instructor_manager', 'finance']) {
+    const defaults = extractDefaultPermission(src, role);
+    assert.match(defaults, /view_catalog: 'yes'/, `${role} should get catalog default permission`);
+    assert.match(defaults, /can_review_requests: 'no'/, `${role} should not get review permission`);
+  }
+});


### PR DESCRIPTION
### Motivation
- Restore red-badge/edit-requests visibility for users who can submit or view their own edit requests (activities_manager, instructor_manager, business_development_manager, finance) while keeping approval/reject authority unchanged. 
- Make `catalog` available by default to requested roles (activities_manager, instructor_manager, finance) without granting unrelated `orders` access.
- Ensure new frontend assets are picked up by clients by bumping Service Worker cache version.

### Description
- Added `catalog` and `edit-requests` to the default `SUPABASE_ROLE_ROUTES` for the roles: `activities_manager`, `instructor_manager`, `finance`, and also added `edit-requests` for `business_development_manager`. (edited `frontend/src/api.js`).
- Changed bootstrap logic in `buildBootstrapFromUser` to expose the `edit-requests` route when a user `canRequestEdit` (submit requests) rather than only when they can review, so requesters see the badge/screen while reviewers remain unchanged. (edited `frontend/src/api.js`).
- Updated `roleDefaults` in the permissions payload to give `view_catalog: 'yes'` to `finance`, `activities_manager`, and `instructor_manager` without granting `can_review_requests`. (edited `frontend/src/api.js`).
- Kept review+approve server-side guard intact: review actions still require `canDirectManageActivities` (admin / operation_manager) and server-side checks remain unchanged.
- Bumped Service Worker/cache version from `605` to `606` in both root `sw.js` and `frontend/sw.js` and updated built `dist` files so clients will load the new assets after refresh/hard-refresh. (edited `sw.js`, `frontend/sw.js`, regenerated `dist/*`).
- Added focused tests (`tests/navigation-permissions-routes.test.mjs`) and strengthened `tests/edit-requests-screen.test.mjs` to cover the new route defaults and UI behavior for non-reviewers.

### Testing
- Ran focused unit/smoke checks: `node --check frontend/src/api.js`, `node --check frontend/sw.js`, and `node --check sw.js` (all passed).
- Ran the focused test command: `node --test tests/navigation-permissions-routes.test.mjs tests/edit-requests-screen.test.mjs tests/service-worker-pwa-cache.test.mjs`, and all tests passed.
- Executed the project verification scripts: `npm run check:changed` (passed) and `npm run check:build` (full frontend build completed successfully and `dist` updated).
- Verified Service Worker version bump and updated `dist` references so precache and entry import use the new `606` version (validated by `tests/service-worker-pwa-cache.test.mjs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c1e4ce84832b8b6dac66d6d12121)