### PR TITLE
Sanitize proposal agreement payload columns

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1530,8 +1530,14 @@ function normalizeData(data) {
 
 const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
 const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
-const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,authority,school,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
 const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = 'id,authority_id,authority_code,school_id,contact_school_id,authority_name,legacy_client_authority,contact_client_type,contact_client_name,school_name,legacy_school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_WRITABLE_COLUMNS = new Set([
+  'authority_id', 'school_id', 'contact_school_id', 'client_authority', 'school_framework',
+  'document_type', 'activity_type_group', 'proposal_date', 'activity_names', 'contact_name',
+  'contact_role', 'phone', 'email', 'notes', 'status', 'approval_note', 'total_amount',
+  'custom_document_sections', 'include_catalog'
+]);
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
 function parseActivityNamesFromNotes(notes) {
@@ -1647,8 +1653,8 @@ function normalizeProposalAgreementRow(row = {}) {
   const parsedNotes = parseActivityNamesFromNotes(row.notes);
   const PA_VALID_STATUSES = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
   const rawStatus = cleanProposalAgreementText(row.status);
-  const authorityName = cleanProposalAgreementText(row.authority_name || row.legacy_client_authority);
-  const schoolFramework = cleanProposalAgreementText(row.school_name || row.contact_client_name || row.legacy_school_framework);
+  const authorityName = cleanProposalAgreementText(row.client_authority || row.authority_name || row.legacy_client_authority || row.authority);
+  const schoolFramework = cleanProposalAgreementText(row.school_framework || row.school_name || row.contact_client_name || row.legacy_school_framework || row.school);
   const normalized = {
     id:                  cleanProposalAgreementText(row.id),
     client_type:         cleanProposalAgreementText(row.contact_client_type) || (row.school_id ? 'school' : 'authority'),
@@ -1784,15 +1790,12 @@ function sanitizeProposalAgreementPayload(payload = {}, groupLookup = proposalGr
   const rawStatus = cleanProposalAgreementText(payload.status);
   const rawGroup = cleanProposalAgreementText(payload.activity_type_group);
   const clientType = cleanProposalAgreementText(payload.client_type) || (payload.school_id ? 'school' : 'authority');
-  const clientAuthority = cleanProposalAgreementText(payload.client_authority || payload.authority);
-  const schoolFramework = cleanProposalAgreementText(payload.school_framework || payload.school) || (clientType === 'other' ? cleanProposalAgreementText(payload.client_name) : clientAuthority);
+  const clientAuthority = cleanProposalAgreementText(payload.client_authority || payload.authority_name || payload.authority);
+  const schoolFramework = cleanProposalAgreementText(payload.school_framework || payload.school_name || payload.school) || (clientType === 'other' ? cleanProposalAgreementText(payload.client_name) : clientAuthority);
   const row = {
-    client_type:         clientType,
     authority_id:        payload.authority_id || null,
     school_id:           clientType === 'school' ? (payload.school_id || null) : null,
     contact_school_id:   payload.contact_school_id || null,
-    authority:           clientAuthority || null,
-    school:              schoolFramework || null,
     client_authority:    clientAuthority,
     school_framework:    schoolFramework,
     document_type:       cleanProposalAgreementText(payload.document_type) || 'הצעת מחיר',
@@ -1815,7 +1818,9 @@ function sanitizeProposalAgreementPayload(payload = {}, groupLookup = proposalGr
     : ['client_authority', 'document_type', 'activity_type_group'];
   const missing = requiredKeys.filter((key) => !row[key]);
   if (missing.length) throw new Error(`missing_required_fields:${missing.join(',')}`);
-  return row;
+  return Object.fromEntries(
+    Object.entries(row).filter(([key]) => PROPOSALS_AGREEMENTS_WRITABLE_COLUMNS.has(key))
+  );
 }
 
 


### PR DESCRIPTION
### Motivation
- A save error occurred because the client code sent non-existent `authority`/`school` columns to `proposals_agreements`, causing Supabase schema-cache failures; the client must stop sending fields that are not in the table.
- The goal is to map incoming contact/view fields into the existing columns (`client_authority`, `school_framework`, `authority_id`, `school_id`, `contact_school_id`) and strip any other keys before `insert`/`update` to avoid server errors.

### Description
- Modified `frontend/src/api.js` to normalize incoming aliases and avoid sending `authority` or `school` columns by mapping `authority_name`/`authority` -> `client_authority` and `school_name`/`school` -> `school_framework` before saving.
- Added an explicit `PROPOSALS_AGREEMENTS_WRITABLE_COLUMNS` allowlist and changed `sanitizeProposalAgreementPayload` to return only entries whose keys appear in that set so only real DB columns are written.
- Removed `authority`/`school` from the post-save `select` columns constant and ensured both `addProposalAgreement` and `updateProposalAgreement` call the same sanitizer before sending data to Supabase.

### Testing
- Ran syntax/type checks with `node --check frontend/src/api.js` and `node --check frontend/src/screens/proposals-agreements.js` and executed the focused verifier with `npm run check:changed`, all checks passed.
- Executed the focused screen test `node --test tests/proposals-agreements-screen.test.mjs`, which ran the suite (63 tests) with `pass 63 / fail 0`.
- No other automated tests were run because this is a frontend payload sanitization fix and the focused checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fdbcf48b8832b9fe05573f63464f9)