### PR TITLE
Fix duplicate לכבוד block in proposal print/PDF header

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1520,7 +1520,6 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
           >
           ${dateDisplay ? `<div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>` : ''}
         </div>
-        ${recipientBlockHtml(row)}
       </div>
       <hr class="pa-doc-divider">
       <div class="proposal-document-body">

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1412,6 +1412,7 @@ test('proposal preview renders recipient block before title without empty commas
     const address = dom.window.document.querySelector('.pa-doc-address');
     const intro = dom.window.document.querySelector('.pa-doc-intro');
     assert.ok(subject, 'proposal title should render');
+    assert.equal(dom.window.document.querySelectorAll('.pa-doc-address').length, 1, 'recipient block should render once');
     assert.ok(address, 'recipient block should render');
     assert.ok(intro, 'intro should render after recipient block');
     assert.ok(address.compareDocumentPosition(subject) & dom.window.Node.DOCUMENT_POSITION_FOLLOWING);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes the duplicate `recipientBlockHtml(row)` call in `buildProposalDocumentHtml`, which caused the "לכבוד" customer block to render twice in print/PDF view (right and left).
- Keeps a single recipient block in the RTL header layout so it appears once on the right, with logo/date on the left.
- Adds a regression assertion that only one `.pa-doc-address` element is rendered in the proposal preview.

## Root cause

`buildProposalDocumentHtml` rendered `recipientBlockHtml(row)` twice inside `.proposal-document-header` — once before the logo block and once after it. With RTL flex layout, both copies were visible in print/PDF.

## Verification

- `node --check frontend/src/screens/proposals-agreements.js`
- `node --test tests/proposals-agreements-screen.test.mjs` — 64/64 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bcb2a27-8c3a-4fe1-85b7-7d5f3c759ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bcb2a27-8c3a-4fe1-85b7-7d5f3c759ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

