### PR TITLE
Add print styles for proposal document layout

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15126,4 +15126,80 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     margin-inline-start: 0 !important;
     margin-inline-end: auto !important;
   }
+
+  /* ── Proposal document footer: fixed to bottom of every printed page ── */
+  .proposal-document-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+  }
+
+  .proposal-document-body {
+    padding-bottom: 60px;
+  }
+
+  /* ── Spacing between sections ── */
+  .pa-section {
+    margin-bottom: 14pt;
+  }
+
+  .pa-section h3 {
+    margin-bottom: 4pt;
+    font-size: 11pt;
+    font-weight: 700;
+  }
+
+  .pa-section-body p,
+  .pa-section-body ul,
+  .pa-section-body li {
+    margin-bottom: 4pt;
+    line-height: 1.5;
+  }
+
+  .pa-section-body ul {
+    padding-right: 16pt;
+  }
+
+  .pa-doc-address {
+    margin-bottom: 12pt;
+  }
+
+  .pa-doc-address p {
+    margin: 2pt 0;
+  }
+
+  .pa-doc-divider {
+    margin: 8pt 0;
+  }
+
+  .pa-doc-subject {
+    margin: 8pt 0 12pt;
+  }
+
+  .pa-cost-table {
+    margin-top: 8pt;
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .pa-cost-table th,
+  .pa-cost-table td {
+    padding: 4pt 6pt;
+    border: 1pt solid #ccc;
+    font-size: 9pt;
+  }
+
+  .proposal-signature {
+    margin-top: 20pt;
+  }
+
+  .proposal-signature-greeting {
+    margin-bottom: 24pt;
+  }
+
+  .pa-doc-intro {
+    margin-bottom: 10pt;
+  }
 }


### PR DESCRIPTION
## Summary
Added comprehensive print-specific CSS styles to support proper formatting and layout of proposal documents when printed or exported to PDF.

## Key Changes
- **Fixed footer positioning**: Added `.proposal-document-footer` styles to keep the footer fixed at the bottom of every printed page
- **Body padding**: Added bottom padding to `.proposal-document-body` to prevent content overlap with the fixed footer
- **Section spacing**: Defined consistent margins and typography for proposal sections (`.pa-section`, `.pa-section h3`)
- **Content typography**: Set line-height, margins, and font sizes for paragraphs, lists, and list items within section bodies
- **Address block styling**: Added specific spacing for `.pa-doc-address` and its paragraphs
- **Dividers and subjects**: Added margin rules for visual separators and subject lines
- **Cost table formatting**: Styled `.pa-cost-table` with borders, padding, and appropriate font sizing for tabular data
- **Signature section**: Added spacing for `.proposal-signature`, `.proposal-signature-greeting`, and `.pa-doc-intro` elements

## Implementation Details
All styles are scoped within a print media query context, ensuring they only apply to printed output without affecting the web display. Measurements use points (pt) for print-appropriate sizing, and the layout uses fixed positioning for the footer to ensure it appears on every page of a multi-page document.

https://claude.ai/code/session_01P5uoA7nA6dngWATrjRbhcp