### PR TITLE
enrich bundle child display with activity_no, unit_price; bump SW 630…

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CgJigUl-.js"></script>
+  <script type="module" crossorigin src="./assets/index-Bb8LlEBh.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-D6CUDewa.css">
 </head>
 <body>

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -652,20 +652,28 @@ function itemsSummaryHtml(items = []) {
   const rows = visibleSummaryItems.map((item) => {
     const t = Number(item.total_price) || ((Number(item.quantity) || 1) * (Number(item.unit_price) || 0));
     const bundleItems = Array.isArray(item.selected_bundle_items) ? item.selected_bundle_items : [];
-    const bundleNames = bundleItems.map((bi) => typeof bi === 'object' ? text(bi.activity_name) : text(bi)).filter(Boolean);
-    const bundleStr = bundleNames.length ? bundleNames.join(', ') : '';
+    const bundleLinesList = bundleItems.map((bi) => {
+      if (typeof bi === 'object') {
+        const parts = [text(bi.activity_no), text(bi.activity_name)].filter(Boolean);
+        if (bi.unit_price != null && bi.unit_price !== '') parts.push(`₪${formatCurrency(Number(bi.unit_price))}`);
+        return parts.join(' — ');
+      }
+      return text(bi);
+    }).filter(Boolean);
     const details = [
       text(item.activity_no) ? `מס׳ פעילות: ${text(item.activity_no)}` : '',
       text(item.gefen_number) ? `גפ״ן: ${text(item.gefen_number)}` : '',
       text(item.meetings_count) ? `מפגשים: ${text(item.meetings_count)}` : '',
       text(item.hours_count) ? `שעות: ${text(item.hours_count)}` : '',
       text(item.unit_duration) ? `משך: ${text(item.unit_duration)}` : '',
-      bundleStr ? `פירוט: ${bundleStr}` : '',
       text(item.proposal_group) ? `קבוצה: ${text(item.proposal_group)}` : '',
-      !bundleStr ? text(item.description) : ''
+      !bundleLinesList.length ? text(item.description) : ''
     ].filter(Boolean).join(' | ');
+    const bundleDetailHtml = bundleLinesList.length
+      ? `<ul style="margin:2px 0 0;padding-right:14px;font-size:0.71rem">${bundleLinesList.map((l) => `<li>${escapeHtml(l)}</li>`).join('')}</ul>`
+      : '';
     return `<tr>
-      <td>${escapeHtml(item.item_name || '')}${details ? `<div class="ds-muted" style="font-size:0.72rem">${escapeHtml(details)}</div>` : ''}</td>
+      <td>${escapeHtml(item.item_name || '')}${details ? `<div class="ds-muted" style="font-size:0.72rem">${escapeHtml(details)}</div>` : ''}${bundleDetailHtml}</td>
       <td>${escapeHtml(item.item_type || '')}</td>
       <td>${item.quantity != null ? item.quantity : ''}</td>
       <td>${item.unit_price != null ? '₪' + formatCurrency(item.unit_price) : ''}</td>
@@ -772,6 +780,16 @@ function proposalLineHtml(item = {}, options = {}) {
   }
 
   const suffix = parts.length ? `: ${parts.join(' | ')}` : ':';
+  const bundleItems = Array.isArray(item.selected_bundle_items) ? item.selected_bundle_items : [];
+  if (bundleItems.length && (item.proposal_display_mode === 'bundle_parent' || item.is_bundle_parent)) {
+    const subLines = bundleItems.map((bi) => {
+      const no = typeof bi === 'object' ? text(bi.activity_no) : '';
+      const name = typeof bi === 'object' ? text(bi.activity_name) : text(bi);
+      const price = typeof bi === 'object' && bi.unit_price != null ? `${formatCurrency(Number(bi.unit_price))} ₪` : '';
+      return [no, name, price].filter(Boolean).join(' — ');
+    }).filter(Boolean);
+    if (subLines.length) return ` ${itemName}${suffix}\n${subLines.map((l) => `  • ${l}`).join('\n')}`;
+  }
   return ` ${itemName}${suffix}`;
 }
 
@@ -2233,12 +2251,21 @@ export const proposalsAgreementsScreen = {
           text(r.parent_pricing_key) === text(picked.pricing_key)
         );
         const childCheckboxesHtml = children.length
-          ? children.map((child, ci) =>
-              `<label class="ds-pa-bundle-child-option">
-                <input type="checkbox" name="bundle_child_sel" value="${escapeHtml(text(child.activity_name))}" data-bundle-child-idx="${ci}">
-                <span>${escapeHtml(text(child.activity_name))}</span>
-              </label>`
-            ).join('')
+          ? children.map((child, ci) => {
+              const noStr = text(child.activity_no) ? `${text(child.activity_no)} — ` : '';
+              const priceStr = child.unit_price != null && child.unit_price !== '' ? ` — ₪${formatCurrency(Number(child.unit_price))}` : '';
+              const childData = {
+                activity_no: text(child.activity_no),
+                pricing_key: text(child.pricing_key),
+                activity_name: text(child.activity_name),
+                unit_price: child.unit_price ?? null,
+                proposal_bundle_label: text(picked.activity_name)
+              };
+              return `<label class="ds-pa-bundle-child-option">
+                <input type="checkbox" name="bundle_child_sel" value="${escapeHtml(text(child.activity_name))}" data-bundle-child-idx="${ci}" data-child-json="${escapeHtml(JSON.stringify(childData))}">
+                <span>${escapeHtml(`${noStr}${text(child.activity_name)}${priceStr}`)}</span>
+              </label>`;
+            }).join('')
           : '<p style="font-size:0.8rem;margin:4px 0;color:var(--ds-text-muted,#888)">אין פריטי פירוט מוגדרים עבור הגדרה זו</p>';
         bundlePrompt.innerHTML = `
           <div style="margin:6px 0 4px;font-size:0.82rem;font-weight:600">${escapeHtml(text(picked.activity_name))} — הגדרה כוללת</div>
@@ -2561,12 +2588,23 @@ export const proposalsAgreementsScreen = {
         try { pickedData = JSON.parse(itemRow.dataset.paBundlePicked || '{}'); } catch { /* ignore */ }
         const bundlePrompt = itemRow.querySelector('[data-pa-bundle-prompt]');
         if (bundlePrompt) bundlePrompt.hidden = true;
+        const bundleParentLabel = pickedData.activity_name || '';
         const checkedBundleItems = Array.from(itemRow.querySelectorAll('[name="bundle_child_sel"]:checked'))
           .map((cb) => {
             const name = text(cb.value);
             if (!name) return null;
+            try {
+              const parsed = JSON.parse(cb.dataset.childJson || 'null');
+              if (parsed && parsed.activity_name) return parsed;
+            } catch { /* fallthrough */ }
             const childPricing = proposalActivityPricing.find((r) => text(r.activity_name) === name && text(r.proposal_display_mode) === 'bundle_child');
-            return { pricing_key: text(childPricing?.pricing_key) || '', activity_name: name };
+            return {
+              activity_no: text(childPricing?.activity_no) || '',
+              pricing_key: text(childPricing?.pricing_key) || '',
+              activity_name: name,
+              unit_price: childPricing?.unit_price ?? null,
+              proposal_bundle_label: bundleParentLabel
+            };
           }).filter(Boolean);
         const checkedNames = checkedBundleItems.map((i) => i.activity_name);
         const description = checkedNames.length > 0 ? checkedNames.map((n) => `• ${n}`).join('\n') : '';

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 665;
+const CACHE_VERSION = 666;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 629;
+const SW_ENTRY_VERSION = 630;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
…/666

- Bundle child checkboxes: show 'activity_no — name — ₪price' per row; embed full child data in data-child-json attribute for reliable saving
- bundleConfirmBtn: read data-child-json first, falls back to pricing lookup; saves {activity_no, pricing_key, activity_name, unit_price, proposal_bundle_label} (backward compat: old string-only items still render correctly)
- itemsSummaryHtml (drawer): bundle children shown as <ul> with 'activity_no — name — ₪price' lines instead of comma-joined names
- proposalLineHtml (document): appends '  • no — name — price' sub-lines for bundle_parent items that have selected_bundle_items
- Main pricing list already filtered bundle_child (no change needed)
- SW_ENTRY_VERSION 629→630, CACHE_VERSION 665→666

https://claude.ai/code/session_01VdVUZex8owfV9dvPUBmncS