### PR TITLE
Fix contacts loading and proposal client selection

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BUwZVICh.js"></script>
+  <script type="module" crossorigin src="./assets/index-DooWfPHe.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DAjhsA7U.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -412,31 +412,41 @@ async function selectActivitiesByDateRangeFromSupabase({
 }
 
 /**
- * Reads contacts_instructors + contacts_schools from Supabase.
- * Returns { instructor_rows, school_rows, can_view_instructors, can_view_schools, _source }
- * or null on any failure.
+ * Reads contacts_instructors + contacts_directory_view from Supabase.
+ * Returns partial data when one source fails; contacts_directory_view falls back to contacts_schools.
  *
  * ⚠️ permissions table is intentionally excluded — login credentials must never be read client-side.
  */
 async function readContactsFromSupabase() {
   if (!supabase) return null;
+
+  const readInstructors = async () => {
+    const result = await supabase.from('contacts_instructors').select('*');
+    if (result.error) {
+      // eslint-disable-next-line no-console
+      console.warn('[supabase] Failed to load contacts_instructors:', result.error);
+      return [];
+    }
+    return Array.isArray(result.data) ? result.data : [];
+  };
+
+  const readSchoolContacts = async () => {
+    const viewResult = await supabase.from('contacts_directory_view').select('*');
+    if (!viewResult.error) return Array.isArray(viewResult.data) ? viewResult.data : [];
+
+    // eslint-disable-next-line no-console
+    console.warn('[supabase] Failed to load contacts_directory_view; falling back to contacts_schools:', viewResult.error);
+    const fallbackResult = await supabase.from('contacts_schools').select('*');
+    if (fallbackResult.error) {
+      // eslint-disable-next-line no-console
+      console.warn('[supabase] Failed to load contacts_schools fallback:', fallbackResult.error);
+      return [];
+    }
+    return Array.isArray(fallbackResult.data) ? fallbackResult.data : [];
+  };
+
   try {
-    const [instrResult, schoolResult] = await Promise.all([
-      supabase.from('contacts_instructors').select('*'),
-      supabase.from('contacts_directory_view').select('*')
-    ]);
-    if (instrResult.error) {
-      // eslint-disable-next-line no-console
-      console.error('[supabase] Failed to load contacts_instructors:', instrResult.error);
-      return null;
-    }
-    if (schoolResult.error) {
-      // eslint-disable-next-line no-console
-      console.error('[supabase] Failed to load contacts_directory_view:', schoolResult.error);
-      return null;
-    }
-    const instructor_rows = Array.isArray(instrResult.data) ? instrResult.data : [];
-    const school_rows = Array.isArray(schoolResult.data) ? schoolResult.data : [];
+    const [instructor_rows, school_rows] = await Promise.all([readInstructors(), readSchoolContacts()]);
     return {
       instructor_rows,
       school_rows,
@@ -446,8 +456,14 @@ async function readContactsFromSupabase() {
     };
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error('[supabase] Unexpected contacts fetch error:', error);
-    return null;
+    console.warn('[supabase] Unexpected contacts fetch error:', error);
+    return {
+      instructor_rows: [],
+      school_rows: [],
+      can_view_instructors: true,
+      can_view_schools: true,
+      _source: 'supabase'
+    };
   }
 }
 
@@ -1954,10 +1970,21 @@ async function readProposalTemplateSectionsFromSupabase() {
 
 async function readContactsSchoolsForProposals() {
   try {
-    const { data, error } = await supabase
-      .from('contacts_schools')
-      .select('id,client_type,client_name,authority_id,school_id,semel_mosad,authority,school,contact_name,contact_role,phone,email,mobile')
+    const selectColumns = 'id,client_type,client_name,authority_id,school_id,semel_mosad,authority,school,contact_name,contact_role,phone,email,mobile';
+    let { data, error } = await supabase
+      .from('contacts_directory_view')
+      .select(selectColumns)
       .order('authority', { ascending: true });
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.warn('[supabase] Failed to load contacts_directory_view for proposals; falling back to contacts_schools:', error);
+      const fallback = await supabase
+        .from('contacts_schools')
+        .select(selectColumns)
+        .order('authority', { ascending: true });
+      data = fallback.data;
+      error = fallback.error;
+    }
     if (error) return [];
     return (Array.isArray(data) ? data : []).map((c) => ({
       id:           cleanProposalAgreementText(c.id),

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -98,10 +98,22 @@ function renderInstrCard(row) {
     </div>`;
 }
 
+function hasActiveContactFilters(filters = {}) {
+  return Boolean(String(filters.appliedQ || filters.q || '').trim())
+    || Object.entries(filters || {}).some(([key, value]) => key.startsWith('field:') && String(value || '').trim());
+}
+
+function contactEmptyState(rows, filters) {
+  if (Array.isArray(rows) && rows.length && hasActiveContactFilters(filters)) {
+    return dsEmptyState('לא נמצאו אנשי קשר שתואמים לסינון הפעיל.');
+  }
+  return dsEmptyState('לא נמצאו אנשי קשר');
+}
+
 function instrTabHtml(rows, filters) {
   const filtered = applyLocalFilters(rows, filters, { filterFields: [] });
   const body = filtered.length === 0
-    ? dsEmptyState('לא נמצאו אנשי קשר')
+    ? contactEmptyState(rows, filters)
     : `<div class="ci-person-grid">${filtered.map((r) => renderInstrCard(r)).join('')}</div>`;
   return { filtered, body };
 }
@@ -305,7 +317,7 @@ function contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr = tru
 
 function schoolTabHtml(rows, filters) {
   const filtered = applyLocalFilters(rows, filters, { filterFields: [] });
-  if (filtered.length === 0) return { filtered, body: dsEmptyState('לא נמצאו אנשי קשר') };
+  if (filtered.length === 0) return { filtered, body: contactEmptyState(rows, filters) };
   const authorityGroups = groupByAuthorityThenSchool(filtered);
   const byLetter = groupByLetter(authorityGroups);
 

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1744,6 +1744,8 @@ function contactSourceInputsHtml(contact = {}) {
   const source = contact || {};
   return `
     <input type="hidden" name="contact_source_id" value="${escapeHtml(text(source.id))}">
+    <input type="hidden" name="contact_source_authority_id" value="${escapeHtml(text(source.authority_id))}">
+    <input type="hidden" name="contact_source_school_id" value="${escapeHtml(text(source.school_id))}">
     <input type="hidden" name="contact_source_client_type" value="${escapeHtml(text(source.client_type))}">
     <input type="hidden" name="contact_source_client_name" value="${escapeHtml(text(source.client_name))}">
     <input type="hidden" name="contact_source_authority" value="${escapeHtml(text(source.authority))}">
@@ -1888,7 +1890,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
       <div data-pa-step-panel="client">
         <div class="ds-pa-client-row" data-pa-client-search-row${isLocked ? ' hidden' : ''}>
           ${clientSearchHtml(contactOptions, row)}
-          <button type="button" class="ds-btn ds-btn--sm" data-pa-new-client-toggle>לא מצאת? הוסף ידנית</button>
+          <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-new-client-toggle hidden>לא מצאת? הוסף ידנית</button>
         </div>
         <div data-pa-client-card${isLocked ? '' : ' hidden'}>${isLocked ? clientLockedBannerHtml(initAuth, initSchool, initContact, initRole, initPhone, initEmail, initClientName) : ''}</div>
         <div data-pa-new-client-hint hidden><span class="ds-pa-new-client-label">לקוח חדש / הזנה ידנית</span><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-back-existing-client>חזרה לחיפוש</button></div>
@@ -2112,9 +2114,15 @@ function payloadFromForm(form) {
   if (itemNames.length) payload.activity_names = itemNames;
   payload.total_amount = items.reduce((s, i) => s + (Number(i.total_price) || ((Number(i.quantity) || 0) * (Number(i.unit_price) || 0))), 0) || null;
   payload._items = items;
+  payload.contact_school_id = text(formData.get('contact_source_id')) || null;
+  payload.authority_id = text(formData.get('contact_source_authority_id')) || null;
+  payload.school_id = text(formData.get('contact_source_school_id')) || null;
+  payload.client_type = text(formData.get('contact_source_client_type')) || text(formData.get('new_client_type')) || (payload.school_id ? 'school' : 'authority');
   payload._contact_original = {
     id:           text(formData.get('contact_source_id')),
-    client_type:  text(formData.get('contact_source_client_type')) || text(formData.get('new_client_type')),
+    client_type:  payload.client_type,
+    authority_id: text(formData.get('contact_source_authority_id')) || null,
+    school_id:    text(formData.get('contact_source_school_id')) || null,
     client_name:  text(formData.get('contact_source_client_name')),
     authority:    text(formData.get('contact_source_authority')),
     school:       text(formData.get('contact_source_school')),
@@ -2350,7 +2358,7 @@ export const proposalsAgreementsScreen = {
       <section class="ds-pa-screen" data-pa-screen dir="rtl">
         <style>
           .ds-pa-screen-tab{border-radius:10px 10px 0 0;transition:background .15s,color .15s,border-color .15s}.ds-pa-screen-tab:hover{background:rgba(14,165,233,.08)}
-          .ds-pa-form{max-width:100%}.ds-pa-item-card{border:1px solid #dbe7f3;border-radius:14px;background:#fff;padding:14px;margin:10px 0;box-shadow:0 1px 3px rgba(15,23,42,.04)}
+          .ds-pa-form{max-width:1080px;margin-inline:auto}.ds-pa-form .ds-pa-form-grid{max-width:100%}.ds-pa-item-card{border:1px solid #dbe7f3;border-radius:14px;background:#fff;padding:14px;margin:10px 0;box-shadow:0 1px 3px rgba(15,23,42,.04)}
           .ds-pa-item-quick-row{display:grid;grid-template-columns:minmax(260px,1fr) 110px 130px 130px auto;gap:10px;align-items:end}.ds-pa-item-field span{display:block;font-size:.74rem;color:#64748b;margin-bottom:4px;font-weight:600}.ds-pa-line-total output{min-height:34px;display:flex;align-items:center;justify-content:center;border:1px solid #dbe7f3;border-radius:10px;background:#f8fbff;font-weight:700;color:#0f766e}.ds-pa-items-total-row{margin-top:10px;padding:10px 12px;border-radius:12px;background:#eef8ff;font-size:.9rem}.ds-pa-items-total-row strong{color:#0369a1}
           .ds-pa-bundle-prompt{margin-top:12px}.ds-pa-bundle-panel{border:1px solid #b7e0f5;background:#f8fdff;border-radius:14px;padding:12px}.ds-pa-bundle-head{display:flex;justify-content:space-between;gap:10px;align-items:center;margin-bottom:6px}.ds-pa-bundle-head strong{font-size:.9rem;color:#0f172a}.ds-pa-bundle-head span,.ds-pa-bundle-help,.ds-pa-bundle-empty{font-size:.78rem;color:#64748b}.ds-pa-bundle-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:8px;margin-top:10px}.ds-pa-bundle-child-card{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:8px;border:1px solid #dbe7f3;border-radius:12px;background:#fff;padding:9px 10px;cursor:pointer;min-height:42px}.ds-pa-bundle-child-card:hover{border-color:#38bdf8;background:#f0f9ff}.ds-pa-bundle-child-card:has(input:checked){border-color:#0ea5e9;background:#e0f2fe;box-shadow:0 0 0 1px #0ea5e9 inset}.ds-pa-bundle-child-name{font-size:.82rem;color:#0f172a;line-height:1.25}.ds-pa-bundle-child-price{font-size:.8rem;font-weight:700;color:#0f766e;white-space:nowrap}.ds-pa-bundle-footer{display:flex;justify-content:space-between;align-items:center;gap:10px;margin-top:10px;flex-wrap:wrap}.ds-pa-bundle-actions{display:flex;gap:6px}.ds-pa-bundle-selection-summary{font-size:.78rem;color:#0369a1;font-weight:700}.ds-pa-summary-bundle-list{margin:4px 0 0;padding-right:16px;font-size:.72rem}.ds-pa-items-summary-table{width:100%;border-collapse:collapse;font-size:.78rem}.ds-pa-items-summary-table th,.ds-pa-items-summary-table td{border-bottom:1px solid #e5eef6;padding:6px;text-align:right}.ds-pa-items-summary-table th{color:#64748b;font-weight:700;background:#f8fbff}
           @media (max-width:900px){.ds-pa-item-quick-row{grid-template-columns:1fr 1fr}.ds-pa-item-field--select,.ds-pa-line-total{grid-column:1/-1}.ds-pa-bundle-grid{grid-template-columns:1fr}}
@@ -2604,7 +2612,7 @@ export const proposalsAgreementsScreen = {
       if (!q || q.length < 2) return [];
       const seen = new Set();
       return contactOptions.filter((c) => {
-        const typeOk = selectedType === 'authority' ? text(c.authority) : text(c.school);
+        const typeOk = selectedType === 'authority' ? text(c.authority) : (text(c.school) || text(c.authority) || text(c.client_name));
         if (!typeOk) return false;
         const haystack = [c.school, c.authority, c.client_name, c.contact_name, c.phone, c.mobile, c.email]
           .map(normalizeSearch).join(' ');
@@ -2684,12 +2692,15 @@ export const proposalsAgreementsScreen = {
       const results = form?.querySelector('[data-pa-client-results]');
       if (!input || !results || type === 'other') return;
       const matches = clientSearchMatches(input.value, type);
+      const manualBtn = form.querySelector('[data-pa-client-search-row] > [data-pa-new-client-toggle]');
+      if (manualBtn) manualBtn.hidden = true;
       if (!text(input.value) || text(input.value).length < 2) {
         results.innerHTML = '<p class="ds-pa-client-results-empty">הקלידו לפחות שני תווים לחיפוש.</p>';
         results.hidden = true;
         return;
       }
       if (!matches.length) {
+        if (manualBtn) manualBtn.hidden = false;
         results.innerHTML = '<p class="ds-pa-client-results-empty">לא נמצאו תוצאות.</p><button type="button" class="ds-pa-client-result ds-pa-client-result--manual" data-pa-new-client-toggle>לא מצאת? הוסף ידנית</button>';
         results.hidden = false;
         return;
@@ -2711,7 +2722,7 @@ export const proposalsAgreementsScreen = {
       applyClientTypeMode(form);
       form.querySelector('[data-pa-client-search-input]')?.addEventListener('input', () => renderClientResults(form), { signal });
       form.querySelector('[data-pa-new-client-type]')?.addEventListener('change', () => {
-        form.dataset.paNewClient = 'yes';
+        form.dataset.paNewClient = 'no';
         unlockClientFields(form);
         applyClientTypeMode(form);
         ['client_authority', 'school_framework', 'contact_name', 'contact_role', 'phone', 'email'].forEach((name) => {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 718;
+const CACHE_VERSION = 719;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 718;
+const SW_ENTRY_VERSION = 719;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- לתקן מצב שבו מסך אנשי קשר ונגלות ההצעות נופלים או מציגים "0" בגלל כישלון קריאת מקור אחד בלבד, ולחבר את בחירת הלקוח בטופס הצעת מחיר לנתוני אנשי הקשר המרכזיים.
- למנוע פתיחת טופס יצירה אוטומטית ולהפוך את הטופס לקומפקטי מבחינת רוחב כדי שלא יפרוש על כל המסך.
- לשפר את הזרימה של הוספת לקוח ידנית כך שלא תהיה ברירת מחדל אלא אופציה משנית.

### Description
- `frontend/src/api.js`: מרחיב את `readContactsFromSupabase` לקרוא `contacts_instructors` ו-`contacts_directory_view` בנפרד; כישלון מקור מתועד כ-`console.warn` ומחזיר חלק מהנתונים במקום `null`, ו-`contacts_directory_view` נופל חזרה ל-`contacts_schools` כאשר ה-view נכשל; שונתה גם `readContactsSchoolsForProposals` כדי להשתמש ב-directory עם fallback ל-`contacts_schools`.
- `frontend/src/screens/contacts.js`: הוסרו המקרים שבהם כישלון מקור מאפס את הטאבים; נוספה לוגיקה להצגת הודעת "סינון" כשיש נתונים אך פילטר פעיל (`hasActiveContactFilters` / `contactEmptyState`).
- `frontend/src/screens/proposals-agreements.js`: לא נפתחת טופס ברירת מחדל — ברירת המחדל היא טאב `records` והטופס נפתח רק על `+ הצעה חדשה`; הוגבל `max-width` של הטופס ל-`1080px` עם `margin-inline:auto` כדי להיות קומפקטי; הוספו שדות חבויים בטופס (`contact_source_authority_id`, `contact_source_school_id`) וה-payload עכשיו שומר/מעביר `contact_school_id`, `authority_id`, `school_id` ו-`client_type` כאשר בוחרים לקוח קיים; כפתור "לא מצאת? הוסף ידנית" שובצמ במצב מוסתר כברירת מחדל ומוצג רק כאשר אין תוצאות חיפוש.
- Service Worker / cache: עדכון `frontend/sw.js` ו-`sw.js` ל-`CACHE_VERSION/SW_ENTRY_VERSION` 719 ופעולת build עדכנית שמעדכנת הקבצים ב-`dist/index.html` לשם ה-bundle החדש.
- לא בוצעו שינויים ב-Supabase, טבלאות או תבניות SQL (SQL מטופל בנפרד כפי שנדרש) ולא בוצע refactor רחב.

### Testing
- נקלטו והורצו בדיקות סטטיות על הקבצים השונו עם `node --check frontend/src/api.js` ו-`node --check frontend/src/screens/*.js` ועמדו ללא שגיאות.
- הושלמה בדיקת שינויים ממוקדת עם `npm run check:changed` כולל הרצת `tests/proposals-agreements-screen.test.mjs` ועמדה (63 tests passed, 0 failed).
- בנייה ופרה-בדיקות frontend בוצעו באמצעות `npm run check:build` / `npm run build` וה-build עבר בהצלחה; ה-`dist/index.html` עודכן כדי לשקף ה-bundle החדש.
- Service Worker/cache גרסאות הועלו (718 → 719); ממליץ לרענן בדפדפן ב-`Ctrl+Shift+R` לאחר ההפצה כדי לנקות קאש ולהטען ה-bundle החדש.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd2d0c8bc832b8c0fffedcbabc123)