### PR TITLE
Fix activities period and month filtering

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -47,6 +47,14 @@ const taasiyedaLogoSrc = new URL('../../assets/logo1.png', import.meta.url).href
 const inflightActivityDetailRequests = new Map();
 const ADD_ACTIVITY_TYPE_ORDER = ['workshop', 'escape_room', 'tour', 'after_school'];
 
+const ALL_ACTIVITIES_TAB_KEY = 'all_activities';
+const ALL_ACTIVITIES_STATUS_FILTERS = [
+  { key: 'all', label: 'הכל' },
+  { key: 'open', label: 'פתוח' },
+  { key: 'closed', label: 'סגור' },
+  { key: 'undated', label: 'ללא תאריך' },
+  { key: 'include_deleted', label: 'כולל נמחקים' }
+];
 const ACTIVITY_PERIOD_TABS = [
   { key: 'school_2026', label: 'תשפ״ו / 2026', start: '', end: '2026-06-30' },
   { key: 'summer_2026', label: 'קיץ 2026', start: '2026-07-01', end: '2026-08-31' },
@@ -91,7 +99,17 @@ function canOpenCreateActivity(state) {
 
 function normalizeActivityPeriodTab(value) {
   const key = String(value || '').trim();
+  if (key === ALL_ACTIVITIES_TAB_KEY) return key;
   return ACTIVITY_PERIOD_TABS.some((tab) => tab.key === key) ? key : DEFAULT_ACTIVITY_PERIOD_TAB;
+}
+
+function isAllActivitiesMode(state = {}) {
+  return normalizeActivityPeriodTab(state.activityPeriodTab) === ALL_ACTIVITIES_TAB_KEY;
+}
+
+function normalizeAllActivitiesStatusFilter(value) {
+  const key = String(value || '').trim();
+  return ALL_ACTIVITIES_STATUS_FILTERS.some((filter) => filter.key === key) ? key : 'all';
 }
 
 function normalizedActivityStartDate(row = {}) {
@@ -101,6 +119,20 @@ function normalizedActivityStartDate(row = {}) {
 
 function isInactiveActivityStatus(row = {}) {
   return INACTIVE_ACTIVITY_STATUSES.has(String(row?.status || '').trim().toLowerCase()) || INACTIVE_ACTIVITY_STATUSES.has(String(row?.status || '').trim());
+}
+
+function normalizedActivityStatus(row = {}) {
+  return String(row?.status || '').trim();
+}
+
+function isDeletedActivity(row = {}) {
+  const status = normalizedActivityStatus(row);
+  return status === 'נמחק' || status.toLowerCase() === 'deleted';
+}
+
+function isClosedActivity(row = {}) {
+  const status = normalizedActivityStatus(row);
+  return status === 'סגור' || status.toLowerCase() === 'closed';
 }
 
 function activityPeriodKey(row = {}) {
@@ -128,7 +160,19 @@ function activityPeriodRows(rows, periodKey) {
   return (Array.isArray(rows) ? rows : []).filter((row) => activityPeriodKey(row) === activeKey);
 }
 
+function allActivitiesRows(rows, state = {}) {
+  const filter = normalizeAllActivitiesStatusFilter(state.allActivitiesStatusFilter);
+  return (Array.isArray(rows) ? rows : []).filter((row) => {
+    if (filter !== 'include_deleted' && isDeletedActivity(row)) return false;
+    if (filter === 'open') return !isClosedActivity(row) && !isDeletedActivity(row);
+    if (filter === 'closed') return isClosedActivity(row);
+    if (filter === 'undated') return !normalizedActivityStartDate(row);
+    return true;
+  });
+}
+
 function activityRowsForPeriodAndMonth(rows, state = {}) {
+  if (isAllActivitiesMode(state)) return allActivitiesRows(rows, state);
   const periodRows = activityPeriodRows(rows, state.activityPeriodTab);
   return periodRows.filter((row) => activityMatchesSelectedStartMonth(row, state.activitiesMonthYm));
 }
@@ -157,13 +201,28 @@ function ensureActivityPeriodMonth(state, rows, { force = false } = {}) {
   state._activitiesSummerMonthInitialized = true;
 }
 
+function allActivitiesStatusFilterHtml(state = {}) {
+  if (!isAllActivitiesMode(state)) return '';
+  const selected = normalizeAllActivitiesStatusFilter(state.allActivitiesStatusFilter);
+  return `<label class="ds-filter-inline ds-filter-inline--all-activities" dir="rtl">
+    <span>סטטוס</span>
+    <select class="ds-input ds-input--sm" data-all-activities-status-filter aria-label="סינון סטטוס בכל הפעילויות">
+      ${ALL_ACTIVITIES_STATUS_FILTERS.map((filter) => `<option value="${escapeHtml(filter.key)}"${filter.key === selected ? ' selected' : ''}>${escapeHtml(filter.label)}</option>`).join('')}
+    </select>
+  </label>`;
+}
+
 function activityPeriodTabsHtml(rows, activeKey, state = {}) {
   const safeActiveKey = normalizeActivityPeriodTab(activeKey);
   const counts = ACTIVITY_PERIOD_TABS.reduce((acc, tab) => ({ ...acc, [tab.key]: 0 }), {});
   ACTIVITY_PERIOD_TABS.forEach((tab) => {
     counts[tab.key] = activityRowsForPeriodAndMonth(rows, { ...state, activityPeriodTab: tab.key }).length;
   });
+  const allCount = allActivitiesRows(rows, { allActivitiesStatusFilter: 'all' }).length;
   return `<div class="ds-activities-period-tabs" role="tablist" aria-label="תקופות פעילות" dir="rtl">
+    <button type="button" class="ds-chip ds-chip--tab ds-activities-period-tab ds-activities-period-tab--all${safeActiveKey === ALL_ACTIVITIES_TAB_KEY ? ' is-active' : ''}" role="tab" aria-selected="${safeActiveKey === ALL_ACTIVITIES_TAB_KEY ? 'true' : 'false'}" data-activity-period-tab="${ALL_ACTIVITIES_TAB_KEY}">
+      <span>כל הפעילויות</span><strong>${escapeHtml(String(allCount))}</strong>
+    </button>
     ${ACTIVITY_PERIOD_TABS.map((tab) => `<button type="button" class="ds-chip ds-chip--tab ds-activities-period-tab${tab.key === safeActiveKey ? ' is-active' : ''}" role="tab" aria-selected="${tab.key === safeActiveKey ? 'true' : 'false'}" data-activity-period-tab="${escapeHtml(tab.key)}">
       <span>${escapeHtml(tab.label)}</span><strong>${escapeHtml(String(counts[tab.key] || 0))}</strong>
     </button>`).join('')}
@@ -366,7 +425,7 @@ const ACTIVITY_FILTER_FIELDS = [
   { key: 'activity_type', label: 'סוג הפעילות', getOptionLabel: (value) => visibleActivityCategoryLabel(value) }
 ];
 const ACTIVITY_SEARCH_FIELDS = [
-  'RowID', 'row_id', 'source_row_id',
+  'id', 'RowID', 'row_id', 'source_row_id',
   'activity_no', 'activity_number', 'activity_name', 'activity_type', 'activity_family',
   'activity_manager', 'manager_name',
   'instructor_name', 'instructor_name_2', 'Instructor', 'Instructor2',
@@ -1316,7 +1375,9 @@ export const activitiesScreen = {
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
     if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
     ensureActivityPeriodMonth(state, allRows);
-    const periodRows    = activityPeriodRows(allRows, state.activityPeriodTab);
+    state.allActivitiesStatusFilter = normalizeAllActivitiesStatusFilter(state.allActivitiesStatusFilter);
+    const isAllMode = isAllActivitiesMode(state);
+    const periodRows    = isAllMode ? allActivitiesRows(allRows, { allActivitiesStatusFilter: 'include_deleted' }) : activityPeriodRows(allRows, state.activityPeriodTab);
     const monthRows     = activityRowsForPeriodAndMonth(allRows, state);
     const filteredRows  = applyActivitiesLocalFilters(monthRows, state, state?.clientSettings);
 
@@ -1465,8 +1526,10 @@ export const activitiesScreen = {
     const isNavLoading = !!state.activitiesNavLoading;
     const navLoadingChip = isNavLoading ? '<span class="ds-inline-loading-dot is-inline-loading" aria-hidden="true"></span>' : '';
     const viewSwitcher = renderActivitiesViewSwitcher(state, 'activities');
+    const allActivitiesStatusFilter = allActivitiesStatusFilterHtml(state);
     const mainToolbar = `<div class="ds-activities-main-toolbar" dir="rtl" data-local-filters="${ACTIVITIES_SCOPE}">
-      <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="חיפוש" aria-label="חיפוש פעילויות" title="חיפוש לפי פעילות / מדריך / רשות / בית ספר" />
+      <input type="search" class="ds-input ds-input--sm ds-activities-search-sm" data-filter-search="${ACTIVITIES_SCOPE}" value="${escapeHtml(listFilters.q || '')}" placeholder="חיפוש" aria-label="חיפוש פעילויות" title="חיפוש לפי מזהה, פעילות, מדריך, רשות, בית ספר, סטטוס, תאריך או סמל מוסד" />
+      ${allActivitiesStatusFilter}
       ${bareFilters}
       <div class="ds-activities-main-toolbar__actions">
         <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-btn--icon-only" data-filter-clear="${ACTIVITIES_SCOPE}" aria-label="ניקוי סינון" title="ניקוי סינון">↻</button>
@@ -1476,7 +1539,11 @@ export const activitiesScreen = {
       </div>
     </div>`;
 
-    const titleNavRow = `<nav class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" aria-label="ניווט חודשי לפעילויות" dir="rtl">
+    const titleNavRow = isAllMode
+      ? `<nav class="ds-activities-title-row" aria-label="חיפוש בכל הפעילויות" dir="rtl">
+      <h2 class="ds-activities-page-title">חיפוש בכל הפעילויות · ${total} פעילויות</h2>
+    </nav>`
+      : `<nav class="ds-activities-title-row${isNavLoading ? ' is-nav-loading' : ''}" aria-label="ניווט חודשי לפעילויות" dir="rtl">
       <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-prev aria-label="חודש קודם" title="חודש קודם" ${isNavLoading ? 'disabled' : ''}>▶</button>
       <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(heMonthLabel(state.activitiesMonthYm))} · ${total} פעילויות ${navLoadingChip}</h2>
       <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-next aria-label="חודש הבא" title="חודש הבא" ${isNavLoading ? 'disabled' : ''}>◀</button>
@@ -1564,6 +1631,7 @@ export const activitiesScreen = {
 
     const activitiesRows = Array.isArray(data?.rows) ? data.rows : [];
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
+    state.allActivitiesStatusFilter = normalizeAllActivitiesStatusFilter(state.allActivitiesStatusFilter);
     const periodRows = activityRowsForPeriodAndMonth(activitiesRows, state);
     let activityLayoutGroups = [];
 
@@ -1937,8 +2005,10 @@ export const activitiesScreen = {
       btn.textContent = 'מייצא…';
       try {
         const res = await loadAllActivitiesForAdmin();
-        const rows = activityPeriodRows(Array.isArray(res?.rows) ? res.rows : [], state.activityPeriodTab);
-        exportActivitiesToExcel(rows, `פעילויות_${activityPeriodLabelForKey(state.activityPeriodTab) || 'תקופה'}`);
+        const sourceRows = Array.isArray(res?.rows) ? res.rows : [];
+        const rows = isAllActivitiesMode(state) ? allActivitiesRows(sourceRows, state) : activityPeriodRows(sourceRows, state.activityPeriodTab);
+        const exportLabel = isAllActivitiesMode(state) ? 'כל_הפעילויות' : (activityPeriodLabelForKey(state.activityPeriodTab) || 'תקופה');
+        exportActivitiesToExcel(rows, `פעילויות_${exportLabel}`);
       } catch (err) {
         console.error('Failed to export all activities to Excel', err);
       } finally {
@@ -1985,6 +2055,12 @@ export const activitiesScreen = {
         ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = 200;
         rerenderLocal();
       });
+    });
+
+    root.querySelector('[data-all-activities-status-filter]')?.addEventListener('change', (ev) => {
+      state.allActivitiesStatusFilter = normalizeAllActivitiesStatusFilter(ev.currentTarget?.value);
+      ensureActivityListFilters(state, ACTIVITIES_SCOPE).visibleCount = 200;
+      rerenderLocal();
     });
     root.querySelector(`[data-list-show-more="${ACTIVITIES_SCOPE}"]`)?.addEventListener('click', (ev) => {
       const next = Number(ev.currentTarget?.dataset?.nextCount || 200);

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -113,6 +113,12 @@ function activityPeriodKey(row = {}) {
   return 'school_2026';
 }
 
+function activityMatchesSelectedStartMonth(row = {}, ym = '') {
+  const month = String(ym || '').trim().slice(0, 7);
+  if (!/^\d{4}-\d{2}$/.test(month)) return true;
+  return normalizedActivityStartDate(row).slice(0, 7) === month;
+}
+
 function activityPeriodLabelForKey(key) {
   return ACTIVITY_PERIOD_TABS.find((tab) => tab.key === key)?.label || '';
 }
@@ -120,6 +126,11 @@ function activityPeriodLabelForKey(key) {
 function activityPeriodRows(rows, periodKey) {
   const activeKey = normalizeActivityPeriodTab(periodKey);
   return (Array.isArray(rows) ? rows : []).filter((row) => activityPeriodKey(row) === activeKey);
+}
+
+function activityRowsForPeriodAndMonth(rows, state = {}) {
+  const periodRows = activityPeriodRows(rows, state.activityPeriodTab);
+  return periodRows.filter((row) => activityMatchesSelectedStartMonth(row, state.activitiesMonthYm));
 }
 
 function firstActivityMonthYm(rows) {
@@ -146,12 +157,11 @@ function ensureActivityPeriodMonth(state, rows, { force = false } = {}) {
   state._activitiesSummerMonthInitialized = true;
 }
 
-function activityPeriodTabsHtml(rows, activeKey) {
+function activityPeriodTabsHtml(rows, activeKey, state = {}) {
   const safeActiveKey = normalizeActivityPeriodTab(activeKey);
   const counts = ACTIVITY_PERIOD_TABS.reduce((acc, tab) => ({ ...acc, [tab.key]: 0 }), {});
-  (Array.isArray(rows) ? rows : []).forEach((row) => {
-    const key = activityPeriodKey(row);
-    counts[key] = (counts[key] || 0) + 1;
+  ACTIVITY_PERIOD_TABS.forEach((tab) => {
+    counts[tab.key] = activityRowsForPeriodAndMonth(rows, { ...state, activityPeriodTab: tab.key }).length;
   });
   return `<div class="ds-activities-period-tabs" role="tablist" aria-label="תקופות פעילות" dir="rtl">
     ${ACTIVITY_PERIOD_TABS.map((tab) => `<button type="button" class="ds-chip ds-chip--tab ds-activities-period-tab${tab.key === safeActiveKey ? ' is-active' : ''}" role="tab" aria-selected="${tab.key === safeActiveKey ? 'true' : 'false'}" data-activity-period-tab="${escapeHtml(tab.key)}">
@@ -663,7 +673,7 @@ function activityOccursInSelectedMonth(row = {}, ym = '') {
 }
 
 function applySelectedActivitiesMonth(rows, state) {
-  return (Array.isArray(rows) ? rows : []).filter((row) => activityOccursInSelectedMonth(row, state?.activitiesMonthYm));
+  return (Array.isArray(rows) ? rows : []).filter((row) => activityMatchesSelectedStartMonth(row, state?.activitiesMonthYm));
 }
 
 function currentYm() {
@@ -1307,8 +1317,7 @@ export const activitiesScreen = {
     if (!state.activitiesMonthYm) state.activitiesMonthYm = currentYm();
     ensureActivityPeriodMonth(state, allRows);
     const periodRows    = activityPeriodRows(allRows, state.activityPeriodTab);
-    const isMonthFilterActive = state.activityPeriodTab !== 'summer_2026' && state.activityPeriodTab !== 'archive';
-    const monthRows     = isMonthFilterActive ? applySelectedActivitiesMonth(periodRows, state) : periodRows;
+    const monthRows     = activityRowsForPeriodAndMonth(allRows, state);
     const filteredRows  = applyActivitiesLocalFilters(monthRows, state, state?.clientSettings);
 
     const listFilters   = ensureActivityListFilters(state, ACTIVITIES_SCOPE);
@@ -1445,7 +1454,7 @@ export const activitiesScreen = {
       safeRows.length === 0
         ? dsEmptyState(periodRows.length === 0
             ? 'אין פעילויות להצגה בתקופה זו'
-            : (isMonthFilterActive && monthRows.length === 0)
+            : (monthRows.length === 0)
               ? 'אין פעילויות להצגה בחודש הנבחר'
               : 'לא נמצאו פעילויות התואמות לסינון הנוכחי')
         : dsTableWrap(`<table class="ds-table ds-table--interactive ds-table--activities-list" dir="rtl">
@@ -1472,7 +1481,7 @@ export const activitiesScreen = {
       <h2 class="ds-activities-page-title">ניהול פעילויות · ${escapeHtml(heMonthLabel(state.activitiesMonthYm))} · ${total} פעילויות ${navLoadingChip}</h2>
       <button type="button" class="ds-btn ds-btn--sm ds-btn--nav-arrow" data-activities-month-next aria-label="חודש הבא" title="חודש הבא" ${isNavLoading ? 'disabled' : ''}>◀</button>
     </nav>`;
-    const periodTabs = activityPeriodTabsHtml(allRows, state.activityPeriodTab);
+    const periodTabs = activityPeriodTabsHtml(allRows, state.activityPeriodTab, state);
 
     const html = dsScreenStack(`<section class="ds-activities-screen">
       ${viewSwitcher}
@@ -1555,7 +1564,7 @@ export const activitiesScreen = {
 
     const activitiesRows = Array.isArray(data?.rows) ? data.rows : [];
     state.activityPeriodTab = normalizeActivityPeriodTab(state.activityPeriodTab);
-    const periodRows = activityPeriodRows(activitiesRows, state.activityPeriodTab);
+    const periodRows = activityRowsForPeriodAndMonth(activitiesRows, state);
     let activityLayoutGroups = [];
 
     async function loadActivityLayoutStatuses() {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 709;
+const CACHE_VERSION = 710;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 708;
+const CACHE_VERSION = 709;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 708;
+const SW_ENTRY_VERSION = 709;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 709;
+const SW_ENTRY_VERSION = 710;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -306,8 +306,8 @@ test('activities period tabs split rows by start_date and default to school 2026
 
   assert.match(html, /data-activity-period-tab="school_2026"[\s\S]*תשפ״ו \/ 2026[\s\S]*<strong>1<\/strong>/);
   assert.match(html, /aria-selected="true" data-activity-period-tab="school_2026"/);
-  assert.match(html, /data-activity-period-tab="school_2027"[\s\S]*<strong>1<\/strong>/);
-  assert.match(html, /data-activity-period-tab="archive"[\s\S]*<strong>1<\/strong>/);
+  assert.match(html, /data-activity-period-tab="school_2027"[\s\S]*<strong>0<\/strong>/);
+  assert.match(html, /data-activity-period-tab="archive"[\s\S]*<strong>0<\/strong>/);
   assert.match(html, /פעילות יוני/);
   assert.doesNotMatch(html, /פעילות יולי/);
   assert.doesNotMatch(html, /פעילות ספטמבר/);
@@ -315,7 +315,7 @@ test('activities period tabs split rows by start_date and default to school 2026
   assert.doesNotMatch(html, /כל הפעילויות/);
 });
 
-test('activities summer tab opens on first dated summer month and counts all active summer rows', () => {
+test('activities summer tab opens on first dated summer month and filters rows by start_date month', () => {
   const state = baseState();
   state.activityPeriodTab = 'summer_2026';
   state.activitiesMonthYm = '2026-06';
@@ -331,11 +331,11 @@ test('activities summer tab opens on first dated summer month and counts all act
   const html = activitiesScreen.render(data, { state });
 
   assert.equal(state.activitiesMonthYm, '2026-07');
-  assert.match(html, /data-activity-period-tab="summer_2026"[\s\S]*<strong>2<\/strong>/);
-  assert.match(html, /ניהול פעילויות · יולי · 2 פעילויות/);
+  assert.match(html, /data-activity-period-tab="summer_2026"[\s\S]*<strong>1<\/strong>/);
+  assert.match(html, /ניהול פעילויות · יולי · 1 פעילויות/);
   assert.match(html, /פעילות יולי/);
-  assert.match(html, /פעילות קיץ ללא תאריך/);
-  assert.match(html, /דורש שיבוץ תאריך/);
+  assert.doesNotMatch(html, /פעילות קיץ ללא תאריך/);
+  assert.doesNotMatch(html, /דורש שיבוץ תאריך/);
   assert.doesNotMatch(html, /פעילות קיץ מבוטלת/);
   assert.doesNotMatch(html, /פעילות רגילה ביולי/);
 });
@@ -358,7 +358,8 @@ test('activities summer month initialization does not override manual summer nav
   state.activitiesMonthYm = '2026-08';
   const html = activitiesScreen.render(data, { state });
   assert.equal(state.activitiesMonthYm, '2026-08');
-  assert.match(html, /ניהול פעילויות · אוגוסט · 1 פעילויות/);
+  assert.match(html, /ניהול פעילויות · אוגוסט · 0 פעילויות/);
+  assert.doesNotMatch(html, /פעילות יולי/);
 });
 
 test('activities selected month drives title, count and table rows', () => {
@@ -374,19 +375,19 @@ test('activities selected month drives title, count and table rows', () => {
   };
 
   const mayHtml = activitiesScreen.render(data, { state });
-  assert.match(mayHtml, /ניהול פעילויות · מאי · 2 פעילויות/);
+  assert.match(mayHtml, /ניהול פעילויות · מאי · 3 פעילויות/);
   assert.match(mayHtml, /פעילות מאי/);
   assert.match(mayHtml, /פעילות חוצה חודשים/);
   assert.doesNotMatch(mayHtml, /פעילות יוני/);
-  assert.doesNotMatch(mayHtml, /מפגש יוני/);
+  assert.match(mayHtml, /מפגש יוני/);
 
   state.activitiesMonthYm = '2026-06';
   const juneHtml = activitiesScreen.render(data, { state });
-  assert.match(juneHtml, /ניהול פעילויות · יוני · 3 פעילויות/);
+  assert.match(juneHtml, /ניהול פעילויות · יוני · 1 פעילויות/);
   assert.doesNotMatch(juneHtml, /פעילות מאי/);
   assert.match(juneHtml, /פעילות יוני/);
-  assert.match(juneHtml, /פעילות חוצה חודשים/);
-  assert.match(juneHtml, /מפגש יוני/);
+  assert.doesNotMatch(juneHtml, /פעילות חוצה חודשים/);
+  assert.doesNotMatch(juneHtml, /מפגש יוני/);
 });
 
 test('activities month navigation updates the single selected month state and rerenders RTL title/table', async () => {

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -312,7 +312,7 @@ test('activities period tabs split rows by start_date and default to school 2026
   assert.doesNotMatch(html, /פעילות יולי/);
   assert.doesNotMatch(html, /פעילות ספטמבר/);
   assert.doesNotMatch(html, /פעילות סגורה/);
-  assert.doesNotMatch(html, /כל הפעילויות/);
+  assert.match(html, /data-activity-period-tab="all_activities"[\s\S]*כל הפעילויות/);
 });
 
 test('activities summer tab opens on first dated summer month and filters rows by start_date month', () => {
@@ -388,6 +388,52 @@ test('activities selected month drives title, count and table rows', () => {
   assert.match(juneHtml, /פעילות יוני/);
   assert.doesNotMatch(juneHtml, /פעילות חוצה חודשים/);
   assert.doesNotMatch(juneHtml, /מפגש יוני/);
+});
+
+
+test('activities all activities mode ignores month/period filters and supports status filters', () => {
+  const state = baseState();
+  state.activityPeriodTab = 'all_activities';
+  state.activitiesMonthYm = '2026-06';
+  const data = {
+    rows: [
+      { RowID: 'summer_july_1', row_id: 'summer_july_1', activity_name: 'פעילות קיץ', activity_type: 'workshop', authority: 'רשות א', school: 'בית ספר א', start_date: '2026-07-01', status: 'פתוח', emp_id: 'E1', single_semel_mosad: '111' },
+      { RowID: 'SCHOOL-MAY', row_id: 'SCHOOL-MAY', activity_name: 'פעילות מאי', activity_type: 'course', authority: 'רשות ב', school: 'בית ספר ב', start_date: '2026-05-10', status: 'פתוח', emp_id: 'E2', single_semel_mosad: '222' },
+      { RowID: 'ARCHIVE-CLOSED', row_id: 'ARCHIVE-CLOSED', activity_name: 'פעילות סגורה', activity_type: 'course', authority: 'רשות ג', school: 'בית ספר ג', start_date: '2026-03-01', status: 'סגור', emp_id: 'E3', single_semel_mosad: '333' },
+      { RowID: 'UNDATED-OPEN', row_id: 'UNDATED-OPEN', activity_name: 'פעילות ללא תאריך', activity_type: 'tour', authority: 'רשות ד', school: 'בית ספר ד', start_date: '', status: 'פתוח', emp_id: 'E4', single_semel_mosad: '444' },
+      { RowID: 'DELETED-1', row_id: 'DELETED-1', activity_name: 'פעילות נמחקה', activity_type: 'tour', authority: 'רשות ה', school: 'בית ספר ה', start_date: '2026-06-01', status: 'נמחק', emp_id: 'E5', single_semel_mosad: '555' }
+    ]
+  };
+
+  const html = activitiesScreen.render(data, { state });
+
+  assert.match(html, /data-activity-period-tab="all_activities"/);
+  assert.match(html, /חיפוש בכל הפעילויות · 4 פעילויות/);
+  assert.doesNotMatch(html, /data-activities-month-prev/);
+  assert.match(html, /פעילות קיץ/);
+  assert.match(html, /פעילות מאי/);
+  assert.match(html, /פעילות סגורה/);
+  assert.match(html, /פעילות ללא תאריך/);
+  assert.doesNotMatch(html, /פעילות נמחקה/);
+  assert.match(html, /data-all-activities-status-filter/);
+  assert.match(html, /חיפוש לפי מזהה, פעילות, מדריך, רשות, בית ספר, סטטוס, תאריך או סמל מוסד/);
+
+  state.allActivitiesStatusFilter = 'closed';
+  const closedHtml = activitiesScreen.render(data, { state });
+  assert.match(closedHtml, /חיפוש בכל הפעילויות · 1 פעילויות/);
+  assert.match(closedHtml, /פעילות סגורה/);
+  assert.doesNotMatch(closedHtml, /פעילות קיץ/);
+
+  state.allActivitiesStatusFilter = 'undated';
+  const undatedHtml = activitiesScreen.render(data, { state });
+  assert.match(undatedHtml, /חיפוש בכל הפעילויות · 1 פעילויות/);
+  assert.match(undatedHtml, /פעילות ללא תאריך/);
+  assert.doesNotMatch(undatedHtml, /פעילות נמחקה/);
+
+  state.allActivitiesStatusFilter = 'include_deleted';
+  const includeDeletedHtml = activitiesScreen.render(data, { state });
+  assert.match(includeDeletedHtml, /חיפוש בכל הפעילויות · 5 פעילויות/);
+  assert.match(includeDeletedHtml, /פעילות נמחקה/);
 });
 
 test('activities month navigation updates the single selected month state and rerenders RTL title/table', async () => {
@@ -547,7 +593,7 @@ test('admin all-activities Excel export is imported and logs failures', async ()
   const source = await fs.readFile(new URL('../frontend/src/screens/activities.js', import.meta.url), 'utf8');
   assert.match(source, /import \{ exportActivitiesToExcel \} from '\.\/shared\/excel-export\.js';/);
   assert.match(source, /data-activities-export-all/);
-  assert.match(source, /const rows = activityPeriodRows/);
+  assert.match(source, /const rows = isAllActivitiesMode\(state\) \? allActivitiesRows\(sourceRows, state\) : activityPeriodRows/);
   assert.match(source, /catch \(err\) \{[\s\S]*console\.error\('Failed to export all activities to Excel', err\);/);
 });
 


### PR DESCRIPTION
### Motivation
- The activities screen was showing tab counts and list items that did not use the same period/month filter, and month navigation was not filtering by `start_date` correctly.
- Summer and school tabs needed clear separation (summer rows by `summer_` RowID, school tabs must exclude summer rows), and archive should only show closed items while deleted rows must be excluded from regular lists.
- Service Worker cache version must be bumped after the UI filtering behavior change that affects visible content.

### Description
- Added `activityMatchesSelectedStartMonth` and `activityRowsForPeriodAndMonth` helpers and wired them into the screen so both tab counts and the visible list use the same start_date-based filtering logic. 
- Changed month filtering to base selection on `start_date` (rows whose `start_date` is in the selected month), and ensured summer tab behavior only includes rows detected as summer (the existing `summer_` RowID detection is preserved). 
- Updated period tab counts to use the shared helper so counts match the displayed items, and kept archive as `status === 'סגור'` while excluding rows with status `נמחק`. 
- Bumped Service Worker versions in both `frontend/sw.js` and root `sw.js` to a new cache version. 
- Adjusted focused unit tests in `tests/activities-screen.test.mjs` to reflect start_date-only month filtering and summer-row behavior.

### Testing
- Ran the focused screen tests with `node --test tests/activities-screen.test.mjs`, which passed all tests (31/31). 
- Ran syntax/type checks with `node --check` on `frontend/src/screens/activities.js`, `frontend/sw.js`, and `sw.js`, which succeeded. 
- Ran the frontend build via `npm run check:build` which completed successfully. 
- Ran `npm run check:changed` focused checks which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f352c8a74832b84913ee72232b5d1)