### PR TITLE
Fix summer exception tab split

### DIFF
--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -24,7 +24,6 @@ import { showToast } from './shared/toast.js';
 const EXCEPTIONS_SCOPE = 'exceptions';
 const EXCEPTIONS_TAB_GENERAL = 'general';
 const EXCEPTIONS_TAB_SUMMER_DATES = 'summer_dates';
-const DATE_MISSING_EXCEPTION_TYPES = new Set(['missing_start_date', 'missing_end_date']);
 
 const HEBREW_MONTHS = ['ינואר','פברואר','מרץ','אפריל','מאי','יוני','יולי','אוגוסט','ספטמבר','אוקטובר','נובמבר','דצמבר'];
 function hebrewMonthLabel(ym) {
@@ -88,23 +87,11 @@ function exceptionInstanceRows(rows = []) {
   });
 }
 
-function hasMissingDateException(row) {
-  return normalizedExceptionTypes(row).some((type) => DATE_MISSING_EXCEPTION_TYPES.has(type));
-}
-
-function isSummerMissingDateException(row) {
-  const status = String(row?.status || '').trim();
-  if (status === 'סגור' || status === 'נמחק') return false;
-  const season = String(row?.activity_season || '').trim();
-  if (season !== 'summer_2026' && season !== 'summer') return false;
-  return hasMissingDateException(row);
-}
-
 function splitRowsByExceptionTab(rows = []) {
   const general = [];
   const summerDates = [];
   for (const row of Array.isArray(rows) ? rows : []) {
-    if (isSummerMissingDateException(row)) {
+    if (isSummerActivity(row)) {
       summerDates.push(row);
     } else {
       general.push(row);
@@ -288,7 +275,7 @@ export const exceptionsScreen = {
       rows: byType.get(type) || []
     })).filter((group) => group.rows.length > 0);
     const emptyText = activeTab === EXCEPTIONS_TAB_SUMMER_DATES
-      ? 'אין פעילויות קיץ ללא תאריך להצגה.'
+      ? 'אין חריגות קיץ פעילות להצגה.'
       : 'אין חריגות כלליות פעילות להצגה.';
 
     return dsScreenStack(`
@@ -297,7 +284,7 @@ export const exceptionsScreen = {
       <section class="ds-exceptions-screen__section"><h2 class="ds-section-title ds-exceptions-screen__title">חריגות${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}</h2></section>
       ${(() => { try { return sessionStorage.getItem('ds_exceptions_save_notice') === '1'; } catch { return false; } })() ? `<div class="ds-exceptions-save-notice" role="status" dir="rtl"><strong>הפעילות נשמרה בהצלחה.</strong> החריגה תוקנה ולכן הפעילות הוסרה ממסך החריגות. <button type="button" class="ds-btn ds-btn--sm" data-exception-go-activities>מעבר למסך פעילויות</button></div>` : ''}
       ${exceptionTabsHtml(activeTab, { general: uniqueExceptionActivityCount(tabRows.general), summerDates: uniqueExceptionActivityCount(tabRows.summerDates) })}
-      ${activeTab === EXCEPTIONS_TAB_SUMMER_DATES ? '<p class="ds-exceptions-tab-note">פעילויות קיץ ללא תאריך מוצגות כאן בנפרד, מאחר שבדרך כלל מדובר בהזמנות שנכנסו למערכת ונמצאות עדיין בשלב תיאום.</p>' : ''}
+      ${activeTab === EXCEPTIONS_TAB_SUMMER_DATES ? '<p class="ds-exceptions-tab-note">חריגות של פעילויות קיץ מוצגות כאן בנפרד כדי להפריד בין פעילות קיץ לבין פעילות רגילה.</p>' : ''}
       ${exceptionsSummaryHtml(visibleRows)}
       ${!hasAnyRows ? `<section class="ds-exceptions-screen__section">${dsEmptyState(emptyText)}</section>` : groups.map((group) => `<section class="ds-exceptions-screen__section">${exceptionGroupCard(group)}</section>`).join('')}
       </div>

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -436,7 +436,7 @@ test('exceptions screen totals, district sum, and rendered cards use the same ex
   assert.equal((html.match(/data-card-action="exception:/g) || []).length, 3);
 });
 
-test('exceptions screen separates summer missing-date rows from general exceptions', () => {
+test('exceptions screen separates all summer rows from general exceptions', () => {
   const data = {
     month: '2026-05',
     rows: [
@@ -457,30 +457,47 @@ test('exceptions screen separates summer missing-date rows from general exceptio
         exception_types: ['missing_start_date']
       },
       {
-        RowID: 'SUMMER-DATED',
-        activity_name: 'פעילות קיץ עם תאריך',
+        RowID: 'SUMMER-MISSING-INSTRUCTOR',
+        activity_name: 'פעילות קיץ עם מדריך חסר',
         activity_season: 'summer_2026',
         start_date: '2026-07-15',
         end_date: '2026-07-15',
         exception_types: ['missing_instructor']
+      },
+      {
+        RowID: 'SUMMER-MISSING-DISTRICT',
+        activity_name: 'פעילות קיץ עם מחוז חסר',
+        activity_season: 'summer_2026',
+        start_date: '2026-07-16',
+        end_date: '2026-07-16',
+        exception_types: ['missing_district']
+      },
+      {
+        RowID: 'SUMMER-END-DATE-PASSED',
+        activity_name: 'פעילות קיץ עם תאריך סיום עבר',
+        activity_season: 'summer_2026',
+        start_date: '2026-07-17',
+        end_date: '2026-07-17',
+        exception_types: ['end_date_passed']
       }
     ]
   };
 
   const generalHtml = exceptionsScreen.render(data, { state: { listFilters: {}, clientSettings: {} } });
-  assert.match(generalHtml, /חריגות כלליות[\s\S]*<span>2<\/span>/);
-  assert.match(generalHtml, /חריגות קיץ[\s\S]*<span>1<\/span>/);
+  assert.match(generalHtml, /חריגות כלליות[\s\S]*<span>1<\/span>/);
+  assert.match(generalHtml, /חריגות קיץ[\s\S]*<span>4<\/span>/);
   assert.match(generalHtml, /פעילות רגילה ללא תאריך/);
-  assert.match(generalHtml, /פעילות קיץ עם תאריך/);
   assert.doesNotMatch(generalHtml, /הזמנת קיץ ללא תאריך/);
-  assert.equal((generalHtml.match(/data-card-action="exception:/g) || []).length, 2);
+  assert.equal((generalHtml.match(/data-card-action="exception:/g) || []).length, 1);
 
   const summerHtml = exceptionsScreen.render(data, { state: { exceptionsTab: 'summer_dates', listFilters: {}, clientSettings: {} } });
-  assert.match(summerHtml, /פעילויות קיץ ללא תאריך מוצגות כאן בנפרד/);
+  assert.match(summerHtml, /חריגות של פעילויות קיץ מוצגות כאן בנפרד כדי להפריד בין פעילות קיץ לבין פעילות רגילה/);
   assert.match(summerHtml, /הזמנת קיץ ללא תאריך/);
   assert.doesNotMatch(summerHtml, /פעילות רגילה ללא תאריך/);
-  assert.doesNotMatch(summerHtml, /פעילות קיץ עם תאריך/);
-  assert.equal((summerHtml.match(/data-card-action="exception:/g) || []).length, 1);
+  assert.match(summerHtml, /פעילות קיץ עם מדריך חסר/);
+  assert.match(summerHtml, /פעילות קיץ עם מחוז חסר/);
+  assert.match(summerHtml, /פעילות קיץ עם תאריך סיום עבר/);
+  assert.equal((summerHtml.match(/data-card-action="exception:/g) || []).length, 4);
 });
 
 test('frontend drawer shows exception type chip when opening activity detail', async () => {


### PR DESCRIPTION
### Motivation
- The summer tab previously only collected summer activities with missing start/end dates, causing other summer exceptions to appear in the general tab instead of being grouped with summer activities.

### Description
- Update `splitRowsByExceptionTab` to route rows to the summer tab when `isSummerActivity(row)` returns `true`, and to general otherwise, removing the old missing-date condition and its helper constant.
- Keep the existing `EXCEPTIONS_TAB_SUMMER_DATES` key (`summer_dates`) to avoid state regressions while updating UI strings to: tab label `חריגות קיץ`, empty state `אין חריגות קיץ פעילות להצגה.`, and explanatory note `חריגות של פעילויות קיץ מוצגות כאן בנפרד כדי להפריד בין פעילות קיץ לבין פעילות רגילה.`
- Ensure tab counts and the exceptions summary reflect the new split (general = non-summer, summerDates = all summer activities).
- Add/adjust focused test expectations in `tests/exceptions-all-types.test.mjs` to cover summer exceptions such as missing instructor, missing district, and end-date-passed appearing in the summer tab.

### Testing
- Ran `npm run check:changed` and focused checks completed successfully.
- Ran `node --test tests/exceptions-all-types.test.mjs` and the focused tests passed (20 passed, 0 failed).
- Ran `npm run check:build` and the frontend build succeeded.
- Files changed: `frontend/src/screens/exceptions.js`, `tests/exceptions-all-types.test.mjs`; no Service Worker/cache updates were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bae4e1430832b8340f8d7caa54c19)