### PR TITLE
Fix username-based login, permission routes mapping, and cache/version refresh

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-bUKGcCkp.js"></script>
+  <script type="module" crossorigin src="./assets/index-Cyjr7YGa.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-JEyVz5bg.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1970,14 +1970,14 @@ const PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_repor
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
-  admin: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-lists', 'certificates'],
-  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  admin: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-home', 'admin-settings', 'admin-lists', 'finance', 'certificates'],
+  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
   authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'certificates'],
-  finance: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
-  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
-  domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'certificates'],
-  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
-  instructor_manager: ['dashboard', 'activities', 'archive', 'catalog', 'orders', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  finance: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'certificates'],
+  business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  instructor_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
   instructor: ['my-data', 'week', 'month']
 };
 
@@ -2152,7 +2152,7 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
   if (!hasFinanceAccess && financeIdx >= 0) allowedRoutes.splice(financeIdx, 1);
   if (permissionFlagYes(flat.view_activities) && !allowedRoutes.includes('activities')) allowedRoutes.push('activities');
   if (permissionFlagYes(flat.view_catalog) && !allowedRoutes.includes('catalog')) allowedRoutes.push('catalog');
-  if ((permissionFlagYes(flat.view_orders) || permissionFlagYes(flat.view_invitations)) && !allowedRoutes.includes('orders')) allowedRoutes.push('orders');
+  if ((permissionFlagYes(flat.view_orders) || permissionFlagYes(flat.view_invitations)) && !allowedRoutes.includes('invitations')) allowedRoutes.push('invitations');
   if (
     PROPOSALS_AGREEMENTS_ALLOWED_ROLES.has(role) ||
     permissionFlagYes(flat.view_proposals) ||
@@ -2171,10 +2171,15 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
   const personalReportsIdx = allowedRoutes.indexOf('personal-reports');
   if (hasPersonalReportsAccess && personalReportsIdx === -1) allowedRoutes.push('personal-reports');
   if (!hasPersonalReportsAccess && personalReportsIdx >= 0) allowedRoutes.splice(personalReportsIdx, 1);
-  // Israa management tab — requires view_israa_management=yes AND (israa user or admin role)
-  const ISRAA_USER_ID = '3030';
-  const ISRAA_AUTH_USER_ID = '92bfb9d9-1b17-4022-901a-5f7cf17a263a';
-  const isIsraaUser = String(flat.user_id || '') === ISRAA_USER_ID || String(flat.auth_user_id || '') === ISRAA_AUTH_USER_ID;
+  // General admin routes are only for role=admin, never for feature-specific flags.
+  if (role !== 'admin') {
+    ['admin-home', 'admin-settings', 'admin-lists', 'permissions'].forEach((route) => {
+      const idx = allowedRoutes.indexOf(route);
+      if (idx >= 0) allowedRoutes.splice(idx, 1);
+    });
+  }
+  // Israa management tab — requires view_israa_management=yes AND (the esraaa username or admin role).
+  const isIsraaUser = String(flat.user_id || '').trim().toLowerCase() === 'esraaa';
   const isAdminRole = role === 'admin';
   if ((isIsraaUser || isAdminRole) && permissionFlagYes(flat.view_israa_management)) {
     if (!allowedRoutes.includes('israa-management')) allowedRoutes.push('israa-management');
@@ -2251,7 +2256,8 @@ async function loginWithSupabaseAuth(user_id, entry_code) {
   const code = String(entry_code || '').trim();
   if (!uid || !code) throwLoginError('missing_user_id_or_entry_code');
 
-  const authEmail = uid.includes('@') ? uid : `${uid}@think.org.il`;
+  const username = uid.toLowerCase();
+  const authEmail = `${username}@think.org.il`;
 
   const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
     email: authEmail,
@@ -2268,6 +2274,7 @@ async function loginWithSupabaseAuth(user_id, entry_code) {
     .from('users')
     .select(USER_PUBLIC_COLUMNS)
     .eq('auth_user_id', authUserId)
+    .eq('user_id', username)
     .eq('is_active', true)
     .single();
 

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'emergency-disable-diagnostics-v2'
+  HOTFIX_VERSION: 'login-permissions-routes-v1'
 };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -70,8 +70,32 @@ const SUPABASE_READONLY_ROUTES = ['dashboard', 'activities', 'week', 'month', 'i
 
 if (typeof window !== 'undefined') {
   window.__HOTFIX_VERSION__ = config.HOTFIX_VERSION;
-  window.__FRONTEND_BUILD_MARKER__ = 'emergency-disable-diagnostics-v2';
+  window.__FRONTEND_BUILD_MARKER__ = config.HOTFIX_VERSION;
 }
+
+
+function clearStaleBuildStorageIfNeeded() {
+  if (typeof localStorage === 'undefined') return;
+  const key = 'dashboard_build_version';
+  const current = String(config.HOTFIX_VERSION || '').trim();
+  if (!current) return;
+  try {
+    const previous = localStorage.getItem(key) || '';
+    if (previous && previous !== current) {
+      localStorage.removeItem('dashboard_routes');
+      localStorage.removeItem('dashboard_screen_cache_v1');
+      Object.keys(localStorage)
+        .filter((storageKey) => storageKey.startsWith(SCREEN_CACHE_STORAGE_PREFIX))
+        .forEach((storageKey) => localStorage.removeItem(storageKey));
+      console.info('[build-version-changed]', { previous, current, cleared: ['dashboard_routes', 'screen_cache'] });
+    }
+    localStorage.setItem(key, current);
+  } catch {
+    /* ignore */
+  }
+}
+
+clearStaleBuildStorageIfNeeded();
 
 function beginPerfTimer(label) {
   if (!label || typeof console === 'undefined' || typeof console.time !== 'function') return;
@@ -480,6 +504,7 @@ function saveRoutesToStorage(routes, defaultRoute, clientSettings) {
 
 function applyBootstrapFromLoginData(data) {
   if (!data || !Array.isArray(data.routes) || !data.routes.length) return;
+  try { localStorage.removeItem('dashboard_routes'); } catch { /* ignore */ }
   if (data.client_settings && typeof data.client_settings === 'object') {
     state.clientSettings = { ...defaultClientSettings(), ...data.client_settings };
   }
@@ -511,8 +536,8 @@ const screenLabels = {
   archive: 'ארכיון',
   'proposals-agreements': 'הצעות מחיר',
   finance: 'כספים',
-  invitations: 'הזמנות',
-  orders: 'הזמנות',
+  invitations: 'הזמנות לאירועים',
+  orders: 'הזמנות לאירועים',
   catalog: 'קטלוג',
   'personal-reports': 'דוחות אישיים',
   'israa-management': 'ניהול איסראא',
@@ -622,9 +647,9 @@ function applySettingsToRoutes(routes, settings = state.clientSettings) {
   const seen = new Set();
   const baseRoutes = Array.isArray(routes) ? [...routes] : [];
   return baseRoutes
-    .map((route) => (route === 'invitations' ? 'orders' : route))
+    .map((route) => (route === 'orders' ? 'invitations' : route))
     .filter((route) => {
-      if (!route || blocked.has(route) || (route === 'orders' && blocked.has('invitations')) || seen.has(route)) return false;
+      if (!route || blocked.has(route) || (route === 'invitations' && blocked.has('orders')) || seen.has(route)) return false;
       if (!screenLoaders[route]) return false;
       seen.add(route);
       return true;
@@ -684,7 +709,7 @@ function consumePendingRouteFromUrlOrSession() {
       window.history.replaceState({}, '', url);
     }
   } catch { /* ignore */ }
-  if (pending === 'invitations') pending = 'orders';
+  if (pending === 'orders') pending = 'invitations';
   if (isAllowedRoute(pending)) {
     state.route = pending;
     saveRoutesToStorage(state.routes, pending, state.clientSettings);
@@ -1891,9 +1916,18 @@ async function render() {
             initialRoutePerfReported = false;
             beginPerfTimer('login:api.login');
             const loginApiStartMs = performance.now();
+            console.info('[login username]', { username: userId });
             const data = await api.login(userId, code);
             loginApiDurationMs = performance.now() - loginApiStartMs;
             endPerfTimer('login:api.login');
+            console.info('[login user]', {
+              login_username: userId,
+              user_id: data?.user?.user_id,
+              role: data?.user?.display_role,
+              routes_returned: data?.routes || [],
+              default_route: data?.default_route || '',
+              has_client_settings: !!data?.client_settings
+            });
             hasMountedAuthenticatedShell = false;
             firstAuthenticatedRenderTimerStarted = false;
             firstLoadTimerStarted = false;
@@ -1908,6 +1942,10 @@ async function render() {
             beginPerfTimer('login:applyBootstrap');
             const bootstrapApplyStartMs = performance.now();
             applyBootstrapFromLoginData(data);
+            console.info('[effectiveRoutes after applySettingsToRoutes]', {
+              effectiveRoutes: effectiveRoutes(),
+              default_route: state.route
+            });
             refreshOpenEditRequestsCount().catch(() => {});
             loginBootstrapDurationMs = performance.now() - bootstrapApplyStartMs;
             applyGlobalAccent(accentNameFromStorage(state.clientSettings));
@@ -1936,11 +1974,17 @@ async function render() {
                   source: 'login'
                 });
               }
-            }).catch(async (error) => {
+            }).catch((error) => {
+              const message = error?.message || String(error);
               // eslint-disable-next-line no-console
-              console.warn('[first-route-render:failed]', { route: state.route, error: error?.message || String(error) });
-              rollbackToLogin('כשל בטעינת נתוני משתמש אחרי התחברות');
-              await render();
+              console.error('[first route load error]', { route: state.route, error: message });
+              loginInlineError = '';
+              app.innerHTML = `<div class="ds-error" dir="rtl"><h1>שגיאה בטעינת המסך הראשון</h1><p>${escapeHtml(message)}</p><button type="button" id="logoutBtn">חזרה להתחברות</button></div>`;
+              document.getElementById('logoutBtn')?.addEventListener('click', () => {
+                setSession(null);
+                clearRoutesSnapshot();
+                render().catch(() => {});
+              });
             });
           } catch (error) {
             endPerfTimer('login:api.login');

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 701;
+const CACHE_VERSION = 702;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 651;
+const SW_ENTRY_VERSION = 652;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Users must log in with a `username` (not an arbitrary email) and receive a full bootstrap payload including routes and client settings so the UI can apply correct permissions. 
- Old localStorage route snapshots and stale SW caches can hide updated permissions and serve old code, so build-version-driven cleanup is needed. 
- First-route load failures should surface the real error instead of silently rolling the user back to the login screen. 
- Route mapping needs to treat `invitations` as event invitations (not confuse with `orders`) and limit general admin pages to the `admin` role while keeping the Israa management feature scoped to the `esraaa` user plus the `view_israa_management` flag.

### Description
- Enforce username-based auth in `frontend/src/api.js` by deriving the Supabase auth email from the entered username and requiring the returned `users.user_id` to match the username, while keeping `api.login` returning `user` + `routes` + `default_route` + `client_settings`.
- Add clear runtime diagnostics and logging in `frontend/src/main.js` for login flow values (`login username`, `user_id`, `role`, `routes returned`, `default_route`, effective routes after `applySettingsToRoutes`, and first-route load errors) and stop silently redirecting to login on first-route failures by showing the real error with a button to return to login.
- Prevent stale route snapshots by clearing `dashboard_routes` before applying bootstrap routes and add a `dashboard_build_version` check that wipes old `dashboard_routes` and screen cache entries when `config.HOTFIX_VERSION` changes, with `window.__FRONTEND_BUILD_MARKER__` tied to the new marker in `frontend/src/config.js` and `frontend/src/main.js`.
- Normalize route mapping and permissions in `frontend/src/api.js` + `frontend/src/main.js` so `invitations` is the canonical event-invitations route, general admin pages (`admin-home`, `admin-settings`, `admin-lists`, `permissions`) are removed for non-admin roles, Israa management is gated to `esraaa` or admin with `view_israa_management`, and `orders`/`invitations` mapping adjusted in `applySettingsToRoutes`/URL deep-linking.
- Bump Service Worker/cache markers (`frontend/sw.js` `CACHE_VERSION` and root `sw.js` `SW_ENTRY_VERSION`) to force clients to refresh stale caches and update the `dist` build entry.

### Testing
- Focused syntax checks: ran `node --check` on changed files (`frontend/src/api.js`, `frontend/src/main.js`, `frontend/src/state.js`, `frontend/src/screens/login.js`, `frontend/src/config.js`, `frontend/sw.js`, `sw.js`) which completed without errors.
- Focused verification: ran `npm run check:changed` which ran the mapped checks and reported focused checks complete without extra screen tests required.
- Full frontend build: ran `npm run check:build` (executes `npm run build`) which produced a successful `vite build` and `postbuild-dist` run and updated `dist/index.html`.
- Service Worker/cache version bump: `frontend/sw.js` and root `sw.js` cache/version values were incremented, and build artifacts updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea2812f6c832bbd95d6d10983f0b8)