### PR TITLE
Use technical `role` for activities access checks; keep `display_role` for logging

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -677,7 +677,8 @@ function currentUserRoutesForAccess() {
 function hasActivitiesRouteAccess() {
   const user = state?.user || {};
   const permissions = user.permissions && typeof user.permissions === 'object' ? user.permissions : {};
-  const role = String(user.display_role || user.role || '').trim();
+  const role = String(user.role || '').trim();
+  const displayRole = String(user.display_role || '').trim();
   const routes = currentUserRoutesForAccess();
   const hasActivitiesAccess =
     role === 'admin' ||
@@ -687,6 +688,7 @@ function hasActivitiesRouteAccess() {
   console.info('[activities-access]', {
     username: user.username,
     role,
+    displayRole,
     permissions,
     routes,
     hasActivitiesAccess,
@@ -886,7 +888,7 @@ function shellUserRoleLine() {
   const r2 = repairHebrewMojibake(state.user?.display_role2).trim();
   if (r2) return escapeHtml(r2);
   const sheetLabel = repairHebrewMojibake(state.user?.display_role_label).trim();
-  const code = String(state.user?.display_role || state.user?.role || '').trim();
+  const code = String(state.user?.role || '').trim();
   if (sheetLabel && (!code || sheetLabel.toLowerCase() !== code.toLowerCase())) {
     return escapeHtml(sheetLabel);
   }
@@ -902,7 +904,7 @@ function enforceProposalsAgreementsRoute() {
   if (!state.token || !state.user) return;
   if (!screenLoaders['proposals-agreements']) return;
   if ((state.effectiveRoutes || []).includes('proposals-agreements')) return;
-  const role = String(state.user.display_role || state.user.role || '').trim();
+  const role = String(state.user.role || '').trim();
   const hasRole = PROPOSALS_AGREEMENTS_NAV_ROLES.has(role);
   const hasFlag = state.user.view_proposals_agreements === true || state.user.manage_proposals_agreements === true;
   if (hasRole || hasFlag) {
@@ -918,7 +920,7 @@ function shell(content) {
   enforceProposalsAgreementsRoute();
   const hiddenSet = navSidebarHiddenRoutesSet();
   const contextualSet = navContextualRoutesSet();
-  const isAdminUser = state?.user?.display_role === 'admin';
+  const isAdminUser = state?.user?.role === 'admin';
   // לאדמין: הנתונים שלי — מוסתר לחלוטין; הרשאות — בסרגל בלבד
   const adminSidebarExclude = isAdminUser ? new Set(['my-data']) : new Set();
   const nav = effectiveRoutes()
@@ -1962,7 +1964,7 @@ async function render() {
             console.info('[login user]', {
               login_username: userId,
               user_id: data?.user?.user_id,
-              role: data?.user?.display_role,
+              role: data?.user?.role,
               routes_returned: data?.routes || [],
               default_route: data?.default_route || '',
               has_client_settings: !!data?.client_settings

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -139,7 +139,7 @@ function activityPeriodTabsHtml(rows, activeKey) {
 
 
 function isAdminUser(state) {
-  return state?.user?.display_role === 'admin' || state?.user?.role === 'admin';
+  return state?.user?.role === 'admin';
 }
 
 function permissionFlagYes(value) {
@@ -155,7 +155,8 @@ function currentUserRoutes(state) {
 
 export function getActivitiesAccessDebug(state = {}) {
   const currentUser = state?.user || {};
-  const role = String(currentUser.display_role || currentUser.role || '').trim();
+  const role = String(currentUser.role || '').trim();
+  const displayRole = String(currentUser.display_role || '').trim();
   const permissions = currentUser.permissions && typeof currentUser.permissions === 'object' ? currentUser.permissions : {};
   const routes = currentUserRoutes(state);
   const hasActivitiesAccess =
@@ -173,6 +174,7 @@ export function getActivitiesAccessDebug(state = {}) {
     currentUser,
     username: currentUser.username,
     role,
+    displayRole,
     permissions,
     routes,
     hasActivitiesAccess,
@@ -895,7 +897,7 @@ function nextMeetingDate(row) {
 }
 
 function canUseActivityLayout(state) {
-  const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+  const role = String(state?.user?.role || '').trim();
   return ACTIVITY_LAYOUT_ALLOWED_ROLES.has(role);
 }
 
@@ -1286,7 +1288,7 @@ export const activitiesScreen = {
     const hideEmpIds    = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId     = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    const role = String(state?.user?.role || '').trim();
     const canDeleteActivity = canDirectManageActivities(state);
     const canAddActivity = canOpenCreateActivity(state);
     const isCreateRequestOnly = canAddActivity && !canAddActivities(state);
@@ -1613,7 +1615,7 @@ export const activitiesScreen = {
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;
-    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+    const role = String(state?.user?.role || '').trim();
     const canDeleteActivity = canDirectManageActivities(state);
     const canAddActivity = canOpenCreateActivity(state);
     const isCreateRequestOnly = canAddActivity && !canAddActivities(state);
@@ -2236,7 +2238,7 @@ export const activitiesScreen = {
           can_add_activity: state?.user?.can_add_activity,
           can_edit_direct: state?.user?.can_edit_direct,
           can_request_edit: state?.user?.can_request_edit,
-          role: String(state?.user?.display_role || state?.user?.role || '').trim()
+          role: String(state?.user?.role || '').trim()
         }
       };
 

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -28,7 +28,7 @@ function baseState() {
   return {
     activitiesMonthYm: '2026-04',
     activityPeriodTab: 'school_2026',
-    user: { display_role: 'admin', can_add_activity: true },
+    user: { display_role: 'מנהל מערכת', role: 'admin', can_add_activity: true },
     clientSettings: { hide_emp_id_on_screens: true, dropdown_options: {} },
     activityListFilters: {},
     screenDataCache: {}
@@ -125,6 +125,36 @@ test('activities access: admin idann can view without edit or add permissions', 
   assert.equal(debug.reasonDenied, '');
   const html = activitiesScreen.render({ rows: [] }, { state });
   assert.doesNotMatch(html, /אין הרשאה/);
+});
+
+
+test('activities access: allowed technical roles can view when display_role is Hebrew label', () => {
+  const users = [
+    ['idann', 'admin', 'מנהל מערכת'],
+    ['edenc', 'operation_manager', 'מנהלת תפעול'],
+    ['giln', 'activities_manager', 'מנהל פעילויות'],
+    ['yaela', 'domain_manager', 'מנהלת תחום'],
+    ['hilar', 'instructor_manager', 'מנהלת מדריכים'],
+    ['esraaa', 'business_development_manager', 'מנהלת פיתוח עסקי']
+  ];
+
+  for (const [username, role, displayRole] of users) {
+    const state = baseState();
+    state.user = {
+      username,
+      role,
+      display_role: displayRole,
+      permissions: {},
+      can_edit_direct: false,
+      can_add_activity: false
+    };
+    const debug = getActivitiesAccessDebug(state);
+    assert.equal(debug.role, role);
+    assert.equal(debug.displayRole, displayRole);
+    assert.equal(debug.hasActivitiesAccess, true, `${username} with role=${role} should access activities`);
+    const html = activitiesScreen.render({ rows: [] }, { state });
+    assert.doesNotMatch(html, /אין הרשאה/, `${username} with role=${role} should not see access denied`);
+  }
 });
 
 test('activities access: view permission and activities route allow viewing without add/edit permissions', () => {


### PR DESCRIPTION
### Motivation
- A bug used the human-readable Hebrew `display_role` as a fallback when computing permissions, which caused incorrect authorization decisions for users whose `display_role` is a label (e.g. "מנהל מערכת").
- Permission checks and UI decisions must rely on the canonical technical `role` values (e.g. `admin`, `operation_manager`, `activities_manager`) not the localized `display_role` string.

### Description
- Replace fallbacks that used `display_role` for authorization with direct reads of the technical `role` (e.g. `const role = String(user.role || '').trim()`) in `frontend/src/screens/activities.js` and `frontend/src/main.js`.
- Keep `displayRole` as a separate variable for logging/debug output where useful (e.g. `displayRole = String(user.display_role || '').trim()`).
- Update `isAdminUser` and other role-based helpers to check `state.user.role === 'admin'` instead of `display_role` fallback.
- Add a focused regression test to `tests/activities-screen.test.mjs` that verifies the requested users (`idann`, `edenc`, `giln`, `yaela`, `hilar`, `esraaa`) can access activities based on their technical `role` even when `display_role` is a Hebrew label, and update the test base state to include a Hebrew `display_role` with `role: 'admin'`.

### Testing
- Ran syntax checks: `node --check frontend/src/screens/activities.js` and `node --check frontend/src/main.js`, both succeeded.
- Ran focused unit tests: `node --test tests/activities-screen.test.mjs`, all tests passed (27 passed, 0 failed), including the new regression test.
- Ran the workspace focused check: `npm run check:changed`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eaeea821c832bb5e57546b9048576)