### PR TITLE
Activities: fix role-based permissions, enable request flows, and show admin layout button

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -80,6 +80,8 @@ const READ_ACTIONS = {
 const API_TIMEOUT_MS_READ = 20000;
 const API_TIMEOUT_MS_WRITE = 45000;
 const PERF_MAX_REQUESTS = 150;
+const ACTIVITY_DIRECT_MANAGE_ROLES = new Set(['admin', 'operation_manager']);
+const ACTIVITY_REQUEST_ROLES = new Set(['activities_manager', 'instructor_manager', 'business_development_manager']);
 /** Logs direct heavy reads for performance diagnostics. */
 const HEAVY_GUARDED_READ_ACTIONS = new Set([
   'dashboardSnapshot',
@@ -3243,8 +3245,8 @@ export const api = {
     return normalizeData(buildSupabaseErrorPayload({ rows: [] }, 'activities_supabase_failed', { filters: resolvedFilters }));
   },
   activityLayoutStatuses: async (payload = {}) => {
-    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
-    if (!['admin', 'operation_manager'].includes(role)) throw new Error('activity_layout_forbidden');
+    const role = String(state?.user?.role || '').trim();
+    if (!ACTIVITY_DIRECT_MANAGE_ROLES.has(role)) throw new Error('activity_layout_forbidden');
     const season = String(payload?.season || 'summer_2026').trim() || 'summer_2026';
     const { data, error } = await supabase
       .from('activity_layout_statuses')
@@ -3254,8 +3256,8 @@ export const api = {
     return { rows: Array.isArray(data) ? data : [], _source: 'supabase' };
   },
   saveActivityLayoutStatus: async (payload = {}) => {
-    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
-    if (!['admin', 'operation_manager'].includes(role)) throw new Error('activity_layout_forbidden');
+    const role = String(state?.user?.role || '').trim();
+    if (!ACTIVITY_DIRECT_MANAGE_ROLES.has(role)) throw new Error('activity_layout_forbidden');
     const row = {
       season: String(payload?.season || 'summer_2026').trim() || 'summer_2026',
       authority: String(payload?.authority || '').trim(),
@@ -3282,7 +3284,7 @@ export const api = {
     const weekOffset = Number.parseInt(resolved.week_offset, 10);
     const offset = Number.isFinite(weekOffset) ? weekOffset : 0;
     const payload = await readWeekFromSupabase(offset);
-    return String(state?.user?.display_role || '') === 'instructor'
+    return String(state?.user?.role || '') === 'instructor'
       ? filterCalendarPayloadForInstructor(payload)
       : payload;
   },
@@ -3293,7 +3295,7 @@ export const api = {
     const currentYm = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
     const ym = /^\d{4}-\d{2}$/.test(candidate) ? candidate : currentYm;
     const payload = await readMonthFromSupabase(ym);
-    return String(state?.user?.display_role || '') === 'instructor'
+    return String(state?.user?.role || '') === 'instructor'
       ? filterCalendarPayloadForInstructor(payload)
       : payload;
   },
@@ -3727,7 +3729,7 @@ export const api = {
     return upsertActivityToSupabase(payload);
   },
   submitCreateActivityRequest: async (activity) => {
-    if (!canSubmitActivityRequestsUser()) throw new Error('forbidden_create_activity_request');
+    if (!canSubmitCreateActivityRequestsUser()) throw new Error('forbidden_create_activity_request');
     const currentUser = state?.user || {};
     const requestedPayload = sanitizeActivityPayloadForSupabase(
       synchronizeStartDateAndFirstMeeting(sanitizeActivityPayload(activity || {})),
@@ -3762,7 +3764,7 @@ export const api = {
     const payload = (b !== undefined && b !== null)
       ? { source_row_id: a, changes: b }
       : a;
-    const userRole = String(state?.user?.display_role || state?.user?.role || '').trim();
+    const userRole = String(state?.user?.role || '').trim();
     const canEditDirect = canDirectManageActivitiesUser();
     if (!canEditDirect && canSubmitActivityRequestsUser()) {
       // eslint-disable-next-line no-console
@@ -3779,8 +3781,8 @@ export const api = {
   deleteActivity: async (source_row_id) => {
     const rowId = String(source_row_id || '').trim();
     if (!rowId) throw new Error('missing_row_id');
-    const role = String(state?.user?.display_role || state?.user?.role || '').trim();
-    if (!['admin', 'operation_manager'].includes(role)) throw new Error('forbidden_delete_activity');
+    const role = String(state?.user?.role || '').trim();
+    if (!ACTIVITY_DIRECT_MANAGE_ROLES.has(role)) throw new Error('forbidden_delete_activity');
     const { data, error } = await supabase
       .from('activities')
       .update({ status: DELETED_STATUS })

--- a/frontend/src/permissions.js
+++ b/frontend/src/permissions.js
@@ -13,6 +13,12 @@ function userPermissions(user = {}) {
   return { ...nested, ...user };
 }
 
+function userRole(user = {}) {
+  return String(user?.role || '').trim();
+}
+
+const ACTIVITY_REQUEST_ROLES = new Set(['activities_manager', 'instructor_manager', 'business_development_manager']);
+
 export function canEditDirect(user = {}) {
   const p = userPermissions(user);
   return permissionFlagYes(firstDefined(p.can_edit_direct, p.permissions?.can_edit_direct));
@@ -25,12 +31,14 @@ export function canAddActivityDirect(user = {}) {
 
 export function canRequestEdit(user = {}) {
   const p = userPermissions(user);
-  return permissionFlagYes(firstDefined(p.can_request_edit, p.can_request_edit_2, p.permissions?.can_request_edit, p.permissions?.can_request_edit_2));
+  return permissionFlagYes(firstDefined(p.can_request_edit, p.can_request_edit_2, p.permissions?.can_request_edit, p.permissions?.can_request_edit_2))
+    || ACTIVITY_REQUEST_ROLES.has(userRole(user));
 }
 
 export function canRequestCreateActivity(user = {}) {
   const p = userPermissions(user);
-  return permissionFlagYes(firstDefined(p.can_request_create_activity, p.permissions?.can_request_create_activity));
+  return permissionFlagYes(firstDefined(p.can_request_create_activity, p.permissions?.can_request_create_activity))
+    || canRequestEdit(user);
 }
 
 export function canReviewRequests(user = {}) {

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -63,7 +63,7 @@ const ACTIVITIES_ACCESS_ROLES = new Set([
   'instructor_manager',
   'business_development_manager'
 ]);
-const ACTIVITY_LAYOUT_ALLOWED_ROLES = ACTIVITIES_ACCESS_ROLES;
+const ACTIVITY_LAYOUT_ALLOWED_ROLES = new Set(['admin', ...ACTIVITIES_ACCESS_ROLES]);
 
 function canDirectManageActivities(state) {
   return canEditDirect(state?.user);
@@ -1611,7 +1611,7 @@ export const activitiesScreen = {
     }
     const filteredRows      = applyActivitiesLocalFilters(periodRows, state, state?.clientSettings);
     const canSeePrivateNotes = canReviewActivityRequests(state);
-    const canEditActivity   = canRequestActivityChanges(state);
+    const canEditActivity   = canDirectManageActivities(state) || canRequestActivityChanges(state);
     const hideEmpIds        = !!state?.clientSettings?.hide_emp_id_on_screens;
     const hideRowId         = !!state?.clientSettings?.hide_row_id_in_ui;
     const hideActivityNo    = !!state?.clientSettings?.hide_activity_no_on_screens;

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -157,6 +157,40 @@ test('activities access: allowed technical roles can view when display_role is H
   }
 });
 
+
+test('activities render: admin idann sees summer activity layout button without add/edit flags', () => {
+  const state = baseState();
+  state.activityPeriodTab = 'summer_2026';
+  state.user = {
+    username: 'idann',
+    display_role: 'מנהל מערכת',
+    role: 'admin',
+    can_edit_direct: false,
+    can_add_activity: false,
+    can_request_edit: false,
+    can_request_create_activity: false
+  };
+  const html = activitiesScreen.render({ rows: [] }, { state });
+  assert.match(html, /data-activity-layout-list/);
+  assert.match(html, />פריסת פעילות<\/button>/);
+});
+
+test('activities render: giln can request adding an activity when direct add is disabled', () => {
+  const state = baseState();
+  state.user = {
+    username: 'giln',
+    display_role: 'מנהל פעילויות',
+    role: 'activities_manager',
+    can_add_activity: false,
+    can_edit_direct: false,
+    can_request_create_activity: true,
+    can_request_edit: true
+  };
+  const html = activitiesScreen.render({ rows: [] }, { state });
+  assert.match(html, /data-activities-add-btn/);
+  assert.match(html, /בקשה להוספת פעילות/);
+});
+
 test('activities access: view permission and activities route allow viewing without add/edit permissions', () => {
   const permittedByPermission = baseState();
   permittedByPermission.user = {


### PR DESCRIPTION
### Motivation
- Fix incorrect use of `display_role` for authorization and ensure all activity actions use the technical `role` and permission flags.  
- Make `activities_manager` (and related request roles) able to submit edit/create requests even when direct add/edit flags are false.  
- Ensure `admin` users (e.g. `idann`) can see the summer activity layout action (`פריסת פעילות`) in the Summer 2026 tab.  

### Description
- Replace checks that used `display_role` with the technical `user.role` in API-level guards and routing, and centralize the role-based sets as `ACTIVITY_DIRECT_MANAGE_ROLES` and `ACTIVITY_REQUEST_ROLES`.  
- Update permission helpers in `frontend/src/permissions.js` to add `userRole()` and include request-only roles so `canRequestEdit` and `canRequestCreateActivity` return true for configured request roles.  
- Allow edit actions in the activity drawer when the user can either directly edit or request edits by making `canEditActivity` true when `canEditDirect || canRequestEdit`.  
- Add `admin` to the activity layout allowed roles so admins see the layout toolbar button, and tighten API checks for layout/save/delete flows to consult the new role sets.  
- Add focused UI tests verifying that `idann`/`admin` sees the summer layout button and that `giln`/`activities_manager` can see the "בקשה להוספת פעילות" request button when direct-add/edit are disabled.  

### Testing
- Ran focused static checks with `npm run check:changed` which completed successfully.  
- Ran the focused unit tests with `node --test tests/activities-screen.test.mjs tests/activity-request-permissions.test.mjs` and all focused tests passed.  
- Performed a frontend build with `npm run check:build` and the build succeeded.  
- Changed files: `frontend/src/permissions.js`, `frontend/src/api.js`, `frontend/src/screens/activities.js`, and `tests/activities-screen.test.mjs`, and the changes were verified by the focused checks and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec98e39b4832b8c2dbe366878118b)