### PR TITLE
Proposal appendix: classify activity types, avoid duplicated activity details, and dedupe catalog appendices

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-D-v1yC62.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DfGgyaSx.css">
+  <script type="module" crossorigin src="./assets/index-KgznSwlK.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-DEt7ORas.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -644,6 +644,92 @@ function isTestHoursItem(item = {}) {
   return TEST_HOURS_REGEX.test(itemIdentityText(item));
 }
 
+
+function normalizedKindText(value) {
+  return text(value).replace(/["'׳״]/g, '').toLowerCase();
+}
+
+function groupKindText(value) {
+  const normalized = normalizeProposalGroup(value);
+  const meta = proposalGroupMeta(normalized);
+  return [
+    normalized,
+    meta?.display_name,
+    meta?.template_key,
+    meta?.document_title,
+    meta?.proposal_title,
+    meta?.title,
+    ...(Array.isArray(meta?.aliases) ? meta.aliases : [])
+  ].map(normalizedKindText).filter(Boolean).join(' ');
+}
+
+function itemKindText(item = {}) {
+  return [
+    item.item_type,
+    item.proposal_group,
+    item.activity_type_group,
+    item.item_name,
+    item.pricing_activity_name,
+    item.activity_name,
+    item.source_pricing_key,
+    item.pricing_key
+  ].map(normalizedKindText).filter(Boolean).join(' ');
+}
+
+function isSummerKindText(value = '') {
+  return /קיץ|קייטנה|summer/.test(value);
+}
+
+function isWorkshopKindText(value = '') {
+  return /סדנ|workshop|stem|חלל/.test(value);
+}
+
+function isCourseKindText(value = '') {
+  return /קורס|תוכנית|תכנית|הדרכה|שנת|שנה הבאה|תשפ|program|course/.test(value);
+}
+
+function itemCatalogKind(item = {}) {
+  if (!item || isTestHoursItem(item)) return '';
+  const displayMode = text(item.proposal_display_mode);
+  if (displayMode === 'bundle_child') return '';
+  if (displayMode === 'bundle_parent' || item.is_bundle_parent) return 'workshop';
+  const kindText = itemKindText(item);
+  if (isSummerKindText(kindText)) return 'summer';
+  if (isWorkshopKindText(kindText)) return 'workshop';
+  if (text(item.gefen_number) || isCourseKindText(kindText)) return 'course';
+  return text(item.activity_no || item.pricing_key || item.source_pricing_key) ? 'workshop' : '';
+}
+
+function proposalActivityKind(row = {}, items = []) {
+  const group = normalizeProposalGroup(row.activity_type_group);
+  if (isCombinedProposalGroup(group)) return 'combined';
+  const kindText = groupKindText(group || row.activity_type_group);
+  if (/משולב|combined/.test(kindText)) return 'combined';
+  if (isSummerKindText(kindText)) return 'summer';
+  if (isWorkshopKindText(kindText)) return 'workshop';
+  if (isCourseKindText(kindText)) return 'course';
+
+  const itemKinds = new Set((Array.isArray(items) ? items : [])
+    .map(itemCatalogKind)
+    .filter(Boolean));
+  if (itemKinds.size > 1) return 'combined';
+  return itemKinds.values().next().value || 'course';
+}
+
+function activityIntroForCatalog(row = {}, items = []) {
+  switch (proposalActivityKind(row, items)) {
+    case 'workshop':
+      return 'פירוט הסדנאות המוצעות מצורף כנספח להצעה זו.';
+    case 'summer':
+      return 'פירוט פעילויות הקיץ המוצעות מצורף כנספח להצעה זו.';
+    case 'combined':
+      return 'פירוט הפעילויות המוצעות מצורף כנספח להצעה זו.';
+    case 'course':
+    default:
+      return 'להלן הקורסים המוצעים לשנת הלימודים תשפ״ז. פירוט מלא של הקורסים מצורף כנספח להצעה זו.';
+  }
+}
+
 function pricingOptionKey(row = {}) {
   return [row.activity_no, row.activity_name, row.item_type, row.proposal_group, row.unit_duration, row.unit_price, row.sort_order].map(text).join('||');
 }
@@ -1268,7 +1354,7 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
     </div>`;
 }
 
-function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
+export function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const activityTypeGroup = normalizeProposalGroup(row.activity_type_group);
   const templateKey = proposalGroupTemplateKey(activityTypeGroup);
   // Date comes only from the proposal row — no "today" fallback in customer documents.
@@ -1284,7 +1370,9 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const includeCatalog = includeCatalogValue(row.include_catalog);
   const introText = sectionBody('intro');
   const remarks = sectionBody('notes') || String(row.notes || '').replace(/\r\n?/g, '\n').trim();
-  const activityIntro = filterCatalogContentFromBody(sectionBody('activity_intro'), includeCatalog);
+  const activityIntro = includeCatalog
+    ? activityIntroForCatalog(row, items)
+    : filterCatalogContentFromBody(sectionBody('activity_intro'), includeCatalog);
 
   const renderActivitySection = (heading, body) => {
     const bodyHtml = body ? sectionBodyHtml(body) : '';
@@ -1294,7 +1382,7 @@ function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
 
   const sections = [];
   const childGroups = isCombinedProposalGroup(activityTypeGroup) ? includedProposalGroups(activityTypeGroup) : [];
-  if (childGroups.length) {
+  if (childGroups.length && !includeCatalog) {
     childGroups.forEach((groupKey) => {
       // Supabase template sections may use either naming convention for per-group intros.
       const candidateKeys = [`activity_intro_${groupKey}`, `${groupKey}_activity_intro`];
@@ -1867,53 +1955,93 @@ function replaceLocalRow(data, savedRow) {
 
 // ─── Catalog appendix via hidden iframe extraction ───────────────────────────
 
-function buildProposalCatalogEntries(items) {
+export function buildProposalCatalogEntries(items) {
   if (!Array.isArray(items) || !items.length) return [];
   const catalogBase = `${PUBLIC_BASE}catalog/summercatalog/`;
-  const allWorkshopIds = [];
+  const workshopIds = [];
+  const workshopIdSet = new Set();
+  const programGefenIds = [];
+  const programGefenSet = new Set();
+  const activityNoSet = new Set();
   let needSpaceAll = false;
   let needStemAll = false;
-  const programGefenIds = [];
-  const seenGefenIds = new Set();
 
+  const cleanActivityNo = (value) => text(value || '').replace(/^cat-/, '');
+  const addActivityNo = (value) => {
+    const key = cleanActivityNo(value);
+    if (key) activityNoSet.add(key);
+    return key;
+  };
   const addWorkshopId = (value) => {
-    const raw = text(value || '').replace(/^cat-/, '');
+    const raw = addActivityNo(value);
     const n = Number(raw);
-    if (n > 0) allWorkshopIds.push(n);
+    if (n > 0 && !workshopIdSet.has(String(n))) {
+      workshopIdSet.add(String(n));
+      workshopIds.push(n);
+      return true;
+    }
+    return false;
+  };
+  const addGefenId = (value) => {
+    const gef = text(value);
+    if (gef && !programGefenSet.has(gef)) {
+      programGefenSet.add(gef);
+      programGefenIds.push(gef);
+      return true;
+    }
+    return false;
+  };
+
+  const addBundleWorkshops = (item) => {
+    const selected = Array.isArray(item.selected_bundle_items) ? item.selected_bundle_items : [];
+    if (selected.length > 0) {
+      selected.forEach((sel) => addWorkshopId(sel.activity_no || sel.pricing_key || sel.source_pricing_key));
+      return;
+    }
+    const isSpace = text(item.source_pricing_key) === 'space_workshop' || text(item.item_name).includes('חלל');
+    if (isSpace) needSpaceAll = true;
+    else needStemAll = true;
   };
 
   for (const item of items) {
     if (isTestHoursItem(item)) continue;
     const displayMode = text(item.proposal_display_mode);
-    const itemType = text(item.item_type);
     if (displayMode === 'bundle_child') continue;
 
-    if (displayMode === 'bundle_parent') {
-      const selected = Array.isArray(item.selected_bundle_items) ? item.selected_bundle_items : [];
-      if (selected.length > 0) {
-        for (const sel of selected) addWorkshopId(sel.activity_no || sel.pricing_key);
-      } else {
-        const isSpace = text(item.source_pricing_key) === 'space_workshop' || text(item.item_name).includes('חלל');
-        if (isSpace) needSpaceAll = true; else needStemAll = true;
-      }
-    } else if (itemType === 'קורס' || itemType === 'תוכנית' || itemType === 'הדרכה') {
-      const gef = text(item.gefen_number);
-      if (gef && !seenGefenIds.has(gef)) { seenGefenIds.add(gef); programGefenIds.push(gef); }
-    } else {
-      addWorkshopId(item.activity_no || item.pricing_key || item.source_pricing_key);
+    if (displayMode === 'bundle_parent' || item.is_bundle_parent) {
+      addBundleWorkshops(item);
+      continue;
+    }
+
+    const kind = itemCatalogKind(item);
+    if (kind === 'course') {
+      // Course/program appendices are driven by Gefen/activity identifiers only;
+      // do not also request workshops.html for the same activity row.
+      addGefenId(item.gefen_number || item.activity_no || item.pricing_activity_no);
+      continue;
+    }
+
+    if (kind === 'workshop' || kind === 'summer') {
+      addWorkshopId(item.activity_no || item.pricing_key || item.source_pricing_key || item.pricing_activity_no);
     }
   }
 
   const entries = [];
-  if (allWorkshopIds.length > 0) {
-    entries.push(`${catalogBase}workshops.html?proposalMode=1&workshopIds=${[...new Set(allWorkshopIds)].join(',')}`);
+  const seenUrls = new Set();
+  const addUrl = (url) => {
+    if (!url || seenUrls.has(url)) return;
+    seenUrls.add(url);
+    entries.push(url);
+  };
+
+  if (workshopIds.length > 0) {
+    addUrl(`${catalogBase}workshops.html?proposalMode=1&workshopIds=${workshopIds.join(',')}`);
   }
-  if (needStemAll) entries.push(`${catalogBase}workshops.html?proposalMode=1&domain=stem`);
-  if (needSpaceAll) entries.push(`${catalogBase}workshops.html?proposalMode=1&domain=space`);
-  if (programGefenIds.length > 0) entries.push(`${catalogBase}course-page.html?ids=${programGefenIds.join(',')}&proposalMode=1`);
+  if (needStemAll) addUrl(`${catalogBase}workshops.html?proposalMode=1&domain=stem`);
+  if (needSpaceAll) addUrl(`${catalogBase}workshops.html?proposalMode=1&domain=space`);
+  if (programGefenIds.length > 0) addUrl(`${catalogBase}course-page.html?ids=${programGefenIds.join(',')}&proposalMode=1`);
   return entries;
 }
-
 async function loadCatalogViaIframe(url) {
   return new Promise((resolve, reject) => {
     const iframe = document.createElement('iframe');

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 688;
+const CACHE_VERSION = 689;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 638;
+const SW_ENTRY_VERSION = 639;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -59,7 +59,7 @@ const SCREEN_FILE = new URL('../frontend/src/screens/proposals-agreements.js', i
 const MIGRATION_FILE = new URL('../supabase/migrations/20260518_create_proposals_agreements.sql', import.meta.url);
 const ROLE_UPDATE_MIGRATION_FILE = new URL('../supabase/migrations/20260602_add_business_development_manager_role.sql', import.meta.url);
 
-const { proposalsAgreementsScreen, canAccessProposalsAgreements, canManageProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS } = await import('../frontend/src/screens/proposals-agreements.js');
+const { proposalsAgreementsScreen, canAccessProposalsAgreements, canManageProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS, buildProposalCatalogEntries, proposalPreviewBodyHtml } = await import('../frontend/src/screens/proposals-agreements.js');
 
 function stateFor(role) {
   return {
@@ -1303,6 +1303,67 @@ test('summer proposal preview keeps prices out of activity section and expands b
   });
 });
 
+
+test('catalog appendix entries load workshop proposals only from workshops catalog and dedupe ids', () => {
+  const urls = buildProposalCatalogEntries([
+    { item_name: 'סדנת רובוטיקה', item_type: 'סדנה', activity_no: 'cat-12', pricing_key: 'cat-12', unit_price: 500 },
+    { item_name: 'סדנת רובוטיקה', item_type: 'סדנה', activity_no: '12', pricing_key: 'cat-12', unit_price: 500 }
+  ]);
+
+  assert.deepEqual(urls, ['./catalog/summercatalog/workshops.html?proposalMode=1&workshopIds=12']);
+  assert.equal(urls.some((url) => url.includes('course-page.html')), false);
+});
+
+test('catalog appendix entries split mixed proposals by true item type without duplicate appendices', () => {
+  const urls = buildProposalCatalogEntries([
+    { item_name: 'קורס רובוטיקה', item_type: 'קורס', gefen_number: '1234', activity_no: '555' },
+    { item_name: 'קורס רובוטיקה נוסף', item_type: 'תוכנית', gefen_number: '1234', activity_no: '555' },
+    { item_name: 'סדנת רחפנים', item_type: 'סדנה', activity_no: '88', pricing_key: 'cat-88' },
+    { item_name: 'סדנת רחפנים', item_type: 'סדנה', activity_no: '88', pricing_key: 'cat-88' }
+  ]);
+
+  assert.deepEqual(urls, [
+    './catalog/summercatalog/workshops.html?proposalMode=1&workshopIds=88',
+    './catalog/summercatalog/course-page.html?ids=1234&proposalMode=1'
+  ]);
+});
+
+test('workshop proposal preview uses short appendix wording and keeps prices only in cost table', async () => {
+  const row = {
+    ...sampleRows[0],
+    id: '77777777-7777-7777-7777-777777777777',
+    activity_type_group: 'סדנאות',
+    include_catalog: true,
+    proposal_date: '2026-06-01'
+  };
+  const proposalTemplateSections = [
+    { template_key: 'workshops', template_name: 'הצעת מחיר לסדנאות', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח.' },
+    { template_key: 'workshops', section_key: 'activity_intro', section_title: 'הפעילות המוצעת', section_body: `להלן הקורסים המוצעים לשנת הלימודים תשפ״ז.
+ גפ״ן 1234 | 10 מפגשים | 20 שעות | ₪200 לשעה | מחיר לקבוצה ₪4,000
+ סדנת רובוטיקה` },
+    { template_key: 'workshops', section_key: 'payment_terms', section_title: 'עלות ותנאי תשלום', section_body: ' תנאי תשלום.' }
+  ];
+  const items = [{ item_name: 'סדנת רובוטיקה', item_type: 'סדנה', activity_no: '12', unit_price: 4000, total_price: 4000, quantity: 1, proposal_group: 'סדנאות' }];
+
+  proposalsAgreementsScreen.render({
+    rows: [row],
+    proposalActivityGroups: [{ group_key: 'סדנאות', display_name: 'סדנאות', template_key: 'workshops', show_gefen: false }]
+  }, { state: stateFor('admin') });
+
+  await withJSDOM(proposalPreviewBodyHtml(row, items, proposalTemplateSections), async (_root, dom) => {
+    const activitySection = [...dom.window.document.querySelectorAll('.proposal-document .pa-section')]
+      .find((section) => section.querySelector('h3')?.textContent.includes('הפעילות המוצעת'));
+    const paymentSection = [...dom.window.document.querySelectorAll('.proposal-document .pa-section')]
+      .find((section) => section.querySelector('h3')?.textContent.includes('עלות ותנאי תשלום'));
+
+    assert.ok(activitySection);
+    assert.match(activitySection.textContent, /פירוט הסדנאות המוצעות מצורף כנספח להצעה זו/);
+    assert.doesNotMatch(activitySection.textContent, /קורסים|גפ״ן|מפגשים|שעות|לשעה|מחיר לקבוצה|4,000|סדנת רובוטיקה/);
+    assert.ok(paymentSection);
+    assert.match(paymentSection.textContent, /4,000/);
+  });
+});
+
 test('summer proposal preview shows catalog sentence only when include_catalog is enabled', async () => {
   const baseSections = [
     { template_key: 'summer', template_name: 'הצעת מחיר', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח.' },
@@ -1335,7 +1396,7 @@ test('summer proposal preview shows catalog sentence only when include_catalog i
 
     const onText = await openPreviewForRow(rowOn, dom, root);
     assert.doesNotMatch(offText, /מצורף להצעה/);
-    assert.match(onText, /מצורף להצעה/);
+    assert.match(onText, /מצורף[\s\S]*להצעה/);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent workshop/summer/combined proposals from showing an annual-course wording and duplicating detailed activity lines and prices outside the cost table in the printed proposal document.
- Ensure the catalog appendix loader only requests the correct appendix pages for each item (workshops vs course/program) and avoids loading duplicate appendices that produce spurious warnings.
- Bump service-worker cache version so a deploy drops old caches consistently after this frontend change.

### Description
- Classify proposal/activity kinds with helpers `itemCatalogKind`, `proposalActivityKind` and `activityIntroForCatalog` and choose the short appendix wording depending on whether the proposal is `course`, `workshop`, `summer` or `combined`.
- When a catalog is attached, make `proposalPreviewBodyHtml` render only a short appendix sentence in the `הפעילות המוצעת` section (no duplicated item lists, Gefen, meetings, hours, per-hour/group prices, counts), keeping all prices and quantities in the `עלות ותנאי תשלום` table only.
- Rework `buildProposalCatalogEntries` to request `workshops.html` for workshop/summer items and `course-page.html` for course/program items, add stronger dedupe by final URL/workshopId/Gefen id and avoid requesting both paths for the same item.
- Bumped SW/cache versions in `frontend/sw.js` and `sw.js` and updated the built entry in `dist/index.html`; added focused tests in `tests/proposals-agreements-screen.test.mjs` for catalog URL generation and workshop preview behavior.

### Testing
- Ran focused unit tests with `node --test --test-name-pattern "catalog appendix entries|workshop proposal preview" tests/proposals-agreements-screen.test.mjs`, and those focused tests passed.
- Ran syntax checks and build verification with `node --check frontend/src/screens/proposals-agreements.js && node --check frontend/sw.js && node --check sw.js && node --check tests/proposals-agreements-screen.test.mjs && npm run check:build`, and the checks/build succeeded.
- Ran the repository-level changed-file check `npm run check:changed`; the new focused tests passed but the broader changed-file test run still surface unrelated historical/legacy failures in that large test file (these failures pre-existed and are outside the scope of this fix). 
- Confirmed service-worker cache versions were incremented in both `frontend/sw.js` and `sw.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a8c3e36e8832bb08ba8bed8a1a4f4)