### PR TITLE
Fix instructor contact cards display on contacts screen

### DIFF
--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -184,10 +184,6 @@ function instrDrawerHtml(row, hideEmpIds) {
 function renderInstrCard(row) {
   const nameRaw = row.full_name || row.emp_id || '—';
   const name = escapeHtml(nameRaw);
-  const phone = escapeHtml(row.mobile || '');
-  const email = row.email ? escapeHtml(String(row.email)) : '';
-  const roleRaw = String(row.contact_role || row.role || row.employment_type || '').trim();
-  const role = roleRaw ? escapeHtml(roleRaw) : '';
   const isInactive = String(row.active || '').toLowerCase() === 'no';
   const initials = escapeHtml(avatarInitials(nameRaw));
   const bg = avatarColor(row.emp_id || nameRaw);
@@ -199,9 +195,6 @@ function renderInstrCard(row) {
         <span class="ci-person-card__avatar" style="background:${bg}" aria-hidden="true">${initials}</span>
         <span class="ci-person-card__info">
           <span class="ci-person-card__name">${name}</span>
-          ${role ? `<span class="ci-person-card__role">${role}</span>` : ''}
-          <span class="ci-person-card__phone">${phone || '—'}</span>
-          <span class="ci-person-card__email">${email || '—'}</span>
         </span>
       </button>
       <span class="ci-person-card__actions">${actionBtn('edit-instr', { emp_id: row.emp_id }, '✎')}</span>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4497,21 +4497,22 @@ select.ds-input {
 .contacts-list-wrap {
   display: flex;
   flex-direction: column;
+  padding: 8px 12px 16px;
 }
 
 /* ── Instructor cards ── */
 .ci-person-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 8px;
-  padding: 8px 0 0;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 14px;
+  padding: 12px 4px 4px;
 }
 
 .ci-instr-count {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 2px 8px;
+  padding: 4px 4px 12px;
   font-size: 0.78rem;
   color: var(--ds-text-secondary);
 }
@@ -4538,23 +4539,23 @@ select.ds-input {
 }
 
 .ci-person-card-wrap .ci-person-card {
-  padding: 8px 10px 8px 28px;
-  min-height: 72px;
+  padding-block: 12px;
+  padding-inline: 12px 36px;
 }
 
 .ci-person-card__actions {
   position: absolute;
-  top: 4px;
-  inset-inline-start: 4px;
+  top: 8px;
+  inset-inline-end: 8px;
   z-index: 1;
   line-height: 1;
 }
 
 .ci-person-card {
   display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 8px 10px;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
   background: var(--ds-surface);
   border: 1px solid var(--ds-border);
   border-radius: var(--ds-radius-sm);
@@ -4594,19 +4595,19 @@ select.ds-input {
 .ci-person-card__info {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 2px;
   min-width: 0;
   flex: 1;
 }
 
 .ci-person-card__name {
-  font-size: 0.74rem;
+  font-size: 0.8rem;
   font-weight: 700;
   color: var(--ds-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  line-height: 1.3;
+  line-height: 1.35;
 }
 
 .ci-person-card__role {
@@ -5033,6 +5034,16 @@ select.ds-input {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .ci-person-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    padding: 10px 2px 2px;
+  }
+
+  .contacts-list-wrap {
+    padding: 6px 8px 12px;
+  }
+
   .sc-person__contact-sep {
     display: none;
   }
@@ -5057,7 +5068,8 @@ select.ds-input {
   }
 
   .ci-person-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the **אנשי קשר מדריכים** tab on the contacts screen (`אנשי קשר > אנשי קשר מדריכים`).

## Changes

### 1. Edit icon position
- Moved the edit button from `inset-inline-start` (overlapping the colorful avatar) to `inset-inline-end` (opposite side of the card).
- Added inline-end padding on the card so the name does not run under the edit icon.

### 2. Outer card content
- The collapsed instructor card now shows **only the guide name** (plus avatar).
- Phone, email, and role are no longer rendered on the outer card.
- Full details remain available via the existing drawer (`instrDrawerHtml`) when clicking the card.

### 3. Spacing
- Increased grid gap and padding (`ci-person-grid`, `contacts-list-wrap`).
- Cards use more comfortable internal padding and vertical alignment.
- Mobile: 2-column grid at ≤760px and ≤560px (instead of collapsing to a single column).

## Files changed
- `frontend/src/screens/contacts.js` — simplified `renderInstrCard`
- `frontend/src/styles/main.css` — layout/spacing CSS for instructor cards only

## Not changed
- Contact data / Supabase
- Avatar colors
- Drawer open mechanism and drawer content
- School contacts tab or other contact pages

## Verification
- `node --check frontend/src/screens/contacts.js` ✅
- `npm run check:changed` ✅
- `npm run check:build` ✅

## Acceptance criteria
- [x] Outer card shows only guide name
- [x] Edit icon does not overlap the colorful avatar box
- [x] Clicking a card still opens full details in the drawer
- [x] No phone / email / role on the outer card
- [x] More spacing between cards and from page edges
- [x] Responsive layout for desktop and mobile
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e40750d5-09cb-4898-b391-8f4916c98a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e40750d5-09cb-4898-b391-8f4916c98a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

