### PR TITLE
Adjust certificate logo positioning and sizing

### DIFF
--- a/frontend/src/screens/certificates.js
+++ b/frontend/src/screens/certificates.js
@@ -201,10 +201,10 @@ html,body{background:#e5e7eb;font-family:Arial,sans-serif;direction:rtl}
   object-fit:fill;
   display:block;
 }
-/* Logo overlay — transparent, centered, top ~8% inside the certificate */
+/* Logo overlay — transparent, centered, top ~5% inside the certificate */
 .cert-print-logo-bar{
   position:absolute;
-  top:8%;
+  top:5%;
   left:50%;
   transform:translateX(-50%);
   z-index:10;
@@ -216,7 +216,7 @@ html,body{background:#e5e7eb;font-family:Arial,sans-serif;direction:rtl}
   padding:0;
   white-space:nowrap;
 }
-.pl{height:14mm;max-width:35mm;object-fit:contain;display:block;flex-shrink:0}
+.pl{max-height:11mm;height:auto;max-width:28mm;width:auto;object-fit:contain;display:block;flex-shrink:0}
 </style>
 </head>
 <body>
@@ -344,10 +344,10 @@ function ensureStyles() {
 .cert-preview-viewer{display:flex;flex-direction:column;align-items:center;width:100%;max-width:460px}
 .cert-preview-iframe-wrap{position:relative;width:100%;aspect-ratio:210/297;background:#f1f5f9;flex-shrink:0;border-radius:4px;overflow:hidden}
 .cert-preview-iframe-wrap iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:none;display:block}
-/* ─ Logo overlay — transparent, centered, top ~8% inside the certificate ─ */
+/* ─ Logo overlay — transparent, centered, top ~5% inside the certificate ─ */
 .cert-preview-logo-strip{
   position:absolute;
-  top:8%;
+  top:5%;
   left:50%;
   transform:translateX(-50%);
   z-index:10;
@@ -361,7 +361,7 @@ function ensureStyles() {
   pointer-events:none;
 }
 .cert-preview-logo-strip--empty{display:none}
-.cert-strip-logo{height:5%;max-width:22%;object-fit:contain;display:block;flex-shrink:0}
+.cert-strip-logo{max-height:36px;height:auto;max-width:80px;width:auto;object-fit:contain;display:block;flex-shrink:0}
 @media print{
   body>*{display:none!important}
 }`;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 632;
+const CACHE_VERSION = 633;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 617;
+const SW_ENTRY_VERSION = 618;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR adjusts the positioning and sizing of logos in certificate templates to improve visual layout and consistency across both print and preview views.

## Key Changes
- **Logo positioning**: Moved logo overlay from 8% to 5% from the top of certificates in both print and preview styles
- **Print logo sizing**: Updated `.pl` class from fixed `height:14mm` to flexible `max-height:11mm;height:auto` with adjusted max-width from `35mm` to `28mm`
- **Preview logo sizing**: Changed `.cert-strip-logo` class from percentage-based sizing (`height:5%;max-width:22%`) to fixed pixel dimensions (`max-height:36px;max-width:80px`) with auto height/width for better responsiveness
- **Cache version bumps**: Incremented `CACHE_VERSION` in `frontend/sw.js` from 632 to 633 and `SW_ENTRY_VERSION` in `sw.js` from 617 to 618 to invalidate cached assets

## Implementation Details
The logo sizing changes use `object-fit:contain` to maintain aspect ratio while fitting within the new constraints. The shift from percentage-based to fixed pixel dimensions in the preview provides more predictable sizing across different viewport widths, while the print version uses millimeter units for precise physical output.

https://claude.ai/code/session_01MUg5WdYkd4E7YmWfXQvoW3