### PR TITLE
חיבור מודול הצעות מחיר ל־Supabase: סוגי הצעות, aliases ותבניות ללא hardcoded

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1609,7 +1609,7 @@ function normalizeProposalAgreementRow(row = {}) {
     client_authority:    cleanProposalAgreementText(row.client_authority),
     school_framework:    cleanProposalAgreementText(row.school_framework),
     document_type:       cleanProposalAgreementText(row.document_type),
-    activity_type_group: cleanProposalAgreementText(row.activity_type_group),
+    activity_type_group: normalizeProposalGroupValue(row.activity_type_group),
     proposal_date:       cleanProposalAgreementText(row.proposal_date),
     activity_names:      normalizeProposalAgreementActivityNames(
       Array.isArray(row.activity_names) && row.activity_names.length
@@ -1639,15 +1639,95 @@ function normalizeProposalAgreementRow(row = {}) {
 
 const PA_VALID_STATUSES_SET = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
 
-const PROPOSAL_GROUP_CANONICAL_MAP = {
-  'קיץ תשפ״ו':                       'פעילויות קיץ',
-  'שנת הלימודים תשפ״ז':              'שנה הבאה',
-  'תוכניות תשפ״ז':                   'שנה הבאה',
-  'קיץ תשפ״ו ושנת הלימודים תשפ״ז': 'הצעה משולבת',
-  'קיץ תשפ״ו + תשפ״ז':              'הצעה משולבת'
-};
+// Proposal group definitions and legacy-name aliases are business data and live in Supabase
+// (proposal_activity_groups / proposal_group_aliases). The lookup below is loaded from there
+// and used to normalize any group value (legacy Hebrew label, display name) to its group_key.
+let proposalGroupLookupCache = null;
 
-function sanitizeProposalAgreementPayload(payload = {}) {
+async function readProposalActivityGroupsFromSupabase() {
+  try {
+    const { data, error } = await supabase
+      .from('proposal_activity_groups')
+      .select('group_key,display_name,template_key,included_group_keys,sort_order,is_active')
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true });
+    if (error) return [];
+    return (Array.isArray(data) ? data : []).map((row) => ({
+      group_key:           cleanProposalAgreementText(row?.group_key),
+      display_name:        cleanProposalAgreementText(row?.display_name),
+      template_key:        cleanProposalAgreementText(row?.template_key) || cleanProposalAgreementText(row?.group_key),
+      included_group_keys: Array.isArray(row?.included_group_keys)
+        ? row.included_group_keys.map(cleanProposalAgreementText).filter(Boolean)
+        : [],
+      sort_order:          Number(row?.sort_order) || 0,
+      is_active:           row?.is_active !== false
+    })).filter((row) => row.group_key);
+  } catch {
+    return [];
+  }
+}
+
+async function readProposalGroupAliasesFromSupabase() {
+  try {
+    const { data, error } = await supabase
+      .from('proposal_group_aliases')
+      .select('alias_name,group_key,is_active')
+      .eq('is_active', true);
+    if (error) return [];
+    return (Array.isArray(data) ? data : []).map((row) => ({
+      alias_name: cleanProposalAgreementText(row?.alias_name),
+      group_key:  cleanProposalAgreementText(row?.group_key),
+      is_active:  row?.is_active !== false
+    })).filter((row) => row.alias_name && row.group_key);
+  } catch {
+    return [];
+  }
+}
+
+function buildProposalGroupLookup(groups = [], aliases = []) {
+  const aliasToKey = new Map();
+  const groupByKey = new Map();
+  (Array.isArray(groups) ? groups : []).forEach((group) => {
+    if (!group?.group_key) return;
+    groupByKey.set(group.group_key, group);
+    aliasToKey.set(group.group_key, group.group_key);
+    if (group.display_name) aliasToKey.set(group.display_name, group.group_key);
+  });
+  (Array.isArray(aliases) ? aliases : []).forEach((alias) => {
+    if (alias?.alias_name && alias?.group_key) aliasToKey.set(alias.alias_name, alias.group_key);
+  });
+  return { groups, aliases, aliasToKey, groupByKey };
+}
+
+function normalizeProposalGroupValue(value, groupLookup = proposalGroupLookupCache) {
+  const raw = cleanProposalAgreementText(value);
+  if (!raw) return '';
+  return groupLookup?.aliasToKey?.get(raw) || raw;
+}
+
+async function getProposalGroupLookup() {
+  if (proposalGroupLookupCache) return proposalGroupLookupCache;
+  const [groups, aliases] = await Promise.all([
+    readProposalActivityGroupsFromSupabase(),
+    readProposalGroupAliasesFromSupabase()
+  ]);
+  proposalGroupLookupCache = buildProposalGroupLookup(groups, aliases);
+  return proposalGroupLookupCache;
+}
+
+function enrichProposalPricingRows(rows = [], groupLookup = proposalGroupLookupCache) {
+  return (Array.isArray(rows) ? rows : []).map((row) => {
+    const groupKey = normalizeProposalGroupValue(row?.proposal_group, groupLookup);
+    const groupMeta = groupLookup?.groupByKey?.get(groupKey) || null;
+    return {
+      ...row,
+      group_key:    groupKey,
+      template_key: cleanProposalAgreementText(groupMeta?.template_key) || groupKey
+    };
+  });
+}
+
+function sanitizeProposalAgreementPayload(payload = {}, groupLookup = proposalGroupLookupCache) {
   const activity_names = normalizeProposalAgreementActivityNames(payload.activity_names);
   const rawStatus = cleanProposalAgreementText(payload.status);
   const rawGroup = cleanProposalAgreementText(payload.activity_type_group);
@@ -1657,7 +1737,7 @@ function sanitizeProposalAgreementPayload(payload = {}) {
     client_authority:    clientAuthority,
     school_framework:    schoolFramework,
     document_type:       cleanProposalAgreementText(payload.document_type) || 'הצעת מחיר',
-    activity_type_group: PROPOSAL_GROUP_CANONICAL_MAP[rawGroup] || rawGroup,
+    activity_type_group: normalizeProposalGroupValue(rawGroup, groupLookup),
     proposal_date:       cleanProposalAgreementText(payload.proposal_date) || null,
     activity_names:      activity_names,
     contact_name:        cleanProposalAgreementText(payload.contact_name),
@@ -1850,7 +1930,7 @@ async function readContactsSchoolsForProposals() {
 
 async function readProposalsAgreementsFromSupabase() {
   assertCanUseProposalsAgreementsApi();
-  const [paResult, contactOptions, proposalActivityPricing, proposalTemplateSections] = await Promise.all([
+  const [paResult, contactOptions, rawProposalActivityPricing, proposalTemplateSections, proposalActivityGroups, proposalGroupAliases] = await Promise.all([
     supabase
       .from('proposals_agreements')
       .select(PROPOSALS_AGREEMENTS_COLUMNS)
@@ -1860,14 +1940,22 @@ async function readProposalsAgreementsFromSupabase() {
       .order('activity_type_group', { ascending: true }),
     readContactsSchoolsForProposals(),
     readProposalActivityPricingFromSupabase(),
-    readProposalTemplateSectionsFromSupabase()
+    readProposalTemplateSectionsFromSupabase(),
+    readProposalActivityGroupsFromSupabase(),
+    readProposalGroupAliasesFromSupabase()
   ]);
   if (paResult.error) throw new Error(paResult.error.message || 'proposals_agreements_read_failed');
+  // Group/alias normalization happens here in the loader so the frontend receives
+  // logical group keys (e.g. summer/next_year/combined) instead of legacy Hebrew labels.
+  proposalGroupLookupCache = buildProposalGroupLookup(proposalActivityGroups, proposalGroupAliases);
+  const proposalActivityPricing = enrichProposalPricingRows(rawProposalActivityPricing, proposalGroupLookupCache);
   const activityNameOptions = await readProposalActivityNamesFromSupabase();
   return {
     rows: (Array.isArray(paResult.data) ? paResult.data : []).map(normalizeProposalAgreementRow),
     activityNameOptions,
     contactOptions,
+    proposalActivityGroups,
+    proposalGroupAliases,
     proposalActivityPricing,
     proposalTemplateSections,
     _source: 'supabase'
@@ -3340,7 +3428,8 @@ export const api = {
   },
   addProposalAgreement: async (payload) => {
     assertCanManageProposalsAgreementsApi();
-    const insert = sanitizeProposalAgreementPayload(payload);
+    const groupLookup = await getProposalGroupLookup();
+    const insert = sanitizeProposalAgreementPayload(payload, groupLookup);
     const contactSchoolId = await ensureContactSchoolFromProposal({ ...insert, _contact_original: payload?._contact_original });
     if (contactSchoolId != null) insert.contact_school_id = contactSchoolId;
     const { data, error } = await supabase
@@ -3355,7 +3444,8 @@ export const api = {
     assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(id);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
-    const patch = sanitizeProposalAgreementPayload(payload);
+    const groupLookup = await getProposalGroupLookup();
+    const patch = sanitizeProposalAgreementPayload(payload, groupLookup);
     const contactSchoolId = await ensureContactSchoolFromProposal({ ...patch, _contact_original: payload?._contact_original });
     if (contactSchoolId != null) patch.contact_school_id = contactSchoolId;
     const { data, error } = await supabase
@@ -3399,6 +3489,7 @@ export const api = {
     assertCanUseProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(proposalId);
     if (!rowId) return [];
+    const groupLookup = await getProposalGroupLookup();
     const { data, error } = await supabase
       .from('proposal_agreement_items')
       .select('id,activity_no,item_name,item_type,gefen_number,meetings_count,hours_count,quantity,unit_duration,unit_price,hourly_price,total_price,description,proposal_group,sort_order,proposal_display_mode,source_pricing_key,selected_bundle_items')
@@ -3423,17 +3514,28 @@ export const api = {
         total_price:           item.total_price != null ? Number(item.total_price) : null,
         description:           cleanProposalAgreementText(item.description),
         unit_duration:         cleanProposalAgreementText(item.unit_duration),
-        proposal_group:        cleanProposalAgreementText(item.proposal_group),
+        proposal_group:        normalizeProposalGroupValue(item.proposal_group, groupLookup),
+        group_key:             normalizeProposalGroupValue(item.proposal_group, groupLookup),
         sort_order:            Number(item.sort_order) || 0,
         proposal_display_mode: cleanProposalAgreementText(item.proposal_display_mode) || 'single',
         source_pricing_key:    cleanProposalAgreementText(item.source_pricing_key),
+        pricing_key:           cleanProposalAgreementText(item.source_pricing_key),
         selected_bundle_items: selectedBundleItems
       };
     });
   },
   readProposalActivityPricing: async () => {
     assertCanUseProposalsAgreementsApi();
-    return readProposalActivityPricingFromSupabase();
+    const groupLookup = await getProposalGroupLookup();
+    return enrichProposalPricingRows(await readProposalActivityPricingFromSupabase(), groupLookup);
+  },
+  readProposalActivityGroups: async () => {
+    assertCanUseProposalsAgreementsApi();
+    return readProposalActivityGroupsFromSupabase();
+  },
+  readProposalGroupAliases: async () => {
+    assertCanUseProposalsAgreementsApi();
+    return readProposalGroupAliasesFromSupabase();
   },
   readProposalTemplateSections: async () => {
     assertCanUseProposalsAgreementsApi();
@@ -3462,6 +3564,7 @@ export const api = {
     assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(proposalId);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
+    const groupLookup = await getProposalGroupLookup();
     const { error: delError } = await supabase
       .from('proposal_agreement_items')
       .delete()
@@ -3486,7 +3589,7 @@ export const api = {
           total_price:           item.total_price != null ? Number(item.total_price) || null : null,
           description:           cleanProposalAgreementText(item.description),
           unit_duration:         cleanProposalAgreementText(item.unit_duration),
-          proposal_group:        cleanProposalAgreementText(item.proposal_group),
+          proposal_group:        normalizeProposalGroupValue(item.proposal_group || item.group_key, groupLookup),
           sort_order:            idx,
           proposal_display_mode: cleanProposalAgreementText(item.proposal_display_mode) || 'single',
           source_pricing_key:    cleanProposalAgreementText(item.source_pricing_key) || null,

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -107,6 +107,12 @@ function normalizeProposalGroupRecord(record = {}, fallbackIndex = 0) {
   };
 }
 
+function dataGroupAliasRows(data = {}) {
+  return Array.isArray(data.proposalGroupAliases)
+    ? data.proposalGroupAliases
+    : Array.isArray(data.proposal_group_aliases) ? data.proposal_group_aliases : [];
+}
+
 function collectGroupRecords(data = {}, rows = [], pricingOptions = []) {
   const directGroups = [
     data.proposalActivityGroups,
@@ -116,10 +122,19 @@ function collectGroupRecords(data = {}, rows = [], pricingOptions = []) {
   ].find(Array.isArray) || [];
   const groups = [];
   const seen = new Set();
+  // Names already covered by Supabase groups/aliases must not become standalone groups.
+  const knownNames = new Set();
+  dataGroupAliasRows(data).forEach((aliasRow) => {
+    const alias = text(aliasRow.alias_name || aliasRow.alias || aliasRow.name || aliasRow.value);
+    if (alias) knownNames.add(alias);
+  });
   const addGroup = (record, idx = groups.length) => {
     const normalized = normalizeProposalGroupRecord(record, idx);
     if (!normalized || seen.has(normalized.group_key)) return;
     seen.add(normalized.group_key);
+    knownNames.add(normalized.group_key);
+    knownNames.add(normalized.display_name);
+    normalized.aliases.forEach((alias) => knownNames.add(alias));
     groups.push(normalized);
   };
 
@@ -127,7 +142,7 @@ function collectGroupRecords(data = {}, rows = [], pricingOptions = []) {
 
   const addRawGroup = (value) => {
     const raw = text(value);
-    if (!raw || seen.has(raw)) return;
+    if (!raw || seen.has(raw) || knownNames.has(raw)) return;
     addGroup({ group_key: raw, display_name: raw, template_key: raw, is_active: true }, groups.length);
   };
 
@@ -147,7 +162,7 @@ function setProposalGroupLookups(data = {}, rows = [], pricingOptions = []) {
     aliasToKey.set(group.display_name, group.group_key);
     group.aliases.forEach((alias) => aliasToKey.set(alias, group.group_key));
   });
-  (Array.isArray(data.proposalGroupAliases) ? data.proposalGroupAliases : Array.isArray(data.proposal_group_aliases) ? data.proposal_group_aliases : [])
+  dataGroupAliasRows(data)
     .forEach((aliasRow) => {
       const alias = text(aliasRow.alias_name || aliasRow.alias || aliasRow.name || aliasRow.value);
       const groupKey = text(aliasRow.group_key || aliasRow.target_group_key || aliasRow.proposal_group_key);
@@ -199,7 +214,7 @@ function shouldShowGefenForGroup(value) {
 
 function proposalGroupOptions(data = {}, rows = [], pricingOptions = []) {
   const lookups = setProposalGroupLookups(data, rows, pricingOptions);
-  return lookups.groups.map((group) => group.display_name);
+  return lookups.groups.map((group) => ({ value: group.group_key, label: group.display_name }));
 }
 
 function itemTypeOptions(pricingOptions = []) {
@@ -284,7 +299,7 @@ function normalizeSearch(value) {
 export function buildProposalsAgreementsSearchText(row = {}) {
   return [
     row.id, row.client_name, row.client_authority, row.school_framework, row.document_type,
-    row.activity_type_group,
+    row.activity_type_group, proposalGroupDisplayName(row.activity_type_group),
     Array.isArray(row.activity_names) ? row.activity_names.join(' ') : row.activity_names,
     row.notes, row.contact_name, row.contact_role, row.phone, row.email,
     row.status ? (STATUS_LABELS[row.status] || row.status) : ''
@@ -361,7 +376,7 @@ function sortRows(rows) {
 function rowMatches(row, filters) {
   const q = normalizeSearch(filters.q);
   if (q && !normalizeSearch(row._searchText).includes(q)) return false;
-  if (filters.activity_type_group && text(row.activity_type_group) !== filters.activity_type_group) return false;
+  if (filters.activity_type_group && normalizeProposalGroup(row.activity_type_group) !== normalizeProposalGroup(filters.activity_type_group)) return false;
   if (filters.status && text(row.status) !== filters.status) return false;
   return true;
 }
@@ -378,7 +393,9 @@ function optionHtml(value, selected = '', display = '') {
 }
 
 function filterSelectHtml(key, label, values) {
-  const options = ['<option value="">הכול</option>', ...values.map((value) => optionHtml(value))].join('');
+  const pairs = (Array.isArray(values) ? values : []).map((value) =>
+    (value && typeof value === 'object') ? { value: text(value.value), label: text(value.label || value.value) } : { value: text(value), label: text(value) });
+  const options = ['<option value="">הכול</option>', ...pairs.map((pair) => optionHtml(pair.value, '', pair.label))].join('');
   return `<label class="ds-pa-filter"><span>${escapeHtml(label)}</span><select class="ds-input ds-input--sm" data-pa-filter="${escapeHtml(key)}">${options}</select></label>`;
 }
 
@@ -412,6 +429,8 @@ function detailRowsHtml(row) {
       displayValue = `<ul class="ds-pa-activity-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
     } else if (key === 'proposal_date') {
       displayValue = formatDateDisplay(row[key]);
+    } else if (key === 'activity_type_group') {
+      displayValue = proposalGroupDisplayName(row[key]);
     } else {
       displayValue = row[key] || '';
     }
@@ -466,7 +485,7 @@ export function proposalsAgreementsTableRowsHtml(rows, state) {
     <tr data-pa-row-id="${escapeHtml(row.id)}" tabindex="0">
       <td>${escapeHtml(row.client_name || row.client_authority || '—')}</td>
       <td>${escapeHtml(row.school_framework || '—')}</td>
-      <td>${escapeHtml(row.activity_type_group || '—')}</td>
+      <td>${escapeHtml(proposalGroupDisplayName(row.activity_type_group) || '—')}</td>
       <td>${escapeHtml(formatDateDisplay(row.proposal_date) || '')}</td>
       <td>${statusBadgeHtml(row.status)}</td>
       <td>${row.total_amount != null ? `₪${escapeHtml(formatCurrency(row.total_amount))}` : ''}</td>
@@ -819,7 +838,7 @@ function itemsSummaryHtml(items = []) {
       text(item.meetings_count) ? `מפגשים: ${text(item.meetings_count)}` : '',
       text(item.hours_count) ? `שעות: ${text(item.hours_count)}` : '',
       text(item.unit_duration) ? `משך: ${text(item.unit_duration)}` : '',
-      text(item.proposal_group) ? `קבוצה: ${text(item.proposal_group)}` : '',
+      text(item.proposal_group) ? `קבוצה: ${proposalGroupDisplayName(item.proposal_group)}` : '',
       !bundleLinesList.length ? cleanCustomerText(item.description) : ''
     ].filter(Boolean).join(' | ');
     const bundleDetailHtml = bundleLinesList.length
@@ -1057,7 +1076,7 @@ function resolveDocumentSections(row, templateSections = []) {
 function documentSectionsEditorHtml(sections = [], isCustom = false) {
   if (!Array.isArray(sections) || !sections.length) {
     return `<div class="ds-pa-doc-editor" data-pa-doc-editor>
-      <p class="ds-pa-doc-indicator ds-pa-doc-indicator--missing">לא נמצאו סעיפי מסמך מ־Supabase עבור סוג ההצעה הזה. יש להגדיר תבנית במסד הנתונים לפני עריכת מסמך.</p>
+      <p class="ds-pa-doc-indicator ds-pa-doc-indicator--missing">לא נמצאה תבנית פעילה לסוג הצעה זה</p>
     </div>`;
   }
   const indicator = isCustom
@@ -1149,7 +1168,9 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const childGroups = isCombinedProposalGroup(activityTypeGroup) ? includedProposalGroups(activityTypeGroup) : [];
   if (childGroups.length) {
     childGroups.forEach((groupKey) => {
-      const key = `activity_intro_${groupKey}`;
+      // Supabase template sections may use either naming convention for per-group intros.
+      const candidateKeys = [`activity_intro_${groupKey}`, `${groupKey}_activity_intro`];
+      const key = candidateKeys.find((candidate) => byKey.has(candidate)) || candidateKeys[0];
       const body = sectionBody(key);
       const heading = sectionTitle(key) || proposalGroupDisplayName(groupKey);
       const section = renderActivitySection(key, heading, body, itemsByGroup[groupKey] || [], { showGefen: shouldShowGefenForGroup(groupKey) });
@@ -2056,7 +2077,7 @@ export const proposalsAgreementsScreen = {
         const clientEl = form.querySelector('[data-pa-summary-client]');
         if (clientEl) clientEl.textContent = text(form.querySelector('[name="client_authority"]')?.value) || '—';
         const typeEl = form.querySelector('[data-pa-summary-type]');
-        if (typeEl) typeEl.textContent = text(form.querySelector('[name="activity_type_group"]')?.value) || '—';
+        if (typeEl) typeEl.textContent = proposalGroupDisplayName(form.querySelector('[name="activity_type_group"]')?.value) || '—';
         const countEl = form.querySelector('[data-pa-summary-count]');
         if (countEl) countEl.textContent = String(form.querySelectorAll('[data-pa-item-row]').length) || '—';
       }
@@ -2209,12 +2230,17 @@ export const proposalsAgreementsScreen = {
       overlay.setAttribute('dir', 'rtl');
       const clientLabel = [freshRow.client_authority, freshRow.school_framework].filter(Boolean).map(escapeHtml).join(' — ');
       const saveBtnHtml = options.onSave ? `<button type="button" class="ds-btn ds-btn--sm no-print" id="pa-preview-save">שמירת טיוטה</button>` : '';
+      const hasCustomSections = Array.isArray(freshRow.custom_document_sections) && freshRow.custom_document_sections.length > 0;
+      const missingTemplateNotice = (!templateSections.length && !hasCustomSections)
+        ? '<p class="ds-pa-template-missing-notice no-print" role="alert" style="margin:6px 0 0;color:#b45309;font-size:0.85rem">לא נמצאה תבנית פעילה לסוג הצעה זה</p>'
+        : '';
       overlay.innerHTML = `
         <div class="proposal-preview-toolbar no-print">
           <button type="button" class="ds-btn ds-btn--sm no-print" id="pa-preview-close">← חזרה לעריכה</button>
           ${saveBtnHtml}
           <button type="button" class="ds-btn ds-btn--primary ds-btn--sm no-print" id="pa-print-btn">הדפסה / שמירה כ-PDF</button>
           <span class="ds-pa-preview-client no-print">${clientLabel}</span>
+          ${missingTemplateNotice}
         </div>
         <div class="proposal-preview-area">
           ${proposalPreviewBodyHtml(freshRow, items, templateSections)}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 675;
+const CACHE_VERSION = 676;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260614_proposal_activity_groups_and_aliases.sql
+++ b/supabase/migrations/20260614_proposal_activity_groups_and_aliases.sql
@@ -1,0 +1,110 @@
+-- Proposal activity groups + aliases: move proposal-type business data from the frontend into Supabase.
+-- The proposals-agreements loader reads these tables and the UI derives proposal types,
+-- display names, template keys and legacy-name normalization from them.
+
+create extension if not exists pgcrypto;
+
+-- ─── proposal_activity_groups ────────────────────────────────────────────────
+create table if not exists public.proposal_activity_groups (
+  id uuid primary key default gen_random_uuid(),
+  group_key text not null unique,
+  display_name text not null,
+  template_key text not null,
+  included_group_keys text[] not null default '{}',
+  sort_order integer not null default 100,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint proposal_activity_groups_group_key_not_blank check (btrim(group_key) <> ''),
+  constraint proposal_activity_groups_display_name_not_blank check (btrim(display_name) <> ''),
+  constraint proposal_activity_groups_template_key_not_blank check (btrim(template_key) <> '')
+);
+
+create index if not exists proposal_activity_groups_sort_idx
+  on public.proposal_activity_groups (is_active, sort_order);
+
+create or replace function public.touch_proposal_activity_groups_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_touch_proposal_activity_groups_updated_at on public.proposal_activity_groups;
+create trigger trg_touch_proposal_activity_groups_updated_at
+before update on public.proposal_activity_groups
+for each row
+execute function public.touch_proposal_activity_groups_updated_at();
+
+-- ─── proposal_group_aliases ──────────────────────────────────────────────────
+create table if not exists public.proposal_group_aliases (
+  id uuid primary key default gen_random_uuid(),
+  alias_name text not null unique,
+  group_key text not null references public.proposal_activity_groups(group_key) on update cascade,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  constraint proposal_group_aliases_alias_name_not_blank check (btrim(alias_name) <> '')
+);
+
+create index if not exists proposal_group_aliases_group_key_idx
+  on public.proposal_group_aliases (group_key);
+
+-- ─── RLS: readable by proposals-agreements users only ────────────────────────
+alter table public.proposal_activity_groups enable row level security;
+alter table public.proposal_group_aliases enable row level security;
+
+drop policy if exists proposal_activity_groups_select_allowed_roles on public.proposal_activity_groups;
+create policy proposal_activity_groups_select_allowed_roles
+on public.proposal_activity_groups
+for select
+to authenticated
+using (public.app_can_use_proposals_agreements());
+
+drop policy if exists proposal_group_aliases_select_allowed_roles on public.proposal_group_aliases;
+create policy proposal_group_aliases_select_allowed_roles
+on public.proposal_group_aliases
+for select
+to authenticated
+using (public.app_can_use_proposals_agreements());
+
+revoke all on public.proposal_activity_groups from anon;
+revoke all on public.proposal_group_aliases from anon;
+grant select on public.proposal_activity_groups to authenticated;
+grant select on public.proposal_group_aliases to authenticated;
+
+-- ─── Seed: proposal types (logical key, Hebrew display name, template key) ───
+insert into public.proposal_activity_groups
+  (group_key, display_name, template_key, included_group_keys, sort_order, is_active)
+values
+  ('summer',    'פעילויות קיץ', 'summer',    '{}',                   1, true),
+  ('next_year', 'שנה הבאה',     'next_year', '{}',                   2, true),
+  ('combined',  'הצעה משולבת',  'combined',  '{summer,next_year}',   3, true)
+on conflict (group_key) do update set
+  display_name = excluded.display_name,
+  template_key = excluded.template_key,
+  included_group_keys = excluded.included_group_keys,
+  sort_order = excluded.sort_order,
+  is_active = excluded.is_active,
+  updated_at = now();
+
+-- ─── Seed: legacy / alternative names that normalize to a logical group ──────
+insert into public.proposal_group_aliases
+  (alias_name, group_key, is_active)
+values
+  ('קיץ תשפ״ו',                       'summer',    true),
+  ('שנת הלימודים תשפ״ז',              'next_year', true),
+  ('תוכניות תשפ״ז',                   'next_year', true),
+  ('קיץ תשפ״ו ושנת הלימודים תשפ״ז',  'combined',  true),
+  ('קיץ תשפ״ו + תשפ״ז',               'combined',  true),
+  ('קורסים',                          'combined',  true),
+  ('סדנאות',                          'combined',  true),
+  ('סיור',                            'combined',  true),
+  ('תוכניות חינוכיות',                'combined',  true),
+  ('STEM ומייקרים',                   'combined',  true),
+  ('התנסות בתעשייה',                  'combined',  true)
+on conflict (alias_name) do update set
+  group_key = excluded.group_key,
+  is_active = excluded.is_active;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 630;
+const SW_ENTRY_VERSION = 631;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## מה השתנה

מודול הצעות המחיר מקבל כעת את כל ההגדרות העסקיות (סוגי הצעות, aliases, תבניות, מחירים) מ־Supabase דרך ה־loader, ללא ערכים עסקיים hardcoded ב־Frontend.

### טבלאות Supabase חדשות (migration: `20260614_proposal_activity_groups_and_aliases.sql`)

- **`proposal_activity_groups`** — סוגי הצעות לוגיים: `summer` / `next_year` / `combined` עם `display_name` בעברית, `template_key`, `included_group_keys` (להצעה משולבת), `sort_order`, `is_active`. כולל RLS (`app_can_use_proposals_agreements`), grants ו־trigger ל־`updated_at`.
- **`proposal_group_aliases`** — מיפוי שמות ישנים ("קיץ תשפ״ו", "תוכניות תשפ״ז" וכו') ל־`group_key`, כולל seed מלא.

⚠️ **נדרש להריץ את ה־migration ידנית ב־Supabase SQL Editor** (אין credentials בסביבת ה־agent). עד אז ה־loader מחזיר מערכים ריקים והמסך ממשיך לעבוד במצב הנגזר הקיים.

### Loader / API (`frontend/src/api.js`)

- `readProposalsAgreementsFromSupabase` קורא במקביל גם את `proposal_activity_groups` ו־`proposal_group_aliases` ומחזיר אותם ב־data (`proposalActivityGroups`, `proposalGroupAliases`).
- הוסר `PROPOSAL_GROUP_CANONICAL_MAP` ה־hardcoded; הנרמול נעשה עם lookup שנטען מ־Supabase (`normalizeProposalGroupValue`).
- נרמול בצד ה־loader (לא ב־Frontend): `rows[].activity_type_group`, שורות הצעה (`proposal_group`), ושמירת הצעות — נשמר `group_key` לוגי (`summer`/`next_year`/`combined`) ולא טקסט עברי.
- שורות קטלוג המחירים מועשרות ב־`group_key` + `template_key` (נרמול של `proposal_group` העברי דרך aliases).
- `readProposalAgreementItems` מחזיר גם `group_key` ו־`pricing_key` מנורמלים.
- נוספו `api.readProposalActivityGroups` / `api.readProposalGroupAliases`.

### Frontend (`frontend/src/screens/proposals-agreements.js`)

- אין קבועים עסקיים (`ACTIVITY_TYPE_GROUP_OPTIONS`, `LEGACY_GROUP_MAP`, `TEMPLATE_KEY_BY_GROUP` וכו' — לא קיימים), ואין תבניות/טקסטים hardcoded.
- תצוגה תמיד ב־`display_name`; `group_key` לא מוצג ללקוח (טבלה, drawer, סיכום, פילטר).
- פילטר "סוג הצעה" עובד עם `group_key` כערך ו־`display_name` כתווית, עם השוואה מנורמלת.
- קבוצות שכוסו ע"י groups/aliases לא נוצרות כקבוצות כפולות מנתוני rows/pricing.
- הצעה משולבת: תמיכה בשני סגנונות מפתחות תבנית (`activity_intro_summer` וגם `summer_activity_intro` הקיים ב־DB).
- כשאין תבנית פעילה: הודעת ניהול בלבד "לא נמצאה תבנית פעילה לסוג הצעה זה" (no-print, לא במסמך ללקוח).

### Service Worker

- `frontend/sw.js`: `CACHE_VERSION` 675 → 676; `sw.js`: `SW_ENTRY_VERSION` 630 → 631.

## בדיקות

- `node --check` על שני הקבצים — עבר.
- `npm run check:build` — עבר (build + postbuild, 145 precache entries).
- `node --test tests/proposals-agreements-screen.test.mjs` — 21 pass / 21 fail, **זהה לחלוטין ל־baseline ב־main** (הכשלים קיימים לפני השינוי ואינם קשורים אליו).
- סימולציה פונקציונלית: נרמול aliases עבריים → group_key, תצוגת display_name בטבלה ובפילטר, ללא כפילויות קבוצות — עבר.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22a7fc73-66b4-4ee7-8053-b4e800e837af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22a7fc73-66b4-4ee7-8053-b4e800e837af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

