### PR TITLE
Add end_date_passed exception type for short activities

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Bb8LlEBh.js"></script>
+  <script type="module" crossorigin src="./assets/index-ggxbZITV.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-D6CUDewa.css">
 </head>
 <body>

--- a/frontend/src/screens/shared/exceptions-metrics.js
+++ b/frontend/src/screens/shared/exceptions-metrics.js
@@ -18,6 +18,7 @@ export const APPROVED_EXCEPTION_TYPES = new Set(EXCEPTION_TYPE_ORDER);
 export const COURSE_EXCEPTION_TYPES = new Set(EXCEPTION_TYPE_ORDER);
 
 export const SHORT_ACTIVITY_EXCEPTION_TYPES = new Set([
+  'end_date_passed',
   'missing_instructor',
   'missing_start_date'
 ]);

--- a/tests/exceptions-canonical-logic.test.mjs
+++ b/tests/exceptions-canonical-logic.test.mjs
@@ -101,7 +101,8 @@ test('exception relevance follows activity_type before counts and display', () =
       activity({ RowID: `${activity_type}-late`, activity_type, status: 'פתוח', end_date: '2026-06-16', date_1: '2026-06-16' }),
       activity({ RowID: `${activity_type}-missing-end`, activity_type, end_date: '', date_1: '' }),
       activity({ RowID: `${activity_type}-missing-instructor`, activity_type, instructor_name: '', emp_id: '', instructor_name_2: '', emp_id_2: '' }),
-      activity({ RowID: `${activity_type}-missing-start`, activity_type, start_date: '', date_1: '' })
+      activity({ RowID: `${activity_type}-missing-start`, activity_type, start_date: '', date_1: '' }),
+      activity({ RowID: `${activity_type}-ended-open`, activity_type, status: 'פתוח', end_date: '2026-01-01', date_1: '2026-01-01' })
     ])
   ];
 
@@ -113,7 +114,7 @@ test('exception relevance follows activity_type before counts and display', () =
   assert.equal(model.counts.end_date_after_cutoff, 2, 'only actual summer activities should be exempt from late end date');
   assert.equal(model.counts.missing_end_date, 0, 'short activity missing end date should not count');
   assert.equal(model.counts.missing_district, 0, 'short activity district gaps should not count');
-  assert.equal(model.counts.end_date_passed, 0, 'short activity ended-open should not count');
+  assert.equal(model.counts.end_date_passed, shortTypes.length, 'short activity ended-open should count as end_date_passed');
   assert.equal(model.counts.missing_instructor, shortTypes.length);
   assert.equal(model.counts.missing_start_date, shortTypes.length + 1);
   assert.ok(model.rows.some((row) => row.RowID === 'COURSE-LATE' && row.exception_types.includes('end_date_after_cutoff')));
@@ -123,6 +124,12 @@ test('exception relevance follows activity_type before counts and display', () =
   assert.ok(model.rows.some((row) => row.RowID === 'SUMMER-EXPLICIT-NO-START' && row.exception_types.includes('missing_start_date')));
   assert.ok(!model.exceptionInstances.some((row) => String(row.RowID || '').includes('-late') && row.activity_type !== 'course'));
   assert.ok(!model.exceptionInstances.some((row) => String(row.RowID || '').includes('-missing-end')));
+  assert.ok(
+    shortTypes.every((activity_type) =>
+      model.exceptionInstances.some((row) => row.RowID === `${activity_type}-ended-open` && row.exception_types.includes('end_date_passed'))
+    ),
+    'short activities with past end_date and open status should appear with end_date_passed'
+  );
 });
 
 test('unassigned manager with valid district is counted under the district and totals are exception instances', () => {


### PR DESCRIPTION
## Summary
This PR adds support for tracking activities with past end dates and open status as an exception type for short activities (courses, workshops, etc.).

## Key Changes
- Added `end_date_passed` to the `SHORT_ACTIVITY_EXCEPTION_TYPES` set in the exceptions metrics configuration
- Updated test expectations to count short activities with ended but open status as `end_date_passed` exceptions
- Added test case validating that short activities with past end dates and open status are properly flagged with the `end_date_passed` exception type

## Implementation Details
- Short activities (non-summer activities) that have a past `end_date` but remain in 'פתוח' (open) status are now properly identified and counted as `end_date_passed` exceptions
- The test now verifies that all short activity types correctly report this exception when the condition is met
- This aligns the exception tracking for short activities with the existing behavior for other activity types

https://claude.ai/code/session_01E2TZ2yaQT6UXhCUdejB75C