### PR TITLE
Update operations management test and bump SW cache to 740

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CekU3t2k.js"></script>
+  <script type="module" crossorigin src="./assets/index-NIEQucQY.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BWrCKHf6.css">
 </head>
 <body>

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 739;
+const CACHE_VERSION = 740;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/replit.md
+++ b/replit.md
@@ -6,7 +6,7 @@ Preserve: RTL, Hebrew, dark shell + light panels. Communication with user: Hebre
 ## Runtime
 - Static server: `npx serve dist -l 5000` (workflow: "Start application")
 - SW cache bump: edit `CACHE_VERSION` in `frontend/sw.js` after any JS/CSS change.
-- **Current versions**: SW v739 (frontend/sw.js + root sw.js)
+- **Current versions**: SW v740 (frontend/sw.js + root sw.js)
 
 ## Key identifiers
 - Supabase URL: `https://szinlhjuwyiyszdpsdop.supabase.co` (anon key in `frontend/src/supabase-client.js`)

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 739;
+const SW_ENTRY_VERSION = 740;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -98,7 +98,6 @@ test('operations management render includes menu page structure and tabs', () =>
   const html = operationsManagementScreen.render({ rows: TEXT_SCHOOL_ROWS, workshopStockMap: new Map() }, { state: baseState() });
   assert.match(html, /ניהול תפעול/);
   assert.match(html, /סידור מדריכים/);
-  assert.match(html, /תכנון קיץ/);
   assert.match(html, /כמויות סדנאות/);
   assert.match(html, /לפי בתי ספר/);
   assert.match(html, /הדפס סידור מדריך/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the obsolete `תכנון קיץ` tab assertion from the operations management screen test to match the simplified screen uploaded in `operations-management.js`.
- Bumps Service Worker cache version from **739 → 740** in both `frontend/sw.js` and root `sw.js`.
- Updates `replit.md` version note and `dist/index.html` build hash from `npm run check:build`.

## Verification
- `node --test tests/operations-management-screen.test.mjs` — 13/13 passed
- `npm run check:build` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be304587-e306-43cb-b2d4-9886d124de07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be304587-e306-43cb-b2d4-9886d124de07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

