### PR TITLE
feat: ניהול איסראא — simulator redesign, collab calc, date/commission columns, prog table expand

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DQ8Y7zxp.js"></script>
+  <script type="module" crossorigin src="./assets/index-CeuHB_Pm.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-B6EnAemo.css">
 </head>
 <body>

--- a/frontend/src/screens/israa-management.js
+++ b/frontend/src/screens/israa-management.js
@@ -245,25 +245,33 @@ function simGoalOptionsHtml(calc, collab) {
 }
 
 function simRowHtml(row, editingId, editData) {
-  const ed     = row.id === editingId;
-  const payerV = ed ? escapeHtml(String(editData.payer_name ?? row.payer_name ?? '')) : escapeHtml(String(row.payer_name ?? ''));
-  const amtRaw = ed ? (editData.amount ?? row.amount ?? '') : (row.amount ?? '');
+  const ed      = row.id === editingId;
+  const dateRaw = ed ? (editData.revenue_date ?? row.revenue_date ?? '') : (row.revenue_date ?? '');
+  const payerV  = ed ? escapeHtml(String(editData.payer_name ?? row.payer_name ?? '')) : escapeHtml(String(row.payer_name ?? ''));
+  const amtRaw  = ed ? (editData.amount ?? row.amount ?? '') : (row.amount ?? '');
+  const comm    = Number(amtRaw) > 0 ? Number(amtRaw) * 0.1 : null;
+  const dateCell  = ed
+    ? `<td class="israa-cell sim-cell--date"><input class="israa-inp" name="revenue_date" type="date" value="${escapeHtml(String(dateRaw))}" /></td>`
+    : `<td class="israa-cell sim-cell--date">${escapeHtml(fmtDate(dateRaw))}</td>`;
   const payerCell = ed
     ? `<td class="israa-cell"><input class="israa-inp" name="payer_name" type="text" value="${payerV}" /></td>`
     : `<td class="israa-cell">${payerV}</td>`;
-  const amtCell = ed
+  const amtCell   = ed
     ? `<td class="israa-cell sim-cell--amt"><input class="israa-inp sim-inp--amt" name="amount" type="number" min="0" step="1" value="${escapeHtml(String(amtRaw))}" /></td>`
-    : `<td class="israa-cell sim-cell--amt">${amtRaw !== '' && amtRaw != null ? escapeHtml(fmtIls(amtRaw)) : ''}</td>`;
-  const actions = ed
+    : `<td class="israa-cell sim-cell--amt">${amtRaw !== '' && amtRaw != null ? fmtIls(amtRaw) : ''}</td>`;
+  const commCell  = `<td class="israa-cell sim-cell--comm">${comm != null ? fmtIls(comm) : ''}</td>`;
+  const actions   = ed
     ? `<td class="israa-cell israa-cell--actions"><button class="israa-btn israa-btn--save" data-sim-save="${escapeHtml(row.id)}" title="שמירה">💾</button> <button class="israa-btn israa-btn--cancel" data-sim-cancel="${escapeHtml(row.id)}" title="ביטול">✕</button></td>`
     : `<td class="israa-cell israa-cell--actions"><button class="israa-btn israa-btn--edit" data-sim-edit="${escapeHtml(row.id)}" title="עריכה">✏️</button> <button class="israa-btn israa-btn--del" data-sim-del="${escapeHtml(row.id)}" title="מחיקה">🗑️</button></td>`;
-  return `<tr class="israa-row${ed ? ' israa-row--editing' : ''}" data-sim-row-id="${escapeHtml(row.id)}">${payerCell}${amtCell}${actions}</tr>`;
+  return `<tr class="israa-row${ed ? ' israa-row--editing' : ''}" data-sim-row-id="${escapeHtml(row.id)}">${dateCell}${payerCell}${amtCell}${commCell}${actions}</tr>`;
 }
 
 function simNewRowHtml(newData) {
   return `<tr class="israa-row israa-row--new">
+    <td class="israa-cell sim-cell--date"><input class="israa-inp" name="revenue_date" type="date" value="${escapeHtml(String(newData.revenue_date ?? ''))}" /></td>
     <td class="israa-cell"><input class="israa-inp" name="payer_name" type="text" value="${escapeHtml(String(newData.payer_name ?? ''))}" placeholder="גורם משלם" /></td>
     <td class="israa-cell sim-cell--amt"><input class="israa-inp sim-inp--amt" name="amount" type="number" min="0" step="1" value="${escapeHtml(String(newData.amount ?? ''))}" placeholder="0" /></td>
+    <td class="israa-cell sim-cell--comm"></td>
     <td class="israa-cell israa-cell--actions"><button class="israa-btn israa-btn--save" data-sim-save-new title="שמירה">💾</button> <button class="israa-btn israa-btn--cancel" data-sim-cancel-new title="ביטול">✕</button></td>
   </tr>`;
 }
@@ -272,7 +280,7 @@ function simPanelHtml(rows, editingId, editData, addingNew, newData, error, load
   if (loading) return `<div class="sim-loading">טוען נתוני סימולטור…</div>`;
   const calc = simCalc(rows, collab);
   const body = [
-    !rows.length && !addingNew ? `<tr><td colspan="3" class="israa-empty">אין הכנסות. לחצי "+ הוספת הכנסה" להתחיל.</td></tr>` : '',
+    !rows.length && !addingNew ? `<tr><td colspan="5" class="israa-empty">אין הכנסות. לחצי "+ הוספת הכנסה" להתחיל.</td></tr>` : '',
     rows.map((r) => simRowHtml(r, editingId, editData)).join(''),
     addingNew ? simNewRowHtml(newData) : ''
   ].join('');
@@ -287,7 +295,13 @@ function simPanelHtml(rows, editingId, editData, addingNew, newData, error, load
     ${error ? `<div class="israa-error">${escapeHtml(error)}</div>` : ''}
     <div class="israa-table-wrap">
       <table class="israa-table sim-table" dir="rtl">
-        <thead><tr><th class="israa-th">גורם משלם</th><th class="israa-th sim-th--amt">סכום (₪)</th><th class="israa-th israa-th--actions">פעולות</th></tr></thead>
+        <thead><tr>
+          <th class="israa-th sim-th--date">תאריך</th>
+          <th class="israa-th">גורם משלם</th>
+          <th class="israa-th sim-th--amt">סכום (₪)</th>
+          <th class="israa-th sim-th--comm">עמלות (₪)</th>
+          <th class="israa-th israa-th--actions">פעולות</th>
+        </tr></thead>
         <tbody>${body}</tbody>
       </table>
     </div>
@@ -346,10 +360,12 @@ function collectProgForm(mainTr) {
 }
 
 function collectSimForm(tr) {
-  const amtVal = tr.querySelector('[name="amount"]')?.value ?? '';
+  const amtVal  = tr.querySelector('[name="amount"]')?.value ?? '';
+  const dateVal = tr.querySelector('[name="revenue_date"]')?.value ?? '';
   return {
-    payer_name: tr.querySelector('[name="payer_name"]')?.value ?? '',
-    amount: amtVal === '' ? null : parseFloat(amtVal)
+    revenue_date: dateVal || null,
+    payer_name:   tr.querySelector('[name="payer_name"]')?.value ?? '',
+    amount:       amtVal === '' ? null : parseFloat(amtVal)
   };
 }
 
@@ -410,12 +426,16 @@ const ISRAA_CSS = `<style data-israa-styles>
 .sim-goal-opts__ils{font-size:13px}
 .sim-goal-opts__result{font-size:14px;color:var(--ds-text,#1e293b);line-height:1.8}
 .sim-table-section{margin-top:4px}
-.sim-table-section .israa-table-wrap{max-width:55%;margin-right:0}
-@media (max-width:700px){.sim-table-section .israa-table-wrap{max-width:100%}}
-.sim-table{table-layout:auto}
-.sim-th--amt{width:130px;text-align:left}
-.sim-cell--amt{text-align:left;font-variant-numeric:tabular-nums}
-.sim-inp--amt{text-align:left}
+.sim-table-section .israa-table-wrap{width:fit-content;min-width:300px;max-width:100%}
+@media (max-width:700px){.sim-table-section .israa-table-wrap{width:100%}}
+.sim-table{table-layout:auto;width:auto}
+.sim-th--date{width:90px;text-align:right}
+.sim-th--amt{width:110px;text-align:right}
+.sim-th--comm{width:100px;text-align:right}
+.sim-cell--date{text-align:right;white-space:nowrap}
+.sim-cell--amt{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+.sim-cell--comm{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap;color:var(--ds-text-secondary,#64748b)}
+.sim-inp--amt{text-align:left;direction:ltr}
 .prog-section{max-width:80%}
 @media (max-width:768px){.prog-section{max-width:100%}}
 .prog-section .israa-table-wrap{background:#fff;box-shadow:0 2px 8px rgba(26,51,88,.07)}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 613;
+const CACHE_VERSION = 614;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260612c_add_revenue_date.sql
+++ b/supabase/migrations/20260612c_add_revenue_date.sql
@@ -1,0 +1,2 @@
+alter table public.israa_revenue_simulator_entries
+  add column if not exists revenue_date date;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 613;
+const SW_ENTRY_VERSION = 614;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary

- **Simulator cards**: compact centered cards (max-width 200px), larger label font
- **Collaboration input**: replaces avg-price field with "סה"כ שיתופי פעולה" — added to goal calc (income rows + collab vs. target); 70% to courses ÷ 9,000 / 30% to workshops ÷ 500 goal lines shown
- **Income table**: added `revenue_date` (optional date, stored in DB) and `commission` (10% of amount, frontend-only, read-only) columns; table width is `fit-content`; amounts formatted as `50,000 ₪`
- **Program table**: 80% max-width, white card with shadow, contact fields (איש קשר / טלפון / אימייל) hidden in expandable detail row — click row to open/close
- **SQL migration**: `add column if not exists revenue_date date` on `israa_revenue_simulator_entries`
- **Service Worker**: bumped 611 → 614 to invalidate stale caches

## Security

- Access restricted to Israa (user_id `3030` / auth_user_id `92bfb9d9-…`) and admin only
- Commission is **never stored** — computed locally in `simRowHtml`

## Test plan

- [ ] Switch to Simulator tab → cards appear compact and centered
- [ ] Enter a collab amount → goal lines update live, cards update on blur
- [ ] Add an income row with a date → date saved, commission shown as 10%
- [ ] Export CSV includes date and commission columns
- [ ] Click a program table row → contact detail row expands/collapses
- [ ] Edit a program row → contact fields editable in detail row, save persists all fields
- [ ] Reload page → SW 614 picked up, old cache cleared

https://claude.ai/code/session_018nTWiV59fpxpa8HFdchNjm

---
_Generated by [Claude Code](https://claude.ai/code/session_018nTWiV59fpxpa8HFdchNjm)_