### PR TITLE
Fix summer activities tab counts

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -137,11 +137,13 @@ function firstActivityMonthYm(rows) {
   return [...months].sort()[0] || '';
 }
 
-function ensureActivityPeriodMonth(state, rows) {
+function ensureActivityPeriodMonth(state, rows, { force = false } = {}) {
   if (state?.activityPeriodTab !== 'summer_2026') return;
+  if (!force && state._activitiesSummerMonthInitialized) return;
   const firstMonth = firstActivityMonthYm(activityPeriodRows(rows, 'summer_2026'));
   const targetMonth = firstMonth || SUMMER_DEFAULT_MONTH_YM;
   if (state.activitiesMonthYm !== targetMonth) state.activitiesMonthYm = targetMonth;
+  state._activitiesSummerMonthInitialized = true;
 }
 
 function activityPeriodTabsHtml(rows, activeKey) {
@@ -1365,7 +1367,7 @@ export const activitiesScreen = {
 
         if (isSummerTab) {
           const activityDateRaw = String(row.date_1 || row.start_date || '').trim();
-          const activityDateHe = activityDateRaw ? (formatDateHe(activityDateRaw) || activityDateRaw) : '—';
+          const activityDateHe = activityDateRaw ? (formatDateHe(activityDateRaw) || activityDateRaw) : 'דורש שיבוץ תאריך';
           const gradeDisplay = escapeHtml(String(row.grade || '—'));
           const startTime = activityLayoutStartTime(row);
           const endTime = activityLayoutEndTime(row);
@@ -1970,7 +1972,7 @@ export const activitiesScreen = {
     root.querySelectorAll('[data-activity-period-tab]').forEach((btn) => {
       btn.addEventListener('click', () => {
         state.activityPeriodTab = normalizeActivityPeriodTab(btn.getAttribute('data-activity-period-tab'));
-        ensureActivityPeriodMonth(state, activitiesRows);
+        ensureActivityPeriodMonth(state, activitiesRows, { force: true });
         ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = 200;
         rerenderLocal();
       });

--- a/frontend/src/screens/shared/summer-activity.js
+++ b/frontend/src/screens/shared/summer-activity.js
@@ -1,7 +1,7 @@
 const SUMMER_START_DATE = '2026-07-01';
 const SUMMER_END_DATE = '2026-08-31';
 const SUMMER_ROW_ID_PREFIX = 'summer_';
-const EXCLUDED_SUMMER_STATUSES = new Set(['בוטל', 'נמחק']);
+const EXCLUDED_SUMMER_STATUSES = new Set(['בוטל', 'נמחק', 'cancelled', 'canceled', 'deleted']);
 export const SUMMER_DEFAULT_MONTH_YM = SUMMER_START_DATE.slice(0, 7);
 export const ACTIVITY_SEASON_REGULAR = 'regular';
 export const ACTIVITY_SEASON_SUMMER_2026 = 'summer_2026';
@@ -39,5 +39,6 @@ export function activitySeasonLabel(value) {
 export function isSummerActivity(activity = {}) {
   const rowId = String(activity?.row_id ?? activity?.RowID ?? activity?.id ?? '').trim().toLowerCase();
   const status = String(activity?.status || '').trim();
-  return rowId.startsWith(SUMMER_ROW_ID_PREFIX) && !EXCLUDED_SUMMER_STATUSES.has(status);
+  const normalizedStatus = status.toLowerCase();
+  return rowId.startsWith(SUMMER_ROW_ID_PREFIX) && !EXCLUDED_SUMMER_STATUSES.has(status) && !EXCLUDED_SUMMER_STATUSES.has(normalizedStatus);
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 707;
+const CACHE_VERSION = 708;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 707;
+const SW_ENTRY_VERSION = 708;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -335,8 +335,30 @@ test('activities summer tab opens on first dated summer month and counts all act
   assert.match(html, /ניהול פעילויות · יולי · 2 פעילויות/);
   assert.match(html, /פעילות יולי/);
   assert.match(html, /פעילות קיץ ללא תאריך/);
+  assert.match(html, /דורש שיבוץ תאריך/);
   assert.doesNotMatch(html, /פעילות קיץ מבוטלת/);
   assert.doesNotMatch(html, /פעילות רגילה ביולי/);
+});
+
+
+
+test('activities summer month initialization does not override manual summer navigation after first entry', () => {
+  const state = baseState();
+  state.activityPeriodTab = 'summer_2026';
+  state.activitiesMonthYm = '2026-06';
+  const data = {
+    rows: [
+      { RowID: 'summer_july_1', activity_name: 'פעילות יולי', activity_type: 'workshop', authority: 'רשות א', school: 'בית ספר א', start_date: '2026-07-01', status: 'פעיל' }
+    ]
+  };
+
+  activitiesScreen.render(data, { state });
+  assert.equal(state.activitiesMonthYm, '2026-07');
+
+  state.activitiesMonthYm = '2026-08';
+  const html = activitiesScreen.render(data, { state });
+  assert.equal(state.activitiesMonthYm, '2026-08');
+  assert.match(html, /ניהול פעילויות · אוגוסט · 1 פעילויות/);
 });
 
 test('activities selected month drives title, count and table rows', () => {


### PR DESCRIPTION
### Motivation
- The summer tab was showing counts based on the currently selected month instead of counting all active summer rows, and undated summer rows were disappearing or showing an empty date cell.
- The UI should open the summer tab on the first dated summer month on first visit but respect manual month navigation afterwards.

### Description
- Count summer activities by `row_id`/`RowID` prefix `summer_` and exclude cancelled/deleted statuses (added English variants) in `frontend/src/screens/shared/summer-activity.js` so the tab total reflects all active summer rows.
- Initialize the summer view month to the first dated summer month only once by adding `ensureActivityPeriodMonth(state, rows, { force })` and a `_activitiesSummerMonthInitialized` guard in `frontend/src/screens/activities.js` so manual navigation is preserved after first entry.
- Keep undated summer rows visible and display the label `דורש שיבוץ תאריך` instead of an empty date in the summer table in `frontend/src/screens/activities.js`.
- Add a focused test to ensure initialization does not override manual summer navigation and update the existing summer tests in `tests/activities-screen.test.mjs` to assert the new behavior and label.
- Bump Service Worker versions in both `frontend/sw.js` and root `sw.js` (`707` → `708`) to invalidate caches after deploy.
- No data/schema changes — code-only fix.

### Testing
- Ran focused syntax checks with `npm run check:changed -- frontend/src/screens/activities.js frontend/src/screens/shared/summer-activity.js frontend/sw.js sw.js tests/activities-screen.test.mjs` and they completed successfully.
- Ran the focused unit tests with `node --test tests/activities-screen.test.mjs` and all tests passed (`31 passed, 0 failed`).
- Built production artifacts with `npm run check:build` and the build completed successfully; Service Worker cache version was bumped in both `frontend/sw.js` and `sw.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f3117a7e0832bb5346f8b4f9d72b6)