### PR TITLE
Fix activities month filter to handle period/month mismatches

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1384,9 +1384,17 @@ export const activitiesScreen = {
       include_inactive: true
     });
     const loadedRows = Array.isArray(result?.rows) ? result.rows : [];
+    if (state.activityPeriodTab === 'summer_2026') {
+      state._activitiesSummerMonthInitialized = false;
+    }
     ensureActivityPeriodMonth(state, loadedRows);
     if (!state.activitiesMonthYm) {
       state.activitiesMonthYm = pickBestMonthForPeriod(loadedRows, state.activityPeriodTab);
+    } else if (shouldApplyActivitiesMonthFilter(state)) {
+      const pRows = activityPeriodRows(loadedRows, state.activityPeriodTab);
+      if (pRows.length > 0 && !pRows.some((row) => activityOccursInSelectedMonth(row, state.activitiesMonthYm))) {
+        state.activitiesMonthYm = firstActivityMonthYm(pRows) || pickBestMonthForPeriod(loadedRows, state.activityPeriodTab);
+      }
     }
     return result;
   },
@@ -1406,6 +1414,10 @@ export const activitiesScreen = {
     state.allActivitiesStatusFilter = normalizeAllActivitiesStatusFilter(state.allActivitiesStatusFilter);
     const isAllMode = isAllActivitiesMode(state);
     const periodRows    = isAllMode ? allActivitiesRows(allRows, state) : activityPeriodRows(allRows, state.activityPeriodTab);
+    if (!isAllMode && shouldApplyActivitiesMonthFilter(state) && periodRows.length > 0 &&
+        !periodRows.some((row) => activityOccursInSelectedMonth(row, state.activitiesMonthYm))) {
+      state.activitiesMonthYm = firstActivityMonthYm(periodRows) || pickBestMonthForPeriod(allRows, state.activityPeriodTab);
+    }
     const monthRows     = activityRowsForPeriodAndMonth(allRows, state);
     const filteredRows  = applyActivitiesLocalFilters(monthRows, state, state?.clientSettings);
 


### PR DESCRIPTION
## Summary
This PR fixes an issue where the selected month filter could become invalid when the activity period changes or when no activities exist in the currently selected month. The changes ensure the month filter is automatically adjusted to a valid month within the selected period.

## Key Changes
- **Summer 2026 period reset**: When switching to the summer_2026 activity period, reset the `_activitiesSummerMonthInitialized` flag to ensure proper initialization
- **Month validation on data load**: After loading activities, validate that the selected month contains activities for the current period. If not, automatically select the first available month or the best month for the period
- **Month validation on filter application**: Before applying month-based filters, check if the selected month is valid for the current period and adjust if necessary

## Implementation Details
- Added checks using `shouldApplyActivitiesMonthFilter()` to determine when month filtering should be applied
- Introduced `activityOccursInSelectedMonth()` to validate if activities exist in the selected month
- Used `firstActivityMonthYm()` as the primary fallback for selecting a valid month, with `pickBestMonthForPeriod()` as a secondary fallback
- Applied the same validation logic in two locations: after initial data load and before applying filters to ensure consistency

https://claude.ai/code/session_01B52DegsksAXFdvEKFGdpEg