### PR TITLE
Proposal preview: remove embedded PDF viewers, compact client search, date & SW updates

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1440,6 +1440,15 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
     </div>`;
 }
 
+function catalogAppendixNoticeHtml(row = {}, items = []) {
+  if (!includeCatalogValue(row.include_catalog)) return '';
+  const count = buildProposalCatalogPdfEntries(row, items).filter((entry) => entry.path && !entry.missing).length;
+  const message = count > 1
+    ? `מצורפים ${count} נספחי קטלוג לקובץ ההפקה`
+    : 'נספח קטלוג יצורף לקובץ הסופי';
+  return `<section class="pa-catalog-appendix-notice" data-pa-catalog-appendix-notice>${escapeHtml(message)}</section>`;
+}
+
 export function proposalPreviewBodyHtml(row, items = [], templateSections = []) {
   const activityTypeGroup = normalizeProposalGroup(row.activity_type_group);
   const templateKey = proposalGroupTemplateKey(activityTypeGroup);
@@ -1518,7 +1527,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
     schoolResponsibility: renderSectionFromSupabase('school_responsibility', { alwaysBullet: true }),
     paymentTerms,
     changesCancellation: renderSectionFromSupabase('cancellation_terms', { alwaysBullet: true }),
-    remarks: remarks ? sectionHtml(sectionTitle('notes') || '', remarks) : '',
+    remarks: `${remarks ? sectionHtml(sectionTitle('notes') || '', remarks) : ''}${catalogAppendixNoticeHtml(row, items)}`,
     signatureHtml,
     sectionLinesHtml,
   });
@@ -1614,18 +1623,24 @@ function templateIndicatorHtml(group) {
 function clientLockedBannerHtml(auth, school, contactName, contactRole, phone, email, clientName = '') {
   if (!auth && !clientName) return '';
   const displayName = clientName || school || auth;
+  const summaryParts = [
+    displayName,
+    auth && auth !== displayName ? auth : '',
+    contactName || 'ללא איש קשר'
+  ].filter(Boolean);
   return `<div class="ds-pa-client-locked">
-    <p class="ds-pa-client-locked-state">גורם נבחר</p>
     <div class="ds-pa-client-locked-body">
-      <strong class="ds-pa-client-locked-name">${escapeHtml(displayName)}</strong>
+      <p class="ds-pa-client-locked-state">נבחר: ${escapeHtml(summaryParts.join(' — '))}</p>
       ${school && school !== displayName ? `<span class="ds-pa-client-locked-detail">מסגרת: ${escapeHtml(school)}</span>` : ''}
-      ${auth && auth !== displayName ? `<span class="ds-pa-client-locked-detail">רשות: ${escapeHtml(auth)}</span>` : ''}
-      ${contactName ? `<span class="ds-pa-client-locked-detail">איש קשר: ${escapeHtml(contactName)}</span>` : ''}
       ${contactRole ? `<span class="ds-pa-client-locked-detail">תפקיד: ${escapeHtml(contactRole)}</span>` : ''}
       ${phone ? `<span class="ds-pa-client-locked-detail">טלפון: ${escapeHtml(phone)}</span>` : ''}
       ${email ? `<span class="ds-pa-client-locked-detail">דוא״ל: ${escapeHtml(email)}</span>` : ''}
+      ${!contactName ? '<span class="ds-pa-client-locked-detail ds-pa-client-locked-detail--warn">אפשר להשלים איש קשר ידנית.</span>' : ''}
     </div>
-    <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-unlock-client>שינוי גורם</button>
+    <div class="ds-pa-client-locked-actions">
+      <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-unlock-client>שינוי</button>
+      <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-clear-client>נקה בחירה</button>
+    </div>
   </div>`;
 }
 
@@ -1771,12 +1786,12 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
 
     <div class="ds-pa-form-meta-panel">
       <div data-pa-step-panel="client">
-        <div class="ds-pa-client-row">
+        <div class="ds-pa-client-row" data-pa-client-search-row${isLocked ? ' hidden' : ''}>
           ${clientSearchHtml(contactOptions, row)}
-          <button type="button" class="ds-btn ds-btn--sm" data-pa-new-client-toggle>הזנה ידנית</button>
+          <button type="button" class="ds-btn ds-btn--sm" data-pa-new-client-toggle>לא מצאת? הוסף ידנית</button>
         </div>
         <div data-pa-client-card${isLocked ? '' : ' hidden'}>${isLocked ? clientLockedBannerHtml(initAuth, initSchool, initContact, initRole, initPhone, initEmail, initClientName) : ''}</div>
-        <div data-pa-new-client-hint hidden><span class="ds-pa-new-client-label">הזנה ידנית</span><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-back-existing-client>חזרה לחיפוש</button></div>
+        <div data-pa-new-client-hint hidden><span class="ds-pa-new-client-label">לקוח חדש / הזנה ידנית</span><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-back-existing-client>חזרה לחיפוש</button></div>
         <div class="ds-pa-form-grid" data-pa-client-fields${isLocked ? ' hidden' : ''}>
           ${textField('client_authority', FIELD_LABELS.client_authority, row.client_authority, true)}
           <div data-pa-school-field>
@@ -2163,20 +2178,22 @@ async function resolvePrintableCatalogPdfEntries(entries = []) {
   return printable;
 }
 
-function appendCatalogPdfPlaceholders(previewArea, entries = []) {
-  if (!previewArea || !entries.length) return;
-  const existing = new Set(Array.from(previewArea.querySelectorAll('[data-pa-catalog-pdf-path]')).map((el) => text(el.dataset.paCatalogPdfPath)));
-  entries.forEach((entry, idx) => {
-    if (!entry?.path || existing.has(entry.path)) return;
-    existing.add(entry.path);
-    const appendix = document.createElement('section');
-    appendix.className = `pa-catalog-pdf-appendix${idx === 0 && !previewArea.querySelector('[data-pa-catalog-pdf-path]') ? ' pa-appendix-start' : ''}`;
-    appendix.dataset.paCatalogPdfPath = entry.path;
-    const pdfUrl = `${entry.url}#toolbar=0&navpanes=0&scrollbar=0&view=FitH`;
-    appendix.innerHTML = `<div class="pa-catalog-pdf-clean-title">נספח קטלוג</div>
-      <iframe src="${escapeHtml(pdfUrl)}" class="pa-catalog-pdf-frame" title="נספח קטלוג" loading="lazy"></iframe>`;
-    previewArea.appendChild(appendix);
-  });
+function ensureCatalogAppendixNotice(previewArea, row = {}, items = []) {
+  const doc = previewArea?.querySelector?.('.proposal-document-body');
+  if (!doc || doc.querySelector('[data-pa-catalog-appendix-notice]')) return;
+  const tmp = document.createElement('div');
+  tmp.innerHTML = catalogAppendixNoticeHtml({ ...row, include_catalog: true }, items);
+  const notice = tmp.firstElementChild;
+  if (!notice) return;
+  const signature = doc.querySelector('.proposal-signature');
+  if (signature) doc.insertBefore(notice, signature);
+  else doc.appendChild(notice);
+}
+
+function appendCatalogPdfPlaceholders(_previewArea, _entries = []) {
+  // Browser print cannot reliably merge external PDF pages without printing the
+  // built-in PDF viewer chrome. Keep preview/print clean; the proposal document
+  // itself shows a small non-technical appendix indication instead.
 }
 
 
@@ -2354,17 +2371,23 @@ export const proposalsAgreementsScreen = {
       const cardEl = form?.querySelector('[data-pa-client-card]');
       const fieldsEl = form?.querySelector('[data-pa-client-fields]');
       const hintEl = form?.querySelector('[data-pa-new-client-hint]');
+      const searchRow = form?.querySelector('[data-pa-client-search-row]');
+      const results = form?.querySelector('[data-pa-client-results]');
       if (cardEl) { cardEl.innerHTML = clientLockedBannerHtml(auth, school, cName, cRole, phone, email, clientName); cardEl.hidden = false; }
       if (fieldsEl) fieldsEl.hidden = true;
-      form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+      if (searchRow) searchRow.hidden = true;
+      if (results) { results.hidden = true; results.innerHTML = ''; }
+      form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = Boolean(cName); });
       if (hintEl) hintEl.hidden = true;
     };
 
     const unlockClientFields = (form) => {
       const cardEl = form?.querySelector('[data-pa-client-card]');
       const fieldsEl = form?.querySelector('[data-pa-client-fields]');
+      const searchRow = form?.querySelector('[data-pa-client-search-row]');
       if (cardEl) cardEl.hidden = true;
       if (fieldsEl) fieldsEl.hidden = false;
+      if (searchRow) searchRow.hidden = false;
       form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = false; });
     };
 
@@ -2496,7 +2519,7 @@ export const proposalsAgreementsScreen = {
       }
       if (authorityInput) {
         const label = authorityInput.closest('label')?.querySelector('span');
-        if (label) label.textContent = `${clientTypeLabel(type)} *`;
+        if (label) label.textContent = `${isOther ? 'שם גוף' : clientTypeLabel(type)} *`;
       }
     };
 
@@ -2518,6 +2541,10 @@ export const proposalsAgreementsScreen = {
       const phone = text(contact.phone || contact.mobile || '');
       const email = text(contact.email || '');
       lockClientFields(form, authority, school, cName, cRole, phone, email, text(contact.client_name) || school || authority);
+      const input = form.querySelector('[data-pa-client-search-input]');
+      const results = form.querySelector('[data-pa-client-results]');
+      if (input) input.value = '';
+      if (results) { results.hidden = true; results.innerHTML = ''; }
     };
 
     const renderClientResults = (form) => {
@@ -2532,7 +2559,7 @@ export const proposalsAgreementsScreen = {
         return;
       }
       if (!matches.length) {
-        results.innerHTML = '<p class="ds-pa-client-results-empty">לא נמצאו תוצאות. ניתן לעבור להזנה ידנית.</p>';
+        results.innerHTML = '<p class="ds-pa-client-results-empty">לא נמצאו תוצאות.</p><button type="button" class="ds-pa-client-result ds-pa-client-result--manual" data-pa-new-client-toggle>לא מצאת? הוסף ידנית</button>';
         results.hidden = false;
         return;
       }
@@ -2792,9 +2819,11 @@ export const proposalsAgreementsScreen = {
           }
         }
         if (includeCatalogValue(freshRow.include_catalog) && !catalogValidationDone) {
-          const printableEntries = await resolvePrintableCatalogPdfEntries(buildProposalCatalogPdfEntries(freshRow, items));
-          if (printableEntries === null) return;
-          appendCatalogPdfPlaceholders(overlay.querySelector('.proposal-preview-area'), printableEntries);
+          const previewArea = overlay.querySelector('.proposal-preview-area');
+          ensureCatalogAppendixNotice(previewArea, freshRow, items);
+          // Do not embed external PDF files in the printable DOM; browsers print
+          // the PDF viewer shell rather than clean A4 appendix pages.
+          appendCatalogPdfPlaceholders(previewArea, buildProposalCatalogPdfEntries(freshRow, items));
           catalogValidationDone = true;
         }
         window.print();
@@ -3506,11 +3535,35 @@ export const proposalsAgreementsScreen = {
         return;
       }
 
+      if (event.target.closest?.('[data-pa-clear-client]')) {
+        const form = event.target.closest('[data-pa-form]');
+        if (!form) return;
+        form.dataset.paNewClient = 'no';
+        ['client_authority', 'school_framework', 'contact_name', 'contact_role', 'phone', 'email'].forEach((name) => {
+          const inp = form.querySelector(`input[name="${name}"]`);
+          if (inp) inp.value = '';
+        });
+        setContactSource(form, {});
+        const card = form.querySelector('[data-pa-client-card]');
+        if (card) { card.hidden = true; card.innerHTML = ''; }
+        const searchRow = form.querySelector('[data-pa-client-search-row]');
+        if (searchRow) searchRow.hidden = false;
+        const fields = form.querySelector('[data-pa-client-fields]');
+        if (fields) fields.hidden = true;
+        form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+        const search = form.querySelector('[data-pa-client-search-input]');
+        if (search) { search.value = ''; search.focus(); }
+        updateProposalStepper(form);
+        return;
+      }
+
       if (event.target.closest?.('[data-pa-new-client-toggle]')) {
         const form = event.target.closest('[data-pa-form]');
         const clientSearchInput = form?.querySelector('[data-pa-client-search-input]');
         if (clientSearchInput) clientSearchInput.value = '';
         if (form) form.dataset.paNewClient = 'yes';
+        const typeSelect = form?.querySelector('[data-pa-new-client-type]');
+        if (typeSelect) typeSelect.value = 'other';
         unlockClientFields(form);
         const sourceHost = form?.querySelector('[data-pa-contact-source]');
         if (sourceHost) sourceHost.innerHTML = contactSourceInputsHtml({});
@@ -3518,8 +3571,6 @@ export const proposalsAgreementsScreen = {
         if (hint) hint.hidden = false;
         form?.querySelectorAll('[data-pa-new-client-only]').forEach((el) => { el.hidden = false; });
         applyClientTypeMode(form);
-        const schoolField = form?.querySelector('[data-pa-school-field]');
-        if (schoolField) schoolField.hidden = false;
         ['client_authority', 'school_framework', 'contact_name', 'contact_role', 'phone', 'email'].forEach((name) => {
           const inp = form?.querySelector(`input[name="${name}"]`);
           if (inp) inp.value = '';
@@ -3536,6 +3587,10 @@ export const proposalsAgreementsScreen = {
         if (hint) hint.hidden = true;
         form.querySelectorAll('[data-pa-new-client-only]').forEach((el) => { el.hidden = true; });
         form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+        const fields = form.querySelector('[data-pa-client-fields]');
+        if (fields) fields.hidden = true;
+        const searchRow = form.querySelector('[data-pa-client-search-row]');
+        if (searchRow) searchRow.hidden = false;
         applyClientTypeMode(form);
         updateProposalStepper(form);
         form.querySelector('[data-pa-client-search-input]')?.focus();

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -10678,10 +10678,10 @@ select.ds-input {
 /* Readonly client card */
 .ds-pa-client-locked {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 8px;
+  flex-wrap: wrap;
   background: var(--ds-surface-2, #f8fafc);
   border: 1px solid var(--ds-border, #e2e8f0);
   border-radius: 8px;
@@ -10696,16 +10696,26 @@ select.ds-input {
 }
 .ds-pa-client-locked-body {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 .ds-pa-client-locked-name {
   font-size: 0.82rem;
   color: var(--ds-color-text, #0f172a);
 }
+.ds-pa-client-locked-actions {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
 .ds-pa-client-locked-detail {
   font-size: 0.76rem;
   color: var(--ds-color-text-muted, #64748b);
+}
+.ds-pa-client-locked-detail--warn {
+  color: #b45309;
+  font-weight: 700;
 }
 .ds-pa-new-client-label {
   font-size: 0.78rem;
@@ -11428,6 +11438,7 @@ select.ds-input {
   margin-top: 4px;
   margin-left: 0;
   margin-right: 0;
+  transform: translateX(10mm);
 }
 .pa-doc-address {
   margin: 0 0 6pt;
@@ -11619,6 +11630,18 @@ select.ds-input {
 }
 
 /* ─── Catalog appendix (proposal PDF) ──────────────────────────────────── */
+
+.pa-catalog-appendix-notice {
+  margin: 8pt 0 0;
+  padding: 5pt 7pt;
+  border: 1px solid #dbe7f3;
+  border-radius: 8px;
+  background: #f8fbff;
+  color: #475569;
+  font-size: 8pt;
+  font-weight: 700;
+}
+
 .pa-appendix-start {
   break-before: page;
   page-break-before: always;
@@ -11861,6 +11884,7 @@ select.ds-input {
     margin-top: 3pt !important;
     margin-left: 0 !important;
     margin-right: 0 !important;
+    transform: translateX(10mm) !important;
   }
   .pa-doc-address {
     text-align: right !important;
@@ -14949,7 +14973,7 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   .proposal-signature-line { width: 42mm !important; border-top: 0.3mm solid #111827 !important; margin: 0 0 0 auto !important; }
   .proposal-signature-name { font-size: 9pt !important; }
   .pa-catalog-pdf-appendix { box-shadow: none !important; width: 210mm !important; min-height: 297mm !important; padding: 10mm 12mm !important; break-before: page !important; page-break-before: always !important; }
-  .pa-catalog-pdf-object, .pa-catalog-pdf-frame { height: 260mm !important; }
+  .pa-catalog-pdf-appendix, .pa-catalog-pdf-object, .pa-catalog-pdf-frame { display: none !important; }
 }
 
 /* Proposals polish: wider workspace, clearer fields, search-first client picking. */
@@ -15087,9 +15111,9 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   .proposal-signature { width: 58mm !important; margin-top: 8pt !important; margin-inline-start: auto !important; }
   .proposal-signature-line { width: 100% !important; margin: 0 auto !important; }
   .proposal-signature-name { text-align: center !important; direction: rtl !important; }
-  .pa-catalog-pdf-clean-title { display: none !important; }
-  .pa-catalog-pdf-appendix { padding: 0 !important; overflow: hidden !important; }
-  .pa-catalog-pdf-frame { width: 210mm !important; height: 297mm !important; border: 0 !important; }
+  .pa-catalog-pdf-clean-title,
+  .pa-catalog-pdf-appendix,
+  .pa-catalog-pdf-frame { display: none !important; }
 }
 @media (max-width: 900px) {
   .ds-pa-form { width: 100%; padding: 12px; }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 698;
+const CACHE_VERSION = 699;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 648;
+const SW_ENTRY_VERSION = 649;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -357,6 +357,9 @@ test('client selector auto-fills contact fields when existing client is chosen',
       assert.equal(schoolInput.value, 'מסגרת ב', 'school should be filled');
       assert.equal(contactInput.value, 'יוסי קשר', 'contact_name should be auto-filled');
       assert.equal(phoneInput.value, '050-2222222', 'phone should be auto-filled');
+      assert.equal(form.querySelector('[data-pa-client-results]').hidden, true, 'results should close after selection');
+      assert.equal(form.querySelector('[data-pa-client-search-row]').hidden, true, 'search row should close after selection');
+      assert.match(form.querySelector('[data-pa-client-card]').textContent, /נבחר:.*מסגרת ב.*רשות ב.*יוסי קשר/, 'clear selected-client summary should be shown');
     }
   );
 });
@@ -562,7 +565,7 @@ test('saving after new client toggle keeps manual contact fields in pending payl
       assert.equal(savedPayloads.length, 1);
       assert.equal(savedPayloads[0].status, 'approved');
       assert.equal(savedPayloads[0].contact_name, 'שרון חדש', 'manual contact name should be saved');
-      assert.equal(savedPayloads[0]._contact_original.client_type, 'school', 'new-client source metadata should be preserved');
+      assert.equal(savedPayloads[0]._contact_original.client_type, 'other', 'manual client source metadata should be preserved');
     }
   );
 });
@@ -1371,7 +1374,7 @@ test('catalog PDF appendices use fixed workshop/tour PDFs and specific selected 
 });
 
 
-test('print catalog prompt warns when selected course PDF is missing and continues without that appendix', async () => {
+test('print catalog prompt keeps PDF viewers out of the preview and printed DOM', async () => {
   const row = {
     ...sampleRows[0],
     id: 'course-missing-pdf-row',
@@ -1402,11 +1405,11 @@ test('print catalog prompt warns when selected course PDF is missing and continu
       await delay(30);
 
       assert.ok(confirmMessages.some((message) => /האם להוסיף קטלוג להצעה/.test(message)), 'print should ask whether to add a catalog');
-      assert.ok(confirmMessages.some((message) => /לא נמצא קובץ נספח לקורס: קורס רובוטיקה/.test(message)), 'missing selected course PDF should be reported');
-      assert.equal(printCalls, 1, 'print should continue when the user confirms continuing without appendix');
-      assert.doesNotMatch(dom.window.document.body.innerHTML, /catalog\/appendices\/9545\.pdf/);
-      assert.doesNotMatch(dom.window.document.body.innerHTML, new RegExp(`course${'-'}9545\\.pdf`));
-      assert.doesNotMatch(dom.window.document.body.innerHTML, new RegExp(`catalog-${'courses'}\\.pdf`));
+      assert.equal(printCalls, 1, 'print should continue with a clean proposal document');
+      assert.match(dom.window.document.querySelector('.proposal-document')?.textContent || '', /נספח קטלוג יצורף לקובץ הסופי/);
+      assert.doesNotMatch(dom.window.document.body.innerHTML, /<iframe|<object|PDF viewer|catalog\/appendices\/9545\.pdf/i);
+      assert.doesNotMatch(dom.window.document.body.innerHTML, new RegExp(`course${'-'}9545\.pdf`));
+      assert.doesNotMatch(dom.window.document.body.innerHTML, new RegExp(`catalog-${'courses'}\.pdf`));
     } finally {
       globalThis.fetch = savedFetch;
     }


### PR DESCRIPTION
### Motivation
- Remove PDF `iframe/object` viewers from the proposal preview/print flow to avoid printing viewer chrome and produce a clean A4 PDF output. 
- Make client selection faster and clearer by closing results after selection, showing a compact selected-client summary, and adding a clear/change flow. 
- Keep changes generic so they apply to all proposal types and keep the UI compact and non-technical. 

### Description
- Replace embedded catalog appendix rendering in the preview with a small non-technical notice using `catalogAppendixNoticeHtml` and `ensureCatalogAppendixNotice`, and prevent embedding external PDF viewers in the printable DOM by making `appendCatalogPdfPlaceholders` a no-op for print. 
- Update preview print handler to inject the small appendix notice and avoid adding `iframe`/`object` viewers into the printed DOM. 
- Revamp client selector behavior so selecting a contact closes results and the search row, fills contact fields, shows a concise locked-client summary with `נבחר: …`, and adds actions to `שינוי` and `נקה בחירה`; add a compact “not found? add manually” button and an explicit manual (`other`) client mode. 
- UI polish and layout tweaks: compact locked-client card CSS, add a warning hint when contact is missing, and move the proposal document date ~10mm to the right via `transform: translateX(10mm)` in CSS without changing logo/title layout. 
- Prevent leftover PDF-appendix frames from printing by hiding legacy appendix frame styles in print CSS. 
- Bump Service Worker/cache constants (`frontend/sw.js` `CACHE_VERSION` and `sw.js` `SW_ENTRY_VERSION`) to ensure new front-end assets are picked up. 
- Update and extend the proposals screen tests to assert the new client-selection UX and to assert that preview/print DOM does not include embedded PDF viewers but does include the small appendix notice. 

### Testing
- Ran `node --check frontend/src/screens/proposals-agreements.js` and static JS checks, which passed. 
- Ran focused screen tests with `node --test tests/proposals-agreements-screen.test.mjs`, which passed (all tests in that file green). 
- Ran the project checks `npm run check:changed` and full frontend build check `npm run check:build`, both completed successfully and produced a new `dist` build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c2b34a744832ba60729d9c68f5e35)