### PR TITLE
Support Supabase proposal templates: recipient block, course placeholders, single cost table

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1300,9 +1300,11 @@ function recipientLineHtml(...values) {
 }
 
 function recipientBlockHtml(row = {}) {
+  const schoolName = text(row.school_framework) || text(row.school_name);
+  const authorityName = text(row.client_authority) || text(row.authority_name);
   const lines = [
     recipientLineHtml(row.contact_name, row.contact_role),
-    recipientLineHtml(row.school_framework, row.client_authority)
+    recipientLineHtml(schoolName, authorityName)
   ].filter(Boolean);
   if (!lines.length) return '';
   return `<div class="pa-doc-address">
@@ -1368,6 +1370,32 @@ function parseSectionBodyStructure(value, options = {}) {
   flushParagraph();
   flushBullets();
   return groups;
+}
+
+
+function selectedCourseShortNamesText(row = {}, items = []) {
+  const proposalGroup = normalizeProposalGroup(row.activity_type_group);
+  const sourceItems = (Array.isArray(items) ? items : []).filter((item) => {
+    if (isTestHoursItem(item) || text(item.proposal_display_mode) === 'bundle_child') return false;
+    if (!text(item.item_name)) return false;
+    const rowKind = `${groupKindText(proposalGroup)} ${normalizedKindText(row.activity_type_group)} ${proposalGroupTemplateKey(proposalGroup)}`;
+    const combined = isCombinedProposalGroup(proposalGroup) || /משולב(?:ת)?|combined/.test(rowKind);
+    if (!combined) return true;
+    const itemGroup = normalizeProposalGroup(item.proposal_group || item.activity_type_group);
+    const itemKind = itemKindText(item);
+    if (isSummerKindText(itemKind) || isWorkshopKindText(itemKind)) return false;
+    return isCourseKindText(groupKindText(itemGroup)) || isCourseKindText(itemKind) || itemCatalogKind(item) === 'course';
+  });
+  return sourceItems
+    .map((item) => text(item.course_short_name || item.short_name || item.item_short_name || item.item_name))
+    .filter(Boolean)
+    .join('\n');
+}
+
+function applyProposalTemplatePlaceholders(body, row = {}, items = []) {
+  const raw = normalizeMultilineText(body);
+  if (!raw) return '';
+  return raw.replace(/{{\s*selected_course_short_names\s*}}/g, selectedCourseShortNamesText(row, items));
 }
 
 function renderProposalSectionBody(body, options = {}) {
@@ -1507,7 +1535,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
     : [];
   const sectionsSource = resolveDocumentSections(row, sourceTemplateSections);
   const byKey = new Map(sectionsSource.map((section) => [text(section.section_key), section]));
-  const sectionBody = (key) => templateBodyText(byKey.get(key));
+  const sectionBody = (key) => applyProposalTemplatePlaceholders(templateBodyText(byKey.get(key)), row, items);
   const sectionTitle = (key) => text(byKey.get(key)?.section_title);
 
   const includeCatalog = false;
@@ -1536,6 +1564,13 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
       const section = renderActivitySection(heading, body);
       if (section) sections.push(section);
     });
+    if (!sections.length) {
+      const activitySection = renderActivitySection(
+        sectionTitle('activity_intro'),
+        activityIntro
+      );
+      if (activitySection) sections.push(activitySection);
+    }
   } else {
     const activitySection = renderActivitySection(
       sectionTitle('activity_intro'),
@@ -1553,12 +1588,10 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
   // Payment section: general terms text comes from Supabase, while the price
   // breakdown is always built dynamically from proposal_agreement_items.
   const paymentTermsBody = sectionBody('payment_terms');
-  const itemDetailsHtml = proposalItemDetailsTableHtml(items, activityTypeGroup);
-  const usesUnifiedCourseCostTable = proposalActivityKind(row, items) === 'course' && itemDetailsHtml;
-  const costTableHtml = usesUnifiedCourseCostTable ? proposalDiscountSummaryHtml(items) : proposalCostTableHtml(items);
+  const costTableHtml = proposalCostTableHtml(items);
   const costsIntro = costsIntroBody(row, items);
-  const paymentTerms = (paymentTermsBody || costTableHtml || itemDetailsHtml || costsIntro)
-    ? `<section class="pa-section pa-cost-section">${sectionTitle('payment_terms') ? `<h3>${escapeHtml(sectionHeadingText(sectionTitle('payment_terms')))}</h3>` : ''}${costsIntro ? sectionBodyHtml(costsIntro) : ''}${itemDetailsHtml}${costTableHtml}${paymentTermsBody ? sectionBodyHtml(paymentTermsBody, { alwaysBullet: true }) : ''}</section>`
+  const paymentTerms = (paymentTermsBody || costTableHtml || costsIntro)
+    ? `<section class="pa-section pa-cost-section">${sectionTitle('payment_terms') ? `<h3>${escapeHtml(sectionHeadingText(sectionTitle('payment_terms')))}</h3>` : ''}${paymentTermsBody ? sectionBodyHtml(paymentTermsBody, { alwaysBullet: true }) : ''}${costsIntro ? sectionBodyHtml(costsIntro) : ''}${costTableHtml}</section>`
     : '';
 
   const signatureHtml = signatureSectionHtml(sectionBody('signature'));

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1504,7 +1504,7 @@ test('catalog PDF appendices use fixed workshop/tour PDFs and specific selected 
 });
 
 
-test('course item details table separates quantity, unit group price, and quantity total', async () => {
+test('course preview renders one cost table with quantity, unit group price, and quantity total', async () => {
   const row = {
     ...sampleRows[0],
     id: 'course-price-breakdown-row',
@@ -1525,18 +1525,20 @@ test('course item details table separates quantity, unit group price, and quanti
   }];
 
   await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
-    const itemDetailsTable = dom.window.document.querySelector('.pa-item-details-table');
-    assert.ok(itemDetailsTable, 'course item details table should render');
-    const headers = [...itemDetailsTable.querySelectorAll('thead th')].map((th) => th.textContent.trim());
-    assert.deepEqual(headers.slice(-3), ['כמות', 'מחיר לקורס / קבוצה אחת', 'סה״כ לפי כמות']);
-    const cells = [...itemDetailsTable.querySelectorAll('tbody td')].map((td) => td.textContent.trim());
+    assert.equal(dom.window.document.querySelectorAll('.pa-cost-table').length, 1);
+    assert.equal(dom.window.document.querySelector('.pa-item-details-table'), null);
+    const costTable = dom.window.document.querySelector('.pa-cost-table');
+    assert.ok(costTable, 'cost table should render');
+    const headers = [...costTable.querySelectorAll('thead th')].map((th) => th.textContent.trim());
+    assert.deepEqual(headers, ['פעילות', 'כמות', 'מחיר יחידה', 'סה״כ שורה']);
+    const cells = [...costTable.querySelectorAll('tbody td')].map((td) => td.textContent.trim());
     assert.equal(cells.at(-3), '2');
     assert.equal(cells.at(-2), '9,000 ₪');
     assert.equal(cells.at(-1), '18,000 ₪');
   });
 });
 
-test('course item details table calculates quantity total when total price is empty', async () => {
+test('course cost table calculates quantity total when total price is empty', async () => {
   const row = {
     ...sampleRows[0],
     id: 'course-price-breakdown-fallback-row',
@@ -1555,7 +1557,9 @@ test('course item details table calculates quantity total when total price is em
   }];
 
   await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
-    const cells = [...dom.window.document.querySelectorAll('.pa-item-details-table tbody td')].map((td) => td.textContent.trim());
+    assert.equal(dom.window.document.querySelectorAll('.pa-cost-table').length, 1);
+    assert.equal(dom.window.document.querySelector('.pa-item-details-table'), null);
+    const cells = [...dom.window.document.querySelectorAll('.pa-cost-table tbody td')].map((td) => td.textContent.trim());
     assert.equal(cells.at(-3), '2');
     assert.equal(cells.at(-2), '9,000 ₪');
     assert.equal(cells.at(-1), '18,000 ₪');
@@ -1877,6 +1881,69 @@ test('next_year proposal title uses template_name תוכניות from Supabase',
     const title = dom.window.document.querySelector('.pa-doc-subject')?.textContent || '';
     assert.match(title, /הצעת מחיר לתוכניות תעשיידע \| שנת הלימודים תשפ״ז/);
     assert.doesNotMatch(title, /קורסי תעשיידע/);
+  });
+});
+
+
+test('proposal preview replaces selected course placeholder and renders one cost table after payment text', async () => {
+  const row = {
+    ...sampleRows[0],
+    id: '77777777-7777-7777-7777-777777777777',
+    activity_type_group: 'הצעה משולבת',
+    contact_name: 'דנה לוי',
+    contact_role: 'מנהלת',
+    school_framework: 'בית ספר אופק',
+    client_authority: 'רשות אביב'
+  };
+  const proposalTemplateSections = [
+    { template_key: 'combined', template_name: 'הצעת מחיר משולבת', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח.' },
+    { template_key: 'combined', section_key: 'activity_intro', section_title: 'הפעילות המוצעת', section_body: 'הקורסים שנבחרו:\n{{selected_course_short_names}}' },
+    { template_key: 'combined', section_key: 'payment_terms', section_title: 'עלות ותנאי תשלום', section_body: 'טקסט תנאי תשלום מסופק מסופאבייס.' }
+  ];
+  const items = [
+    { item_name: 'סדנת קיץ', unit_price: 300, total_price: 300, quantity: 1, proposal_group: 'קיץ תשפ״ו' },
+    { item_name: 'קורס רובוטיקה', unit_price: 500, total_price: 500, quantity: 1, proposal_group: 'שנת הלימודים תשפ״ז' },
+    { item_name: 'תוכנית יזמות', unit_price: 700, total_price: 700, quantity: 1, proposal_group: 'שנת הלימודים תשפ״ז' }
+  ];
+
+  await withJSDOM(proposalsAgreementsScreen.render({ rows: [row] }, { state: stateFor('admin') }), async (root, dom) => {
+    proposalsAgreementsScreen.bind({
+      root,
+      data: {
+        rows: [row],
+        proposalTemplateSections,
+        proposalActivityGroups: [
+          { group_key: 'הצעה משולבת', display_name: 'הצעה משולבת', template_key: 'combined', is_combined: true, included_group_keys: ['קיץ תשפ״ו', 'שנת הלימודים תשפ״ז'] },
+          { group_key: 'קיץ תשפ״ו', display_name: 'קיץ תשפ״ו', template_key: 'summer' },
+          { group_key: 'שנת הלימודים תשפ״ז', display_name: 'שנת הלימודים תשפ״ז', template_key: 'next_year' }
+        ]
+      },
+      state: stateFor('admin'),
+      api: { readProposalAgreementItems: async () => items }
+    });
+    root.querySelector(`[data-pa-row-id="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+    root.querySelector(`[data-pa-preview="${row.id}"]`)?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    await delay(20);
+
+    const doc = dom.window.document.querySelector('.proposal-document');
+    assert.ok(doc, 'proposal document should render');
+    assert.match(doc.querySelector('.pa-doc-address')?.textContent || '', /לכבוד:/);
+    assert.match(doc.querySelector('.pa-doc-address')?.textContent || '', /דנה לוי, מנהלת/);
+    assert.doesNotMatch(doc.textContent, /undefined|{{selected_course_short_names}}/);
+    assert.match(doc.textContent, /קורס רובוטיקה/);
+    assert.match(doc.textContent, /תוכנית יזמות/);
+
+    const activitySection = Array.from(doc.querySelectorAll('.pa-section')).find((section) => section.textContent.includes('הקורסים שנבחרו'));
+    assert.ok(activitySection, 'activity section should contain selected courses');
+    assert.doesNotMatch(activitySection.textContent, /סדנת קיץ|300|500|700|גפ"ן|מפגשים|שעות/);
+
+    const tables = doc.querySelectorAll('.pa-cost-table');
+    assert.equal(tables.length, 1);
+    const paymentSection = doc.querySelector('.pa-cost-section');
+    assert.ok(paymentSection?.contains(tables[0]), 'cost table should be inside payment section');
+    assert.ok((paymentSection.textContent || '').indexOf('טקסט תנאי תשלום') < (paymentSection.textContent || '').indexOf('סה״כ לתשלום'));
+    assert.equal(doc.querySelectorAll('.proposal-signature').length, 1);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The Supabase-driven proposal templates include new placeholders and fields and the frontend must render them without hardcoding or altering template text. 
- Ensure the recipient block uses safe fallbacks so no `undefined`/empty fragments appear in the printed document. 
- Place the dynamic costs table exactly once inside the “עלות ותנאי תשלום” section and make combined-template course lists render only short course names.

### Description
- Updated the recipient block to use `school_framework || school_name` and `client_authority || authority_name` and to dedupe/omit empty values so the “לכבוד:” block never renders stray commas or `undefined`. (modified `frontend/src/screens/proposals-agreements.js`).
- Added placeholder substitution for `{{selected_course_short_names}}` via `applyProposalTemplatePlaceholders` and `selectedCourseShortNamesText`, which picks short-name fields when present and filters combined proposals to only include course-year items while excluding summer/workshop items. (added helper functions in `frontend/src/screens/proposals-agreements.js`).
- Always apply template placeholder replacement when rendering Supabase-provided sections so templates from the DB are rendered verbatim except for the allowed dynamic placeholders. (integration in `proposalPreviewBodyHtml`).
- Render a single dynamic cost table built from `proposal_agreement_items` inside the payment terms section after Supabase-provided payment text, and remove the duplicate/alternate item-details rendering to avoid printing multiple cost tables. (changed payment section assembly in `frontend/src/screens/proposals-agreements.js`).
- Extended/updated focused tests to cover placeholder replacement, recipient rendering, single cost-table rendering and placement, and signature behavior. (modified `tests/proposals-agreements-screen.test.mjs`).

### Testing
- Ran the focused proposal screen tests with `node --test tests/proposals-agreements-screen.test.mjs` and all tests passed (`63` tests, `0` failures). 
- Ran the change-focused checks with `npm run check:changed` and the frontend build with `npm run check:build`, both completed successfully. 
- Changed files: `frontend/src/screens/proposals-agreements.js` and `tests/proposals-agreements-screen.test.mjs`, and the focused checks above were used rather than the full legacy suite as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f43fa161c832b9174f2680dcb28d2)