### PR TITLE
Fix activity edit request permissions diagnostics

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BaHWciyN.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-JEyVz5bg.css">
+  <script type="module" crossorigin src="./assets/index-BUwZVICh.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-DAjhsA7U.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2180,6 +2180,11 @@ function flattenUserRow(userRow = {}) {
     active: userRow.is_active ? 'yes' : 'no',
     ...permissions
   };
+  if (userRow.can_request_edit != null) flat.can_request_edit = userRow.can_request_edit;
+  if (userRow.can_request_edit_2 != null) flat.can_request_edit_2 = userRow.can_request_edit_2;
+  if (userRow.can_request_create_activity != null) flat.can_request_create_activity = userRow.can_request_create_activity;
+  if (userRow.can_edit_direct != null) flat.can_edit_direct = userRow.can_edit_direct;
+  if (userRow.can_add_activity != null) flat.can_add_activity = userRow.can_add_activity;
   if (userRow.can_review_requests != null) flat.can_review_requests = userRow.can_review_requests;
   if (userRow.view_proposals_agreements != null) flat.view_proposals_agreements = userRow.view_proposals_agreements;
   if (userRow.manage_proposals_agreements != null) flat.manage_proposals_agreements = userRow.manage_proposals_agreements;
@@ -2380,9 +2385,12 @@ async function buildActivityMutationAuthContext() {
   const context = {
     auth_uid: '',
     user_id: '',
-    role: '',
-    can_edit_direct: null,
-    can_add_activity: null
+    state_user_id: String(state?.user?.user_id || '').trim(),
+    requested_by_user_id: String(state?.user?.user_id || '').trim(),
+    role: String(state?.user?.role || '').trim(),
+    can_request_edit: state?.user?.can_request_edit ?? null,
+    can_edit_direct: state?.user?.can_edit_direct ?? null,
+    can_add_activity: state?.user?.can_add_activity ?? null
   };
   if (!supabase) return context;
   try {
@@ -2398,19 +2406,23 @@ async function buildActivityMutationAuthContext() {
       supabase.rpc('app_can_edit_direct'),
       supabase.rpc('app_can_add_activity')
     ]);
-    context.role = typeof roleData === 'string' ? roleData : '';
-    context.can_edit_direct = typeof canEditData === 'boolean' ? canEditData : null;
-    context.can_add_activity = typeof canAddData === 'boolean' ? canAddData : null;
+    context.role = typeof roleData === 'string' && roleData ? roleData : context.role;
+    context.can_edit_direct = typeof canEditData === 'boolean' ? canEditData : context.can_edit_direct;
+    context.can_add_activity = typeof canAddData === 'boolean' ? canAddData : context.can_add_activity;
   } catch {
     /* ignore */
   }
   try {
     const { data: userRow } = await supabase
       .from('users')
-      .select('user_id')
+      .select('user_id,role,can_request_edit,can_request_edit_2,can_edit_direct,can_add_activity')
       .eq('auth_user_id', context.auth_uid)
       .maybeSingle();
     context.user_id = String(userRow?.user_id || '').trim();
+    context.role = String(userRow?.role || context.role || '').trim();
+    context.can_request_edit = permissionFlagYes(userRow?.can_request_edit) || permissionFlagYes(userRow?.can_request_edit_2) || context.can_request_edit;
+    context.can_edit_direct = userRow?.can_edit_direct == null ? context.can_edit_direct : permissionFlagYes(userRow.can_edit_direct);
+    context.can_add_activity = userRow?.can_add_activity == null ? context.can_add_activity : permissionFlagYes(userRow.can_add_activity);
   } catch {
     /* ignore */
   }
@@ -3940,8 +3952,11 @@ export const api = {
         table: 'edit_requests',
         row_id: rowId,
         auth_uid: authContext.auth_uid,
+        state_user_id: authContext.state_user_id,
         user_id: authContext.user_id,
+        requested_by_user_id: row.requested_by_user_id,
         role: authContext.role,
+        can_request_edit: authContext.can_request_edit,
         can_edit_direct: authContext.can_edit_direct,
         can_add_activity: authContext.can_add_activity,
         supabase_error_code: error?.code || error?.status || '',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 717;
+const CACHE_VERSION = 718;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 717;
+const SW_ENTRY_VERSION = 718;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The client flattened user row lost top-level permission columns, so users with column-based flags (e.g. `can_request_edit`) could appear as not allowed and the edit-form would set `data-can-request-edit="no"` instead of `yes`, preventing `submitEditRequest` from being used.
- When Supabase returns an error inserting an edit request the diagnostics were too sparse to debug session/auth mismatches, so richer logging was needed.
- The client bundle must be deployed to users promptly, so the Service Worker cache version needs bumping to ensure browsers fetch the fix.

### Description
- Preserve top-level permission flags in `flattenUserRow` by copying `can_request_edit`, `can_request_edit_2`, `can_request_create_activity`, `can_edit_direct`, and `can_add_activity` into the flattened user object (`frontend/src/api.js`).
- Improve `submitEditRequest` failure diagnostics in `frontend/src/api.js` to log `auth_uid`, `state_user_id`, `requested_by_user_id`, `role`, `can_request_edit`, `can_edit_direct`, Supabase error code/message/details, and the payload sent.
- Add more robust auth-context building in `buildActivityMutationAuthContext` to combine RPC results and user row flags for accurate diagnostic values (`frontend/src/api.js`).
- Bump Service Worker cache version constants in `frontend/sw.js` and `sw.js` and rebuild `dist/index.html` so clients receive the updated bundle.

### Testing
- Changed files: `frontend/src/api.js`, `frontend/sw.js`, `sw.js`, and `dist/index.html` (rebuilt output).
- Ran `npm run check:changed` which runs `node --check` on changed files; focused checks completed successfully.
- Ran `npm run check:build` (full frontend build); build completed and `dist` was updated successfully.
- Verified Service Worker/cache version was bumped to `718` in both `frontend/sw.js` and `sw.js` so clients will pick up the new bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc7a5202c832bb88be26dea848054)