### PR TITLE
Count unique exception activities, separate all summer activities, and surface group meta

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -774,11 +774,23 @@ function exceptionsNavCount() {
   const rows = Array.isArray(entry?.data?.rows) ? entry.data.rows : [];
   const uniqueRowActivities = uniqueExceptionActivityCount(rows);
   if (uniqueRowActivities > 0) return uniqueRowActivities;
-  const explicit = Number(entry?.data?.totalExceptionRows ?? entry?.data?.summary?.totalExceptionRows ?? entry?.data?.summary?.total_exception_rows);
+  const explicit = Number(
+    entry?.data?.uniqueExceptionActivities ??
+    entry?.data?.summary?.uniqueExceptionActivities ??
+    entry?.data?.summary?.operational_gaps_unique_count ??
+    entry?.data?.totalExceptionRows ??
+    entry?.data?.summary?.totalExceptionRows ??
+    entry?.data?.summary?.total_exception_rows
+  );
   if (Number.isFinite(explicit) && explicit > 0) return explicit;
   const dashboardKey = buildScreenDataCacheKey('dashboard', state);
   const dashboardEntry = state.screenDataCache?.[dashboardKey] || state.screenDataCache?.dashboard;
-  const dashboardCount = Number(dashboardEntry?.data?.summary?.totalExceptionRows ?? dashboardEntry?.data?.summary?.total_exception_rows);
+  const dashboardCount = Number(
+    dashboardEntry?.data?.summary?.uniqueExceptionActivities ??
+    dashboardEntry?.data?.summary?.operational_gaps_unique_count ??
+    dashboardEntry?.data?.summary?.totalExceptionRows ??
+    dashboardEntry?.data?.summary?.total_exception_rows
+  );
   return Number.isFinite(dashboardCount) && dashboardCount > 0 ? dashboardCount : 0;
 }
 

--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -24,7 +24,6 @@ import { showToast } from './shared/toast.js';
 const EXCEPTIONS_SCOPE = 'exceptions';
 const EXCEPTIONS_TAB_GENERAL = 'general';
 const EXCEPTIONS_TAB_SUMMER_DATES = 'summer_dates';
-const DATE_MISSING_EXCEPTION_TYPES = new Set(['missing_start_date', 'missing_end_date']);
 
 const HEBREW_MONTHS = ['ינואר','פברואר','מרץ','אפריל','מאי','יוני','יולי','אוגוסט','ספטמבר','אוקטובר','נובמבר','דצמבר'];
 function hebrewMonthLabel(ym) {
@@ -88,23 +87,11 @@ function exceptionInstanceRows(rows = []) {
   });
 }
 
-function hasMissingDateException(row) {
-  return normalizedExceptionTypes(row).some((type) => DATE_MISSING_EXCEPTION_TYPES.has(type));
-}
-
-function isSummerMissingDateException(row) {
-  const status = String(row?.status || '').trim();
-  if (status === 'סגור' || status === 'נמחק') return false;
-  const season = String(row?.activity_season || '').trim();
-  if (season !== 'summer_2026' && season !== 'summer') return false;
-  return hasMissingDateException(row);
-}
-
 function splitRowsByExceptionTab(rows = []) {
   const general = [];
   const summerDates = [];
   for (const row of Array.isArray(rows) ? rows : []) {
-    if (isSummerMissingDateException(row)) {
+    if (isSummerActivity(row)) {
       summerDates.push(row);
     } else {
       general.push(row);
@@ -167,12 +154,17 @@ function exceptionCardHtml(row, groupKey) {
 }
 
 function exceptionGroupCard({ title, rows, key }) {
-  const groupTitle = `${title} · ${rows.length}`;
+  const uniqueCount = uniqueExceptionActivityCount(rows);
+  const groupTitle = `${title} · ${uniqueCount}`;
+  const rowCount = Array.isArray(rows) ? rows.length : 0;
+  const countMeta = rowCount !== uniqueCount
+    ? `<span class="ds-exception-group__meta">${escapeHtml(String(uniqueCount))} פעילויות (${escapeHtml(String(rowCount))} רשומות)</span>`
+    : '';
   const body = `<div class="ds-exceptions-grid">${rows.map((row) => exceptionCardHtml(row, key)).join('')}</div>`;
-  // Keep the historical dsCard title contract for group-count regressions: return dsCard({ title: `${title} · ${rows.length}`
   return `<section class="ds-exception-group" data-exception-group="${escapeHtml(key || 'other')}">
     <header class="ds-exception-group__head">
       <button type="button" class="ds-exception-group__title" data-exception-type-filter="${escapeHtml(String(rows[0]?.exception_type || ''))}">${escapeHtml(groupTitle)}</button>
+      ${countMeta}
     </header>
     <div class="ds-exception-group__body">${body}</div>
   </section>`;
@@ -288,7 +280,7 @@ export const exceptionsScreen = {
       rows: byType.get(type) || []
     })).filter((group) => group.rows.length > 0);
     const emptyText = activeTab === EXCEPTIONS_TAB_SUMMER_DATES
-      ? 'אין פעילויות קיץ ללא תאריך להצגה.'
+      ? 'אין חריגות קיץ פעילות להצגה.'
       : 'אין חריגות כלליות פעילות להצגה.';
 
     return dsScreenStack(`
@@ -297,7 +289,7 @@ export const exceptionsScreen = {
       <section class="ds-exceptions-screen__section"><h2 class="ds-section-title ds-exceptions-screen__title">חריגות${data?.month ? ` · ${escapeHtml(hebrewMonthLabel(data.month))}` : ''}</h2></section>
       ${(() => { try { return sessionStorage.getItem('ds_exceptions_save_notice') === '1'; } catch { return false; } })() ? `<div class="ds-exceptions-save-notice" role="status" dir="rtl"><strong>הפעילות נשמרה בהצלחה.</strong> החריגה תוקנה ולכן הפעילות הוסרה ממסך החריגות. <button type="button" class="ds-btn ds-btn--sm" data-exception-go-activities>מעבר למסך פעילויות</button></div>` : ''}
       ${exceptionTabsHtml(activeTab, { general: uniqueExceptionActivityCount(tabRows.general), summerDates: uniqueExceptionActivityCount(tabRows.summerDates) })}
-      ${activeTab === EXCEPTIONS_TAB_SUMMER_DATES ? '<p class="ds-exceptions-tab-note">פעילויות קיץ ללא תאריך מוצגות כאן בנפרד, מאחר שבדרך כלל מדובר בהזמנות שנכנסו למערכת ונמצאות עדיין בשלב תיאום.</p>' : ''}
+      ${activeTab === EXCEPTIONS_TAB_SUMMER_DATES ? '<p class="ds-exceptions-tab-note">חריגות של פעילויות קיץ מוצגות כאן בנפרד כדי להפריד בין פעילות קיץ לבין פעילות רגילה.</p>' : ''}
       ${exceptionsSummaryHtml(visibleRows)}
       ${!hasAnyRows ? `<section class="ds-exceptions-screen__section">${dsEmptyState(emptyText)}</section>` : groups.map((group) => `<section class="ds-exceptions-screen__section">${exceptionGroupCard(group)}</section>`).join('')}
       </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12207,6 +12207,14 @@ select.ds-input {
   box-shadow: 0 2px 0 color-mix(in srgb, var(--ds-accent) 42%, transparent);
 }
 
+.ds-exception-group__meta {
+  color: var(--ds-text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
 .ds-exception-group__body {
   overflow: visible;
 }

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -379,8 +379,10 @@ test('frontend exceptions screen renders only non-empty groups', async () => {
   const src = await read('frontend/src/screens/exceptions.js');
   assert.match(src, /\.filter\(\(group\) => group\.rows\.length > 0\)/,
     'empty exception groups should be filtered out');
-  assert.match(src, /const groupTitle = `\$\{title\} · \$\{rows\.length\}`/,
-    'group titles should include item count');
+  assert.match(src, /const uniqueCount = uniqueExceptionActivityCount\(rows\)/,
+    'group titles should use unique activity count');
+  assert.match(src, /const groupTitle = `\$\{title\} · \$\{uniqueCount\}`/,
+    'group titles should include unique activity count');
 });
 
 test('frontend exception Hebrew labels describe the exception details clearly', async () => {
@@ -398,21 +400,24 @@ test('exceptions screen separates end_date_passed and end_date_after_cutoff into
   assert.doesNotMatch(src, /פעילויות עם חריגת תאריך סיום/);
 });
 
-test('exceptions screen group count matches rendered clickable cards', () => {
+test('exceptions screen group count uses unique activities and explains duplicate records', () => {
   const state = { exceptionsListFilters: {}, activityListFilters: {}, clientSettings: {} };
   const data = {
     month: '2026-05',
     rows: [
       { RowID: '1', activity_name: 'א', authority: 'ר1', school: 'ב1', exception_types: ['end_date_passed'] },
       { RowID: '2', activity_name: 'ב', authority: 'ר1', school: 'ב1', exception_types: ['end_date_after_cutoff'] },
-      { RowID: '3', activity_name: 'ג', authority: 'ר1', school: 'ב1', exception_types: ['end_date_after_cutoff', 'missing_instructor'] }
+      { RowID: '3', activity_name: 'ג', authority: 'ר1', school: 'ב1', exception_types: ['end_date_after_cutoff', 'missing_instructor'] },
+      { RowID: '3', activity_name: 'ג', authority: 'ר1', school: 'ב1', exception_types: ['missing_instructor'] }
     ]
   };
   const html = exceptionsScreen.render(data, { state });
   assert.match(html, /הסתיימה ולא נסגרה · 1/);
   assert.match(html, /תאריך סיום מאוחר · 2/);
+  assert.match(html, /ללא מדריך · 1/);
+  assert.match(html, /1 פעילויות \(2 רשומות\)/);
   const clickableCards = (html.match(/data-card-action="exception:/g) || []).length;
-  assert.equal(clickableCards, 4, 'each grouped appearance must be rendered as a clickable card');
+  assert.equal(clickableCards, 5, 'each grouped appearance must still be rendered as a clickable card');
   assert.doesNotMatch(html, /data-action="delete"/);
 });
 
@@ -432,11 +437,12 @@ test('exceptions screen totals, district sum, and rendered cards use the same ex
   assert.match(html, /data-exceptions-unique-activities>2</);
   assert.doesNotMatch(html, /סה״כ חריגות/);
   assert.doesNotMatch(html, /סכום לפי מחוזות/);
-  assert.match(html, /ללא מחוז \/ לא משויך/);
+  assert.match(html, /data-exception-district-filter="ללא מחוז \/ לא משויך"><span>ללא מחוז \/ לא משויך<\/span><strong>1<\/strong>/);
+  assert.match(html, /data-exception-district-filter="צפון"><span>צפון<\/span><strong>1<\/strong>/);
   assert.equal((html.match(/data-card-action="exception:/g) || []).length, 3);
 });
 
-test('exceptions screen separates summer missing-date rows from general exceptions', () => {
+test('exceptions screen separates all summer rows from general exceptions', () => {
   const data = {
     month: '2026-05',
     rows: [
@@ -457,30 +463,47 @@ test('exceptions screen separates summer missing-date rows from general exceptio
         exception_types: ['missing_start_date']
       },
       {
-        RowID: 'SUMMER-DATED',
-        activity_name: 'פעילות קיץ עם תאריך',
+        RowID: 'SUMMER-MISSING-INSTRUCTOR',
+        activity_name: 'פעילות קיץ עם מדריך חסר',
         activity_season: 'summer_2026',
         start_date: '2026-07-15',
         end_date: '2026-07-15',
         exception_types: ['missing_instructor']
+      },
+      {
+        RowID: 'SUMMER-MISSING-DISTRICT',
+        activity_name: 'פעילות קיץ עם מחוז חסר',
+        activity_season: 'summer_2026',
+        start_date: '2026-07-16',
+        end_date: '2026-07-16',
+        exception_types: ['missing_district']
+      },
+      {
+        RowID: 'SUMMER-END-DATE-PASSED',
+        activity_name: 'פעילות קיץ עם תאריך סיום עבר',
+        activity_season: 'summer_2026',
+        start_date: '2026-07-17',
+        end_date: '2026-07-17',
+        exception_types: ['end_date_passed']
       }
     ]
   };
 
   const generalHtml = exceptionsScreen.render(data, { state: { listFilters: {}, clientSettings: {} } });
-  assert.match(generalHtml, /חריגות כלליות[\s\S]*<span>2<\/span>/);
-  assert.match(generalHtml, /חריגות קיץ[\s\S]*<span>1<\/span>/);
+  assert.match(generalHtml, /חריגות כלליות[\s\S]*<span>1<\/span>/);
+  assert.match(generalHtml, /חריגות קיץ[\s\S]*<span>4<\/span>/);
   assert.match(generalHtml, /פעילות רגילה ללא תאריך/);
-  assert.match(generalHtml, /פעילות קיץ עם תאריך/);
   assert.doesNotMatch(generalHtml, /הזמנת קיץ ללא תאריך/);
-  assert.equal((generalHtml.match(/data-card-action="exception:/g) || []).length, 2);
+  assert.equal((generalHtml.match(/data-card-action="exception:/g) || []).length, 1);
 
   const summerHtml = exceptionsScreen.render(data, { state: { exceptionsTab: 'summer_dates', listFilters: {}, clientSettings: {} } });
-  assert.match(summerHtml, /פעילויות קיץ ללא תאריך מוצגות כאן בנפרד/);
+  assert.match(summerHtml, /חריגות של פעילויות קיץ מוצגות כאן בנפרד כדי להפריד בין פעילות קיץ לבין פעילות רגילה/);
   assert.match(summerHtml, /הזמנת קיץ ללא תאריך/);
   assert.doesNotMatch(summerHtml, /פעילות רגילה ללא תאריך/);
-  assert.doesNotMatch(summerHtml, /פעילות קיץ עם תאריך/);
-  assert.equal((summerHtml.match(/data-card-action="exception:/g) || []).length, 1);
+  assert.match(summerHtml, /פעילות קיץ עם מדריך חסר/);
+  assert.match(summerHtml, /פעילות קיץ עם מחוז חסר/);
+  assert.match(summerHtml, /פעילות קיץ עם תאריך סיום עבר/);
+  assert.equal((summerHtml.match(/data-card-action="exception:/g) || []).length, 4);
 });
 
 test('frontend drawer shows exception type chip when opening activity detail', async () => {


### PR DESCRIPTION
### Motivation
- Ensure exception counts reflect unique activities rather than raw row records so UI totals match user expectations.
- Include alternative server keys for exception counts to be resilient to API changes (`uniqueExceptionActivities`, `operational_gaps_unique_count`).
- Treat all summer activities as a distinct tab regardless of which exception they have instead of only those missing dates, and make the tab copy clearer.
- Provide a small visual hint when a group contains duplicate rows for the same activity (unique vs record counts).

### Description
- Update `exceptionsNavCount` in `frontend/src/main.js` to prefer `uniqueExceptionActivities` and `operational_gaps_unique_count` from cached screen data before falling back to legacy total fields.
- Change group titles in `frontend/src/screens/exceptions.js` to compute `uniqueExceptionActivityCount(rows)` and render `title · {uniqueCount}` while still rendering each row card, plus render a `ds-exception-group__meta` element when the unique activity count differs from the raw row count.
- Replace the specialized `isSummerMissingDateException` check with the broader `isSummerActivity` predicate so all summer rows are shown on the summer tab, and update the summer tab explanatory text and empty-state copy.
- Add CSS for the new `.ds-exception-group__meta` in `frontend/src/styles/main.css` and update test expectations in `tests/exceptions-all-types.test.mjs` to reflect the new counting and tab behavior.

### Testing
- Ran the exceptions unit test file `tests/exceptions-all-types.test.mjs` and its assertions for group counts, tab splits, and rendered card counts; all tests passed.
- Verified updated string/HTML expectations in the test suite that assert use of `uniqueExceptionActivityCount`, changed summer tab text, and new meta output, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bae4e1430832b8340f8d7caa54c19)