### PR TITLE
Fix Supabase view field mappings, pick first summer month with data, and bump SW version

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -199,12 +199,23 @@ function normalizeActivityRow(row = {}) {
   const isLegacyOneDay = canonicalOneDayType && (String(row?.activity_family || '').trim() === 'one_day' || !String(row?.item_type || '').trim());
   const rowId = String(row?.row_id ?? row?.RowID ?? '').trim();
   const activitySeason = normalizeActivitySeason(row?.activity_season ?? row?.activitySeason);
+  const authorityName = String(row?.authority_name || row?.legacy_authority || row?.authority || '').trim();
+  const schoolName = String(
+    row?.single_school_name ||
+    row?.linked_school_names ||
+    row?.linked_school_name_list ||
+    row?.legacy_school ||
+    row?.school ||
+    ''
+  ).trim();
   const normalized = {
     ...row,
     row_id: rowId,
     RowID: rowId,
     source_sheet: 'activities',
     source_table: ACTIVITIES_TABLE,
+    authority: authorityName,
+    school: schoolName,
     activity_season: activitySeason,
     activitySeason,
     activity_family: isLegacyOneDay ? 'one_day' : row?.activity_family,
@@ -1504,6 +1515,7 @@ function normalizeData(data) {
 const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
 const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
 const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,authority,school,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = 'id,authority_id,school_id,contact_school_id,authority_name,legacy_client_authority,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
 function parseActivityNamesFromNotes(notes) {
@@ -1619,16 +1631,18 @@ function normalizeProposalAgreementRow(row = {}) {
   const parsedNotes = parseActivityNamesFromNotes(row.notes);
   const PA_VALID_STATUSES = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
   const rawStatus = cleanProposalAgreementText(row.status);
+  const authorityName = cleanProposalAgreementText(row.authority_name || row.legacy_client_authority || row.client_authority || row.authority);
+  const schoolFramework = cleanProposalAgreementText(row.school_framework || row.school);
   const normalized = {
     id:                  cleanProposalAgreementText(row.id),
     client_type:         cleanProposalAgreementText(row.client_type) || (row.school_id ? 'school' : 'authority'),
     authority_id:        row.authority_id ?? null,
     school_id:           row.school_id ?? null,
     contact_school_id:   row.contact_school_id ?? null,
-    authority:           cleanProposalAgreementText(row.authority),
-    school:              cleanProposalAgreementText(row.school),
-    client_authority:    cleanProposalAgreementText(row.client_authority || row.authority),
-    school_framework:    cleanProposalAgreementText(row.school_framework || row.school || row.authority),
+    authority:           authorityName,
+    school:              schoolFramework,
+    client_authority:    cleanProposalAgreementText(row.client_authority) || authorityName,
+    school_framework:    schoolFramework || authorityName,
     document_type:       cleanProposalAgreementText(row.document_type),
     activity_type_group: normalizeProposalGroupValue(row.activity_type_group),
     proposal_date:       cleanProposalAgreementText(row.proposal_date),
@@ -1969,7 +1983,7 @@ async function readProposalsAgreementsFromSupabase() {
   const [paResult, contactOptions, rawProposalActivityPricing, proposalTemplateSections, proposalActivityGroups, proposalGroupAliases] = await Promise.all([
     supabase
       .from('proposals_agreements_directory_view')
-      .select(PROPOSALS_AGREEMENTS_COLUMNS)
+      .select(PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS)
       .order('client_authority', { ascending: true })
       .order('school_framework', { ascending: true })
       .order('document_type', { ascending: true })

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -122,6 +122,27 @@ function activityPeriodRows(rows, periodKey) {
   return (Array.isArray(rows) ? rows : []).filter((row) => activityPeriodKey(row) === activeKey);
 }
 
+function firstActivityMonthYm(rows) {
+  const months = new Set();
+  (Array.isArray(rows) ? rows : []).forEach((row) => {
+    [
+      normalizedActivityStartDate(row),
+      String(row?.end_date ?? row?.date_end ?? '').trim().slice(0, 10),
+      ...activityMeetingDates(row)
+    ].forEach((date) => {
+      const value = String(date || '').trim().slice(0, 10);
+      if (/^\d{4}-\d{2}-\d{2}$/.test(value)) months.add(value.slice(0, 7));
+    });
+  });
+  return [...months].sort()[0] || '';
+}
+
+function ensureActivityPeriodMonth(state, rows) {
+  if (state?.activityPeriodTab !== 'summer_2026') return;
+  const firstMonth = firstActivityMonthYm(activityPeriodRows(rows, 'summer_2026'));
+  if (firstMonth && state.activitiesMonthYm !== firstMonth) state.activitiesMonthYm = firstMonth;
+}
+
 function activityPeriodTabsHtml(rows, activeKey) {
   const safeActiveKey = normalizeActivityPeriodTab(activeKey);
   const counts = ACTIVITY_PERIOD_TABS.reduce((acc, tab) => ({ ...acc, [tab.key]: 0 }), {});
@@ -1264,10 +1285,12 @@ export const activitiesScreen = {
   async load({ api, state }) {
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
     if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
-    return api.activities({
+    const result = await api.activities({
       activity_type: 'all',
       include_inactive: true
     });
+    ensureActivityPeriodMonth(state, Array.isArray(result?.rows) ? result.rows : []);
+    return result;
   },
 
   render(data, { state }) {
@@ -1279,6 +1302,7 @@ export const activitiesScreen = {
     const allRows       = Array.isArray(data?.rows) ? data.rows : [];
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
     if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
+    ensureActivityPeriodMonth(state, allRows);
     const periodRows    = activityPeriodRows(allRows, state.activityPeriodTab);
     const isMonthFilterActive = state.activityPeriodTab !== 'summer_2026' && state.activityPeriodTab !== 'archive';
     const monthRows     = isMonthFilterActive ? applySelectedActivitiesMonth(periodRows, state) : periodRows;
@@ -1945,6 +1969,7 @@ export const activitiesScreen = {
     root.querySelectorAll('[data-activity-period-tab]').forEach((btn) => {
       btn.addEventListener('click', () => {
         state.activityPeriodTab = normalizeActivityPeriodTab(btn.getAttribute('data-activity-period-tab'));
+        ensureActivityPeriodMonth(state, activitiesRows);
         ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = 200;
         rerenderLocal();
       });

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 704;
+const CACHE_VERSION = 705;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 704;
+const SW_ENTRY_VERSION = 705;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The `proposals_agreements_directory_view` and `activities_directory_view` in Supabase do not expose `authority`/`school` columns, which caused runtime errors when the frontend attempted to read them.  
- When opening the summer activities tab the UI could land on an empty month (e.g. June 2026) even though summer activities start in July, causing a confusing empty view.  
- Service Worker cache version must be bumped after data/behavior fixes so clients pick up the deploy immediately.

### Description
- Map activity rows from `activities_directory_view` to existing view fields by normalizing `authority` from `authority_name || legacy_authority || authority` and `school` from `single_school_name || linked_school_names || linked_school_name_list || legacy_school || school` in `normalizeActivityRow` in `frontend/src/api.js`.  
- Stop selecting non-existent `authority`/`school` columns from `proposals_agreements_directory_view` and add a safe directory-view column set (`PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS`) that includes `authority_name` and `legacy_client_authority`, and use that when reading the directory view in `frontend/src/api.js`.  
- Normalize proposal rows in `normalizeProposalAgreementRow` to use `authority_name` with fallback to `legacy_client_authority`/`client_authority`/`authority`, and set `school_framework` from the directory fields to avoid referencing missing columns.  
- Ensure the summer activities tab opens on the first month that contains activity dates by adding `firstActivityMonthYm` / `ensureActivityPeriodMonth` and calling them during `load`, `render`, and when switching period tabs in `frontend/src/screens/activities.js`.  
- Use the normalized meeting dates (`activityMeetingDates`) when computing the first month instead of a missing helper.  
- Bump Service Worker versions: `CACHE_VERSION` in `frontend/sw.js` and `SW_ENTRY_VERSION` in `sw.js` were incremented so clients will refresh; the worker already calls `self.skipWaiting()` and `self.clients.claim()`.

### Testing
- Ran `node --check frontend/src/api.js` and `node --check frontend/src/screens/activities.js` and both checks passed.  
- Ran focused UI tests with `node --test tests/activities-screen.test.mjs tests/proposals-agreements-screen.test.mjs` and all tests passed (90 passed, 0 failed).  
- Ran the frontend build check with `npm run check:build` (executed `vite build` + postbuild) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f2a686a98832b91658cdd890bc51d)