### PR TITLE
Add catalog/orders/edit-requests to manager/finance routes; keep review restricted

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 606;
+const CACHE_VERSION = 607;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DQAzjYv4.js",
+  "./assets/index-B1v3eR2c.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DQAzjYv4.js"></script>
+  <script type="module" crossorigin src="./assets/index-B1v3eR2c.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-Dl2MJDjC.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 606;
+const CACHE_VERSION = 607;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -15,7 +15,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-DQAzjYv4.js",
+  "./assets/index-B1v3eR2c.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1876,11 +1876,11 @@ const SUPABASE_ROLE_ROUTES = {
   admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists'],
   operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
-  finance: ['dashboard', 'activities', 'archive', 'catalog', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
-  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  finance: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates'],
   business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
-  instructor_manager: ['dashboard', 'activities', 'archive', 'catalog', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
+  instructor_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests'],
   instructor: ['my-data', 'week', 'month']
 };
 
@@ -2052,7 +2052,8 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
   const canEditDirect = canDirectManageActivities;
   const canRequestEdit = canDirectManageActivities || canRequestActivities;
   const canReviewRequests = canDirectManageActivities;
-  if (canRequestEdit && !allowedRoutes.includes('edit-requests')) {
+  const canViewEditRequests = canReviewRequests || canRequestEdit || permissionFlagYes(flat.view_edit_requests) || allowedRoutes.includes('edit-requests');
+  if (canViewEditRequests && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
   const hasPersonalReportsAccess = profileCanAccessPersonalReports(profileRow);
@@ -3270,11 +3271,11 @@ export const api = {
         admin: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'yes', view_permissions: 'yes', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         operation_manager: { can_add_activity: 'yes', can_edit_direct: 'yes', can_request_edit: 'yes', can_review_requests: 'yes', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         authorized_user: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' },
-        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes', view_catalog: 'yes', can_access_personal_reports: 'yes' },
-        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', can_access_personal_reports: 'yes' },
+        finance: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', finance_access: 'yes', view_finance: 'yes', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
+        activities_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         domain_manager: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         business_development_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', finance_access: 'no', can_access_personal_reports: 'yes' },
-        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', can_access_personal_reports: 'yes' },
+        instructor_manager: { can_add_activity: 'yes', can_edit_direct: 'no', can_request_edit: 'yes', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', view_catalog: 'yes', view_orders: 'yes', can_access_personal_reports: 'yes' },
         instructor: { can_add_activity: 'no', can_edit_direct: 'no', can_request_edit: 'no', can_review_requests: 'no', view_admin: 'no', view_permissions: 'no', can_access_personal_reports: 'yes' }
       }
     };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 606;
+const CACHE_VERSION = 607;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 606;
+const SW_ENTRY_VERSION = 607;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/navigation-permissions-routes.test.mjs
+++ b/tests/navigation-permissions-routes.test.mjs
@@ -22,17 +22,15 @@ function extractDefaultPermission(src, role) {
   return match[1];
 }
 
-test('catalog is a default route for requested manager and finance roles without adding orders', async () => {
+test('catalog and orders are default routes for requested manager and finance roles', async () => {
   const src = await readApiSource();
 
   for (const role of ['activities_manager', 'instructor_manager', 'finance']) {
     const routes = extractRoleRoutes(src, role);
     assert.match(routes, /'catalog'/, `${role} should see catalog by default`);
+    assert.match(routes, /'orders'/, `${role} should see orders by default`);
+    assert.match(routes, /'edit-requests'/, `${role} should see edit requests for its badge/screen`);
   }
-
-  assert.doesNotMatch(extractRoleRoutes(src, 'activities_manager'), /'orders'/, 'activities_manager should not gain orders by default');
-  assert.doesNotMatch(extractRoleRoutes(src, 'instructor_manager'), /'orders'/, 'instructor_manager should not gain orders by default');
-  assert.doesNotMatch(extractRoleRoutes(src, 'finance'), /'orders'/, 'finance should not gain orders by default');
 });
 
 test('edit requests route is available to request submitters while review remains direct-manager only', async () => {
@@ -43,7 +41,8 @@ test('edit requests route is available to request submitters while review remain
   }
 
   assert.match(src, /const canReviewRequests = canDirectManageActivities;/, 'review permission should stay limited to admin and operation_manager');
-  assert.match(src, /if \(canRequestEdit && !allowedRoutes\.includes\('edit-requests'\)\)/, 'bootstrap should expose edit-requests to users who can request edits');
+  assert.match(src, /const canViewEditRequests = canReviewRequests \|\| canRequestEdit \|\| permissionFlagYes\(flat\.view_edit_requests\) \|\| allowedRoutes\.includes\('edit-requests'\);/, 'bootstrap should distinguish viewing edit requests from approving them');
+  assert.match(src, /if \(canViewEditRequests && !allowedRoutes\.includes\('edit-requests'\)\)/, 'bootstrap should expose edit-requests to users who may view or submit edit requests');
   assert.match(src, /if \(!canReviewEditRequestsUser\(\)\) throw new Error\('forbidden_review_edit_request'\);/, 'review action should keep the server-side non-reviewer guard');
 });
 
@@ -53,6 +52,7 @@ test('default permissions grant catalog but not edit-review to requested roles',
   for (const role of ['activities_manager', 'instructor_manager', 'finance']) {
     const defaults = extractDefaultPermission(src, role);
     assert.match(defaults, /view_catalog: 'yes'/, `${role} should get catalog default permission`);
+    assert.match(defaults, /view_orders: 'yes'/, `${role} should get orders default permission`);
     assert.match(defaults, /can_review_requests: 'no'/, `${role} should not get review permission`);
   }
 });


### PR DESCRIPTION
### Motivation
- Users in `activities_manager`, `instructor_manager` and `finance` were missing `catalog`, `orders` and the `edit-requests` badge/screen after recent changes, and the UI badge/count for edit requests must be visible to them without granting review rights.
- The change must be frontend-only and must not expand approval/rejection privileges which must remain limited to direct managers (`admin`, `operation_manager`).
- The Service Worker cache needs a version bump so clients receive updated frontend assets and do not load stale cached files.

### Description
- Added `catalog`, `orders`, and `edit-requests` to `SUPABASE_ROLE_ROUTES` for the roles `activities_manager`, `instructor_manager`, and `finance` in `frontend/src/api.js` so these routes appear in navigation for those users.
- Updated `buildBootstrapFromUser` in `frontend/src/api.js` to compute `canViewEditRequests` (view/submit badge) separately from `canReviewRequests` (approve/reject), and expose the `edit-requests` route to viewers/submitters while leaving `can_review_requests` tied only to direct-manage roles.
- Kept server-side guard for review actions intact (`reviewEditRequest` still throws `forbidden_review_edit_request` for non-reviewers) and ensured `editRequests` and `editRequestsOpenCount` continue to filter rows for non-reviewers so they only see their own requests.
- Updated role default permissions so `finance`, `activities_manager`, and `instructor_manager` include `view_catalog` and `view_orders` but still have `can_review_requests: 'no'` in `frontend/src/api.js` role defaults.
- Adjusted the focused navigation tests in `tests/navigation-permissions-routes.test.mjs` to assert the new routes and the new `canViewEditRequests` condition.
- Bumped Service Worker cache/version from `606` to `607` in `frontend/sw.js` and `sw.js` and updated the built `dist` entries so browsers will fetch fresh assets after deploy.

### Testing
- Ran focused checks with `npm run check:changed` and `node --check` on changed files; checks completed successfully.
- Ran focused tests: `node --test tests/navigation-permissions-routes.test.mjs` — passed (3 tests).
- Ran edit-requests related tests: `node --test tests/edit-requests-feedback-regression.test.mjs` and `node --test tests/edit-requests-screen.test.mjs` — both passed (all assertions in those files passed).
- Attempted `node --test tests/edit-requests-flow.test.mjs`; some subtests failed in this CI environment due to `sessionStorage is not defined` (test environment limitation), not because of the permission logic change; this prevented a full run of that legacy flow test here.
- Ran `npm run check:build` (`vite build` + postbuild) — build succeeded and `dist` updated; verified SW version bump with `rg -n "CACHE_VERSION =|SW_ENTRY_VERSION =" frontend/sw.js sw.js dist/frontend/sw.js dist/sw.js` which shows the version changed to `607`.
- Summary: focused permission/navigation tests and build succeeded; one legacy flow test requires a browser-like environment (sessionStorage) to run fully and failed here due to environment limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25caefd62c832b9344585bb74ae03f)