### PR TITLE
Fix add-activity modal saving state and validation

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-C6hCzYkT.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DEt7ORas.css">
+  <script type="module" crossorigin src="./assets/index-Du7cHA9q.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-B6VyMLYQ.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -327,6 +327,7 @@ const TIME_OPTIONS = Array.from({ length: 48 }, (_, i) => {
   const m = i % 2 === 0 ? '00' : '30';
   return `${h}:${m}`;
 });
+const GENERIC_ONE_DAY_ACTIVITY_NAMES = new Set(['סדנה', 'סדנאות', 'סיור', 'סיורים', 'חדר בריחה', 'חדרי בריחה']);
 function isOneDayActivityTypeValue(value) {
   return Boolean(normalizeOneDayActivityType(value));
 }
@@ -2047,6 +2048,17 @@ export const activitiesScreen = {
       statusEl.classList.toggle('ds-error-text', isError);
     }
 
+    function resetAddActivitySavingState(form, submitBtn) {
+      if (!form) return;
+      form.dataset.saving = '';
+      form.dataset.submitting = 'no';
+      const button = submitBtn || document.querySelector('[data-add-activity-submit]');
+      if (!button) return;
+      button.disabled = false;
+      button.classList.remove('is-loading');
+      if (button.dataset.defaultText) button.textContent = button.dataset.defaultText;
+    }
+
     function readableActivityAddError(error) {
       const status = String(error?.status || error?.code || '').trim();
       const message = String(error?.message || error || '').trim();
@@ -2057,11 +2069,9 @@ export const activitiesScreen = {
 
     async function submitAddActivityForm(form, submitBtn) {
       const statusEl = form.querySelector('[data-add-activity-status]');
-      if (form.dataset.submitting === 'yes') {
-        setAddActivityStatus(statusEl, 'השמירה כבר בתהליך. אם ההודעה לא משתנה, סגרו ופתחו את החלון מחדש.', { isError: true });
+      if (form.dataset.saving === 'yes' || form.dataset.submitting === 'yes') {
         return;
       }
-      form.dataset.submitting = 'yes';
       const activityMap = decodeJsonAttr(form.dataset.addActivityNames, []);
       const roster = decodeJsonAttr(form.dataset.addRosterUsers, []);
       const fd = new (window?.FormData || FormData)(form);
@@ -2073,14 +2083,24 @@ export const activitiesScreen = {
       const selectedName = get('activity_name');
       const selectedType = normalizeOneDayActivityType(get('activity_type')) || normalizeActivityTypeKey(get('activity_type'));
       let activityAddDiagnostics = {};
+      if (!selectedType) {
+        setAddActivityStatus(statusEl, 'יש לבחור סוג פעילות', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
+        return;
+      }
+      if (!selectedName) {
+        setAddActivityStatus(statusEl, 'יש לבחור שם פעילות', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
+        return;
+      }
       const hit = activityMap.find((x) => {
         const label = String(x?.label || '').trim();
         const parent = x?.parent_value || x?.activity_type;
         return label === selectedName && activityTypeMatches(parent, selectedType);
       });
-      if (!selectedType || !selectedName || !hit) {
-        setAddActivityStatus(statusEl, 'לא ניתן לשמור: חסרה פעילות מקור מתוך הרשימה המסוננת', { isError: true });
-        form.dataset.submitting = 'no';
+      if (!hit) {
+        setAddActivityStatus(statusEl, 'יש לבחור שם פעילות מתוך הרשימה המסוננת', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
       const pickEmp = (name) => {
@@ -2165,13 +2185,28 @@ export const activitiesScreen = {
       };
 
       if (isOneDay && (!String(payload.activity_name || '').trim() || GENERIC_ONE_DAY_ACTIVITY_NAMES.has(String(payload.activity_name || '').trim()))) {
-        setAddActivityStatus(statusEl, 'לא ניתן לשמור: חסר שם פעילות מתוך הרשימה', { isError: true });
-        form.dataset.submitting = 'no';
+        setAddActivityStatus(statusEl, 'יש לבחור שם פעילות מתוך הרשימה', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
+        return;
+      }
+      if (isOneDay && !String(payload.date_1 || payload.start_date || '').trim()) {
+        setAddActivityStatus(statusEl, 'יש למלא תאריך פעילות', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
       if (!isOneDay && !meetingDateValues.some((dateValue) => String(dateValue || '').trim())) {
-        setAddActivityStatus(statusEl, 'לא ניתן לשמור: חסר לפחות תאריך מפגש אחד', { isError: true });
-        form.dataset.submitting = 'no';
+        setAddActivityStatus(statusEl, 'יש למלא לפחות תאריך מפגש אחד', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
+        return;
+      }
+      if (!String(payload.start_time || '').trim()) {
+        setAddActivityStatus(statusEl, 'יש לבחור שעת התחלה', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
+        return;
+      }
+      if (!String(payload.end_time || '').trim()) {
+        setAddActivityStatus(statusEl, 'יש לבחור שעת סיום', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
 
@@ -2180,33 +2215,37 @@ export const activitiesScreen = {
         ['activity_name', 'שם פעילות'],
         ['authority', 'רשות'],
         ['school', 'בית ספר'],
-        ...(isOneDay ? [['start_date', 'תאריך פעילות חד־יומית'], ['end_date', 'תאריך סיום'], ['date_1', 'תאריך פעילות']] : [])
+        ...(isOneDay ? [['start_date', 'תאריך פעילות'], ['end_date', 'תאריך סיום'], ['date_1', 'תאריך פעילות']] : [])
       ];
       const missing = required.filter(([key]) => !String(payload[key] || '').trim()).map(([, label]) => label);
       if (missing.length) {
         setAddActivityStatus(statusEl, `לא ניתן לשמור: חסר ${missing.join(' / ')}`, { isError: true });
-        form.dataset.submitting = 'no';
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
       if (!String(payload.activity_no || '').trim()) {
         setAddActivityStatus(statusEl, 'לא ניתן לשמור: חסר מזהה פעילות מקור', { isError: true });
-        form.dataset.submitting = 'no';
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
       if (!isCreateRequestOnly && !canAddActivities(state)) {
         setAddActivityStatus(statusEl, 'לא ניתן לשמור: אין הרשאת הוספה', { isError: true });
-        form.dataset.submitting = 'no';
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
       if (isCreateRequestOnly && !canRequestActivityChanges(state)) {
         setAddActivityStatus(statusEl, 'לא ניתן לשמור: אין הרשאה לשליחת בקשת הוספה', { isError: true });
-        form.dataset.submitting = 'no';
+        resetAddActivitySavingState(form, submitBtn);
         return;
       }
       const originalText = submitBtn?.textContent || (isCreateRequestOnly ? 'שליחת בקשה' : 'שמור');
+      if (submitBtn && !submitBtn.dataset.defaultText) submitBtn.dataset.defaultText = originalText;
+      form.dataset.saving = 'yes';
+      form.dataset.submitting = 'yes';
       try {
         if (submitBtn) {
           submitBtn.disabled = true;
+          submitBtn.classList.add('is-loading');
           submitBtn.textContent = isCreateRequestOnly ? 'שולח בקשה...' : 'שומר...';
         }
         setAddActivityStatus(statusEl, isCreateRequestOnly ? 'שולח בקשה לאישור...' : 'שומר...');
@@ -2245,9 +2284,11 @@ export const activitiesScreen = {
         console.error('[activity-add] save failed', { error: err, payload, diagnostics: activityAddDiagnostics });
         setAddActivityStatus(statusEl, `לא ניתן לשמור: ${readableActivityAddError(err)}`, { isError: true });
       } finally {
+        form.dataset.saving = '';
         form.dataset.submitting = 'no';
         if (submitBtn) {
           submitBtn.disabled = false;
+          submitBtn.classList.remove('is-loading');
           submitBtn.textContent = originalText;
         }
       }
@@ -2258,22 +2299,14 @@ export const activitiesScreen = {
       form.dataset.submitBound = 'yes';
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
+        event.stopPropagation();
         const submitBtn = document.querySelector('[data-add-activity-submit]');
         if (submitBtn?.disabled) return;
         await submitAddActivityForm(form, submitBtn);
       }, addActivitySig);
     }
 
-    const modalRoot = document;
-    bindAddActivitySubmit(modalRoot.querySelector('[data-add-activity-form]'));
-    document.addEventListener('submit', async (event) => {
-      const form = event.target?.closest?.('[data-add-activity-form]');
-      if (!form) return;
-      event.preventDefault();
-      const submitBtn = document.querySelector('[data-add-activity-submit]');
-      if (submitBtn?.disabled) return;
-      await submitAddActivityForm(form, submitBtn);
-    }, addActivitySig);
+    bindAddActivitySubmit(document.querySelector('[data-add-activity-form]'));
 
     document.addEventListener('click', (ev) => {
       const submit = ev.target.closest('[data-add-activity-submit]');
@@ -2296,6 +2329,11 @@ export const activitiesScreen = {
       else form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     }, addActivitySig);
 
+    document.addEventListener('click', (ev) => {
+      if (!ev.target.closest('[data-ui-close-modal]')) return;
+      resetAddActivitySavingState(document.querySelector('[data-add-activity-form]'), document.querySelector('[data-add-activity-submit]'));
+    }, addActivitySig);
+
     const addBtn = root.querySelector('[data-activities-add-btn]');
     if (canAddActivity && ui && addBtn) {
       addBtn.addEventListener('click', () => {
@@ -2309,8 +2347,11 @@ export const activitiesScreen = {
             <button type="button" class="ds-btn" data-ui-close-modal>ביטול</button>
           `
         });
+        const addActivityForm = document.querySelector('.ds-modal__content [data-add-activity-form]');
+        const addActivitySubmit = document.querySelector('[data-add-activity-submit]');
+        resetAddActivitySavingState(addActivityForm, addActivitySubmit);
         bindAddActivityForm();
-        bindAddActivitySubmit(document.querySelector('.ds-modal__content [data-add-activity-form]'));
+        bindAddActivitySubmit(addActivityForm);
       }, addActivitySig);
     }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 692;
+const CACHE_VERSION = 693;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 642;
+const SW_ENTRY_VERSION = 643;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -360,9 +360,9 @@ test('activities screen wires add-activity form submit to api.addActivity flow',
   const fs = await import('node:fs/promises');
   const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
   assert.match(source, /data-add-activity-form/);
-  assert.match(source, /document\.addEventListener\('submit'[\s\S]*submitAddActivityForm/);
+  assert.match(source, /form\.addEventListener\('submit'[\s\S]*submitAddActivityForm/);
   assert.match(source, /await api\.addActivity\(payload\)/);
-  assert.match(source, /statusEl\) statusEl\.textContent = `שגיאה בשמירה:/);
+  assert.match(source, /setAddActivityStatus\(statusEl, `לא ניתן לשמור:/);
   assert.match(source, /const ADD_ACTIVITY_TYPE_ORDER = \['workshop', 'escape_room', 'tour', 'after_school'\]/);
   assert.doesNotMatch(source, /data-add-family=/);
   assert.match(source, /'workshop'/);
@@ -570,5 +570,90 @@ test('activity add form refreshes activity_name options and clears stale name wh
     globalThis.window = previousWindow;
     globalThis.document = previousDocument;
     globalThis.AbortController = previousAbortController;
+  }
+});
+
+test('activity add validation clears saving state and does not show duplicate in-progress error', async () => {
+  const settings = activityNameSettings();
+  settings.dropdown_options.authorities = ['רשות א'];
+  settings.dropdown_options.schools = ['בית ספר א'];
+  settings.dropdown_options.activity_managers = ['מנהלת א'];
+  const state = baseState();
+  state.clientSettings = settings;
+  state.user = { display_role: 'admin', role: 'admin', can_add_activity: true };
+  const dom = new JSDOM('<body><main id="root"></main></body>', { url: 'https://example.test/dashboard_system/' });
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousAbortController = globalThis.AbortController;
+  const previousFormData = globalThis.FormData;
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.AbortController = dom.window.AbortController;
+  globalThis.FormData = dom.window.FormData;
+  let addCalls = 0;
+  try {
+    const root = dom.window.document.querySelector('#root');
+    root.innerHTML = activitiesScreen.render({ rows: [] }, { state });
+    activitiesScreen.bind({
+      root,
+      data: { rows: [] },
+      state,
+      rerender: () => {},
+      rerenderActivitiesView: () => {},
+      clearScreenDataCache: () => {},
+      api: {
+        activities: async () => ({ rows: [] }),
+        allActivities: async () => ({ rows: [] }),
+        addActivity: async () => { addCalls += 1; return { row: { RowID: 'A-NEW', start_date: '2026-06-15' } }; }
+      },
+      ui: {
+        bindInteractiveCards: () => {},
+        closeModal: () => {},
+        openModal: ({ content, actions }) => {
+          const modal = dom.window.document.createElement('div');
+          modal.className = 'ds-modal__content';
+          modal.innerHTML = `${content}<footer>${actions}</footer>`;
+          dom.window.document.body.appendChild(modal);
+        }
+      }
+    });
+
+    root.querySelector('[data-activities-add-btn]').click();
+    const form = dom.window.document.querySelector('[data-add-activity-form]');
+    const status = form.querySelector('[data-add-activity-status]');
+    const submit = dom.window.document.querySelector('[data-add-activity-submit]');
+
+    const typeSelect = form.querySelector('[data-add-activity-type]');
+    const nameSelect = form.querySelector('[data-add-activity-name]');
+    typeSelect.value = 'escape_room';
+    typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    nameSelect.value = 'חדר בריחה חלל';
+    nameSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+    form.querySelector('[name="authority"]').value = 'רשות א';
+    form.querySelector('[name="school"]').value = 'בית ספר א';
+
+    form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(status.textContent, 'יש למלא תאריך פעילות');
+    assert.notEqual(form.dataset.saving, 'yes');
+    assert.equal(submit.disabled, false);
+    assert.equal(submit.classList.contains('is-loading'), false);
+    assert.doesNotMatch(status.textContent, /השמירה כבר בתהליך/);
+    assert.equal(addCalls, 0);
+
+    form.querySelector('[name="one_day_date"]').value = '2026-06-15';
+    form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(status.textContent, 'יש לבחור שעת התחלה');
+
+    form.querySelector('[name="start_time"]').value = '09:00';
+    form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(status.textContent, 'יש לבחור שעת סיום');
+  } finally {
+    globalThis.window = previousWindow;
+    globalThis.document = previousDocument;
+    globalThis.AbortController = previousAbortController;
+    globalThis.FormData = previousFormData;
   }
 });


### PR DESCRIPTION
### Motivation
- The add-activity modal could get its `saving`/`submitting` flag stuck and show the generic message `"השמירה כבר בתהליך"` instead of clear validation errors.
- Users hitting `שמור` with missing fields (dates/times/name/etc.) could be blocked by a stale saving flag or get unhelpful feedback.
- The save flow needed deterministic cleanup of the saving state across all validation/error/close paths and removal of duplicate submit handlers.

### Description
- Added a `GENERIC_ONE_DAY_ACTIVITY_NAMES` set and moved add-activity validations earlier so validation runs before any saving flag is set in `frontend/src/screens/activities.js`.
- Introduced `resetAddActivitySavingState(form, submitBtn)` to clear `form.dataset.saving`, clear `form.dataset.submitting`, re-enable the submit button, and remove the `is-loading` class, and call it on validation failure, modal close, and modal open.
- Updated `submitAddActivityForm` to: perform targeted validation messages (e.g. `"יש למלא תאריך פעילות"`, `"יש לבחור שעת התחלה"`), set `form.dataset.saving`/`submitting` only after validation passes, add/remove `is-loading` in the `try`/`finally`, and avoid showing the generic in-progress error to users.
- Removed the global duplicate `document` submit path in favor of a single bound `form.addEventListener('submit', ...)` (with `event.stopPropagation()`), and ensured the footer button triggers `form.requestSubmit()`; added reset on modal open/close.
- Added a focused regression test to `tests/activities-screen.test.mjs` verifying validations clear the saving state and prevent duplicate in-progress errors, and bumped service worker/cache versions in `frontend/sw.js` and `sw.js` and updated the built `dist/index.html` entry.

### Testing
- Ran the focused suite: `node --test tests/activities-screen.test.mjs`, which passed (all tests in that file succeeded).
- Performed static checks: `node --check frontend/src/screens/activities.js`, `node --check frontend/sw.js`, and `node --check sw.js`, which reported no syntax issues.
- Built the frontend with `npm run check:build` (invokes the build), which completed successfully and updated the `dist` precache entries.
- Ran the focused verification script `npm run check:changed`, which completed the expected checks for the changed files without running unrelated legacy tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab07f556c832b84ca07b5405773f3)