### PR TITLE
Fix activity add modal save handler

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-KgznSwlK.js"></script>
+  <script type="module" crossorigin src="./assets/index-C6hCzYkT.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DEt7ORas.css">
 </head>
 <body>

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -2132,6 +2132,11 @@ export const activitiesScreen = {
         form.dataset.submitting = 'no';
         return;
       }
+      if (!isOneDay && !meetingDateValues.some((dateValue) => String(dateValue || '').trim())) {
+        if (statusEl) statusEl.textContent = 'יש להשלים לפחות תאריך מפגש אחד';
+        form.dataset.submitting = 'no';
+        return;
+      }
 
       const required = [
         ['activity_type', 'סוג פעילות'],
@@ -2154,11 +2159,8 @@ export const activitiesScreen = {
           submitBtn.textContent = isCreateRequestOnly ? 'שולח בקשה...' : 'שומר...';
         }
         if (statusEl) statusEl.textContent = isCreateRequestOnly ? 'שולח בקשה לאישור...' : 'שומר...';
-        console.info('[addActivity] submit fired', { requestOnly: isCreateRequestOnly });
-        console.info('[addActivity] payload', payload);
         if (isCreateRequestOnly) {
           const rsp = await api.submitCreateActivityRequest(payload);
-          console.info('[addActivity] request success', rsp);
           clearScreenDataCache?.();
           try { document.dispatchEvent(new CustomEvent('app:edit-requests-updated')); } catch (_) { /* ignore */ }
           const requestId = String(rsp?.request_id || '').trim();
@@ -2167,8 +2169,7 @@ export const activitiesScreen = {
           ui?.closeModal?.();
           return;
         }
-        const rsp = await api.addActivity(payload);
-        console.info('[addActivity] success', rsp);
+        await api.addActivity(payload);
         clearScreenDataCache?.();
         const savedPeriod = activityPeriodKey(payload);
         const savedToOtherPeriod = savedPeriod !== state.activityPeriodTab;
@@ -2193,28 +2194,27 @@ export const activitiesScreen = {
       }
     }
 
-    const modalRoot = document;
-    const addActivityForm = modalRoot.querySelector('[data-add-activity-form]');
-    if (addActivityForm && addActivityForm.dataset.submitBound !== 'yes') {
-      addActivityForm.dataset.submitBound = 'yes';
-      addActivityForm.addEventListener('submit', async (event) => {
-        event.preventDefault();
-        const submitBtn = document.querySelector('[data-add-activity-submit]');
-        if (submitBtn?.disabled) return;
-        await submitAddActivityForm(addActivityForm, submitBtn);
-      }, addActivitySig);
-    }
-    if (document.body?.dataset?.globalActivitySubmitBound !== 'yes') {
-      document.body.dataset.globalActivitySubmitBound = 'yes';
-      document.addEventListener('submit', async (event) => {
-        const form = event.target?.closest?.('[data-add-activity-form]');
-        if (!form) return;
+    function bindAddActivitySubmit(form) {
+      if (!form || form.dataset.submitBound === 'yes') return;
+      form.dataset.submitBound = 'yes';
+      form.addEventListener('submit', async (event) => {
         event.preventDefault();
         const submitBtn = document.querySelector('[data-add-activity-submit]');
         if (submitBtn?.disabled) return;
         await submitAddActivityForm(form, submitBtn);
       }, addActivitySig);
     }
+
+    const modalRoot = document;
+    bindAddActivitySubmit(modalRoot.querySelector('[data-add-activity-form]'));
+    document.addEventListener('submit', async (event) => {
+      const form = event.target?.closest?.('[data-add-activity-form]');
+      if (!form) return;
+      event.preventDefault();
+      const submitBtn = document.querySelector('[data-add-activity-submit]');
+      if (submitBtn?.disabled) return;
+      await submitAddActivityForm(form, submitBtn);
+    }, addActivitySig);
 
     document.addEventListener('click', (ev) => {
       const submit = ev.target.closest('[data-add-activity-submit]');
@@ -2223,7 +2223,8 @@ export const activitiesScreen = {
       const form = modal?.querySelector('[data-add-activity-form]');
       if (!form) return;
       if (submit.disabled) return;
-      form.requestSubmit?.();
+      if (typeof form.requestSubmit === 'function') form.requestSubmit();
+      else form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     }, addActivitySig);
 
     const addBtn = root.querySelector('[data-activities-add-btn]');
@@ -2240,6 +2241,7 @@ export const activitiesScreen = {
           `
         });
         bindAddActivityForm();
+        bindAddActivitySubmit(document.querySelector('.ds-modal__content [data-add-activity-form]'));
       }, addActivitySig);
     }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 690;
+const CACHE_VERSION = 691;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 640;
+const SW_ENTRY_VERSION = 641;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Users reported that the "Add activity" flow opened the modal but Save did not reliably trigger the create/request flow, leaving the button unresponsive in some permission combinations and when date fields were missing.
- Recent permission fixes may have introduced an incorrect gating or brittle event binding that prevented the add flow from reaching `api.addActivity`/`api.submitCreateActivityRequest` and left the modal stuck without clear errors.

### Description
- Ensure the add-activity modal always binds a submit handler when opened by adding `bindAddActivitySubmit` and binding it to the modal form so the Save button triggers `submitAddActivityForm` reliably. (`frontend/src/screens/activities.js`).
- Add explicit validation that multi-session activities have at least one meeting date to avoid silent failures and stuck loading state. (`frontend/src/screens/activities.js`).
- Add a fallback for browsers that lack `form.requestSubmit` by dispatching a submit `Event` so the Save button still works. (`frontend/src/screens/activities.js`).
- Remove noisy `console.info` logs from the add flow to reduce clutter and keep `console.error` for real failures, and ensure `api.addActivity` is awaited properly in the flow. (`frontend/src/screens/activities.js`).
- Bump service-worker cache/version constants to drop old caches after deploy by updating `frontend/sw.js` (`CACHE_VERSION`) and `sw.js` (`SW_ENTRY_VERSION`), and the build output reference in `dist/index.html`. (`frontend/sw.js`, `sw.js`, `dist/index.html`).

### Testing
- Changed files: `frontend/src/screens/activities.js`, `frontend/sw.js`, `sw.js`, and `dist/index.html` (build output); focused checks run were `node --check frontend/src/screens/activities.js`, `node --check frontend/sw.js`, `node --check sw.js`, and `npm run check:changed` as per AGENTS policy. All checks passed.
- Frontend build verification was performed with `npm run check:build` (runs `vite build` + postbuild); the build completed successfully and `dist/index.html` was updated to the new bundle reference.
- Confirmed service worker cache identifiers were bumped (`CACHE_VERSION` and `SW_ENTRY_VERSION`) to ensure old caches will be dropped after deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aaae85270832b8cc7f75ff8d7c311)