### PR TITLE
כלי אימות חי ל־loader של הצעות מחיר מול Supabase

### DIFF
--- a/scripts/verify_live_proposals_loader.mjs
+++ b/scripts/verify_live_proposals_loader.mjs
@@ -1,0 +1,55 @@
+/**
+ * One-off live verification for the proposals-agreements Supabase loader.
+ * Run: node scripts/verify_live_proposals_loader.mjs [email] [entry_code]
+ * Without credentials it runs unauthenticated (RLS returns empty reference data).
+ */
+const storageStub = () => {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+    key: (i) => [...m.keys()][i] ?? null,
+    get length() { return m.size; }
+  };
+};
+globalThis.sessionStorage = storageStub();
+globalThis.localStorage = storageStub();
+globalThis.window = globalThis.window || { addEventListener: () => {}, location: { href: 'http://localhost/' } };
+globalThis.document = globalThis.document || { addEventListener: () => {}, querySelector: () => null };
+
+const { state } = await import('../frontend/src/state.js');
+const { supabase } = await import('../frontend/src/supabase-client.js');
+const { api } = await import('../frontend/src/api.js');
+
+const [email, entryCode] = process.argv.slice(2);
+if (email && entryCode) {
+  const authEmail = email.includes('@') ? email : `${email}@think.org.il`;
+  const { data, error } = await supabase.auth.signInWithPassword({ email: authEmail, password: entryCode });
+  if (error) {
+    console.error('AUTH FAILED:', error.message);
+    process.exit(1);
+  }
+  console.log('authenticated as', data.user?.email);
+} else {
+  console.log('running UNAUTHENTICATED (anon) — reference tables are RLS-protected and will come back empty');
+}
+
+state.user = { display_role: 'admin', role: 'admin', user_id: 'verify' };
+
+const data = await api.proposalsAgreements();
+console.log('loader keys:', Object.keys(data).join(', '));
+console.log('proposalActivityGroups:', JSON.stringify(data.proposalActivityGroups, null, 1));
+console.log('proposalGroupAliases count:', (data.proposalGroupAliases || []).length);
+console.log('aliases:', JSON.stringify((data.proposalGroupAliases || []).map((a) => `${a.alias_name}→${a.group_key}`)));
+const pricing = data.proposalActivityPricing || [];
+console.log('pricing rows:', pricing.length);
+const sample = pricing.slice(0, 3).map((r) => ({ name: r.activity_name, proposal_group: r.proposal_group, group_key: r.group_key, template_key: r.template_key }));
+console.log('pricing sample:', JSON.stringify(sample));
+const badPricing = pricing.filter((r) => r.proposal_group && !['summer', 'next_year', 'combined'].includes(r.group_key));
+console.log('pricing rows NOT normalized to logical key:', badPricing.length, JSON.stringify([...new Set(badPricing.map((r) => r.proposal_group))]));
+console.log('rows:', (data.rows || []).length);
+console.log('row groups:', JSON.stringify([...new Set((data.rows || []).map((r) => r.activity_type_group))]));
+console.log('template sections:', (data.proposalTemplateSections || []).length, 'template keys:', JSON.stringify([...new Set((data.proposalTemplateSections || []).map((s) => s.template_key))]));
+process.exit(0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## מה השתנה

המשך ל־PR #601 (שכבר מוזג): נוסף `scripts/verify_live_proposals_loader.mjs` — סקריפט אימות שמריץ את ה־loader האמיתי (`api.proposalsAgreements`) מתוך Node מול ה־DB החי.

שימוש:

```bash
# ללא אימות (טבלאות reference מוגנות RLS יחזרו ריקות):
node scripts/verify_live_proposals_loader.mjs

# עם משתמש אמיתי — מאמת גם seeds של קבוצות/aliases והעשרת המחירים:
node scripts/verify_live_proposals_loader.mjs <user_id> <entry_code>
```

הסקריפט מדפיס: מפתחות ה־payload, קבוצות, aliases, דוגמת שורות מחירים עם `group_key`/`template_key`, ושורות שלא נורמלו למפתח לוגי (אם יש).

## אימותים שבוצעו מול ה־DB החי לאחר הרצת ה־migration

- הטבלאות `proposal_activity_groups` / `proposal_group_aliases` קיימות ונעולות ל־anon (42501) בהתאם ל־RLS.
- ה־loader רץ end-to-end ומחזיר את כל המפתחות כולל `proposalActivityGroups` / `proposalGroupAliases`.
- כל 59 ערכי `proposal_group` בקטלוג החי מנורמלים ל־`summer`/`next_year` עם ה־seeds.
- שמירה (insert/update/items) דרך `api.js` כותבת `group_key` לוגי בלבד — אומת ברמת גוף בקשת ה־HTTP.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22a7fc73-66b4-4ee7-8053-b4e800e837af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22a7fc73-66b4-4ee7-8053-b4e800e837af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

