### PR TITLE
Add operations management page (ניהול תפעול)

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Bo7kWf5S.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-CImnTvXK.css">
+  <script type="module" crossorigin src="./assets/index-CBIw_b_G.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-CnMGV1dF.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DBKUZBFW.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-7OmalaRK.css">
+  <script type="module" crossorigin src="./assets/index-M3t1nrIi.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-Z1ioUVD_.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CBIw_b_G.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-CnMGV1dF.css">
+  <script type="module" crossorigin src="./assets/index-DBKUZBFW.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-7OmalaRK.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2052,11 +2052,11 @@ const PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_repor
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 
 const SUPABASE_ROLE_ROUTES = {
-  admin: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-home', 'admin-settings', 'admin-lists', 'finance', 'certificates'],
-  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  admin: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'permissions', 'admin-home', 'admin-settings', 'admin-lists', 'finance', 'operations-management', 'certificates'],
+  operation_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'operations-management', 'certificates'],
   authorized_user: ['dashboard', 'activities', 'archive', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'certificates'],
   finance: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
-  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
+  activities_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'operations-management', 'certificates'],
   domain_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'proposals-agreements', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'certificates'],
   business_development_manager: ['dashboard', 'activities', 'archive', 'proposals-agreements', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],
   instructor_manager: ['dashboard', 'activities', 'archive', 'catalog', 'invitations', 'week', 'month', 'exceptions', 'instructors', 'instructor-contacts', 'contacts', 'end-dates', 'edit-requests', 'certificates'],

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -554,6 +554,7 @@ const screenLabels = {
   catalog: 'קטלוג',
   'personal-reports': 'דוחות אישיים',
   'israa-management': 'ניהול איסראא',
+  'operations-management': 'ניהול תפעול',
   certificates: 'תעודות'
 };
 
@@ -604,6 +605,7 @@ const screenLoaders = {
   catalog: () => import('./screens/catalog.js').then((m) => m.catalogScreen),
   'personal-reports': () => import('./screens/personal-reports.js').then((m) => m.personalReportsScreen),
   'israa-management': () => import('./screens/israa-management.js').then((m) => m.israaManagementScreen),
+  'operations-management': () => import('./screens/operations-management.js').then((m) => m.operationsManagementScreen),
   certificates: () => import('./screens/certificates.js').then((m) => m.certificatesScreen)
 };
 const loadedScreens = new Map();

--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -1,0 +1,637 @@
+import { escapeHtml } from './shared/html.js';
+import { formatDateHe, formatDateHeWithWeekday, formatTimeRangeShort } from './shared/format-date.js';
+import {
+  dsPageHeader,
+  dsCard,
+  dsTableWrap,
+  dsEmptyState
+} from './shared/layout.js';
+import {
+  ensureActivityListFilters,
+  prepareRowsForSearch,
+  applyLocalFilters,
+  collectDependentFilterOptions
+} from './shared/activity-list-filters.js';
+import {
+  ACTIVITY_SEASON_SUMMER_2026,
+  ACTIVITY_SEASON_SCHOOL_2027,
+  isSummerActivity
+} from './shared/summer-activity.js';
+import {
+  parseLinkedSchoolsJson,
+  getActivitySchoolNames,
+  getActivitySchoolDisplayName,
+  hasActivitySchoolOrFrame,
+  getActivityInstructorName,
+  isValidInstructorName,
+  getActivityPrimaryDate,
+  getActivityScheduleDates,
+  getActivityAuthorityName,
+  getActivityDistrict,
+  getActivityName,
+  getActivityTimeRange,
+  getActivityGroupsCount,
+  getActivityGradeLabel,
+  getActivityAddress,
+  getActivityContactName,
+  getActivityContactPhone,
+  getActivityOperationalNotes,
+  activityMatchesPeriod,
+  isActivityDeleted,
+  activityDatesInRange,
+  activityOverlapsDateRange,
+  isSummerOperationsException,
+  schoolGroupKey,
+  buildActivitySearchText
+} from './shared/operations-activity-helpers.js';
+
+const SCOPE = 'operations-management';
+const TAB_INSTRUCTORS = 'instructors';
+const TAB_SUMMER = 'summer';
+const TAB_WORKSHOPS = 'workshops';
+const TAB_SCHOOLS = 'schools';
+
+const PERIOD_OPTIONS = [
+  { value: ACTIVITY_SEASON_SUMMER_2026, label: 'קיץ 2026' },
+  { value: 'school_2026', label: 'תשפ״ו / 2026' },
+  { value: ACTIVITY_SEASON_SCHOOL_2027, label: 'תשפ״ז / 2027' },
+  { value: 'all', label: 'כל הפעילויות' }
+];
+
+const STATUS_OPTIONS = ['פתוח', 'סגור', 'בוטל', 'נמחק'];
+
+const FILTER_FIELDS = [
+  { key: 'district', label: 'מחוז / אזור', getValues: (row) => [getActivityDistrict(row)] },
+  { key: 'authority', label: 'רשות', getValues: (row) => [getActivityAuthorityName(row)] },
+  { key: 'school', label: 'בית ספר / מסגרת', getValues: getActivitySchoolNames },
+  { key: 'instructor', label: 'מדריך', getValues: (row) => {
+    const names = [row?.instructor_name, row?.instructor, row?.guide_name, row?.guide]
+      .map((v) => String(v || '').trim())
+      .filter(isValidInstructorName);
+    return names.length ? names : [];
+  } },
+  { key: 'activity_name', label: 'שם סדנה / פעילות', getValues: (row) => [getActivityName(row)] },
+  { key: 'status', label: 'סטטוס', getValues: (row) => [String(row?.status || '').trim()].filter(Boolean) }
+];
+
+const SEARCH_FIELDS = [
+  (row) => buildActivitySearchText(row)
+];
+
+function isoToday() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDaysIso(iso, days) {
+  const date = new Date(`${iso}T12:00:00`);
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function defaultPeriodKey() {
+  const month = isoToday().slice(0, 7);
+  if (month >= '2026-06' && month <= '2026-08') return ACTIVITY_SEASON_SUMMER_2026;
+  return 'school_2026';
+}
+
+function defaultDateRange(periodKey) {
+  if (periodKey === ACTIVITY_SEASON_SUMMER_2026) {
+    return { from: '2026-07-01', to: '2026-08-31' };
+  }
+  const from = isoToday();
+  return { from, to: addDaysIso(from, 30) };
+}
+
+function ensureOpsState(state) {
+  state.operationsManagement = state.operationsManagement || {};
+  const ops = state.operationsManagement;
+  if (!ops.tab) ops.tab = TAB_INSTRUCTORS;
+  if (!ops.period) ops.period = defaultPeriodKey();
+  if (!ops.dateFrom || !ops.dateTo) {
+    const range = defaultDateRange(ops.period);
+    ops.dateFrom = ops.dateFrom || range.from;
+    ops.dateTo = ops.dateTo || range.to;
+  }
+  if (!ops.instructor) ops.instructor = '__all__';
+  if (!ops.expandedWorkshop) ops.expandedWorkshop = '';
+  if (!ops.expandedSchool) ops.expandedSchool = '';
+  const filters = ensureActivityListFilters(state, SCOPE);
+  if (!filters.status) filters.status = 'פתוח';
+  return ops;
+}
+
+function prepareRows(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  list.forEach((row) => {
+    if (!row || typeof row !== 'object') return;
+    row.__searchText = buildActivitySearchText(row);
+  });
+  return prepareRowsForSearch(list, SEARCH_FIELDS);
+}
+
+function applyBaseFilters(rows, state) {
+  const ops = ensureOpsState(state);
+  const filters = ensureActivityListFilters(state, SCOPE);
+  return rows.filter((row) => {
+    if (isActivityDeleted(row) && String(filters.status || '').trim() !== 'נמחק') return false;
+    if (!activityMatchesPeriod(row, ops.period)) return false;
+    if (!activityOverlapsDateRange(row, ops.dateFrom, ops.dateTo)) return false;
+    const status = String(row?.status || '').trim();
+    const selectedStatus = String(filters.status || '').trim();
+    if (selectedStatus && status !== selectedStatus) return false;
+    return true;
+  });
+}
+
+function applyAllFilters(rows, state) {
+  const base = applyBaseFilters(rows, state);
+  const filters = ensureActivityListFilters(state, SCOPE);
+  return applyLocalFilters(base, filters, { filterFields: FILTER_FIELDS });
+}
+
+function filterOptionsHtml(scope, fieldKey, label, options, selected) {
+  return `<label class="ds-filter-field">
+    <span class="ds-filter-field__label">${escapeHtml(label)}</span>
+    <select class="ds-input ds-input--sm" data-ops-filter="${escapeHtml(fieldKey)}">
+      <option value="">הכל</option>
+      ${options.map((value) => `<option value="${escapeHtml(value)}"${value === selected ? ' selected' : ''}>${escapeHtml(value)}</option>`).join('')}
+    </select>
+  </label>`;
+}
+
+function topFiltersHtml(rows, state) {
+  const ops = ensureOpsState(state);
+  const filters = ensureActivityListFilters(state, SCOPE);
+  const optionsMap = collectDependentFilterOptions(rows, FILTER_FIELDS, filters, filters.appliedQ || filters.q || '');
+  FILTER_FIELDS.forEach((field) => {
+    const selected = String(filters[field.key] || '').trim();
+    if (selected && !(optionsMap[field.key] || []).includes(selected)) filters[field.key] = '';
+  });
+
+  return `<section class="ds-ops-mgmt-filters no-print" dir="rtl">
+    <div class="ds-ops-mgmt-filters__row">
+      <label class="ds-filter-field"><span class="ds-filter-field__label">מתאריך</span><input class="ds-input ds-input--sm" type="date" data-ops-date="from" value="${escapeHtml(ops.dateFrom || '')}"></label>
+      <label class="ds-filter-field"><span class="ds-filter-field__label">עד תאריך</span><input class="ds-input ds-input--sm" type="date" data-ops-date="to" value="${escapeHtml(ops.dateTo || '')}"></label>
+      <label class="ds-filter-field"><span class="ds-filter-field__label">תקופה</span>
+        <select class="ds-input ds-input--sm" data-ops-period>
+          ${PERIOD_OPTIONS.map((opt) => `<option value="${escapeHtml(opt.value)}"${opt.value === ops.period ? ' selected' : ''}>${escapeHtml(opt.label)}</option>`).join('')}
+        </select>
+      </label>
+      ${filterFieldsHtml(optionsMap, filters)}
+      <label class="ds-filter-field"><span class="ds-filter-field__label">חיפוש</span><input class="ds-input ds-input--sm" type="search" data-ops-search value="${escapeHtml(filters.q || '')}" placeholder="חיפוש חופשי…"></label>
+      <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-ops-clear-filters>ניקוי</button>
+    </div>
+  </section>`;
+}
+
+function filterFieldsHtml(optionsMap, filters) {
+  return FILTER_FIELDS.map((field) => filterOptionsHtml(
+    SCOPE,
+    field.key,
+    field.label,
+    optionsMap[field.key] || [],
+    String(filters[field.key] || '').trim()
+  )).join('');
+}
+
+function tabsHtml(activeTab) {
+  const tabs = [
+    [TAB_INSTRUCTORS, 'סידור מדריכים'],
+    [TAB_SUMMER, 'תכנון קיץ'],
+    [TAB_WORKSHOPS, 'כמויות סדנאות'],
+    [TAB_SCHOOLS, 'לפי בתי ספר']
+  ];
+  return `<nav class="ds-ops-mgmt-tabs no-print" aria-label="לשוניות ניהול תפעול" dir="rtl">
+    ${tabs.map(([key, label]) => `<button type="button" class="ds-ops-mgmt-tab${activeTab === key ? ' is-active' : ''}" data-ops-tab="${escapeHtml(key)}" aria-pressed="${activeTab === key ? 'true' : 'false'}">${escapeHtml(label)}</button>`).join('')}
+  </nav>`;
+}
+
+function summaryCardsHtml(items) {
+  return `<div class="ds-ops-mgmt-summary" dir="rtl">${items.map(([label, value]) => `
+    <div class="ds-ops-mgmt-summary__card"><span class="ds-ops-mgmt-summary__label">${escapeHtml(label)}</span><strong class="ds-ops-mgmt-summary__value">${escapeHtml(String(value))}</strong></div>
+  `).join('')}</div>`;
+}
+
+function uniqueSorted(values) {
+  return Array.from(new Set(values.map((v) => String(v || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'he'));
+}
+
+function instructorOptions(rows) {
+  const names = new Set();
+  rows.forEach((row) => {
+    [row?.instructor_name, row?.instructor, row?.guide_name, row?.guide].forEach((value) => {
+      const name = String(value || '').trim();
+      if (isValidInstructorName(name)) names.add(name);
+    });
+  });
+  return Array.from(names).sort((a, b) => a.localeCompare(b, 'he'));
+}
+
+function buildScheduleRows(rows, state) {
+  const ops = ensureOpsState(state);
+  const selectedInstructor = String(ops.instructor || '__all__').trim();
+  const schedule = [];
+
+  rows.forEach((activity) => {
+    const instructor = getActivityInstructorName(activity);
+    if (selectedInstructor !== '__all__' && instructor !== selectedInstructor) return;
+    const dates = activityDatesInRange(activity, ops.dateFrom, ops.dateTo);
+    const targetDates = dates.length ? dates : (getActivityPrimaryDate(activity) ? [getActivityPrimaryDate(activity)] : ['']);
+    targetDates.forEach((date) => {
+      schedule.push({
+        date,
+        activity,
+        instructor,
+        time: getActivityTimeRange(activity) || formatTimeRangeShort(activity?.start_time, activity?.end_time),
+        hasTime: Boolean(getActivityTimeRange(activity) || activity?.start_time || activity?.StartTime)
+      });
+    });
+  });
+
+  schedule.sort((a, b) => {
+    const dateCmp = String(a.date || '9999-99-99').localeCompare(String(b.date || '9999-99-99'));
+    if (dateCmp !== 0) return dateCmp;
+    if (a.hasTime && !b.hasTime) return -1;
+    if (!a.hasTime && b.hasTime) return 1;
+    return getActivityName(a.activity).localeCompare(getActivityName(b.activity), 'he');
+  });
+  return schedule;
+}
+
+function instructorSummary(rows, state, scheduleRows) {
+  const ops = ensureOpsState(state);
+  const selected = String(ops.instructor || '__all__').trim();
+  if (selected === '__all__') return '';
+  const workDays = uniqueSorted(scheduleRows.map((row) => row.date).filter(Boolean)).length;
+  const authorities = uniqueSorted(rows.map(getActivityAuthorityName));
+  const schools = uniqueSorted(rows.map(getActivitySchoolDisplayName).filter((name) => name !== 'לא משויך'));
+  return summaryCardsHtml([
+    ['מדריך', selected],
+    ['טווח תאריכים', `${formatDateHe(ops.dateFrom)}–${formatDateHe(ops.dateTo)}`],
+    ['ימי עבודה', workDays],
+    ['פעילויות', rows.length],
+    ['בתי ספר / מסגרות', schools.length],
+    ['רשויות', authorities.join(' · ') || '—']
+  ]);
+}
+
+function instructorsTabHtml(rows, state) {
+  const ops = ensureOpsState(state);
+  const instructors = instructorOptions(rows);
+  if (ops.instructor === '__all__' && instructors.length === 1) ops.instructor = instructors[0];
+  const scheduleRows = buildScheduleRows(rows, state);
+  const selected = String(ops.instructor || '__all__').trim();
+  const printTitle = selected === '__all__' ? 'כל המדריכים' : selected;
+
+  const tableRows = scheduleRows.map((entry) => {
+    const activity = entry.activity;
+  return `<tr>
+      <td>${escapeHtml(formatDateHe(entry.date) || '—')}</td>
+      <td>${escapeHtml(entry.date ? formatDateHeWithWeekday(entry.date).split(' · ')[0] : '—')}</td>
+      <td>${escapeHtml(entry.time || '—')}</td>
+      <td>${escapeHtml(getActivityAuthorityName(activity))}</td>
+      <td>${escapeHtml(getActivitySchoolDisplayName(activity))}</td>
+      <td>${escapeHtml(getActivityName(activity))}</td>
+      <td>${escapeHtml(getActivityGroupsCount(activity) || '—')}</td>
+      <td>${escapeHtml(getActivityGradeLabel(activity) || '—')}</td>
+      <td>${escapeHtml(getActivityAddress(activity) || '—')}</td>
+      <td>${escapeHtml(getActivityContactName(activity) || '—')}</td>
+      <td>${escapeHtml(getActivityContactPhone(activity) || '—')}</td>
+      <td>${escapeHtml(getActivityOperationalNotes(activity) || '—')}</td>
+    </tr>`;
+  }).join('');
+
+  const table = scheduleRows.length
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-schedule">
+      <thead><tr>
+        <th>תאריך</th><th>יום</th><th>שעה</th><th>רשות</th><th>בית ספר / מסגרת</th><th>פעילות</th>
+        <th>קבוצות</th><th>שכבה / כיתה</th><th>כתובת</th><th>איש קשר</th><th>טלפון</th><th>הערות</th>
+      </tr></thead><tbody>${tableRows}</tbody></table>`)
+    : dsEmptyState('לא נמצאו פעילויות בטווח הנבחר');
+
+  return `<section class="ds-ops-mgmt-panel" dir="rtl">
+    <div class="ds-ops-mgmt-panel__toolbar no-print">
+      <label class="ds-filter-field"><span class="ds-filter-field__label">מדריך</span>
+        <select class="ds-input ds-input--sm" data-ops-instructor>
+          <option value="__all__"${selected === '__all__' ? ' selected' : ''}>כל המדריכים</option>
+          ${instructors.map((name) => `<option value="${escapeHtml(name)}"${name === selected ? ' selected' : ''}>${escapeHtml(name)}</option>`).join('')}
+        </select>
+      </label>
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--primary" data-ops-print>הדפס סידור מדריך</button>
+    </div>
+    <div class="ds-ops-mgmt-print-header only-print">
+      <h2>סידור עבודה למדריך: ${escapeHtml(printTitle)}</h2>
+      <p>טווח תאריכים: ${escapeHtml(formatDateHe(ops.dateFrom))}–${escapeHtml(formatDateHe(ops.dateTo))}</p>
+    </div>
+    ${selected !== '__all__' ? instructorSummary(rows.filter((row) => getActivityInstructorName(row) === selected), state, scheduleRows) : ''}
+    ${table}
+    <p class="ds-ops-mgmt-print-footer only-print">יש לבדוק את פרטי הפעילות לפני הגעה. במקרה של שינוי, יש לעדכן את התפעול.</p>
+  </section>`;
+}
+
+function summerTabHtml(rows, state) {
+  const summerRows = rows.filter(isSummerActivity);
+  const instructors = uniqueSorted(summerRows.map(getActivityInstructorName).filter((name) => name !== 'לא משויך'));
+  const authorities = uniqueSorted(summerRows.map(getActivityAuthorityName));
+  const schools = uniqueSorted(summerRows.map(getActivitySchoolDisplayName).filter((name) => name !== 'לא משויך'));
+  const workshops = uniqueSorted(summerRows.map(getActivityName));
+  const exceptions = summerRows.filter(isSummerOperationsException).length;
+
+  const byDistrict = new Map();
+  summerRows.forEach((row) => {
+    const key = getActivityDistrict(row);
+    if (!byDistrict.has(key)) {
+      byDistrict.set(key, { district: key, authorities: new Set(), schools: new Set(), activities: 0, instructors: new Set(), exceptions: 0 });
+    }
+    const bucket = byDistrict.get(key);
+    bucket.activities += 1;
+    bucket.authorities.add(getActivityAuthorityName(row));
+    bucket.schools.add(getActivitySchoolDisplayName(row));
+    const instructor = getActivityInstructorName(row);
+    if (instructor !== 'לא משויך') bucket.instructors.add(instructor);
+    if (isSummerOperationsException(row)) bucket.exceptions += 1;
+  });
+
+  const districtRows = Array.from(byDistrict.values()).sort((a, b) => a.district.localeCompare(b.district, 'he'));
+  const districtTable = districtRows.length
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+      <thead><tr><th>מחוז / אזור</th><th>רשויות</th><th>בתי ספר</th><th>פעילויות</th><th>מדריכים</th><th>חריגות</th></tr></thead>
+      <tbody>${districtRows.map((row) => `<tr data-ops-district="${escapeHtml(row.district)}"><td><button type="button" class="ds-link-btn" data-ops-district="${escapeHtml(row.district)}">${escapeHtml(row.district)}</button></td><td>${row.authorities.size}</td><td>${row.schools.size}</td><td>${row.activities}</td><td>${row.instructors.size}</td><td>${row.exceptions}</td></tr>`).join('')}</tbody>
+    </table>`)
+    : dsEmptyState('אין פעילויות קיץ בטווח הנבחר');
+
+  const byInstructor = new Map();
+  summerRows.forEach((row) => {
+    const instructor = getActivityInstructorName(row);
+    if (!byInstructor.has(instructor)) {
+      byInstructor.set(instructor, { instructor, activities: 0, days: new Set(), authorities: new Set(), schools: new Set(), exceptions: 0 });
+    }
+    const bucket = byInstructor.get(instructor);
+    bucket.activities += 1;
+    activityDatesInRange(row, state.operationsManagement.dateFrom, state.operationsManagement.dateTo).forEach((date) => bucket.days.add(date));
+    bucket.authorities.add(getActivityAuthorityName(row));
+    bucket.schools.add(getActivitySchoolDisplayName(row));
+    if (isSummerOperationsException(row)) bucket.exceptions += 1;
+  });
+  const instructorRows = Array.from(byInstructor.values()).sort((a, b) => a.instructor.localeCompare(b.instructor, 'he'));
+
+  return `<section class="ds-ops-mgmt-panel" dir="rtl">
+    ${summaryCardsHtml([
+      ['פעילויות קיץ', summerRows.length],
+      ['מדריכים פעילים', instructors.length],
+      ['רשויות', authorities.length],
+      ['בתי ספר / מסגרות', schools.length],
+      ['סדנאות שונות', workshops.length],
+      ['חריגות קיץ', exceptions]
+    ])}
+    <h3 class="ds-ops-mgmt-subtitle">לפי אזורים / מחוזות</h3>
+    ${districtTable}
+    <h3 class="ds-ops-mgmt-subtitle">לפי מדריכים בקיץ</h3>
+    ${instructorRows.length ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+      <thead><tr><th>מדריך</th><th>פעילויות</th><th>ימי עבודה</th><th>רשויות</th><th>בתי ספר</th><th>חריגות</th></tr></thead>
+      <tbody>${instructorRows.map((row) => `<tr><td><button type="button" class="ds-link-btn" data-ops-instructor-jump="${escapeHtml(row.instructor)}">${escapeHtml(row.instructor)}</button></td><td>${row.activities}</td><td>${row.days.size}</td><td>${escapeHtml(Array.from(row.authorities).join(' · '))}</td><td>${escapeHtml(Array.from(row.schools).join(' · '))}</td><td>${row.exceptions || '—'}</td></tr>`).join('')}</tbody>
+    </table>`) : dsEmptyState('אין מדריכים בקיץ')}
+  </section>`;
+}
+
+function workshopsTabHtml(rows, state) {
+  const ops = ensureOpsState(state);
+  const groups = new Map();
+  rows.forEach((row) => {
+    const name = getActivityName(row);
+    if (!groups.has(name)) {
+      groups.set(name, { name, activities: 0, schools: new Set(), authorities: new Set(), instructors: new Set(), groupsCount: 0, exceptions: 0, items: [] });
+    }
+    const bucket = groups.get(name);
+    bucket.activities += 1;
+    bucket.schools.add(getActivitySchoolDisplayName(row));
+    bucket.authorities.add(getActivityAuthorityName(row));
+    const instructor = getActivityInstructorName(row);
+    if (instructor !== 'לא משויך') bucket.instructors.add(instructor);
+    const groupsCount = Number(getActivityGroupsCount(row) || 0);
+    if (Number.isFinite(groupsCount) && groupsCount > 0) bucket.groupsCount += groupsCount;
+    if (isSummerOperationsException(row)) bucket.exceptions += 1;
+    bucket.items.push(row);
+  });
+
+  const list = Array.from(groups.values()).sort((a, b) => b.activities - a.activities);
+  const table = list.length
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+      <thead><tr><th>שם סדנה</th><th>פעילויות</th><th>בתי ספר</th><th>רשויות</th><th>מדריכים</th><th>קבוצות</th><th>חריגות</th></tr></thead>
+      <tbody>${list.map((row) => `<tr><td><button type="button" class="ds-link-btn" data-ops-workshop="${escapeHtml(row.name)}">${escapeHtml(row.name)}</button></td><td>${row.activities}</td><td>${row.schools.size}</td><td>${row.authorities.size}</td><td>${row.instructors.size}</td><td>${row.groupsCount || '—'}</td><td>${row.exceptions || '—'}</td></tr>`).join('')}</tbody>
+    </table>`)
+    : dsEmptyState('לא נמצאו סדנאות');
+
+  const expanded = list.find((row) => row.name === ops.expandedWorkshop);
+  const detail = expanded
+    ? dsCard({
+      title: `פירוט: ${expanded.name}`,
+      body: dsTableWrap(`<table class="ds-table ds-table--compact"><thead><tr><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך</th><th>קבוצות</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
+        <td>${escapeHtml(getActivityAuthorityName(row))}</td>
+        <td>${escapeHtml(getActivitySchoolDisplayName(row))}</td>
+        <td>${escapeHtml(getActivityInstructorName(row))}</td>
+        <td>${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || formatDateHe(getActivityScheduleDates(row).join(', ')) || '—')}</td>
+        <td>${escapeHtml(getActivityGroupsCount(row) || '—')}</td>
+        <td>${escapeHtml(getActivityOperationalNotes(row) || '—')}</td>
+      </tr>`).join('')}</tbody></table>`)
+    })
+    : '';
+
+  return `<section class="ds-ops-mgmt-panel" dir="rtl">${table}${detail}</section>`;
+}
+
+function schoolsTabHtml(rows, state) {
+  const ops = ensureOpsState(state);
+  const groups = new Map();
+  rows.forEach((row) => {
+    const key = schoolGroupKey(row);
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        authority: getActivityAuthorityName(row),
+        school: getActivitySchoolDisplayName(row),
+        activities: 0,
+        workshops: new Set(),
+        instructors: new Set(),
+        dates: new Set(),
+        exceptions: 0,
+        items: []
+      });
+    }
+    const bucket = groups.get(key);
+    bucket.activities += 1;
+    bucket.workshops.add(getActivityName(row));
+    const instructor = getActivityInstructorName(row);
+    if (instructor !== 'לא משויך') bucket.instructors.add(instructor);
+    getActivityScheduleDates(row).forEach((date) => bucket.dates.add(date));
+    if (isSummerOperationsException(row)) bucket.exceptions += 1;
+    bucket.items.push(row);
+  });
+
+  const list = Array.from(groups.values()).sort((a, b) => a.authority.localeCompare(b.authority, 'he') || a.school.localeCompare(b.school, 'he'));
+  const table = list.length
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+      <thead><tr><th>רשות</th><th>בית ספר / מסגרת</th><th>פעילויות</th><th>סדנאות</th><th>מדריכים</th><th>תאריכים</th><th>חריגות</th></tr></thead>
+      <tbody>${list.map((row) => `<tr><td>${escapeHtml(row.authority)}</td><td><button type="button" class="ds-link-btn" data-ops-school="${escapeHtml(row.key)}">${escapeHtml(row.school)}</button></td><td>${row.activities}</td><td>${escapeHtml(Array.from(row.workshops).join(' · '))}</td><td>${escapeHtml(Array.from(row.instructors).join(' · '))}</td><td>${escapeHtml(Array.from(row.dates).slice(0, 4).map(formatDateHe).join(' · '))}</td><td>${row.exceptions || '—'}</td></tr>`).join('')}</tbody>
+    </table>`)
+    : dsEmptyState('לא נמצאו בתי ספר / מסגרות');
+
+  const expanded = list.find((row) => row.key === ops.expandedSchool);
+  const detail = expanded
+    ? dsCard({
+      title: `פירוט: ${expanded.school}`,
+      body: dsTableWrap(`<table class="ds-table ds-table--compact"><thead><tr><th>תאריך</th><th>מדריך</th><th>סדנה</th><th>קבוצות</th><th>שכבה</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
+        <td>${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || '—')}</td>
+        <td>${escapeHtml(getActivityInstructorName(row))}</td>
+        <td>${escapeHtml(getActivityName(row))}</td>
+        <td>${escapeHtml(getActivityGroupsCount(row) || '—')}</td>
+        <td>${escapeHtml(getActivityGradeLabel(row) || '—')}</td>
+        <td>${escapeHtml(getActivityOperationalNotes(row) || '—')}</td>
+      </tr>`).join('')}</tbody></table>`)
+    })
+    : '';
+
+  return `<section class="ds-ops-mgmt-panel" dir="rtl">${table}${detail}</section>`;
+}
+
+function renderTab(rows, state) {
+  const ops = ensureOpsState(state);
+  if (ops.tab === TAB_SUMMER) return summerTabHtml(rows, state);
+  if (ops.tab === TAB_WORKSHOPS) return workshopsTabHtml(rows, state);
+  if (ops.tab === TAB_SCHOOLS) return schoolsTabHtml(rows, state);
+  return instructorsTabHtml(rows, state);
+}
+
+export const operationsManagementScreen = {
+  load: ({ api }) => api.allActivities(),
+  render(data, { state } = {}) {
+    const allRows = Array.isArray(data?.rows) ? data.rows : [];
+    const prepared = prepareRows(allRows);
+    const baseRows = applyBaseFilters(prepared, state);
+    const filteredRows = applyAllFilters(baseRows, state);
+    const ops = ensureOpsState(state);
+
+    return `<div class="ds-screen-stack ds-ops-mgmt-screen">${dsPageHeader('ניהול תפעול', 'עמוד תפעולי להצגת סידור עבודה למדריכים, תכנון קיץ, כמויות סדנאות ופירוט לפי בתי ספר.')}
+      ${topFiltersHtml(baseRows, state)}
+      ${tabsHtml(ops.tab)}
+      ${renderTab(filteredRows, state)}
+      <p class="ds-muted ds-ops-mgmt-count no-print" dir="rtl">מציג ${filteredRows.length} פעילויות מתוך ${allRows.length}</p>
+    </div>`;
+  },
+  bind({ root, state, rerender }) {
+    if (!root) return;
+    const ops = ensureOpsState(state);
+    const filters = ensureActivityListFilters(state, SCOPE);
+
+    root.querySelectorAll('[data-ops-tab]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        ops.tab = btn.getAttribute('data-ops-tab') || TAB_INSTRUCTORS;
+        rerender?.();
+      });
+    });
+
+    root.querySelector('[data-ops-period]')?.addEventListener('change', (ev) => {
+      ops.period = ev.target.value || 'all';
+      const range = defaultDateRange(ops.period);
+      ops.dateFrom = range.from;
+      ops.dateTo = range.to;
+      rerender?.();
+    });
+
+    root.querySelector('[data-ops-date="from"]')?.addEventListener('change', (ev) => {
+      ops.dateFrom = ev.target.value || '';
+      rerender?.();
+    });
+    root.querySelector('[data-ops-date="to"]')?.addEventListener('change', (ev) => {
+      ops.dateTo = ev.target.value || '';
+      rerender?.();
+    });
+
+    let searchTimer;
+    root.querySelector('[data-ops-search]')?.addEventListener('input', (ev) => {
+      filters.q = ev.target.value || '';
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => {
+        filters.appliedQ = filters.q;
+        rerender?.();
+      }, 180);
+    });
+
+    root.querySelectorAll('[data-ops-filter]').forEach((select) => {
+      select.addEventListener('change', (ev) => {
+        const key = ev.target.getAttribute('data-ops-filter');
+        if (!key) return;
+        filters[key] = ev.target.value || '';
+        rerender?.();
+      });
+    });
+
+    root.querySelector('[data-ops-clear-filters]')?.addEventListener('click', () => {
+      Object.keys(filters).forEach((key) => {
+        if (key === 'visibleCount') return;
+        filters[key] = '';
+      });
+      filters.status = 'פתוח';
+      filters.q = '';
+      filters.appliedQ = '';
+      rerender?.();
+    });
+
+    root.querySelector('[data-ops-instructor]')?.addEventListener('change', (ev) => {
+      ops.instructor = ev.target.value || '__all__';
+      rerender?.();
+    });
+
+    root.querySelector('[data-ops-print]')?.addEventListener('click', () => {
+      document.body.classList.add('is-ops-mgmt-print');
+      const cleanup = () => {
+        document.body.classList.remove('is-ops-mgmt-print');
+        window.removeEventListener('afterprint', cleanup);
+      };
+      window.addEventListener('afterprint', cleanup);
+      window.print();
+    });
+
+    root.querySelectorAll('[data-ops-district]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        filters.district = btn.getAttribute('data-ops-district') || '';
+        rerender?.();
+      });
+    });
+
+    root.querySelectorAll('[data-ops-instructor-jump]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const instructor = btn.getAttribute('data-ops-instructor-jump') || '';
+        if (!isValidInstructorName(instructor)) return;
+        ops.tab = TAB_INSTRUCTORS;
+        ops.instructor = instructor;
+        rerender?.();
+      });
+    });
+
+    root.querySelectorAll('[data-ops-workshop]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const name = btn.getAttribute('data-ops-workshop') || '';
+        ops.expandedWorkshop = ops.expandedWorkshop === name ? '' : name;
+        rerender?.();
+      });
+    });
+
+    root.querySelectorAll('[data-ops-school]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const key = btn.getAttribute('data-ops-school') || '';
+        ops.expandedSchool = ops.expandedSchool === key ? '' : key;
+        rerender?.();
+      });
+    });
+  }
+};
+
+export {
+  getActivitySchoolDisplayName,
+  hasActivitySchoolOrFrame,
+  getActivityInstructorName,
+  getActivityPrimaryDate,
+  getActivitySchoolNames,
+  parseLinkedSchoolsJson
+};

--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -43,7 +43,11 @@ import {
   activityOverlapsDateRange,
   isSummerOperationsException,
   schoolGroupKey,
-  buildActivitySearchText
+  buildActivitySearchText,
+  buildWorkshopStockMapFromLists,
+  buildWorkshopQuantityMetrics,
+  getActivityActualParticipantCount,
+  WORKSHOP_ESTIMATE_PER_ACTIVITY
 } from './shared/operations-activity-helpers.js';
 
 const SCOPE = 'operations-management';
@@ -242,6 +246,51 @@ function exceptionCountCell(count) {
   const value = Number(count || 0);
   if (!value) return '<span class="ds-ops-mgmt-cell-muted">—</span>';
   return dsStatusChip(String(value), 'warning');
+}
+
+function formatQuantityCell(value) {
+  if (value === null || value === undefined || value === '') {
+    return '<span class="ds-ops-mgmt-cell-muted">—</span>';
+  }
+  return escapeHtml(String(value));
+}
+
+function formatStockCell(value) {
+  if (value === null || value === undefined || value === '') {
+    return '<span class="ds-ops-mgmt-cell-muted">לא הוזן</span>';
+  }
+  return escapeHtml(String(value));
+}
+
+function formatGapCell(gap, hasStock) {
+  if (!hasStock || gap === null || gap === undefined) {
+    return '<span class="ds-ops-mgmt-cell-muted">—</span>';
+  }
+  const value = Number(gap);
+  if (!Number.isFinite(value)) return '<span class="ds-ops-mgmt-cell-muted">—</span>';
+  const tone = value < 0 ? 'ds-ops-gap--shortage' : 'ds-ops-gap--ok';
+  return `<span class="ds-ops-gap ${tone}">${escapeHtml(String(value))}</span>`;
+}
+
+function workshopMetricsRows(rows, stockMap) {
+  const groups = new Map();
+  rows.forEach((row) => {
+    const name = getActivityName(row);
+    if (!groups.has(name)) {
+      groups.set(name, { name, activities: 0, items: [] });
+    }
+    const bucket = groups.get(name);
+    bucket.activities += 1;
+    bucket.items.push(row);
+  });
+  return Array.from(groups.values())
+    .map((group) => buildWorkshopQuantityMetrics({
+      workshopName: group.name,
+      activityCount: group.activities,
+      activities: group.items,
+      stockMap
+    }))
+    .sort((a, b) => b.activityCount - a.activityCount);
 }
 
 function tabOverviewSummary(rows) {
@@ -447,59 +496,73 @@ function summerTabHtml(rows, state) {
   </section>`;
 }
 
-function workshopsTabHtml(rows, state) {
+function workshopsTabHtml(rows, state, stockMap) {
   const ops = ensureOpsState(state);
-  const groups = new Map();
+  const metrics = workshopMetricsRows(rows, stockMap);
+  const groupsByName = new Map();
   rows.forEach((row) => {
     const name = getActivityName(row);
-    if (!groups.has(name)) {
-      groups.set(name, { name, activities: 0, schools: new Set(), authorities: new Set(), instructors: new Set(), groupsCount: 0, exceptions: 0, items: [] });
-    }
-    const bucket = groups.get(name);
-    bucket.activities += 1;
-    bucket.schools.add(getActivitySchoolDisplayName(row));
-    bucket.authorities.add(getActivityAuthorityName(row));
-    const instructor = getActivityInstructorName(row);
-    if (instructor !== 'לא משויך') bucket.instructors.add(instructor);
-    const groupsCount = Number(getActivityGroupsCount(row) || 0);
-    if (Number.isFinite(groupsCount) && groupsCount > 0) bucket.groupsCount += groupsCount;
-    if (isSummerOperationsException(row)) bucket.exceptions += 1;
-    bucket.items.push(row);
+    if (!groupsByName.has(name)) groupsByName.set(name, []);
+    groupsByName.get(name).push(row);
   });
 
-  const list = Array.from(groups.values()).sort((a, b) => b.activities - a.activities);
-  const table = list.length
-    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table">
-      <thead><tr><th>שם סדנה</th><th>פעילויות</th><th>בתי ספר</th><th>רשויות</th><th>מדריכים</th><th>קבוצות</th><th>חריגות</th></tr></thead>
-      <tbody>${list.map((row) => `<tr><td><button type="button" class="ds-link-btn" data-ops-workshop="${escapeHtml(row.name)}">${escapeHtml(row.name)}</button></td><td>${row.activities}</td><td>${row.schools.size}</td><td>${row.authorities.size}</td><td>${row.instructors.size}</td><td>${row.groupsCount || '—'}</td><td>${exceptionCountCell(row.exceptions)}</td></tr>`).join('')}</tbody>
+  const table = metrics.length
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table">
+      <thead><tr>
+        <th>שם סדנה</th>
+        <th>מספר סדנאות</th>
+        <th>כמות משוערת לפי ${WORKSHOP_ESTIMATE_PER_ACTIVITY}</th>
+        <th>כמות בפועל</th>
+        <th>כמות במלאי</th>
+        <th>פער מול מלאי</th>
+      </tr></thead>
+      <tbody>${metrics.map((row) => `<tr>
+        <td><button type="button" class="ds-link-btn" data-ops-workshop="${escapeHtml(row.workshopName)}">${escapeHtml(row.workshopName)}</button></td>
+        <td>${row.activityCount}</td>
+        <td>${row.estimatedQuantity}</td>
+        <td>${formatQuantityCell(row.actualQuantity)}</td>
+        <td>${formatStockCell(row.stockQuantity)}</td>
+        <td>${formatGapCell(row.gap, row.stockQuantity !== null)}</td>
+      </tr>`).join('')}</tbody>
     </table>`)
     : dsEmptyState('לא נמצאו סדנאות');
 
-  const expanded = list.find((row) => row.name === ops.expandedWorkshop);
+  const expanded = metrics.find((row) => row.workshopName === ops.expandedWorkshop);
+  const expandedItems = expanded ? (groupsByName.get(expanded.workshopName) || []) : [];
   const detail = expanded
     ? dsCard({
-      title: `פירוט: ${expanded.name}`,
-      body: dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-data-table"><thead><tr><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך</th><th>קבוצות</th><th>חריגות</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
+      title: `פירוט: ${expanded.workshopName}`,
+      body: dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-data-table"><thead><tr><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך</th><th>כמות בפועל</th><th>הערות</th></tr></thead><tbody>${expandedItems.map((row) => `<tr>
         <td>${escapeHtml(getActivityAuthorityName(row))}</td>
         <td class="ds-ops-col--school">${escapeHtml(getActivitySchoolDisplayName(row))}</td>
         <td class="ds-ops-col--instructor">${escapeHtml(getActivityInstructorName(row))}</td>
         <td class="ds-ops-col--date">${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || '—')}</td>
-        <td>${escapeHtml(getActivityGroupsCount(row) || '—')}</td>
-        <td>${exceptionTagsHtml(row)}</td>
+        <td>${formatQuantityCell(getActivityActualParticipantCount(row))}</td>
         <td>${escapeHtml(getActivityOperationalNotes(row) || '—')}</td>
       </tr>`).join('')}</tbody></table>`),
       padded: false
     })
     : '';
 
-  return `<section class="ds-ops-mgmt-panel" dir="rtl">
+  const stockCount = metrics.filter((row) => row.stockQuantity !== null).length;
+  const shortageCount = metrics.filter((row) => row.stockQuantity !== null && Number(row.gap) < 0).length;
+
+  return `<section class="ds-ops-mgmt-panel ds-ops-workshops-panel" dir="rtl">
     ${summaryKpiHtml([
-      { icon: '🎨', label: 'סדנאות שונות', value: list.length },
+      { icon: '🎨', label: 'סדנאות שונות', value: metrics.length },
       { icon: '📋', label: 'פעילויות', value: rows.length },
-      { icon: '🏫', label: 'בתי ספר', value: uniqueSorted(rows.map(getActivitySchoolDisplayName).filter((name) => name !== 'לא משויך')).length },
-      { icon: '👥', label: 'מדריכים', value: instructorOptions(rows).length }
+      { icon: '📦', label: 'עם נתון מלאי', value: stockCount },
+      { icon: '⚠️', label: 'חוסר במלאי', value: shortageCount, tone: shortageCount ? 'alert' : 'ok' }
     ])}
-    ${dsCard({ title: 'סיכום לפי שם סדנה', badge: String(list.length), body: table, padded: false })}
+    <div class="ds-ops-mgmt-panel__toolbar no-print">
+      <p class="ds-ops-mgmt-note">כמות משוערת = מספר סדנאות × ${WORKSHOP_ESTIMATE_PER_ACTIVITY}. מלאי לפי שם תוצר/סדנה מרשימות המערכת, אם קיים.</p>
+      <button type="button" class="ds-btn ds-btn--sm ds-btn--primary" data-ops-print-workshops>הדפס כמויות סדנאות</button>
+    </div>
+    <div class="ds-ops-mgmt-print-header only-print">
+      <h2>כמויות סדנאות ומלאי</h2>
+      <p>טווח תאריכים: ${escapeHtml(formatDateHe(ops.dateFrom))}–${escapeHtml(formatDateHe(ops.dateTo))}</p>
+    </div>
+    ${dsCard({ title: 'סיכום לפי שם סדנה', badge: String(metrics.length), body: table, padded: false })}
     ${detail}
   </section>`;
 }
@@ -564,16 +627,26 @@ function schoolsTabHtml(rows, state) {
   </section>`;
 }
 
-function renderTab(rows, state) {
+function renderTab(rows, state, data) {
   const ops = ensureOpsState(state);
+  const stockMap = data?.workshopStockMap instanceof Map ? data.workshopStockMap : new Map();
   if (ops.tab === TAB_SUMMER) return summerTabHtml(rows, state);
-  if (ops.tab === TAB_WORKSHOPS) return workshopsTabHtml(rows, state);
+  if (ops.tab === TAB_WORKSHOPS) return workshopsTabHtml(rows, state, stockMap);
   if (ops.tab === TAB_SCHOOLS) return schoolsTabHtml(rows, state);
   return instructorsTabHtml(rows, state);
 }
 
 export const operationsManagementScreen = {
-  load: ({ api }) => api.allActivities(),
+  load: async ({ api }) => {
+    const [activities, lists] = await Promise.all([
+      api.allActivities(),
+      api.adminLists().catch(() => ({ categories: [] }))
+    ]);
+    return {
+      ...activities,
+      workshopStockMap: buildWorkshopStockMapFromLists(lists)
+    };
+  },
   render(data, { state } = {}) {
     const allRows = Array.isArray(data?.rows) ? data.rows : [];
     const prepared = prepareRows(allRows);
@@ -584,7 +657,7 @@ export const operationsManagementScreen = {
     return `<div class="ds-screen-stack ds-ops-mgmt-screen">${dsPageHeader('ניהול תפעול', 'עמוד תפעולי להצגת סידור עבודה למדריכים, תכנון קיץ, כמויות סדנאות ופירוט לפי בתי ספר.')}
       ${topFiltersHtml(baseRows, state)}
       ${tabsHtml(ops.tab)}
-      <div class="ds-ops-mgmt-content">${renderTab(filteredRows, state)}</div>
+      <div class="ds-ops-mgmt-content">${renderTab(filteredRows, state, data)}</div>
       <p class="ds-muted ds-ops-mgmt-count no-print" dir="rtl">מציג ${filteredRows.length} פעילויות מתוך ${allRows.length}</p>
     </div>`;
   },
@@ -656,6 +729,16 @@ export const operationsManagementScreen = {
       document.body.classList.add('is-ops-mgmt-print');
       const cleanup = () => {
         document.body.classList.remove('is-ops-mgmt-print');
+        window.removeEventListener('afterprint', cleanup);
+      };
+      window.addEventListener('afterprint', cleanup);
+      window.print();
+    });
+
+    root.querySelector('[data-ops-print-workshops]')?.addEventListener('click', () => {
+      document.body.classList.add('is-ops-mgmt-print', 'is-ops-mgmt-print-workshops');
+      const cleanup = () => {
+        document.body.classList.remove('is-ops-mgmt-print', 'is-ops-mgmt-print-workshops');
         window.removeEventListener('afterprint', cleanup);
       };
       window.addEventListener('afterprint', cleanup);

--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -4,7 +4,8 @@ import {
   dsPageHeader,
   dsCard,
   dsTableWrap,
-  dsEmptyState
+  dsEmptyState,
+  dsStatusChip
 } from './shared/layout.js';
 import {
   ensureActivityListFilters,
@@ -149,7 +150,7 @@ function applyAllFilters(rows, state) {
   return applyLocalFilters(base, filters, { filterFields: FILTER_FIELDS });
 }
 
-function filterOptionsHtml(scope, fieldKey, label, options, selected) {
+function filterOptionsHtml(fieldKey, label, options, selected) {
   return `<label class="ds-filter-field">
     <span class="ds-filter-field__label">${escapeHtml(label)}</span>
     <select class="ds-input ds-input--sm" data-ops-filter="${escapeHtml(fieldKey)}">
@@ -168,8 +169,9 @@ function topFiltersHtml(rows, state) {
     if (selected && !(optionsMap[field.key] || []).includes(selected)) filters[field.key] = '';
   });
 
-  return `<section class="ds-ops-mgmt-filters no-print" dir="rtl">
-    <div class="ds-ops-mgmt-filters__row">
+  return `<section class="ds-filter-panel ds-ops-mgmt-filters no-print" dir="rtl">
+    <h2 class="ds-filter-panel__title">סינון וחיפוש</h2>
+    <div class="ds-filter-panel__grid ds-ops-mgmt-filters__grid">
       <label class="ds-filter-field"><span class="ds-filter-field__label">מתאריך</span><input class="ds-input ds-input--sm" type="date" data-ops-date="from" value="${escapeHtml(ops.dateFrom || '')}"></label>
       <label class="ds-filter-field"><span class="ds-filter-field__label">עד תאריך</span><input class="ds-input ds-input--sm" type="date" data-ops-date="to" value="${escapeHtml(ops.dateTo || '')}"></label>
       <label class="ds-filter-field"><span class="ds-filter-field__label">תקופה</span>
@@ -178,15 +180,16 @@ function topFiltersHtml(rows, state) {
         </select>
       </label>
       ${filterFieldsHtml(optionsMap, filters)}
-      <label class="ds-filter-field"><span class="ds-filter-field__label">חיפוש</span><input class="ds-input ds-input--sm" type="search" data-ops-search value="${escapeHtml(filters.q || '')}" placeholder="חיפוש חופשי…"></label>
-      <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-ops-clear-filters>ניקוי</button>
+      <label class="ds-filter-field ds-filter-field--search"><span class="ds-filter-field__label">חיפוש חופשי</span><input class="ds-input ds-input--sm" type="search" data-ops-search value="${escapeHtml(filters.q || '')}" placeholder="שם, רשות, בית ספר, מדריך…"></label>
+      <div class="ds-filter-panel__actions ds-ops-mgmt-filters__actions">
+        <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-ops-clear-filters">ניקוי פילטרים</button>
+      </div>
     </div>
   </section>`;
 }
 
 function filterFieldsHtml(optionsMap, filters) {
   return FILTER_FIELDS.map((field) => filterOptionsHtml(
-    SCOPE,
     field.key,
     field.label,
     optionsMap[field.key] || [],
@@ -201,15 +204,59 @@ function tabsHtml(activeTab) {
     [TAB_WORKSHOPS, 'כמויות סדנאות'],
     [TAB_SCHOOLS, 'לפי בתי ספר']
   ];
-  return `<nav class="ds-ops-mgmt-tabs no-print" aria-label="לשוניות ניהול תפעול" dir="rtl">
-    ${tabs.map(([key, label]) => `<button type="button" class="ds-ops-mgmt-tab${activeTab === key ? ' is-active' : ''}" data-ops-tab="${escapeHtml(key)}" aria-pressed="${activeTab === key ? 'true' : 'false'}">${escapeHtml(label)}</button>`).join('')}
+  return `<nav class="ds-exceptions-tabs ds-ops-mgmt-tabs no-print" aria-label="לשוניות ניהול תפעול" dir="rtl">
+    ${tabs.map(([key, label]) => `<button type="button" class="ds-exceptions-tab ds-ops-mgmt-tab${activeTab === key ? ' is-active' : ''}" data-ops-tab="${escapeHtml(key)}" aria-pressed="${activeTab === key ? 'true' : 'false'}">${escapeHtml(label)}</button>`).join('')}
   </nav>`;
 }
 
-function summaryCardsHtml(items) {
-  return `<div class="ds-ops-mgmt-summary" dir="rtl">${items.map(([label, value]) => `
-    <div class="ds-ops-mgmt-summary__card"><span class="ds-ops-mgmt-summary__label">${escapeHtml(label)}</span><strong class="ds-ops-mgmt-summary__value">${escapeHtml(String(value))}</strong></div>
-  `).join('')}</div>`;
+function summaryKpiHtml(items = []) {
+  const list = Array.isArray(items) ? items : [];
+  if (!list.length) return '';
+  return `<div class="ds-ops-mgmt-summary" dir="rtl">${list.map((item) => {
+    const tone = item.tone === 'alert' ? ' ds-ops-mgmt-summary__card--alert' : (item.tone === 'ok' ? ' ds-ops-mgmt-summary__card--ok' : '');
+    return `<article class="ds-ops-mgmt-summary__card${tone}">
+      <span class="ds-ops-mgmt-summary__icon" aria-hidden="true">${escapeHtml(item.icon || '•')}</span>
+      <span class="ds-ops-mgmt-summary__label">${escapeHtml(item.label)}</span>
+      <strong class="ds-ops-mgmt-summary__value">${escapeHtml(String(item.value ?? ''))}</strong>
+    </article>`;
+  }).join('')}</div>`;
+}
+
+function getSummerExceptionTags(activity) {
+  if (!isSummerActivity(activity)) return [];
+  const tags = [];
+  if (getActivityInstructorName(activity) === 'לא משויך') tags.push({ label: 'ללא מדריך', kind: 'warning' });
+  if (!getActivityPrimaryDate(activity) && getActivityScheduleDates(activity).length === 0) {
+    tags.push({ label: 'ללא תאריך', kind: 'danger' });
+  }
+  return tags;
+}
+
+function exceptionTagsHtml(activity) {
+  const tags = getSummerExceptionTags(activity);
+  if (!tags.length) return '<span class="ds-ops-mgmt-cell-muted">—</span>';
+  return `<span class="ds-ops-mgmt-tags">${tags.map((tag) => dsStatusChip(tag.label, tag.kind)).join('')}</span>`;
+}
+
+function exceptionCountCell(count) {
+  const value = Number(count || 0);
+  if (!value) return '<span class="ds-ops-mgmt-cell-muted">—</span>';
+  return dsStatusChip(String(value), 'warning');
+}
+
+function tabOverviewSummary(rows) {
+  const instructors = instructorOptions(rows);
+  const schools = uniqueSorted(rows.map(getActivitySchoolDisplayName).filter((name) => name !== 'לא משויך'));
+  const authorities = uniqueSorted(rows.map(getActivityAuthorityName));
+  const exceptions = rows.filter(isSummerOperationsException).length;
+  const items = [
+    { icon: '📋', label: 'פעילויות', value: rows.length },
+    { icon: '👥', label: 'מדריכים', value: instructors.length },
+    { icon: '🏫', label: 'בתי ספר / מסגרות', value: schools.length },
+    { icon: '🏛️', label: 'רשויות', value: authorities.length }
+  ];
+  if (exceptions > 0) items.push({ icon: '⚠️', label: 'חריגות קיץ', value: exceptions, tone: 'alert' });
+  return summaryKpiHtml(items);
 }
 
 function uniqueSorted(values) {
@@ -265,13 +312,12 @@ function instructorSummary(rows, state, scheduleRows) {
   const workDays = uniqueSorted(scheduleRows.map((row) => row.date).filter(Boolean)).length;
   const authorities = uniqueSorted(rows.map(getActivityAuthorityName));
   const schools = uniqueSorted(rows.map(getActivitySchoolDisplayName).filter((name) => name !== 'לא משויך'));
-  return summaryCardsHtml([
-    ['מדריך', selected],
-    ['טווח תאריכים', `${formatDateHe(ops.dateFrom)}–${formatDateHe(ops.dateTo)}`],
-    ['ימי עבודה', workDays],
-    ['פעילויות', rows.length],
-    ['בתי ספר / מסגרות', schools.length],
-    ['רשויות', authorities.join(' · ') || '—']
+  return summaryKpiHtml([
+    { icon: '👤', label: 'מדריך', value: selected },
+    { icon: '📅', label: 'ימי עבודה', value: workDays },
+    { icon: '📋', label: 'פעילויות', value: rows.length },
+    { icon: '🏫', label: 'בתי ספר / מסגרות', value: schools.length },
+    { icon: '🏛️', label: 'רשויות', value: authorities.length }
   ]);
 }
 
@@ -285,19 +331,19 @@ function instructorsTabHtml(rows, state) {
 
   const tableRows = scheduleRows.map((entry) => {
     const activity = entry.activity;
-  return `<tr>
-      <td>${escapeHtml(formatDateHe(entry.date) || '—')}</td>
-      <td>${escapeHtml(entry.date ? formatDateHeWithWeekday(entry.date).split(' · ')[0] : '—')}</td>
-      <td>${escapeHtml(entry.time || '—')}</td>
+    return `<tr>
+      <td class="ds-ops-col--date"><strong>${escapeHtml(formatDateHe(entry.date) || '—')}</strong></td>
+      <td class="ds-ops-col--weekday">${escapeHtml(entry.date ? formatDateHeWithWeekday(entry.date).split(' · ')[0] : '—')}</td>
+      <td class="ds-ops-col--time">${escapeHtml(entry.time || '—')}</td>
       <td>${escapeHtml(getActivityAuthorityName(activity))}</td>
-      <td>${escapeHtml(getActivitySchoolDisplayName(activity))}</td>
+      <td class="ds-ops-col--school"><strong>${escapeHtml(getActivitySchoolDisplayName(activity))}</strong></td>
       <td>${escapeHtml(getActivityName(activity))}</td>
-      <td>${escapeHtml(getActivityGroupsCount(activity) || '—')}</td>
-      <td>${escapeHtml(getActivityGradeLabel(activity) || '—')}</td>
-      <td>${escapeHtml(getActivityAddress(activity) || '—')}</td>
-      <td>${escapeHtml(getActivityContactName(activity) || '—')}</td>
-      <td>${escapeHtml(getActivityContactPhone(activity) || '—')}</td>
-      <td>${escapeHtml(getActivityOperationalNotes(activity) || '—')}</td>
+      <td class="ds-ops-col--groups">${escapeHtml(getActivityGroupsCount(activity) || '—')}</td>
+      <td class="ds-ops-col--grade">${escapeHtml(getActivityGradeLabel(activity) || '—')}</td>
+      <td class="ds-ops-col--address">${escapeHtml(getActivityAddress(activity) || '—')}</td>
+      <td class="ds-ops-col--contact">${escapeHtml(getActivityContactName(activity) || '—')}</td>
+      <td class="ds-ops-col--phone">${escapeHtml(getActivityContactPhone(activity) || '—')}</td>
+      <td class="ds-ops-col--notes">${escapeHtml(getActivityOperationalNotes(activity) || '—')}</td>
     </tr>`;
   }).join('');
 
@@ -305,13 +351,18 @@ function instructorsTabHtml(rows, state) {
     ? dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-schedule">
       <thead><tr>
         <th>תאריך</th><th>יום</th><th>שעה</th><th>רשות</th><th>בית ספר / מסגרת</th><th>פעילות</th>
-        <th>קבוצות</th><th>שכבה / כיתה</th><th>כתובת</th><th>איש קשר</th><th>טלפון</th><th>הערות</th>
+        <th class="ds-ops-col--groups">קבוצות</th><th class="ds-ops-col--grade">שכבה / כיתה</th><th class="ds-ops-col--address">כתובת</th><th class="ds-ops-col--contact">איש קשר</th><th class="ds-ops-col--phone">טלפון</th><th class="ds-ops-col--notes">הערות</th>
       </tr></thead><tbody>${tableRows}</tbody></table>`)
     : dsEmptyState('לא נמצאו פעילויות בטווח הנבחר');
 
+  const instructorRows = selected === '__all__'
+    ? rows
+    : rows.filter((row) => getActivityInstructorName(row) === selected);
+
   return `<section class="ds-ops-mgmt-panel" dir="rtl">
+    ${tabOverviewSummary(rows)}
     <div class="ds-ops-mgmt-panel__toolbar no-print">
-      <label class="ds-filter-field"><span class="ds-filter-field__label">מדריך</span>
+      <label class="ds-filter-field ds-ops-mgmt-instructor-field"><span class="ds-filter-field__label">מדריך לסידור</span>
         <select class="ds-input ds-input--sm" data-ops-instructor>
           <option value="__all__"${selected === '__all__' ? ' selected' : ''}>כל המדריכים</option>
           ${instructors.map((name) => `<option value="${escapeHtml(name)}"${name === selected ? ' selected' : ''}>${escapeHtml(name)}</option>`).join('')}
@@ -323,8 +374,8 @@ function instructorsTabHtml(rows, state) {
       <h2>סידור עבודה למדריך: ${escapeHtml(printTitle)}</h2>
       <p>טווח תאריכים: ${escapeHtml(formatDateHe(ops.dateFrom))}–${escapeHtml(formatDateHe(ops.dateTo))}</p>
     </div>
-    ${selected !== '__all__' ? instructorSummary(rows.filter((row) => getActivityInstructorName(row) === selected), state, scheduleRows) : ''}
-    ${table}
+    ${selected !== '__all__' ? instructorSummary(instructorRows, state, scheduleRows) : ''}
+    ${dsCard({ title: 'טבלת סידור עבודה', badge: String(scheduleRows.length), body: table, padded: false })}
     <p class="ds-ops-mgmt-print-footer only-print">יש לבדוק את פרטי הפעילות לפני הגעה. במקרה של שינוי, יש לעדכן את התפעול.</p>
   </section>`;
 }
@@ -354,9 +405,9 @@ function summerTabHtml(rows, state) {
 
   const districtRows = Array.from(byDistrict.values()).sort((a, b) => a.district.localeCompare(b.district, 'he'));
   const districtTable = districtRows.length
-    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table">
       <thead><tr><th>מחוז / אזור</th><th>רשויות</th><th>בתי ספר</th><th>פעילויות</th><th>מדריכים</th><th>חריגות</th></tr></thead>
-      <tbody>${districtRows.map((row) => `<tr data-ops-district="${escapeHtml(row.district)}"><td><button type="button" class="ds-link-btn" data-ops-district="${escapeHtml(row.district)}">${escapeHtml(row.district)}</button></td><td>${row.authorities.size}</td><td>${row.schools.size}</td><td>${row.activities}</td><td>${row.instructors.size}</td><td>${row.exceptions}</td></tr>`).join('')}</tbody>
+      <tbody>${districtRows.map((row) => `<tr data-ops-district="${escapeHtml(row.district)}"><td><button type="button" class="ds-link-btn" data-ops-district="${escapeHtml(row.district)}">${escapeHtml(row.district)}</button></td><td>${row.authorities.size}</td><td>${row.schools.size}</td><td>${row.activities}</td><td>${row.instructors.size}</td><td>${exceptionCountCell(row.exceptions)}</td></tr>`).join('')}</tbody>
     </table>`)
     : dsEmptyState('אין פעילויות קיץ בטווח הנבחר');
 
@@ -376,21 +427,23 @@ function summerTabHtml(rows, state) {
   const instructorRows = Array.from(byInstructor.values()).sort((a, b) => a.instructor.localeCompare(b.instructor, 'he'));
 
   return `<section class="ds-ops-mgmt-panel" dir="rtl">
-    ${summaryCardsHtml([
-      ['פעילויות קיץ', summerRows.length],
-      ['מדריכים פעילים', instructors.length],
-      ['רשויות', authorities.length],
-      ['בתי ספר / מסגרות', schools.length],
-      ['סדנאות שונות', workshops.length],
-      ['חריגות קיץ', exceptions]
+    ${summaryKpiHtml([
+      { icon: '☀️', label: 'פעילויות קיץ', value: summerRows.length },
+      { icon: '👥', label: 'מדריכים פעילים', value: instructors.length },
+      { icon: '🏛️', label: 'רשויות', value: authorities.length },
+      { icon: '🏫', label: 'בתי ספר / מסגרות', value: schools.length },
+      { icon: '🎨', label: 'סדנאות שונות', value: workshops.length },
+      { icon: '⚠️', label: 'חריגות קיץ', value: exceptions, tone: exceptions ? 'alert' : 'ok' }
     ])}
-    <h3 class="ds-ops-mgmt-subtitle">לפי אזורים / מחוזות</h3>
-    ${districtTable}
-    <h3 class="ds-ops-mgmt-subtitle">לפי מדריכים בקיץ</h3>
-    ${instructorRows.length ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+    ${dsCard({ title: 'לפי אזורים / מחוזות', body: districtTable, padded: false })}
+    ${instructorRows.length ? dsCard({
+      title: 'לפי מדריכים בקיץ',
+      body: dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table">
       <thead><tr><th>מדריך</th><th>פעילויות</th><th>ימי עבודה</th><th>רשויות</th><th>בתי ספר</th><th>חריגות</th></tr></thead>
-      <tbody>${instructorRows.map((row) => `<tr><td><button type="button" class="ds-link-btn" data-ops-instructor-jump="${escapeHtml(row.instructor)}">${escapeHtml(row.instructor)}</button></td><td>${row.activities}</td><td>${row.days.size}</td><td>${escapeHtml(Array.from(row.authorities).join(' · '))}</td><td>${escapeHtml(Array.from(row.schools).join(' · '))}</td><td>${row.exceptions || '—'}</td></tr>`).join('')}</tbody>
-    </table>`) : dsEmptyState('אין מדריכים בקיץ')}
+      <tbody>${instructorRows.map((row) => `<tr><td class="ds-ops-col--instructor"><button type="button" class="ds-link-btn" data-ops-instructor-jump="${escapeHtml(row.instructor)}">${escapeHtml(row.instructor)}</button></td><td>${row.activities}</td><td>${row.days.size}</td><td>${escapeHtml(Array.from(row.authorities).join(' · '))}</td><td>${escapeHtml(Array.from(row.schools).join(' · '))}</td><td>${exceptionCountCell(row.exceptions)}</td></tr>`).join('')}</tbody>
+    </table>`),
+      padded: false
+    }) : dsCard({ title: 'לפי מדריכים בקיץ', body: dsEmptyState('אין מדריכים בקיץ'), padded: true })}
   </section>`;
 }
 
@@ -416,9 +469,9 @@ function workshopsTabHtml(rows, state) {
 
   const list = Array.from(groups.values()).sort((a, b) => b.activities - a.activities);
   const table = list.length
-    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table">
       <thead><tr><th>שם סדנה</th><th>פעילויות</th><th>בתי ספר</th><th>רשויות</th><th>מדריכים</th><th>קבוצות</th><th>חריגות</th></tr></thead>
-      <tbody>${list.map((row) => `<tr><td><button type="button" class="ds-link-btn" data-ops-workshop="${escapeHtml(row.name)}">${escapeHtml(row.name)}</button></td><td>${row.activities}</td><td>${row.schools.size}</td><td>${row.authorities.size}</td><td>${row.instructors.size}</td><td>${row.groupsCount || '—'}</td><td>${row.exceptions || '—'}</td></tr>`).join('')}</tbody>
+      <tbody>${list.map((row) => `<tr><td><button type="button" class="ds-link-btn" data-ops-workshop="${escapeHtml(row.name)}">${escapeHtml(row.name)}</button></td><td>${row.activities}</td><td>${row.schools.size}</td><td>${row.authorities.size}</td><td>${row.instructors.size}</td><td>${row.groupsCount || '—'}</td><td>${exceptionCountCell(row.exceptions)}</td></tr>`).join('')}</tbody>
     </table>`)
     : dsEmptyState('לא נמצאו סדנאות');
 
@@ -426,18 +479,29 @@ function workshopsTabHtml(rows, state) {
   const detail = expanded
     ? dsCard({
       title: `פירוט: ${expanded.name}`,
-      body: dsTableWrap(`<table class="ds-table ds-table--compact"><thead><tr><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך</th><th>קבוצות</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
+      body: dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-data-table"><thead><tr><th>רשות</th><th>בית ספר</th><th>מדריך</th><th>תאריך</th><th>קבוצות</th><th>חריגות</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
         <td>${escapeHtml(getActivityAuthorityName(row))}</td>
-        <td>${escapeHtml(getActivitySchoolDisplayName(row))}</td>
-        <td>${escapeHtml(getActivityInstructorName(row))}</td>
-        <td>${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || formatDateHe(getActivityScheduleDates(row).join(', ')) || '—')}</td>
+        <td class="ds-ops-col--school">${escapeHtml(getActivitySchoolDisplayName(row))}</td>
+        <td class="ds-ops-col--instructor">${escapeHtml(getActivityInstructorName(row))}</td>
+        <td class="ds-ops-col--date">${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || '—')}</td>
         <td>${escapeHtml(getActivityGroupsCount(row) || '—')}</td>
+        <td>${exceptionTagsHtml(row)}</td>
         <td>${escapeHtml(getActivityOperationalNotes(row) || '—')}</td>
-      </tr>`).join('')}</tbody></table>`)
+      </tr>`).join('')}</tbody></table>`),
+      padded: false
     })
     : '';
 
-  return `<section class="ds-ops-mgmt-panel" dir="rtl">${table}${detail}</section>`;
+  return `<section class="ds-ops-mgmt-panel" dir="rtl">
+    ${summaryKpiHtml([
+      { icon: '🎨', label: 'סדנאות שונות', value: list.length },
+      { icon: '📋', label: 'פעילויות', value: rows.length },
+      { icon: '🏫', label: 'בתי ספר', value: uniqueSorted(rows.map(getActivitySchoolDisplayName).filter((name) => name !== 'לא משויך')).length },
+      { icon: '👥', label: 'מדריכים', value: instructorOptions(rows).length }
+    ])}
+    ${dsCard({ title: 'סיכום לפי שם סדנה', badge: String(list.length), body: table, padded: false })}
+    ${detail}
+  </section>`;
 }
 
 function schoolsTabHtml(rows, state) {
@@ -470,9 +534,9 @@ function schoolsTabHtml(rows, state) {
 
   const list = Array.from(groups.values()).sort((a, b) => a.authority.localeCompare(b.authority, 'he') || a.school.localeCompare(b.school, 'he'));
   const table = list.length
-    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive">
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table">
       <thead><tr><th>רשות</th><th>בית ספר / מסגרת</th><th>פעילויות</th><th>סדנאות</th><th>מדריכים</th><th>תאריכים</th><th>חריגות</th></tr></thead>
-      <tbody>${list.map((row) => `<tr><td>${escapeHtml(row.authority)}</td><td><button type="button" class="ds-link-btn" data-ops-school="${escapeHtml(row.key)}">${escapeHtml(row.school)}</button></td><td>${row.activities}</td><td>${escapeHtml(Array.from(row.workshops).join(' · '))}</td><td>${escapeHtml(Array.from(row.instructors).join(' · '))}</td><td>${escapeHtml(Array.from(row.dates).slice(0, 4).map(formatDateHe).join(' · '))}</td><td>${row.exceptions || '—'}</td></tr>`).join('')}</tbody>
+      <tbody>${list.map((row) => `<tr><td>${escapeHtml(row.authority)}</td><td class="ds-ops-col--school"><button type="button" class="ds-link-btn" data-ops-school="${escapeHtml(row.key)}">${escapeHtml(row.school)}</button></td><td>${row.activities}</td><td>${escapeHtml(Array.from(row.workshops).join(' · '))}</td><td>${escapeHtml(Array.from(row.instructors).join(' · '))}</td><td>${escapeHtml(Array.from(row.dates).slice(0, 4).map(formatDateHe).join(' · '))}</td><td>${exceptionCountCell(row.exceptions)}</td></tr>`).join('')}</tbody>
     </table>`)
     : dsEmptyState('לא נמצאו בתי ספר / מסגרות');
 
@@ -480,18 +544,24 @@ function schoolsTabHtml(rows, state) {
   const detail = expanded
     ? dsCard({
       title: `פירוט: ${expanded.school}`,
-      body: dsTableWrap(`<table class="ds-table ds-table--compact"><thead><tr><th>תאריך</th><th>מדריך</th><th>סדנה</th><th>קבוצות</th><th>שכבה</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
-        <td>${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || '—')}</td>
-        <td>${escapeHtml(getActivityInstructorName(row))}</td>
+      body: dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-data-table"><thead><tr><th>תאריך</th><th>מדריך</th><th>סדנה</th><th>קבוצות</th><th>שכבה</th><th>חריגות</th><th>הערות</th></tr></thead><tbody>${expanded.items.map((row) => `<tr>
+        <td class="ds-ops-col--date">${escapeHtml(formatDateHe(getActivityPrimaryDate(row)) || '—')}</td>
+        <td class="ds-ops-col--instructor">${escapeHtml(getActivityInstructorName(row))}</td>
         <td>${escapeHtml(getActivityName(row))}</td>
         <td>${escapeHtml(getActivityGroupsCount(row) || '—')}</td>
         <td>${escapeHtml(getActivityGradeLabel(row) || '—')}</td>
+        <td>${exceptionTagsHtml(row)}</td>
         <td>${escapeHtml(getActivityOperationalNotes(row) || '—')}</td>
-      </tr>`).join('')}</tbody></table>`)
+      </tr>`).join('')}</tbody></table>`),
+      padded: false
     })
     : '';
 
-  return `<section class="ds-ops-mgmt-panel" dir="rtl">${table}${detail}</section>`;
+  return `<section class="ds-ops-mgmt-panel" dir="rtl">
+    ${tabOverviewSummary(rows)}
+    ${dsCard({ title: 'פעילויות לפי בית ספר / מסגרת', badge: String(list.length), body: table, padded: false })}
+    ${detail}
+  </section>`;
 }
 
 function renderTab(rows, state) {
@@ -514,7 +584,7 @@ export const operationsManagementScreen = {
     return `<div class="ds-screen-stack ds-ops-mgmt-screen">${dsPageHeader('ניהול תפעול', 'עמוד תפעולי להצגת סידור עבודה למדריכים, תכנון קיץ, כמויות סדנאות ופירוט לפי בתי ספר.')}
       ${topFiltersHtml(baseRows, state)}
       ${tabsHtml(ops.tab)}
-      ${renderTab(filteredRows, state)}
+      <div class="ds-ops-mgmt-content">${renderTab(filteredRows, state)}</div>
       <p class="ds-muted ds-ops-mgmt-count no-print" dir="rtl">מציג ${filteredRows.length} פעילויות מתוך ${allRows.length}</p>
     </div>`;
   },

--- a/frontend/src/screens/shared/act-nav-grid.js
+++ b/frontend/src/screens/shared/act-nav-grid.js
@@ -17,6 +17,7 @@ function itemLabelHtml(item, counts = {}) {
 
 export const ACT_SUBNAV_ITEMS = [
   { route: 'activities',    label: 'כל הפעילויות',  icon: '📋' },
+  { route: 'operations-management', label: 'ניהול תפעול', icon: '🛠️' },
   { route: 'end-dates',     label: 'תאריכי סיום',   icon: '🏁' },
   { route: 'exceptions',    label: 'חריגות',         icon: '⚠️' },
   { route: 'instructors',   label: 'מדריכים',        icon: '👥' },

--- a/frontend/src/screens/shared/operations-activity-helpers.js
+++ b/frontend/src/screens/shared/operations-activity-helpers.js
@@ -1,0 +1,225 @@
+import { getActivityDateColumns } from './format-date.js';
+import { isSummerActivity, normalizeActivitySeason, ACTIVITY_SEASON_SUMMER_2026, ACTIVITY_SEASON_SCHOOL_2027 } from './summer-activity.js';
+
+const INVALID_INSTRUCTOR_NAMES = new Set(['-', 'לא משויך', 'ללא שיוך']);
+
+export function parseLinkedSchoolsJson(row) {
+  const raw = row?.linked_schools_json;
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string' && raw.startsWith('[')) {
+    try { return JSON.parse(raw); } catch (_) { return []; }
+  }
+  return [];
+}
+
+export function getActivitySchoolNames(row) {
+  const names = new Set();
+  parseLinkedSchoolsJson(row).forEach((s) => {
+    const n = String(s?.school_name || '').trim();
+    if (n) names.add(n);
+  });
+  const lsn = String(row?.linked_school_names || '').trim();
+  if (lsn) lsn.split(/\s*\+\s*|\s*[,،]\s*/).forEach((n) => { const t = n.trim(); if (t) names.add(t); });
+  const ssn = String(row?.single_school_name || '').trim();
+  if (ssn) names.add(ssn);
+  const school = String(row?.school || '').trim();
+  if (school) names.add(school);
+  const legacy = String(row?.legacy_school || '').trim();
+  if (legacy) names.add(legacy);
+  return Array.from(names);
+}
+
+export function getActivitySchoolDisplayName(activity) {
+  const lsn = String(activity?.linked_school_names || '').trim();
+  if (lsn) return lsn;
+  const ssn = String(activity?.single_school_name || '').trim();
+  if (ssn) return ssn;
+  const school = String(activity?.school || '').trim();
+  if (school) return school;
+  const legacy = String(activity?.legacy_school || '').trim();
+  if (legacy) return legacy;
+  return 'לא משויך';
+}
+
+export function hasActivitySchoolOrFrame(activity) {
+  if (activity?.school_id) return true;
+  if (activity?.single_school_id) return true;
+  if (Number(activity?.linked_schools_count || 0) > 0) return true;
+  if (parseLinkedSchoolsJson(activity).length > 0) return true;
+  if (String(activity?.school || '').trim()) return true;
+  if (String(activity?.legacy_school || '').trim()) return true;
+  return false;
+}
+
+export function getActivityInstructorName(activity) {
+  for (const field of ['instructor_name', 'instructor', 'guide_name', 'guide']) {
+    const value = String(activity?.[field] || '').trim();
+    if (value && !INVALID_INSTRUCTOR_NAMES.has(value)) return value;
+  }
+  return 'לא משויך';
+}
+
+export function isValidInstructorName(name) {
+  const value = String(name || '').trim();
+  return Boolean(value) && !INVALID_INSTRUCTOR_NAMES.has(value);
+}
+
+function normalizeIsoDate(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const iso = raw.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (iso) return iso[1];
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toISOString().slice(0, 10);
+}
+
+export function getActivityPrimaryDate(activity) {
+  for (const field of ['start_date', 'activity_date', 'date', 'date_1']) {
+    const value = normalizeIsoDate(activity?.[field]);
+    if (value) return value;
+  }
+  const meetingDates = Array.isArray(activity?.meeting_dates) && activity.meeting_dates.length
+    ? activity.meeting_dates
+    : getActivityDateColumns(activity);
+  if (meetingDates.length) return normalizeIsoDate(meetingDates[0]);
+  return '';
+}
+
+export function getActivityScheduleDates(activity) {
+  const meetingDates = getActivityDateColumns(activity).map(normalizeIsoDate).filter(Boolean);
+  if (meetingDates.length) return meetingDates;
+  const primary = getActivityPrimaryDate(activity);
+  return primary ? [primary] : [];
+}
+
+export function getActivityAuthorityName(activity) {
+  return String(
+    activity?.authority_name ||
+    activity?.legacy_authority ||
+    activity?.authority ||
+    ''
+  ).trim() || 'לא משויך';
+}
+
+export function getActivityDistrict(activity) {
+  return String(activity?.authority_district || activity?.district || '').trim() || 'ללא מחוז / לא משויך';
+}
+
+export function getActivityName(activity) {
+  return String(activity?.activity_name || activity?.name || activity?.title || activity?.program_name || '').trim() || 'ללא שם';
+}
+
+export function getActivityTimeRange(activity) {
+  const start = String(activity?.start_time || activity?.StartTime || '').trim();
+  const end = String(activity?.end_time || activity?.EndTime || '').trim();
+  if (start && end) return `${start}-${end}`;
+  return start || end || '';
+}
+
+export function getActivityGroupsCount(activity) {
+  const raw = activity?.groups_count ?? activity?.group_count ?? activity?.num_groups ?? activity?.groups ?? '';
+  const text = String(raw || '').trim();
+  return text || '';
+}
+
+export function getActivityGradeLabel(activity) {
+  return String(activity?.grade || activity?.class_group || activity?.group || activity?.class || '').trim();
+}
+
+export function getActivityAddress(activity) {
+  return String(activity?.address || activity?.school_address || '').trim();
+}
+
+export function getActivityContactName(activity) {
+  return String(activity?.contact_name || activity?.school_contact_name || '').trim();
+}
+
+export function getActivityContactPhone(activity) {
+  return String(activity?.contact_phone || activity?.phone || activity?.mobile || '').trim();
+}
+
+export function getActivityOperationalNotes(activity) {
+  return String(activity?.operations_private_notes || activity?.private_note || activity?.notes || '').trim();
+}
+
+export function activityMatchesPeriod(activity, periodKey) {
+  const key = String(periodKey || 'all').trim();
+  if (!key || key === 'all') return true;
+  const season = normalizeActivitySeason(activity?.activity_season ?? activity?.activitySeason);
+  if (key === ACTIVITY_SEASON_SUMMER_2026) return isSummerActivity(activity);
+  if (key === ACTIVITY_SEASON_SCHOOL_2027) return season === ACTIVITY_SEASON_SCHOOL_2027;
+  if (key === 'school_2026') return season !== ACTIVITY_SEASON_SUMMER_2026 && season !== ACTIVITY_SEASON_SCHOOL_2027;
+  return true;
+}
+
+export function isActivityDeleted(activity) {
+  return String(activity?.status || '').trim() === 'נמחק';
+}
+
+export function activityDatesInRange(activity, fromDate, toDate) {
+  const from = normalizeIsoDate(fromDate);
+  const to = normalizeIsoDate(toDate);
+  return getActivityScheduleDates(activity).filter((date) => {
+    if (from && date < from) return false;
+    if (to && date > to) return false;
+    return true;
+  });
+}
+
+export function activityOverlapsDateRange(activity, fromDate, toDate) {
+  const datesInRange = activityDatesInRange(activity, fromDate, toDate);
+  if (datesInRange.length) return true;
+  const start = normalizeIsoDate(activity?.start_date || activity?.date_start || '');
+  const end = normalizeIsoDate(activity?.end_date || activity?.date_end || '') || start;
+  const from = normalizeIsoDate(fromDate);
+  const to = normalizeIsoDate(toDate);
+  if (!start && !end) return !from && !to;
+  const rowStart = start || end;
+  const rowEnd = end || start;
+  if (to && rowStart > to) return false;
+  if (from && rowEnd < from) return false;
+  return true;
+}
+
+export function isSummerOperationsException(activity) {
+  if (!isSummerActivity(activity)) return false;
+  const instructor = getActivityInstructorName(activity);
+  const missingInstructor = instructor === 'לא משויך';
+  const missingDate = !getActivityPrimaryDate(activity) && getActivityScheduleDates(activity).length === 0;
+  return missingInstructor || missingDate;
+}
+
+export function schoolGroupKey(activity) {
+  return `${getActivityAuthorityName(activity)}::${getActivitySchoolDisplayName(activity)}`;
+}
+
+export function buildActivitySearchText(activity) {
+  const parts = [
+    activity?.RowID,
+    activity?.row_id,
+    activity?.activity_no,
+    getActivityName(activity),
+    getActivityAuthorityName(activity),
+    getActivityDistrict(activity),
+    getActivityInstructorName(activity),
+    activity?.instructor_name,
+    activity?.instructor,
+    activity?.guide_name,
+    activity?.guide,
+    activity?.authority,
+    activity?.legacy_authority,
+    activity?.authority_name,
+    activity?.school,
+    activity?.legacy_school,
+    activity?.single_school_name,
+    activity?.linked_school_names,
+    activity?.single_semel_mosad,
+    activity?.linked_semel_mosad_list,
+    activity?.status,
+    getActivityPrimaryDate(activity),
+    ...getActivityScheduleDates(activity),
+    ...getActivitySchoolNames(activity)
+  ];
+  return parts.map((v) => String(v || '').trim()).filter(Boolean).join(' ').toLowerCase();
+}

--- a/frontend/src/screens/shared/operations-activity-helpers.js
+++ b/frontend/src/screens/shared/operations-activity-helpers.js
@@ -117,6 +117,163 @@ export function getActivityTimeRange(activity) {
   return start || end || '';
 }
 
+export const WORKSHOP_ESTIMATE_PER_ACTIVITY = 25;
+
+function parsePositiveNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+function parseJsonObject(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeWorkshopProductKey(name) {
+  return String(name || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function parseStockQuantityFromRow(row = {}) {
+  const candidates = [
+    row.stock_quantity,
+    row.stock_qty,
+    row.inventory_quantity,
+    row.inventory_qty,
+    row.stock,
+    row.inventory,
+    row.quantity,
+    row.amount,
+    row.qty
+  ];
+  for (const candidate of candidates) {
+    const n = parsePositiveNumber(candidate);
+    if (n !== null) return n;
+  }
+  const metadata = parseJsonObject(row.metadata);
+  if (metadata) {
+    for (const key of ['stock_quantity', 'stock_qty', 'inventory_quantity', 'inventory', 'stock', 'quantity']) {
+      const n = parsePositiveNumber(metadata[key]);
+      if (n !== null) return n;
+    }
+  }
+  return null;
+}
+
+const STOCK_LIST_CATEGORIES = new Set([
+  'workshop_stock',
+  'product_stock',
+  'inventory',
+  'stock',
+  'workshop_inventory',
+  'product_inventory',
+  'מלאי',
+  'מלאי סדנאות',
+  'מלאי תוצרים'
+]);
+
+const ACTIVITY_NAME_LIST_CATEGORIES = new Set([
+  'activity_names',
+  'activity_name',
+  'activities',
+  'activity'
+]);
+
+function addStockToMap(map, names, stock) {
+  if (stock === null) return;
+  names.map((name) => String(name || '').trim()).filter(Boolean).forEach((name) => {
+    map.set(normalizeWorkshopProductKey(name), stock);
+  });
+}
+
+export function buildWorkshopStockMapFromLists(listsData) {
+  const map = new Map();
+  const categories = Array.isArray(listsData?.categories) ? listsData.categories : [];
+  categories.forEach(({ category, items }) => {
+    const cat = String(category || '').trim().toLowerCase();
+    const list = Array.isArray(items) ? items : [];
+    const isStockCategory = STOCK_LIST_CATEGORIES.has(cat);
+    const isActivityNamesCategory = ACTIVITY_NAME_LIST_CATEGORIES.has(cat);
+    if (!isStockCategory && !isActivityNamesCategory) return;
+    list.forEach((item) => {
+      const row = item?._row && typeof item._row === 'object' ? item._row : item;
+      const stock = parseStockQuantityFromRow(row);
+      if (stock === null) return;
+      const names = isStockCategory
+        ? [item?.value, item?.label, row?.product_name, row?.item_name, row?.activity_name, row?.workshop_name]
+        : [item?.value, item?.label, row?.activity_name, row?.label_he];
+      addStockToMap(map, names, stock);
+    });
+  });
+  return map;
+}
+
+export function getWorkshopStockQuantity(productName, stockMap) {
+  if (!(stockMap instanceof Map)) return null;
+  const key = normalizeWorkshopProductKey(productName);
+  if (!key || !stockMap.has(key)) return null;
+  return stockMap.get(key);
+}
+
+export function getActivityActualParticipantCount(activity) {
+  const fields = [
+    'participants_count',
+    'participant_count',
+    'students_count',
+    'student_count',
+    'num_participants',
+    'num_students',
+    'participants',
+    'students',
+    'total_participants',
+    'total_students'
+  ];
+  for (const field of fields) {
+    const n = parsePositiveNumber(activity?.[field]);
+    if (n !== null && n > 0) return n;
+  }
+  return null;
+}
+
+export function sumActivityParticipantCounts(activities = []) {
+  let total = 0;
+  let hasAny = false;
+  (Array.isArray(activities) ? activities : []).forEach((activity) => {
+    const count = getActivityActualParticipantCount(activity);
+    if (count === null) return;
+    total += count;
+    hasAny = true;
+  });
+  return hasAny ? total : null;
+}
+
+export function buildWorkshopQuantityMetrics({ workshopName, activityCount, activities = [], stockMap } = {}) {
+  const count = Number(activityCount || 0);
+  const estimatedQuantity = count * WORKSHOP_ESTIMATE_PER_ACTIVITY;
+  const actualQuantity = sumActivityParticipantCounts(activities);
+  const stockQuantity = getWorkshopStockQuantity(workshopName, stockMap);
+  let gap = null;
+  if (stockQuantity !== null) {
+    const required = actualQuantity !== null ? actualQuantity : estimatedQuantity;
+    gap = stockQuantity - required;
+  }
+  return {
+    workshopName: String(workshopName || '').trim(),
+    activityCount: count,
+    estimatedQuantity,
+    actualQuantity,
+    stockQuantity,
+    gap
+  };
+}
+
 export function getActivityGroupsCount(activity) {
   const raw = activity?.groups_count ?? activity?.group_count ?? activity?.num_groups ?? activity?.groups ?? '';
   const text = String(raw || '').trim();

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15489,101 +15489,199 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 /* ═══════════════════════════════════════════════════════════════════
    Operations management screen
    ═══════════════════════════════════════════════════════════════════ */
-.ds-ops-mgmt-filters {
-  margin-bottom: 0.75rem;
+.ds-ops-mgmt-screen {
+  gap: 0.65rem;
 }
 
-.ds-ops-mgmt-filters__row {
+.ds-ops-mgmt-screen .ds-page-header {
+  margin-bottom: 0.15rem;
+}
+
+.ds-ops-mgmt-filters {
+  margin: 0;
+}
+
+.ds-ops-mgmt-filters__grid {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.ds-ops-mgmt-filters .ds-filter-field--search {
+  grid-column: span 2;
+}
+
+.ds-ops-mgmt-filters__actions {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 0.75rem;
   align-items: end;
+  justify-content: flex-end;
 }
 
 .ds-ops-mgmt-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  margin: 0.5rem 0 0.75rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0.15rem 0 0.35rem;
 }
 
-.ds-ops-mgmt-tab {
-  border: 1px solid var(--ds-border, #d5dde8);
-  background: var(--ds-surface, #fff);
-  color: var(--ds-text, #0f172a);
-  border-radius: 999px;
-  padding: 0.35rem 0.8rem;
-  font-size: 0.82rem;
-  cursor: pointer;
+.ds-ops-mgmt-content {
+  display: grid;
+  gap: 0.55rem;
 }
 
-.ds-ops-mgmt-tab.is-active {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #fff;
+.ds-ops-mgmt-panel {
+  display: grid;
+  gap: 0.55rem;
 }
 
 .ds-ops-mgmt-summary {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7.5rem, 1fr));
   gap: 0.45rem;
-  margin-bottom: 0.75rem;
 }
 
 .ds-ops-mgmt-summary__card {
-  min-width: 7rem;
-  border: 1px solid var(--ds-border, #d5dde8);
-  border-radius: 8px;
-  padding: 0.45rem 0.6rem;
-  background: var(--ds-surface-muted, #f8fafc);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  gap: 0.1rem 0.45rem;
+  align-items: center;
+  min-height: 3.4rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--ds-border) 88%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ds-accent) 3%, var(--ds-surface));
+}
+
+.ds-ops-mgmt-summary__card--alert {
+  border-color: color-mix(in srgb, #f59e0b 35%, var(--ds-border));
+  background: color-mix(in srgb, #f59e0b 7%, var(--ds-surface));
+}
+
+.ds-ops-mgmt-summary__card--ok {
+  border-color: color-mix(in srgb, #16a34a 24%, var(--ds-border));
+}
+
+.ds-ops-mgmt-summary__icon {
+  grid-row: 1 / span 2;
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0.9;
 }
 
 .ds-ops-mgmt-summary__label {
-  display: block;
   font-size: 0.72rem;
-  color: var(--ds-text-muted, #64748b);
+  color: var(--ds-text-muted);
+  line-height: 1.2;
 }
 
 .ds-ops-mgmt-summary__value {
-  font-size: 0.95rem;
+  font-size: 1.15rem;
+  line-height: 1.1;
+  color: var(--ds-text);
 }
 
 .ds-ops-mgmt-panel__toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
   align-items: end;
-  margin-bottom: 0.65rem;
+  justify-content: space-between;
 }
 
-.ds-ops-mgmt-subtitle {
-  margin: 0.85rem 0 0.45rem;
-  font-size: 0.95rem;
+.ds-ops-mgmt-instructor-field {
+  min-width: min(100%, 16rem);
 }
 
 .ds-ops-mgmt-count {
-  margin-top: 0.5rem;
-  font-size: 0.78rem;
+  margin: 0;
+  font-size: 0.76rem;
 }
 
+.ds-ops-mgmt-cell-muted {
+  color: var(--ds-text-muted);
+}
+
+.ds-ops-mgmt-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+}
+
+.ds-ops-mgmt-data-table th,
+.ds-ops-mgmt-data-table td,
 .ds-ops-mgmt-schedule th,
 .ds-ops-mgmt-schedule td {
   font-size: 0.78rem;
-  white-space: nowrap;
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+  vertical-align: top;
 }
 
-.ds-link-btn {
-  border: 0;
-  background: none;
-  color: #2563eb;
-  cursor: pointer;
-  padding: 0;
-  font: inherit;
-  text-decoration: underline;
+.ds-ops-mgmt-schedule tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--ds-accent) 2.5%, var(--ds-surface));
+}
+
+.ds-ops-col--date,
+.ds-ops-col--school,
+.ds-ops-col--instructor {
+  color: var(--ds-text);
+}
+
+.ds-ops-mgmt-screen .ds-card {
+  margin: 0;
+}
+
+.ds-ops-mgmt-screen .ds-card__head {
+  padding: 0.55rem 0.7rem;
+}
+
+.ds-ops-mgmt-screen .ds-card__title {
+  font-size: 0.92rem;
+}
+
+.ds-ops-mgmt-screen .ds-table-wrap {
+  overflow-x: auto;
 }
 
 .only-print {
   display: none;
+}
+
+@media (max-width: 1100px) {
+  .ds-ops-mgmt-filters__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .ds-ops-mgmt-filters .ds-filter-field--search {
+    grid-column: span 3;
+  }
+}
+
+@media (max-width: 720px) {
+  .ds-ops-mgmt-filters__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ds-ops-mgmt-filters .ds-filter-field--search,
+  .ds-ops-mgmt-filters__actions {
+    grid-column: 1 / -1;
+  }
+
+  .ds-ops-mgmt-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ds-ops-mgmt-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .ds-ops-mgmt-filters__grid,
+  .ds-ops-mgmt-summary {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media print {
@@ -15591,7 +15689,10 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   body.is-ops-mgmt-print .app-shell .shell-top,
   body.is-ops-mgmt-print .no-print,
   body.is-ops-mgmt-print .ds-ops-mgmt-tabs,
-  body.is-ops-mgmt-print .ds-page-header__subtitle {
+  body.is-ops-mgmt-print .ds-page-header__subtitle,
+  body.is-ops-mgmt-print .ds-ops-mgmt-summary,
+  body.is-ops-mgmt-print .ds-card__head,
+  body.is-ops-mgmt-print .ds-ops-mgmt-count {
     display: none !important;
   }
 
@@ -15599,22 +15700,60 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     display: block !important;
   }
 
+  body.is-ops-mgmt-print .ds-ops-mgmt-print-header {
+    margin: 0 0 10mm;
+    text-align: center;
+  }
+
   body.is-ops-mgmt-print .ds-ops-mgmt-print-header h2 {
-    margin: 0 0 0.25rem;
-    font-size: 1.1rem;
+    margin: 0 0 2mm;
+    font-size: 16pt;
+    font-weight: 800;
   }
 
   body.is-ops-mgmt-print .ds-ops-mgmt-print-header p {
-    margin: 0 0 0.75rem;
+    margin: 0;
+    font-size: 11pt;
+    color: #334155;
   }
 
   body.is-ops-mgmt-print .ds-ops-mgmt-print-footer {
-    margin-top: 1rem;
-    font-size: 0.85rem;
+    margin-top: 8mm;
+    font-size: 9.5pt;
+    color: #475569;
+    text-align: center;
   }
 
   body.is-ops-mgmt-print .ds-ops-mgmt-schedule {
     width: 100%;
     font-size: 9pt;
+    border-collapse: collapse;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule th,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule td {
+    border: 1px solid #cbd5e1;
+    padding: 2.5mm 2mm;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule thead th {
+    background: #e2e8f0 !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-col--groups,
+  body.is-ops-mgmt-print .ds-ops-col--grade,
+  body.is-ops-mgmt-print .ds-ops-col--address,
+  body.is-ops-mgmt-print .ds-ops-col--contact,
+  body.is-ops-mgmt-print .ds-ops-col--phone,
+  body.is-ops-mgmt-print .ds-ops-col--notes,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--groups,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--grade,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--address,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--contact,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--phone,
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--notes {
+    display: none !important;
   }
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15600,6 +15600,25 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   color: var(--ds-text-muted);
 }
 
+.ds-ops-mgmt-note {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--ds-text-muted);
+  line-height: 1.45;
+}
+
+.ds-ops-gap {
+  font-weight: 700;
+}
+
+.ds-ops-gap--ok {
+  color: #15803d;
+}
+
+.ds-ops-gap--shortage {
+  color: #b45309;
+}
+
 .ds-ops-mgmt-tags {
   display: inline-flex;
   flex-wrap: wrap;
@@ -15755,5 +15774,17 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--phone,
   body.is-ops-mgmt-print .ds-ops-mgmt-schedule .ds-ops-col--notes {
     display: none !important;
+  }
+
+  body.is-ops-mgmt-print-workshops .ds-ops-workshops-table {
+    width: 100%;
+    font-size: 9pt;
+    border-collapse: collapse;
+  }
+
+  body.is-ops-mgmt-print-workshops .ds-ops-workshops-table th,
+  body.is-ops-mgmt-print-workshops .ds-ops-workshops-table td {
+    border: 1px solid #cbd5e1;
+    padding: 2.5mm 2mm;
   }
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15485,3 +15485,136 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     font-size: 10pt !important;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Operations management screen
+   ═══════════════════════════════════════════════════════════════════ */
+.ds-ops-mgmt-filters {
+  margin-bottom: 0.75rem;
+}
+
+.ds-ops-mgmt-filters__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: end;
+}
+
+.ds-ops-mgmt-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.ds-ops-mgmt-tab {
+  border: 1px solid var(--ds-border, #d5dde8);
+  background: var(--ds-surface, #fff);
+  color: var(--ds-text, #0f172a);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.ds-ops-mgmt-tab.is-active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.ds-ops-mgmt-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.75rem;
+}
+
+.ds-ops-mgmt-summary__card {
+  min-width: 7rem;
+  border: 1px solid var(--ds-border, #d5dde8);
+  border-radius: 8px;
+  padding: 0.45rem 0.6rem;
+  background: var(--ds-surface-muted, #f8fafc);
+}
+
+.ds-ops-mgmt-summary__label {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--ds-text-muted, #64748b);
+}
+
+.ds-ops-mgmt-summary__value {
+  font-size: 0.95rem;
+}
+
+.ds-ops-mgmt-panel__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: end;
+  margin-bottom: 0.65rem;
+}
+
+.ds-ops-mgmt-subtitle {
+  margin: 0.85rem 0 0.45rem;
+  font-size: 0.95rem;
+}
+
+.ds-ops-mgmt-count {
+  margin-top: 0.5rem;
+  font-size: 0.78rem;
+}
+
+.ds-ops-mgmt-schedule th,
+.ds-ops-mgmt-schedule td {
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.ds-link-btn {
+  border: 0;
+  background: none;
+  color: #2563eb;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.only-print {
+  display: none;
+}
+
+@media print {
+  body.is-ops-mgmt-print .app-shell .shell-sidebar,
+  body.is-ops-mgmt-print .app-shell .shell-top,
+  body.is-ops-mgmt-print .no-print,
+  body.is-ops-mgmt-print .ds-ops-mgmt-tabs,
+  body.is-ops-mgmt-print .ds-page-header__subtitle {
+    display: none !important;
+  }
+
+  body.is-ops-mgmt-print .only-print {
+    display: block !important;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-mgmt-print-header h2 {
+    margin: 0 0 0.25rem;
+    font-size: 1.1rem;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-mgmt-print-header p {
+    margin: 0 0 0.75rem;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-mgmt-print-footer {
+    margin-top: 1rem;
+    font-size: 0.85rem;
+  }
+
+  body.is-ops-mgmt-print .ds-ops-mgmt-schedule {
+    width: 100%;
+    font-size: 9pt;
+  }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 736;
+const CACHE_VERSION = 737;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 734;
+const CACHE_VERSION = 735;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 735;
+const CACHE_VERSION = 736;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 733;
+const CACHE_VERSION = 734;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 719;
+const SW_ENTRY_VERSION = 734;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 736;
+const SW_ENTRY_VERSION = 737;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 735;
+const SW_ENTRY_VERSION = 736;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 734;
+const SW_ENTRY_VERSION = 735;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -1,0 +1,128 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  getActivitySchoolDisplayName,
+  hasActivitySchoolOrFrame,
+  getActivityInstructorName,
+  getActivityPrimaryDate,
+  getActivitySchoolNames,
+  isSummerOperationsException
+} from '../frontend/src/screens/shared/operations-activity-helpers.js';
+import { operationsManagementScreen } from '../frontend/src/screens/operations-management.js';
+
+function baseState(overrides = {}) {
+  return {
+    operationsManagement: {
+      tab: 'instructors',
+      period: 'all',
+      dateFrom: '2026-01-01',
+      dateTo: '2026-12-31',
+      instructor: '__all__',
+      expandedWorkshop: '',
+      expandedSchool: ''
+    },
+    listFilters: {
+      'operations-management': { q: '', appliedQ: '', status: 'פתוח', visibleCount: 200 }
+    },
+    ...overrides
+  };
+}
+
+const TEXT_SCHOOL_ROWS = [
+  { RowID: 'LONG-210', status: 'פתוח', authority: 'בנימינה', school: 'מתנ"ס בנימינה גבעת עדה', activity_name: 'סדנה א', start_date: '2026-04-10', instructor_name: 'דני' },
+  { RowID: 'LONG-211', status: 'פתוח', authority: 'בנימינה', school: 'מתנ"ס בנימינה גבעת עדה', activity_name: 'סדנה ב', start_date: '2026-04-11', instructor_name: 'דני' },
+  { RowID: 'LONG-027', status: 'פתוח', authority: 'דלית אל-כרמל', school: 'אלאשראק', activity_name: 'סדנה ג', start_date: '2026-04-12', instructor_name: 'מיה' },
+  { RowID: 'LONG-032', status: 'פתוח', authority: 'גוש עציון', school: 'יד בנימין', activity_name: 'סדנה ד', start_date: '2026-04-13', instructor_name: 'רון' },
+  { RowID: 'LONG-212', status: 'פתוח', authority: 'רשות א', school: 'מתנ"ס', activity_name: 'סדנה ה', start_date: '2026-04-14', instructor_name: 'נועה' },
+  { RowID: 'LONG-213', status: 'פתוח', authority: 'רשות ב', school: 'מתנ"ס', activity_name: 'סדנה ו', start_date: '2026-04-15', instructor_name: 'נועה' }
+];
+
+test('getActivitySchoolDisplayName supports linked, single and text schools', () => {
+  assert.equal(getActivitySchoolDisplayName({ linked_school_names: 'בן צבי + ויצמן' }), 'בן צבי + ויצמן');
+  assert.equal(getActivitySchoolDisplayName({ school: 'מתנ"ס' }), 'מתנ"ס');
+  assert.equal(getActivitySchoolDisplayName({ school: 'מתנ"ס בנימינה גבעת עדה' }), 'מתנ"ס בנימינה גבעת עדה');
+  assert.equal(getActivitySchoolDisplayName({ school: 'אלאשראק' }), 'אלאשראק');
+  assert.equal(getActivitySchoolDisplayName({ school: 'יד בנימין' }), 'יד בנימין');
+  assert.equal(getActivitySchoolDisplayName({}), 'לא משויך');
+});
+
+test('hasActivitySchoolOrFrame detects text and linked schools without school_id', () => {
+  assert.equal(hasActivitySchoolOrFrame({ school: 'מתנ"ס' }), true);
+  assert.equal(hasActivitySchoolOrFrame({ linked_schools_count: 2, linked_school_names: 'בן צבי + ויצמן' }), true);
+  assert.equal(hasActivitySchoolOrFrame({}), false);
+});
+
+test('getActivityInstructorName priority and invalid names', () => {
+  assert.equal(getActivityInstructorName({ instructor_name: 'אבי', guide: 'גיא' }), 'אבי');
+  assert.equal(getActivityInstructorName({ guide_name: 'גיא' }), 'גיא');
+  assert.equal(getActivityInstructorName({ instructor_name: 'לא משויך' }), 'לא משויך');
+  assert.equal(getActivityInstructorName({}), 'לא משויך');
+});
+
+test('getActivityPrimaryDate uses start_date and meeting dates', () => {
+  assert.equal(getActivityPrimaryDate({ start_date: '2026-05-01' }), '2026-05-01');
+  assert.equal(getActivityPrimaryDate({ date_1: '2026-05-02' }), '2026-05-02');
+  assert.equal(getActivityPrimaryDate({ meeting_dates: ['2026-05-03'] }), '2026-05-03');
+  assert.equal(getActivityPrimaryDate({}), '');
+});
+
+test('multi-school activity names are searchable and displayed', () => {
+  const row = {
+    RowID: 'MULTI-1',
+    status: 'פתוח',
+    linked_schools_count: 2,
+    linked_school_names: 'בן צבי + ויצמן',
+    legacy_school: 'ויצמן+בן צבי',
+    activity_name: 'סדנה משותפת',
+    start_date: '2026-04-20',
+    instructor_name: 'שירה'
+  };
+  assert.equal(getActivitySchoolDisplayName(row), 'בן צבי + ויצמן');
+  assert.equal(hasActivitySchoolOrFrame(row), true);
+  assert.ok(getActivitySchoolNames(row).some((name) => name.includes('ויצמן')));
+  assert.ok(getActivitySchoolNames(row).some((name) => name.includes('בן צבי')));
+});
+
+test('summer exceptions only include missing instructor or missing date', () => {
+  assert.equal(isSummerOperationsException({ activity_season: 'summer_2026', status: 'פתוח', instructor_name: '', start_date: '' }), true);
+  assert.equal(isSummerOperationsException({ activity_season: 'summer_2026', status: 'פתוח', instructor_name: 'דני', start_date: '2026-07-05' }), false);
+  assert.equal(isSummerOperationsException({ activity_season: 'regular', status: 'פתוח', instructor_name: '', start_date: '' }), false);
+});
+
+test('operations management render includes menu page structure and tabs', () => {
+  const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS }, { state: baseState() });
+  assert.match(html, /ניהול תפעול/);
+  assert.match(html, /סידור מדריכים/);
+  assert.match(html, /תכנון קיץ/);
+  assert.match(html, /כמויות סדנאות/);
+  assert.match(html, /לפי בתי ספר/);
+  assert.match(html, /הדפס סידור מדריך/);
+  assert.doesNotMatch(html, /סמל מוסד/);
+});
+
+test('operations management render shows text-school activities without school_id', () => {
+  const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS }, { state: baseState() });
+  assert.match(html, /מתנ(&quot;|")ס בנימינה גבעת עדה/);
+  assert.match(html, /אלאשראק/);
+  assert.match(html, /יד בנימין/);
+  assert.match(html, /מתנ(&quot;|")ס/);
+});
+
+test('route registration exists for operations-management', async () => {
+  const mainSrc = await readFile(new URL('../frontend/src/main.js', import.meta.url), 'utf8');
+  const apiSrc = await readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  const navSrc = await readFile(new URL('../frontend/src/screens/shared/act-nav-grid.js', import.meta.url), 'utf8');
+  assert.match(mainSrc, /'operations-management':/);
+  assert.match(apiSrc, /'operations-management'/);
+  assert.match(navSrc, /operations-management/);
+});
+
+test('service worker cache versions are aligned', async () => {
+  const frontendSw = await readFile(new URL('../frontend/sw.js', import.meta.url), 'utf8');
+  const rootSw = await readFile(new URL('../sw.js', import.meta.url), 'utf8');
+  const frontendMatch = frontendSw.match(/CACHE_VERSION = (\d+)/);
+  const rootMatch = rootSw.match(/SW_ENTRY_VERSION = (\d+)/);
+  assert.ok(frontendMatch && rootMatch);
+  assert.equal(frontendMatch[1], rootMatch[1]);
+});

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -98,6 +98,9 @@ test('operations management render includes menu page structure and tabs', () =>
   assert.match(html, /כמויות סדנאות/);
   assert.match(html, /לפי בתי ספר/);
   assert.match(html, /הדפס סידור מדריך/);
+  assert.match(html, /ds-filter-panel/);
+  assert.match(html, /ds-ops-mgmt-summary/);
+  assert.match(html, /ds-exceptions-tabs/);
   assert.doesNotMatch(html, /סמל מוסד/);
 });
 

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -7,7 +7,11 @@ import {
   getActivityInstructorName,
   getActivityPrimaryDate,
   getActivitySchoolNames,
-  isSummerOperationsException
+  isSummerOperationsException,
+  buildWorkshopStockMapFromLists,
+  buildWorkshopQuantityMetrics,
+  getActivityActualParticipantCount,
+  WORKSHOP_ESTIMATE_PER_ACTIVITY
 } from '../frontend/src/screens/shared/operations-activity-helpers.js';
 import { operationsManagementScreen } from '../frontend/src/screens/operations-management.js';
 
@@ -91,7 +95,7 @@ test('summer exceptions only include missing instructor or missing date', () => 
 });
 
 test('operations management render includes menu page structure and tabs', () => {
-  const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS }, { state: baseState() });
+  const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS, workshopStockMap: new Map() }, { state: baseState() });
   assert.match(html, /ניהול תפעול/);
   assert.match(html, /סידור מדריכים/);
   assert.match(html, /תכנון קיץ/);
@@ -104,8 +108,75 @@ test('operations management render includes menu page structure and tabs', () =>
   assert.doesNotMatch(html, /סמל מוסד/);
 });
 
+test('workshop quantity metrics use x25 estimate and stock gap rules', () => {
+  const stockMap = buildWorkshopStockMapFromLists({
+    categories: [{
+      category: 'workshop_stock',
+      items: [{ label: 'פרוגי המקפצת', value: 'פרוגי המקפצת', _row: { stock_quantity: 300 } }]
+    }]
+  });
+  const withActual = buildWorkshopQuantityMetrics({
+    workshopName: 'פרוגי המקפצת',
+    activityCount: 10,
+    activities: [{ participants_count: 120 }, { participants_count: 118 }],
+    stockMap
+  });
+  assert.equal(withActual.estimatedQuantity, 250);
+  assert.equal(withActual.actualQuantity, 238);
+  assert.equal(withActual.stockQuantity, 300);
+  assert.equal(withActual.gap, 62);
+
+  const withoutActual = buildWorkshopQuantityMetrics({
+    workshopName: 'אסטרונאוט על חוטים',
+    activityCount: 8,
+    activities: [{ activity_name: 'אסטרונאוט על חוטים' }],
+    stockMap: buildWorkshopStockMapFromLists({
+      categories: [{ category: 'inventory', items: [{ value: 'אסטרונאוט על חוטים', _row: { inventory: 150 } }] }]
+    })
+  });
+  assert.equal(withoutActual.estimatedQuantity, 200);
+  assert.equal(withoutActual.actualQuantity, null);
+  assert.equal(withoutActual.gap, -50);
+
+  const noStock = buildWorkshopQuantityMetrics({
+    workshopName: 'צמידי שמש',
+    activityCount: 12,
+    activities: [],
+    stockMap: new Map()
+  });
+  assert.equal(noStock.estimatedQuantity, 300);
+  assert.equal(noStock.stockQuantity, null);
+  assert.equal(noStock.gap, null);
+});
+
+test('workshops tab shows inventory columns and print action', () => {
+  const state = baseState();
+  state.operationsManagement.tab = 'workshops';
+  const rows = [
+    { RowID: 'W-1', status: 'פתוח', activity_name: 'פרוגי המקפצת', start_date: '2026-04-10', participants_count: 120 },
+    { RowID: 'W-2', status: 'פתוח', activity_name: 'פרוגי המקפצת', start_date: '2026-04-11', participants_count: 118 }
+  ];
+  const stockMap = buildWorkshopStockMapFromLists({
+    categories: [{ category: 'workshop_stock', items: [{ value: 'פרוגי המקפצת', _row: { stock_quantity: 300 } }] }]
+  });
+  const html = operationsManagementScreen.render({ rows, workshopStockMap: stockMap }, { state });
+  assert.match(html, /כמות משוערת לפי 25/);
+  assert.match(html, /כמות במלאי/);
+  assert.match(html, /פער מול מלאי/);
+  assert.match(html, /הדפס כמויות סדנאות/);
+  assert.match(html, /ds-ops-gap--ok/);
+  assert.match(html, />62</);
+  assert.match(html, />300</);
+  assert.match(html, />238</);
+});
+
+test('actual participant count only uses existing activity fields', () => {
+  assert.equal(getActivityActualParticipantCount({ participants_count: 25 }), 25);
+  assert.equal(getActivityActualParticipantCount({ activity_name: 'סדנה' }), null);
+});
+
 test('operations management render shows text-school activities without school_id', () => {
-  const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS }, { state: baseState() });
+  const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS, workshopStockMap: new Map() }, { state: baseState() });
   assert.match(html, /מתנ(&quot;|")ס בנימינה גבעת עדה/);
   assert.match(html, /אלאשראק/);
   assert.match(html, /יד בנימין/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new **ניהול תפעול** screen at route `operations-management` for daily operational work:

- **סידור מדריכים** — instructor schedule by date range with print support
- **תכנון קיץ** — summer overview with district/instructor breakdowns and summer exceptions
- **כמויות סדנאות** — workshop counts by activity name with expandable detail
- **לפי בתי ספר** — activities grouped by authority/school with expandable detail

## Data source

Reads from existing `api.allActivities()` → `public.activities` (normalized via `normalizeActivityRow`). No API/Supabase/schema changes.

## Key features

- Shared top filters: date range, period, district, authority, school, instructor, workshop, status, free-text search
- Dynamic dependent filter options
- School display helpers support text-only schools and multi-school activities (`linked_school_names`, `school`, `legacy_school`)
- Summer exceptions limited to missing instructor or missing start/activity date
- Print button hides chrome and outputs a clean instructor schedule document
- Route available to `admin`, `operation_manager`, and `activities_manager`
- Service Worker cache bumped to **734** (both `frontend/sw.js` and `sw.js`)

## Testing

- `node --test tests/operations-management-screen.test.mjs` — 10 tests pass
- `npm run check:changed` — pass
- `npm run check:build` — pass

## Files changed

- `frontend/src/screens/operations-management.js` (new)
- `frontend/src/screens/shared/operations-activity-helpers.js` (new)
- `frontend/src/main.js` — route registration
- `frontend/src/api.js` — role routes
- `frontend/src/screens/shared/act-nav-grid.js` — sub-nav entry
- `frontend/src/styles/main.css` — compact screen + print styles
- `frontend/sw.js`, `sw.js` — cache version bump
- `tests/operations-management-screen.test.mjs` (new)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ba0ff22-da1b-4cc2-978e-22fb701db1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ba0ff22-da1b-4cc2-978e-22fb701db1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

