### PR TITLE
Fix proposal appendix downloads

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BoCBl7fn.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DGbD5V7C.css">
+  <script type="module" crossorigin src="./assets/index-fj-REh9P.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-CVsO1KlA.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -2163,6 +2163,13 @@ async function catalogPdfExists(entry = {}) {
 async function resolvePrintableCatalogPdfEntries(entries = []) {
   const printable = [];
   for (const entry of (Array.isArray(entries) ? entries : [])) {
+    if (entry?.missing) {
+      const courseName = text(entry.label) || 'קורס';
+      const shouldContinue = window.confirm(`לא נמצא מספר גפ״ן לנספח הקורס: ${courseName}. ניתן להמשיך ללא נספח או לבטל ולעדכן את פרטי הקורס.`);
+      if (!shouldContinue) return null;
+      continue;
+    }
+    if (!entry?.url) continue;
     if (entry.kind !== 'course') {
       printable.push(entry);
       continue;
@@ -2178,6 +2185,32 @@ async function resolvePrintableCatalogPdfEntries(entries = []) {
   return printable;
 }
 
+function catalogPdfDownloadName(entry = {}, index = 0) {
+  const pathName = text(entry.path || entry.url).split(/[?#]/)[0].split('/').filter(Boolean).pop();
+  const fallbackName = `catalog-appendix-${index + 1}.pdf`;
+  return /\.pdf$/i.test(pathName) ? pathName : fallbackName;
+}
+
+function triggerCatalogPdfDownload(entry = {}, index = 0) {
+  if (!entry?.url || typeof document === 'undefined') return;
+  const link = document.createElement('a');
+  link.href = entry.url;
+  link.download = catalogPdfDownloadName(entry, index);
+  link.target = '_blank';
+  link.rel = 'noopener';
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+async function prepareCatalogPdfDownloads(entries = []) {
+  const printableEntries = await resolvePrintableCatalogPdfEntries(entries);
+  if (printableEntries === null) return false;
+  printableEntries.forEach((entry, index) => triggerCatalogPdfDownload(entry, index));
+  return true;
+}
+
 function ensureCatalogAppendixNotice(previewArea, row = {}, items = []) {
   const doc = previewArea?.querySelector?.('.proposal-document-body');
   if (!doc || doc.querySelector('[data-pa-catalog-appendix-notice]')) return;
@@ -2188,12 +2221,6 @@ function ensureCatalogAppendixNotice(previewArea, row = {}, items = []) {
   const signature = doc.querySelector('.proposal-signature');
   if (signature) doc.insertBefore(notice, signature);
   else doc.appendChild(notice);
-}
-
-function appendCatalogPdfPlaceholders(_previewArea, _entries = []) {
-  // Browser print cannot reliably merge external PDF pages without printing the
-  // built-in PDF viewer chrome. Keep preview/print clean; the proposal document
-  // itself shows a small non-technical appendix indication instead.
 }
 
 
@@ -2822,8 +2849,10 @@ export const proposalsAgreementsScreen = {
           const previewArea = overlay.querySelector('.proposal-preview-area');
           ensureCatalogAppendixNotice(previewArea, freshRow, items);
           // Do not embed external PDF files in the printable DOM; browsers print
-          // the PDF viewer shell rather than clean A4 appendix pages.
-          appendCatalogPdfPlaceholders(previewArea, buildProposalCatalogPdfEntries(freshRow, items));
+          // the PDF viewer shell rather than clean A4 appendix pages. Download
+          // resolved appendix PDFs alongside the proposal print/save flow instead.
+          const canContinueWithCatalog = await prepareCatalogPdfDownloads(buildProposalCatalogPdfEntries(freshRow, items));
+          if (!canContinueWithCatalog) return;
           catalogValidationDone = true;
         }
         window.print();

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11646,61 +11646,6 @@ select.ds-input {
   break-before: page;
   page-break-before: always;
 }
-.pa-catalog-shadow-host { display: block; }
-.pa-catalog-loading {
-  color: #6b7280;
-  font-style: italic;
-  padding: 4px 12px;
-  font-size: 0.82rem;
-}
-.pa-appendix-note,
-.pa-appendix-missing {
-  font-size: 0.82rem;
-  padding: 6px 14px;
-  border-radius: 4px;
-  margin: 6px 0;
-}
-.pa-appendix-note {
-  color: #92400e;
-  border: 1px solid #fcd34d;
-  background: #fffbeb;
-}
-.pa-appendix-missing {
-  color: #dc2626;
-  border: 1px solid #fca5a5;
-  background: #fef2f2;
-}
-.pa-pdf-appendix-frame {
-  display: block;
-  width: 100%;
-  height: 1123px;
-  border: none;
-  background: #fff;
-}
-
-.pa-catalog-pdf-appendix {
-  width: 794px;
-  min-height: 1123px;
-  max-width: 100%;
-  background: #fff;
-  box-sizing: border-box;
-  padding: 28px 34px;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.13), 0 1px 4px rgba(0,0,0,0.07);
-  direction: rtl;
-  font-family: Arial, "Noto Sans Hebrew", "David", sans-serif;
-}
-.pa-catalog-pdf-appendix h2 {
-  margin: 0 0 8pt;
-  color: #1f4e79;
-  font-size: 13pt;
-}
-.pa-catalog-pdf-object,
-.pa-catalog-pdf-frame {
-  display: block;
-  width: 100%;
-  height: 980px;
-  border: 0;
-}
 
 @media (max-width: 720px) {
   .proposal-preview-area {
@@ -12014,19 +11959,6 @@ select.ds-input {
     color: #1f4e79 !important;
   }
 
-  /* ── Catalog appendix ──────────────────────────────────────────── */
-  .catalog-appendix-page-break {
-    display: none !important;
-  }
-  .pa-appendix-start {
-    break-before: page !important;
-    page-break-before: always !important;
-  }
-  .pa-catalog-shadow-host {
-    display: block !important;
-    -webkit-print-color-adjust: exact !important;
-    print-color-adjust: exact !important;
-  }
 }
 
 /* ===== Exceptions UX refresh: grouped cards, balanced grid, and header count badge ===== */
@@ -14972,8 +14904,6 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   .proposal-signature-greeting { font-size: 8.5pt !important; margin-bottom: 8pt !important; }
   .proposal-signature-line { width: 42mm !important; border-top: 0.3mm solid #111827 !important; margin: 0 0 0 auto !important; }
   .proposal-signature-name { font-size: 9pt !important; }
-  .pa-catalog-pdf-appendix { box-shadow: none !important; width: 210mm !important; min-height: 297mm !important; padding: 10mm 12mm !important; break-before: page !important; page-break-before: always !important; }
-  .pa-catalog-pdf-appendix, .pa-catalog-pdf-object, .pa-catalog-pdf-frame { display: none !important; }
 }
 
 /* Proposals polish: wider workspace, clearer fields, search-first client picking. */
@@ -15089,16 +15019,6 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   text-align: center;
   direction: rtl;
 }
-.pa-catalog-pdf-clean-title {
-  margin: 0 0 8pt;
-  color: #1f4e79;
-  font-size: 13pt;
-  font-weight: 700;
-}
-.pa-catalog-pdf-frame {
-  border: 0;
-  background: #fff;
-}
 @media print {
   .proposal-logo {
     width: auto !important;
@@ -15111,9 +15031,6 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   .proposal-signature { width: 58mm !important; margin-top: 8pt !important; margin-inline-start: auto !important; }
   .proposal-signature-line { width: 100% !important; margin: 0 auto !important; }
   .proposal-signature-name { text-align: center !important; direction: rtl !important; }
-  .pa-catalog-pdf-clean-title,
-  .pa-catalog-pdf-appendix,
-  .pa-catalog-pdf-frame { display: none !important; }
 }
 @media (max-width: 900px) {
   .ds-pa-form { width: 100%; padding: 12px; }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 699;
+const CACHE_VERSION = 700;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 649;
+const SW_ENTRY_VERSION = 650;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1416,6 +1416,61 @@ test('print catalog prompt keeps PDF viewers out of the preview and printed DOM'
   });
 });
 
+test('print flow downloads resolved catalog appendix PDFs without embedding them', async () => {
+  const row = {
+    ...sampleRows[0],
+    id: 'course-download-pdf-row',
+    activity_type_group: 'הצעה משולבת',
+    status: 'approved',
+    include_catalog: true
+  };
+  const items = [
+    { item_name: 'סדנת מייקרים', item_type: 'סדנה', proposal_group: 'סדנאות', quantity: 1, unit_price: 100, total_price: 100 },
+    { item_name: 'קורס רובוטיקה', item_type: 'קורס', proposal_group: 'שנת הלימודים תשפ״ז', gefen_number: '9545', quantity: 1, unit_price: 200, total_price: 200 }
+  ];
+  const savedFetch = globalThis.fetch;
+  await withJSDOM(proposalsAgreementsScreen.render({ rows: [row] }, { state: stateFor('admin') }), async (root, dom) => {
+    const downloads = [];
+    let printCalls = 0;
+    dom.window.HTMLAnchorElement.prototype.click = function click() {
+      downloads.push({ href: this.getAttribute('href'), download: this.getAttribute('download'), connected: this.isConnected });
+    };
+    dom.window.confirm = () => { throw new Error('resolved appendices should not prompt'); };
+    dom.window.print = () => { printCalls += 1; };
+    globalThis.fetch = async () => ({ ok: true, status: 200 });
+    try {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: {
+          rows: [row],
+          proposalActivityGroups: [
+            { group_key: 'הצעה משולבת', display_name: 'הצעה משולבת', template_key: 'combined' },
+            { group_key: 'סדנאות', display_name: 'סדנאות', template_key: 'workshops' },
+            { group_key: 'שנת הלימודים תשפ״ז', display_name: 'שנת הלימודים תשפ״ז', template_key: 'next_year' }
+          ]
+        },
+        state: stateFor('admin'),
+        api: { readProposalAgreementItems: async () => items }
+      });
+      root.querySelector(`[data-pa-row-id="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+      root.querySelector(`[data-pa-preview="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(30);
+      dom.window.document.getElementById('pa-print-btn')?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(30);
+
+      assert.equal(printCalls, 1);
+      assert.deepEqual(downloads.map((entry) => entry.href), ['./catalog/appendices/workshop.pdf', './catalog/appendices/9545.pdf']);
+      assert.deepEqual(downloads.map((entry) => entry.download), ['workshop.pdf', '9545.pdf']);
+      assert.ok(downloads.every((entry) => entry.connected), 'download link should be clicked while temporarily attached');
+      assert.doesNotMatch(dom.window.document.body.innerHTML, /catalog\/appendices\/(workshop|9545)\.pdf/i);
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+});
+
+
 test('catalog PDF appendices report missing selected course appendix identifiers', () => {
   const entries = buildProposalCatalogPdfEntries(
     { activity_type_group: 'שנת הלימודים תשפ״ז' },


### PR DESCRIPTION
### Motivation
- Avoid embedding external PDF viewers in the proposal preview/print DOM and instead provide a safe production path that downloads resolved catalog appendix PDFs alongside the print/save flow.
- Ensure missing course identifiers or missing course PDF files are surfaced to the operator with a confirm/abort choice before production.
- Remove legacy PDF viewer/iframe CSS and logic so the preview stays clean and only a short appendix notice is printed.
- Keep the Service Worker/cache version in sync after JS/CSS/dist-affecting frontend changes.

### Description
- Added entry resolution and download flow: updated printable entry resolution to prompt for missing course IDs, skip unresolved entries when confirmed, and added `catalogPdfDownloadName`, `triggerCatalogPdfDownload`, and `prepareCatalogPdfDownloads` to download resolved appendix PDFs before printing.
- Rewired the preview print handler to call `prepareCatalogPdfDownloads(buildProposalCatalogPdfEntries(...))` and abort printing when the operator cancels the appendix confirmation.
- Removed placeholder viewer injection (`appendCatalogPdfPlaceholders`) and stripped legacy PDF viewer/iframe/object CSS rules so external PDFs are not embedded into the preview DOM.
- Added a focused integration test that verifies the print flow downloads resolved catalog appendices without embedding them and updated tests accordingly, and bumped SW/cache versions and `dist/index.html` asset references.

### Testing
- Changed files: `frontend/src/screens/proposals-agreements.js`, `frontend/src/styles/main.css`, `tests/proposals-agreements-screen.test.mjs`, `frontend/sw.js`, `sw.js`, and updated `dist/index.html`.
- Ran focused checks: `npm run check:changed` (which ran `node --test tests/proposals-agreements-screen.test.mjs`) and all focused tests passed (`tests 55, pass 55`).
- Built the frontend with `npm run check:build` (Vite build + postbuild) and the build completed successfully.
- Service Worker/cache entries were bumped (`frontend/sw.js` CACHE_VERSION and `sw.js` SW_ENTRY_VERSION were updated) and the build artifacts were refreshed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5cacc6fc832ba84299a1d9b56ead)