### PR TITLE
Fix proposal catalog appendix routing and wording

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -666,6 +666,8 @@ function groupKindText(value) {
 function itemKindText(item = {}) {
   return [
     item.item_type,
+    item.type,
+    item.catalog_type,
     item.proposal_group,
     item.activity_type_group,
     item.item_name,
@@ -688,6 +690,25 @@ function isCourseKindText(value = '') {
   return /קורס|תוכנית|תכנית|הדרכה|שנת|שנה הבאה|תשפ|program|course/.test(value);
 }
 
+function isNonCourseActivityKindText(value = '') {
+  return /פעילו|פעילות|משחק|game|activity/.test(value);
+}
+
+function explicitCatalogKindText(item = {}) {
+  return [
+    item.item_type,
+    item.type,
+    item.catalog_type,
+    item.proposal_group,
+    item.activity_type_group
+  ].map(normalizedKindText).filter(Boolean).join(' ');
+}
+
+function hasExplicitCourseKind(item = {}) {
+  const kindText = explicitCatalogKindText(item);
+  return isCourseKindText(kindText) && !isWorkshopKindText(kindText) && !isNonCourseActivityKindText(kindText);
+}
+
 function itemCatalogKind(item = {}) {
   if (!item || isTestHoursItem(item)) return '';
   const displayMode = text(item.proposal_display_mode);
@@ -696,8 +717,8 @@ function itemCatalogKind(item = {}) {
   const kindText = itemKindText(item);
   if (isSummerKindText(kindText)) return 'summer';
   if (isWorkshopKindText(kindText)) return 'workshop';
-  if (text(item.gefen_number) || isCourseKindText(kindText)) return 'course';
-  return text(item.activity_no || item.pricing_key || item.source_pricing_key) ? 'workshop' : '';
+  if (hasExplicitCourseKind(item)) return 'course';
+  return '';
 }
 
 function proposalActivityKind(row = {}, items = []) {
@@ -707,6 +728,7 @@ function proposalActivityKind(row = {}, items = []) {
   if (/משולב|combined/.test(kindText)) return 'combined';
   if (isSummerKindText(kindText)) return 'summer';
   if (isWorkshopKindText(kindText)) return 'workshop';
+  if (isNonCourseActivityKindText(kindText)) return 'activity';
   if (isCourseKindText(kindText)) return 'course';
 
   const itemKinds = new Set((Array.isArray(items) ? items : [])
@@ -716,17 +738,21 @@ function proposalActivityKind(row = {}, items = []) {
   return itemKinds.values().next().value || 'course';
 }
 
-function activityIntroForCatalog(row = {}, items = []) {
+function activityIntroForCatalog(row = {}, items = [], hasCatalogAppendix = true) {
+  const appendixSuffix = hasCatalogAppendix ? ' מצורף כנספח להצעה זו.' : '.';
   switch (proposalActivityKind(row, items)) {
     case 'workshop':
-      return 'פירוט הסדנאות המוצעות מצורף כנספח להצעה זו.';
+      return `פירוט הסדנאות המוצעות${appendixSuffix}`;
     case 'summer':
-      return 'פירוט פעילויות הקיץ המוצעות מצורף כנספח להצעה זו.';
+      return `פירוט הפעילויות המוצעות${appendixSuffix}`;
     case 'combined':
-      return 'פירוט הפעילויות המוצעות מצורף כנספח להצעה זו.';
+    case 'activity':
+      return `פירוט הפעילויות המוצעות${appendixSuffix}`;
     case 'course':
     default:
-      return 'להלן הקורסים המוצעים לשנת הלימודים תשפ״ז. פירוט מלא של הקורסים מצורף כנספח להצעה זו.';
+      return hasCatalogAppendix
+        ? 'להלן הקורסים המוצעים לשנת הלימודים תשפ״ז. פירוט מלא של הקורסים מצורף כנספח להצעה זו.'
+        : 'להלן הקורסים המוצעים לשנת הלימודים תשפ״ז.';
   }
 }
 
@@ -1372,8 +1398,8 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
   const hasCatalogAppendix = catalogEntries.length > 0;
   const introText = sectionBody('intro');
   const remarks = sectionBody('notes') || String(row.notes || '').replace(/\r\n?/g, '\n').trim();
-  const activityIntro = includeCatalog && hasCatalogAppendix
-    ? activityIntroForCatalog(row, items)
+  const activityIntro = includeCatalog
+    ? activityIntroForCatalog(row, items, hasCatalogAppendix)
     : filterCatalogContentFromBody(sectionBody('activity_intro'), false);
 
   const renderActivitySection = (heading, body) => {
@@ -1957,30 +1983,36 @@ function replaceLocalRow(data, savedRow) {
 
 // ─── Catalog appendix via hidden iframe extraction ───────────────────────────
 
-function buildProposalCatalogEntryDetails(items) {
-  if (!Array.isArray(items) || !items.length) return [];
+function buildProposalCatalogAppendixPlan(items) {
+  if (!Array.isArray(items) || !items.length) return { entries: [], skipped: [] };
   const catalogBase = `${PUBLIC_BASE}catalog/summercatalog/`;
   const entries = [];
+  const skipped = [];
   const seenUrls = new Set();
   const seenGefen = new Set();
   const seenActivityNo = new Set();
   const seenWorkshopIds = new Set();
+  const seenSkipped = new Set();
 
-  const cleanIdentifier = (value) => text(value || '').replace(/^cat-/i, '').trim();
+  const cleanIdentifier = (value) => text(value || '').replace(/^cat-/i, '').trim().replace(/\/$/, '');
   const labelForItem = (item = {}, fallback = 'פעילות') => (
     text(item.item_name || item.pricing_activity_name || item.activity_name || item.description) || fallback
   );
+  const activityNoForItem = (item = {}) => cleanIdentifier(
+    item.activity_no || item.pricing_activity_no || item.activity_id || item.id || item.pricing_key || item.source_pricing_key
+  );
   const cleanGefenId = (value) => {
-    const gefen = text(value).trim();
-    // Gefen catalog pages are keyed by Gefen numbers. Do not fall back to
-    // activity_no for courses, because that creates course-page URLs that are
-    // not guaranteed to exist for the selected proposal item.
-    return /\d/.test(gefen) ? gefen : '';
+    const gefen = text(value).trim().replace(/\/$/, '');
+    // Course catalog pages are keyed by Gefen/catalog numbers. Do not fall
+    // back to activity_no/id: those identifiers can also belong to games,
+    // activities or pricing rows that do not have a course-page appendix.
+    return /^\d{3,}$/.test(gefen) ? gefen : '';
   };
   const cleanWorkshopId = (item = {}) => {
     const candidates = [
       item.workshopId,
       item.workshop_id,
+      item.workshop_ids,
       item.activity_no,
       item.pricing_activity_no,
       item.pricing_key,
@@ -1993,15 +2025,28 @@ function buildProposalCatalogEntryDetails(items) {
     }
     return '';
   };
+  const skipItem = (item, reason = 'missing_appendix') => {
+    const label = labelForItem(item);
+    const activityNo = activityNoForItem(item);
+    const key = [label, activityNo, reason].join('||');
+    if (seenSkipped.has(key)) return;
+    seenSkipped.add(key);
+    skipped.push({ label, activityNo, reason });
+  };
   const addEntry = ({ url, label, gefenNumber = '', activityNo = '', workshopId = '' }) => {
-    if (!url || seenUrls.has(url)) return;
+    if (!url || seenUrls.has(url)) return false;
     seenUrls.add(url);
     entries.push({ url, label: text(label) || 'פעילות', gefenNumber, activityNo, workshopId });
+    return true;
   };
   const addCourseEntry = (item) => {
-    const gefenNumber = cleanGefenId(item.gefen_number);
-    const activityNo = cleanIdentifier(item.activity_no || item.pricing_activity_no || item.pricing_key || item.source_pricing_key);
-    if (!gefenNumber || seenGefen.has(gefenNumber) || (activityNo && seenActivityNo.has(activityNo))) return;
+    const gefenNumber = cleanGefenId(item.gefen_number || item.catalog_id || item.catalogId);
+    const activityNo = activityNoForItem(item);
+    if (!hasExplicitCourseKind(item) || !gefenNumber) {
+      skipItem(item, 'no_course_catalog');
+      return;
+    }
+    if (seenGefen.has(gefenNumber) || (activityNo && seenActivityNo.has(activityNo))) return;
     seenGefen.add(gefenNumber);
     if (activityNo) seenActivityNo.add(activityNo);
     addEntry({
@@ -2013,8 +2058,12 @@ function buildProposalCatalogEntryDetails(items) {
   };
   const addWorkshopEntry = (item) => {
     const workshopId = cleanWorkshopId(item);
-    const activityNo = cleanIdentifier(item.activity_no || item.pricing_activity_no || item.pricing_key || item.source_pricing_key || workshopId);
-    if (!workshopId || seenWorkshopIds.has(workshopId) || (activityNo && seenActivityNo.has(activityNo))) return;
+    const activityNo = activityNoForItem(item) || workshopId;
+    if (!workshopId) {
+      skipItem(item, 'no_workshop_catalog');
+      return;
+    }
+    if (seenWorkshopIds.has(workshopId) || (activityNo && seenActivityNo.has(activityNo))) return;
     seenWorkshopIds.add(workshopId);
     if (activityNo) seenActivityNo.add(activityNo);
     addEntry({
@@ -2026,6 +2075,7 @@ function buildProposalCatalogEntryDetails(items) {
   };
   const addBundleWorkshops = (item) => {
     const selected = Array.isArray(item.selected_bundle_items) ? item.selected_bundle_items : [];
+    if (!selected.length) skipItem(item, 'no_workshop_catalog');
     selected.forEach((sel) => addWorkshopEntry({
       ...sel,
       item_name: sel.item_name || sel.activity_name || item.item_name,
@@ -2052,15 +2102,24 @@ function buildProposalCatalogEntryDetails(items) {
 
     if (kind === 'workshop' || kind === 'summer') {
       addWorkshopEntry(item);
+      continue;
     }
+
+    skipItem(item, 'unsupported_catalog_kind');
   }
 
-  return entries.sort((a, b) => {
+  entries.sort((a, b) => {
     const aIsWorkshop = a.url.includes('/workshops.html');
     const bIsWorkshop = b.url.includes('/workshops.html');
     if (aIsWorkshop !== bIsWorkshop) return aIsWorkshop ? -1 : 1;
     return 0;
   });
+
+  return { entries, skipped };
+}
+
+function buildProposalCatalogEntryDetails(items) {
+  return buildProposalCatalogAppendixPlan(items).entries;
 }
 
 export function buildProposalCatalogEntries(items) {
@@ -2666,18 +2725,22 @@ export const proposalsAgreementsScreen = {
             firstAppendixAdded = true;
           }
         };
-        const appendAppendixWarning = (message) => {
+        const appendAppendixNotice = (message, className = 'pa-appendix-note') => {
           const notice = document.createElement('p');
-          notice.className = 'pa-appendix-missing no-print';
+          notice.className = `${className} no-print`;
           notice.textContent = message;
           previewArea?.appendChild(notice);
           return notice;
         };
         const appendixLoads = [];
-        const catalogEntries = buildProposalCatalogEntryDetails(items);
-        if (!catalogEntries.length) {
-          const notice = appendAppendixWarning('לא נמצא נספח קטלוג מתאים לפריטים שנבחרו');
-          markFirst(notice);
+        const catalogPlan = buildProposalCatalogAppendixPlan(items);
+        const catalogEntries = catalogPlan.entries;
+        const skippedCatalogItems = catalogPlan.skipped;
+        if (skippedCatalogItems.length) {
+          skippedCatalogItems.forEach((skipped) => {
+            const notice = appendAppendixNotice(`לא נמצא נספח קטלוג מתאים עבור: ${skipped.label}`);
+            if (!catalogEntries.length) markFirst(notice);
+          });
         }
         for (const entry of catalogEntries) {
           const loadCatalog = (async () => {
@@ -2692,7 +2755,7 @@ export const proposalsAgreementsScreen = {
               return true;
             } catch (e) {
               console.warn('[PA] Catalog iframe failed:', entry.url, e);
-              const notice = appendAppendixWarning(`⚠ לא ניתן לטעון נספח: ${entry.label} — ${entry.url}`);
+              const notice = appendAppendixNotice(`⚠ לא ניתן לטעון נספח: ${entry.label} — ${entry.url}`, 'pa-appendix-missing');
               markFirst(notice);
               return false;
             }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11593,13 +11593,21 @@ select.ds-input {
   padding: 4px 12px;
   font-size: 0.82rem;
 }
+.pa-appendix-note,
 .pa-appendix-missing {
-  color: #dc2626;
   font-size: 0.82rem;
   padding: 6px 14px;
-  border: 1px solid #fca5a5;
   border-radius: 4px;
   margin: 6px 0;
+}
+.pa-appendix-note {
+  color: #92400e;
+  border: 1px solid #fcd34d;
+  background: #fffbeb;
+}
+.pa-appendix-missing {
+  color: #dc2626;
+  border: 1px solid #fca5a5;
   background: #fef2f2;
 }
 .pa-pdf-appendix-frame {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 690;
+const CACHE_VERSION = 691;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 640;
+const SW_ENTRY_VERSION = 641;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1328,6 +1328,35 @@ test('catalog appendix entries split mixed proposals by true item type without d
   ]);
 });
 
+
+test('catalog appendix entries skip non-course activities even when they have Gefen/activity ids', async () => {
+  const gameItem = {
+    item_name: 'משחקי קופסה – פיתוח ופיצוח משחקי לוח',
+    item_type: 'פעילות',
+    type: 'activity',
+    activity_type_group: 'פעילויות',
+    activity_no: '27342',
+    gefen_number: '27342'
+  };
+
+  const urls = buildProposalCatalogEntries([gameItem]);
+  assert.deepEqual(urls, []);
+
+  const html = proposalPreviewBodyHtml(
+    { ...sampleRows[0], activity_type_group: 'פעילויות', include_catalog: true },
+    [gameItem],
+    [{ template_key: '', section_key: 'activity_intro', section_title: 'הפעילות המוצעת', section_body: 'להלן הקורסים המוצעים לשנת הלימודים תשפ״ז. פירוט מלא של הקורסים מצורף כנספח להצעה זו.' }]
+  );
+
+  await withJSDOM(html, async (_root, dom) => {
+    const activitySection = [...dom.window.document.querySelectorAll('.proposal-document .pa-section')]
+      .find((section) => section.querySelector('h3')?.textContent.includes('הפעילות המוצעת'));
+    assert.ok(activitySection);
+    assert.match(activitySection.textContent, /פירוט הפעילויות המוצעות\./);
+    assert.doesNotMatch(activitySection.textContent, /להלן הקורסים|מצורף כנספח/);
+  });
+});
+
 test('workshop proposal preview uses short appendix wording and keeps prices only in cost table', async () => {
   const row = {
     ...sampleRows[0],
@@ -1364,7 +1393,7 @@ test('workshop proposal preview uses short appendix wording and keeps prices onl
   });
 });
 
-test('summer proposal preview shows catalog sentence only when include_catalog is enabled', async () => {
+test('summer proposal preview only mentions an appendix when a matching appendix exists', async () => {
   const baseSections = [
     { template_key: 'summer', template_name: 'הצעת מחיר', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח.' },
     { template_key: 'summer', section_key: 'activity_intro', section_title: 'הפעילות המוצעת', section_body: 'טקסט פעילות.\n דף מידע עם פירוט מגוון הפעילויות המוצעות מצורף להצעה.' },
@@ -1396,7 +1425,7 @@ test('summer proposal preview shows catalog sentence only when include_catalog i
 
     const onText = await openPreviewForRow(rowOn, dom, root);
     assert.doesNotMatch(offText, /מצורף להצעה/);
-    assert.match(onText, /מצורף[\s\S]*להצעה/);
+    assert.doesNotMatch(onText, /מצורף[\s\S]*להצעה/);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent non-course items (games/activities/workshops) from being treated as course catalog pages when they only have `activity_no`/`gefen_number` identifiers.
- Ensure proposal document wording matches the actual appendix attachments and avoid showing a red load-failure warning for items that should not have appendices.
- Keep URL construction clean (no trailing slash on query params) and dedupe appendix loads by the final identifying keys.

### Description
- Tightened catalog classification in `frontend/src/screens/proposals-agreements.js` by adding explicit kind detection (`isNonCourseActivityKindText`, `explicitCatalogKindText`, `hasExplicitCourseKind`) and only routing true course/program items with valid Gefen/catalog IDs to `course-page.html` while routing valid workshop IDs to `workshops.html` or skipping unsupported items entirely.
- Reworked appendix planning with `buildProposalCatalogAppendixPlan(items)` returning `{ entries, skipped }` so we dedupe by URL/`gefen_number`/`workshopId`/`activity_no` and avoid fallback from `activity_no` → `course-page.html` for non-course activities.
- Changed preview behavior so skipped items produce admin-only `no-print` notes (`.pa-appendix-note`) and only real appendix loads that fail show the red missing-warning (`.pa-appendix-missing`), and updated CSS accordingly (`frontend/src/styles/main.css`).
- Adjusted proposal intro wording: the activity section text now varies by proposal kind and includes the appendix phrase only when a matching appendix was actually built; prices remain only in the cost table for workshops/summer items.
- Added a focused test for the previously failing case (game/activity with Gefen/id) in `tests/proposals-agreements-screen.test.mjs` and bumped service worker/cache versions in `frontend/sw.js` and `sw.js` to invalidate caches.

### Testing
- Ran focused unit tests: `node --test --test-name-pattern "catalog appendix entries|summer proposal preview only mentions|workshop proposal preview" tests/proposals-agreements-screen.test.mjs` — all focused catalog-related tests passed.
- Ran syntax and focused checks: `node --check frontend/src/screens/proposals-agreements.js && node --check frontend/sw.js && node --check sw.js && node --check tests/proposals-agreements-screen.test.mjs` — JS checks passed.
- Built the frontend: `npm run check:build` (runs the production build) — build succeeded and `dist` assets were produced.
- Ran the broader `npm run check:changed` which runs the larger proposal screen test file — this reported unrelated legacy expectations failing in other parts of the suite; the focused catalog appendix tests noted above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa81f6e6c832bb737e3c659e9ad57)