### PR TITLE
Simplify permissions screen: remove filters, KPIs, and styling

### DIFF
--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './shared/html.js';
 import { hebrewPermissionField, hebrewRole, translateApiErrorForUser, hebrewColumn } from './shared/ui-hebrew.js';
-import { dsPageHeader, dsCard, dsScreenStack, dsEmptyState, dsStatusChip, dsKpiGrid } from './shared/layout.js';
+import { dsPageHeader, dsScreenStack, dsEmptyState, dsStatusChip } from './shared/layout.js';
 import { showToast } from './shared/toast.js';
 import { showConfirmModal } from './shared/interactions.js';
 
@@ -103,12 +103,6 @@ function sortedPermissionEditorKeys(row) {
   return keys;
 }
 
-function roleChipKind(role) {
-  if (role === 'admin') return 'danger';
-  if (role === 'operation_manager') return 'warning';
-  return 'neutral';
-}
-
 function buildPermFlagGrid(row, keys) {
   const allFlags = keys.filter((k) => k.startsWith('view_') || k.startsWith('can_'));
   if (allFlags.length === 0) return '';
@@ -122,32 +116,6 @@ function buildPermFlagGrid(row, keys) {
   }).join('');
 
   return `<div class="ds-perm-flag-grid">${chips}</div>`;
-}
-
-
-function resolveEmployeeNumber(row) {
-  const source = row && typeof row === 'object' ? row : {};
-  const preferredKeys = [
-    'entry_code',
-    'employee_number',
-    'employeeNumber',
-    'employee_id',
-    'employeeId',
-    'worker_number',
-    'payroll_number',
-    'payrollNumber',
-    'ms',
-    'id'
-  ];
-
-  for (const key of preferredKeys) {
-    if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
-    const value = source[key];
-    if (value == null) continue;
-    const text = String(value).trim();
-    if (text) return text;
-  }
-  return '—';
 }
 
 function buildAddUserDrawerHtml(roleDefaults) {
@@ -247,16 +215,16 @@ function buildEditDrawerHtml(row) {
   </div>`;
 }
 
+const TRASH_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/><path d="M9 6V4h6v2"/></svg>`;
+
 function renderUserRow(row, canEdit, isAdmin, currentUserId, adminCount) {
   const uid = escapeHtml(row.user_id);
   const code = permRowRoleCode(row);
   const label = permRowRoleLabel(row);
-  const searchHay = [row.full_name, row.user_id, code, label, row.display_role2].filter(Boolean).join(' ');
-  const roleKey = code;
   const isActive = String(row.active || '').toLowerCase() === 'yes';
   const activeLabel = isActive ? 'פעיל/ה' : 'לא פעיל/ה';
-  const activeKind = isActive ? 'success' : 'neutral';
   const isSelf = String(row.user_id) === String(currentUserId);
+  const employeeCode = row.user_id ? escapeHtml(String(row.user_id)) : '—';
 
   const editBtn = canEdit
     ? `<button type="button" class="ds-btn ds-btn--sm" data-edit-perm data-user-id="${uid}" title="עריכת הרשאות">עריכה</button>`
@@ -271,17 +239,17 @@ function renderUserRow(row, canEdit, isAdmin, currentUserId, adminCount) {
   const isLastAdmin = adminCount === 1 && permRowRoleCode(row) === 'admin';
   const deleteBtn = isAdmin && !isActive
     ? isLastAdmin
-      ? `<button type="button" class="ds-btn ds-btn--sm ds-btn--danger" disabled title="לא ניתן למחוק את מנהל המערכת האחרון">מחק</button>`
-      : `<button type="button" class="ds-btn ds-btn--sm ds-btn--danger" data-delete-user data-user-id="${uid}">מחק</button>`
+      ? `<button type="button" class="ds-perm-delete-btn" disabled title="לא ניתן למחוק את מנהל המערכת האחרון" aria-label="לא ניתן למחוק">${TRASH_ICON}</button>`
+      : `<button type="button" class="ds-perm-delete-btn" data-delete-user data-user-id="${uid}" title="מחיקת משתמש" aria-label="מחיקת משתמש">${TRASH_ICON}</button>`
     : '';
 
   const actionBtns = [editBtn, permissionsBtn, deactivateBtn, reactivateBtn, deleteBtn].filter(Boolean).join(' ');
 
-  return `<tr class="ds-perm-row" data-perm-user="${uid}" data-list-item data-search="${escapeHtml(searchHay)}" data-filter="${escapeHtml(roleKey)}" data-status-filter="${isActive ? 'yes' : 'no'}">
+  return `<tr class="ds-perm-row" data-perm-user="${uid}">
     <td style="font-weight:600;">${escapeHtml(row.full_name || uid)}</td>
-    <td class="ds-muted" style="font-size:0.75rem;">${escapeHtml(resolveEmployeeNumber(row))}</td>
-    <td>${dsStatusChip(label, roleChipKind(code))}</td>
-    <td>${dsStatusChip(activeLabel, activeKind)}</td>
+    <td class="ds-muted">${employeeCode}</td>
+    <td>${escapeHtml(label)}</td>
+    <td>${escapeHtml(activeLabel)}</td>
     <td><div style="display:flex;gap:4px;flex-wrap:wrap;justify-content:flex-end;">${actionBtns}</div></td>
   </tr>`;
 }
@@ -338,154 +306,27 @@ export const permissionsScreen = {
       state?.user?.display_role === 'admin' || state?.user?.display_role === 'operation_manager';
     const isAdmin = state?.user?.display_role === 'admin';
     const safeRows = Array.isArray(data?.rows) ? data.rows : [];
-
-    const activeCount = safeRows.filter((r) => String(r.active || '').toLowerCase() === 'yes').length;
     const adminCount = safeRows.filter((r) => permRowRoleCode(r) === 'admin').length;
-    const reviewerCount = safeRows.filter((r) => permRowRoleCode(r) === 'operation_manager').length;
-    const authorizedCount = safeRows.filter((r) => permRowRoleCode(r) === 'authorized_user').length;
-    const instructorCount = safeRows.filter((r) => permRowRoleCode(r) === 'instructor').length;
-
-    const kpis = [
-      { label: 'סה"כ משתמשים', value: String(safeRows.length) },
-      { label: 'פעילים', value: String(activeCount) },
-      { label: 'מנהלים', value: String(adminCount) },
-      { label: 'בקרי תפעול', value: String(reviewerCount) },
-      ...(authorizedCount > 0 ? [{ label: 'משתמשים מורשים', value: String(authorizedCount) }] : []),
-      ...(instructorCount > 0 ? [{ label: 'מדריכים', value: String(instructorCount) }] : [])
-    ];
 
     const rowPairs = safeRows.map((row) => renderUserRow(row, canEdit, isAdmin, state?.user?.user_id, adminCount)).join('');
 
-    const body =
+    const tableHtml =
       safeRows.length === 0
         ? dsEmptyState('לא נמצאו שורות הרשאה')
-        : `<div class="ds-table-wrap" dir="rtl"><table class="ds-table ds-perm-table">
-            <thead><tr><th>שם</th><th>מספר עובד</th><th>תפקיד</th><th>סטטוס</th><th style="text-align:start;">פעולות</th></tr></thead>
+        : `<div class="ds-table-wrap ds-perm-table-wrap" dir="rtl"><table class="ds-table ds-perm-table">
+            <thead><tr><th>שם</th><th>קוד עובד</th><th>תפקיד</th><th>סטטוס</th><th style="text-align:start;">פעולות</th></tr></thead>
             <tbody>${rowPairs}</tbody>
           </table></div>`;
 
-    const roleFilters = [...new Set(safeRows.map((r) => permRowRoleCode(r)).filter(Boolean))].map((r) => ({
-      value: r,
-      label: hebrewRole(r)
-    }));
-
-    const statusFilters = [
-      { value: 'yes', label: 'פעיל/ה' },
-      { value: 'no', label: 'לא פעיל/ה' }
-    ];
-
-    const toolsBar = safeRows.length
-      ? `<div class="ds-perm-tools" role="search" aria-label="חיפוש וסינון משתמשים">
-          <input type="search" class="ds-input ds-input--sm ds-perm-tools__q" data-page-q placeholder="חיפוש משתמש…" aria-label="חיפוש משתמש" />
-          <select class="ds-input ds-input--sm ds-perm-tools__select" data-page-role-filter aria-label="סינון לפי תפקיד">
-            <option value="">כל התפקידים</option>
-            ${roleFilters.map((f) => `<option value="${escapeHtml(String(f.value))}">${escapeHtml(f.label)}</option>`).join('')}
-          </select>
-          <select class="ds-input ds-input--sm ds-perm-tools__select" data-page-status-filter aria-label="סינון לפי סטטוס">
-            <option value="">כל הסטטוסים</option>
-            ${statusFilters.map((f) => `<option value="${f.value}">${f.label}</option>`).join('')}
-          </select>
-          ${isAdmin ? '<button type="button" class="ds-btn ds-btn--primary ds-btn--sm" data-add-user>הוסף משתמש</button>' : ''}
-        </div>`
-      : '';
-
     return dsScreenStack(`
       <section class="ds-perm-screen">
-        ${dsPageHeader('הרשאות', '')}
-        ${safeRows.length ? dsKpiGrid(kpis) : ''}
-        ${toolsBar}
-        ${dsCard({
-        title: 'משתמשים והרשאות',
-        badge: `${safeRows.length} משתמשים`,
-        body,
-        padded: safeRows.length === 0
-      })}
+        ${dsPageHeader('משתמשים והרשאות', '')}
+        ${tableHtml}
       </section>
     `);
   },
   bind({ root, data, api, ui, rerender, clearScreenDataCache }) {
     const safeRows = Array.isArray(data?.rows) ? data.rows : [];
-
-    const searchInput = root.querySelector('[data-page-q]');
-    const roleFilter = root.querySelector('[data-page-role-filter]');
-    const statusFilter = root.querySelector('[data-page-status-filter]');
-    const listRows = Array.from(root.querySelectorAll('[data-list-item]'));
-    let searchTimer = null;
-    const applyFilters = () => {
-      const q = String(searchInput?.value || '').trim().toLowerCase();
-      const role = String(roleFilter?.value || '').trim();
-      const status = String(statusFilter?.value || '').trim();
-      listRows.forEach((el) => {
-        const hay = String(el.getAttribute('data-search') || '').toLowerCase();
-        const rowRole = String(el.getAttribute('data-filter') || '').trim();
-        const rowStatus = String(el.getAttribute('data-status-filter') || '').trim();
-        const okQ = !q || hay.includes(q);
-        const okRole = !role || rowRole === role;
-        const okStatus = !status || rowStatus === status;
-        el.toggleAttribute('hidden', !(okQ && okRole && okStatus));
-      });
-    };
-    searchInput?.addEventListener('input', () => {
-      clearTimeout(searchTimer);
-      searchTimer = setTimeout(applyFilters, 120);
-    });
-    roleFilter?.addEventListener('change', applyFilters);
-    statusFilter?.addEventListener('change', applyFilters);
-    const addUserBtn = root.querySelector('[data-add-user]');
-    if (addUserBtn && ui) {
-      addUserBtn.addEventListener('click', () => {
-        ui.openDrawer({
-          title: 'הוסף משתמש חדש',
-          content: buildAddUserDrawerHtml(data?.roleDefaults),
-          onOpen: (contentNode) => {
-            const statusEl = contentNode.querySelector('.ds-perm-save-status');
-            const submitBtn = contentNode.querySelector('[data-add-user-submit]');
-            const roleSelect = contentNode.querySelector('#new-display-role');
-            const previewEl = contentNode.querySelector('[data-role-preview]');
-
-            if (roleSelect && previewEl) {
-              roleSelect.addEventListener('change', () => {
-                previewEl.innerHTML = buildRolePreviewHtml(roleSelect.value, data?.roleDefaults);
-              });
-            }
-
-            if (!submitBtn) return;
-
-            submitBtn.addEventListener('click', async () => {
-              const user_id = contentNode.querySelector('#new-user-id')?.value.trim();
-              const full_name = contentNode.querySelector('#new-full-name')?.value.trim();
-              const entry_code = contentNode.querySelector('#new-entry-code')?.value.trim();
-              const display_role = contentNode.querySelector('#new-display-role')?.value;
-
-              if (!user_id) {
-                if (statusEl) statusEl.textContent = 'יש להזין מזהה משתמש';
-                return;
-              }
-
-              submitBtn.classList.add('is-loading');
-              if (statusEl) statusEl.textContent = '';
-              try {
-                await api.addUser({ user_id, full_name, entry_code, role: display_role });
-                if (statusEl) statusEl.textContent = 'המשתמש נוצר בהצלחה';
-                clearScreenDataCache?.();
-                if (typeof rerender === 'function') await rerender();
-                try {
-                  const freshData = await api.permissions();
-                  const newRow = (freshData?.rows || []).find((r) => String(r.user_id) === String(user_id));
-                  if (newRow) openEditModal(newRow);
-                } catch (autoOpenErr) {
-                  console.warn('[permissions] Could not auto-open edit drawer after user creation:', autoOpenErr);
-                }
-              } catch (error) {
-                if (statusEl) statusEl.textContent = translateApiErrorForUser(error?.message);
-              } finally {
-                submitBtn.classList.remove('is-loading');
-              }
-            });
-          }
-        });
-      });
-    }
 
     root.querySelectorAll('[data-deactivate-user]').forEach((btn) => {
       btn.addEventListener('click', (e) => {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10450,68 +10450,26 @@ select.ds-input {
   }
 }
 
-/* Permissions page compact alignment (content area only) */
+/* Permissions page – compact table, 70% width, no filters */
 .ds-perm-screen .ds-page-header {
-  margin-bottom: var(--ds-space-2);
+  margin-bottom: var(--ds-space-3);
 }
 
-.ds-perm-screen .ds-kpi-grid {
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 8px;
-  margin-bottom: var(--ds-space-2);
-}
-
-.ds-perm-screen .ds-kpi {
-  min-height: 86px;
-  height: 100%;
-}
-
-.ds-perm-screen .ds-perm-tools {
-  margin-bottom: var(--ds-space-2);
-  gap: 8px;
-  flex-wrap: nowrap;
-}
-
-.ds-perm-screen .ds-perm-tools__q,
-.ds-perm-screen .ds-perm-tools__select,
-.ds-perm-screen .ds-perm-tools .ds-btn {
-  min-height: 34px;
-  height: 34px;
-}
-
-.ds-perm-screen .ds-perm-tools__q {
-  flex: 1 1 260px;
-  min-width: 280px;
-  max-width: 360px;
-  order: 1;
-}
-
-.ds-perm-screen .ds-perm-tools__select {
-  flex: 0 0 152px;
-  min-width: 152px;
-}
-
-.ds-perm-screen .ds-perm-tools__select[data-page-role-filter] { order: 2; }
-.ds-perm-screen .ds-perm-tools__select[data-page-status-filter] { order: 3; }
-.ds-perm-screen .ds-perm-tools .ds-btn[data-add-user] { order: 4; }
-
-.ds-perm-screen .ds-card {
-  margin-top: 0;
-}
-
-.ds-perm-screen .ds-card__head {
-  padding-block: 10px;
+.ds-perm-table-wrap {
+  width: 70%;
+  margin-inline: auto;
 }
 
 .ds-perm-screen .ds-perm-table th,
 .ds-perm-screen .ds-perm-table td {
-  padding: 3px 8px;
-  line-height: 1.2;
+  padding: 2px 6px;
+  line-height: 1.15;
   vertical-align: middle;
+  white-space: nowrap;
 }
 
 .ds-perm-screen .ds-perm-table td {
-  height: 34px;
+  height: 30px;
 }
 
 .ds-perm-screen .ds-perm-table td .ds-btn {
@@ -10519,29 +10477,43 @@ select.ds-input {
   padding: 1px 8px;
 }
 
-@media (max-width: 1200px) {
-  .ds-perm-screen .ds-kpi-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+/* Trash icon delete button */
+.ds-perm-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--ds-radius-sm, 4px);
+  background: transparent;
+  color: #ef4444;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: background 0.15s, opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.ds-perm-delete-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  opacity: 1;
+}
+
+.ds-perm-delete-btn:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1100px) {
+  .ds-perm-table-wrap {
+    width: 90%;
   }
 }
 
-@media (max-width: 900px) {
-  .ds-perm-screen .ds-perm-tools {
-    flex-wrap: wrap;
-  }
-
-  .ds-perm-screen .ds-perm-tools__q,
-  .ds-perm-screen .ds-perm-tools__select,
-  .ds-perm-screen .ds-perm-tools .ds-btn {
-    flex: 1 1 100%;
-    min-width: 100%;
-    max-width: 320px;
-    height: auto;
-    min-height: 34px;
-  }
-
-  .ds-perm-screen .ds-kpi-grid {
-    grid-template-columns: repeat(2, minmax(280px, 320px));
+@media (max-width: 700px) {
+  .ds-perm-table-wrap {
+    width: 100%;
   }
 }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 614;
+const CACHE_VERSION = 615;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 614;
+const SW_ENTRY_VERSION = 615;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR significantly simplifies the permissions management screen by removing search/filter functionality, KPI metrics display, and associated styling. The table is now presented in a cleaner, more compact format centered at 70% width.

## Key Changes

- **Removed filtering system**: Eliminated search input and role/status filter dropdowns that were previously used to filter the user list
- **Removed KPI grid**: Deleted the metrics display showing total users, active count, admins, reviewers, etc.
- **Removed helper functions**: Deleted `roleChipKind()` and `resolveEmployeeNumber()` functions that are no longer needed
- **Simplified table rendering**: 
  - Removed data attributes used for filtering (`data-list-item`, `data-search`, `data-filter`, `data-status-filter`)
  - Changed employee number display from resolved value to simple `user_id` with fallback to "—"
  - Replaced styled status chips with plain escaped text for role and active status
- **Updated delete button styling**: Changed from text button to icon-only trash button with hover effects
- **Simplified page layout**: Removed card wrapper and tools bar; table now displays directly with centered 70% width
- **Updated column header**: Changed "מספר עובד" (employee number) to "קוד עובד" (employee code)
- **Removed add user functionality**: Deleted the "Add User" button and associated drawer logic from the bind function
- **Updated CSS**: Removed KPI grid styling, filter tools styling, and card styling; added new trash icon button styles and responsive table width adjustments

## Implementation Details

- The table now uses a simpler, more compact layout with reduced padding and line-height
- Delete button is now a 26×26px icon-only button with red color and hover effects
- Table width is responsive: 70% on desktop, 90% on tablets, 100% on mobile
- Removed approximately 150 lines of filtering and KPI-related code
- Cache version bumped to 615 to invalidate old service worker cache

https://claude.ai/code/session_01FiPBab5jDnpZFbB4uAzZA7