### PR TITLE
Bump service worker cache to v738 after instructor card CSS changes

### DIFF
--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 737;
+const CACHE_VERSION = 738;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/replit.md
+++ b/replit.md
@@ -6,7 +6,7 @@ Preserve: RTL, Hebrew, dark shell + light panels. Communication with user: Hebre
 ## Runtime
 - Static server: `npx serve dist -l 5000` (workflow: "Start application")
 - SW cache bump: edit `CACHE_VERSION` in `frontend/sw.js` after any JS/CSS change.
-- **Current versions**: SW v733 (frontend/sw.js)
+- **Current versions**: SW v738 (frontend/sw.js + root sw.js)
 
 ## Key identifiers
 - Supabase URL: `https://szinlhjuwyiyszdpsdop.supabase.co` (anon key in `frontend/src/supabase-client.js`)

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 737;
+const SW_ENTRY_VERSION = 738;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -187,8 +187,10 @@ test('service worker cache version bumped for personal reports deploy', async ()
   const rootSw = await readFile(new URL('../sw.js', import.meta.url), 'utf8');
   const css = await readFile(new URL('../frontend/src/styles/main.css', import.meta.url), 'utf8');
 
-  assert.match(frontendSw, /const CACHE_VERSION = 609;/);
-  assert.match(rootSw, /const SW_ENTRY_VERSION = 609;/);
+  const frontendMatch = frontendSw.match(/const CACHE_VERSION = (\d+);/);
+  const rootMatch = rootSw.match(/const SW_ENTRY_VERSION = (\d+);/);
+  assert.ok(frontendMatch && rootMatch, 'service worker files should expose version constants');
+  assert.equal(frontendMatch[1], rootMatch[1], 'root and frontend SW versions should match');
   assert.match(css, /\.pr-input--month-compact/);
 });
 


### PR DESCRIPTION
- Align CACHE_VERSION (frontend/sw.js) and SW_ENTRY_VERSION (root sw.js)
- Update replit.md current SW version note
- Fix personal-reports SW test to assert version alignment instead of stale v609