### PR TITLE
Fix permission shadowing in buildBootstrapFromUser

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2160,10 +2160,8 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
     permissionFlagYes(flat.view_proposals_agreements) ||
     permissionFlagYes(flat.manage_proposals_agreements)
   ) { if (!allowedRoutes.includes('proposals-agreements')) allowedRoutes.push('proposals-agreements'); }
-  const canEditDirect = canDirectManageActivities;
-  const canRequestEdit = canRequestActivities;
   const canReviewRequests = canReviewEditRequestsUser(flat);
-  const canViewEditRequests = canReviewRequests || canRequestEdit || permissionFlagYes(flat.view_edit_requests) || allowedRoutes.includes('edit-requests');
+  const canViewEditRequests = canReviewRequests || canRequestActivities || permissionFlagYes(flat.view_edit_requests) || allowedRoutes.includes('edit-requests');
   if (canViewEditRequests && !allowedRoutes.includes('edit-requests')) {
     allowedRoutes.push('edit-requests');
   }
@@ -2198,8 +2196,8 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
       display_role_label: flat.display_role_label || hebrewRole(role)
     },
     can_add_activity: canAddActivities,
-    can_edit_direct: canEditDirect,
-    can_request_edit: canRequestEdit,
+    can_edit_direct: canDirectManageActivities,
+    can_request_edit: canRequestActivities,
     can_request_create_activity: canRequestCreateActivity(flat),
     can_review_requests: canReviewRequests,
     client_settings: {}


### PR DESCRIPTION
### Motivation
- Fix a `ReferenceError` caused by local `canEditDirect` and `canRequestEdit` variables shadowing imported helper functions in `buildBootstrapFromUser`, which prevented proper bootstrap after a successful Supabase login.

### Description
- Removed the local `const canEditDirect` and `const canRequestEdit` and used the already-computed `canDirectManageActivities` and `canRequestActivities` directly in `frontend/src/api.js`.
- Updated the `canViewEditRequests` computation to reference `canRequestActivities` and returned `can_edit_direct` and `can_request_edit` using the non-shadowing values.

### Testing
- Ran `node --check frontend/src/api.js`, `npm run check:changed`, and `npm run check:build`, and all checks completed successfully.
- Could not perform a live `idann` Supabase login in this environment because the entry code/password were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea8eb2358832b8c31fb0af70d63eb)