### PR TITLE
PDF header: enlarge logo and left-align logo+date

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11282,15 +11282,15 @@ select.ds-input {
 .proposal-header-left {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 .proposal-logo {
-  width: 280px;
-  max-width: 42%;
+  width: 320px;
+  max-width: 46%;
   height: auto;
   object-fit: contain;
   display: block;
-  margin-left: -6px;
+  margin-left: 0;
 }
 .proposal-document-body {
   flex: 1 1 auto;
@@ -11336,7 +11336,7 @@ select.ds-input {
   white-space: nowrap;
 }
 .pa-doc-date {
-  text-align: center;
+  text-align: left;
   direction: ltr;
   font-size: 7.5pt;
   color: #374151;
@@ -11593,14 +11593,15 @@ select.ds-input {
   .proposal-header-left {
     display: flex !important;
     flex-direction: column !important;
-    align-items: center !important;
+    align-items: flex-start !important;
   }
   .proposal-logo {
-    width: 260px !important;
-    max-width: 42% !important;
+    width: 300px !important;
+    max-width: 46% !important;
     height: auto !important;
     object-fit: contain !important;
     display: block !important;
+    margin-left: 0 !important;
   }
 
   /* Footer — normal flow (same as screen) */

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 640;
+const CACHE_VERSION = 641;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 625;
+const SW_ENTRY_VERSION = 626;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
- proposal-logo: 280→320px (screen), 260→300px (print), max-width 42→46%
- proposal-header-left: align-items center→flex-start (screen + print)
- pa-doc-date: text-align center→left so date sits flush left under logo
- Remove stray margin-left: -6px offset from logo
- SW cache bump: CACHE_VERSION 640→641, SW_ENTRY_VERSION 625→626

https://claude.ai/code/session_01CiSNYSePBeJvehtbn7qnnS