### PR TITLE
Add operations management permission and route support

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-NIEQucQY.js"></script>
+  <script type="module" crossorigin src="./assets/index-CLwIYG_Y.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BWrCKHf6.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2575,6 +2575,9 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
   if ((isIsraaUser || isAdminRole) && permissionFlagYes(flat.view_israa_management)) {
     if (!allowedRoutes.includes('israa-management')) allowedRoutes.push('israa-management');
   }
+  if (permissionFlagYes(flat.view_operations_management) && !allowedRoutes.includes('operations-management')) {
+    allowedRoutes.push('operations-management');
+  }
   return {
     routes: [...allowedRoutes],
     default_route: allowedRoutes[0] || 'my-data',

--- a/frontend/src/screens/permissions.js
+++ b/frontend/src/screens/permissions.js
@@ -18,6 +18,7 @@ const KEY_PERM_FLAGS = [
   'view_orders',
   'view_proposals',
   'view_israa_management',
+  'view_operations_management',
   'finance_access',
   'can_access_personal_reports'
 ];

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -158,6 +158,7 @@ const PERMISSION_FIELD_LABELS = {
   view_exceptions: 'צפייה — חריגות',
   view_my_data: 'צפייה — הנתונים שלי',
   view_operations_data: 'צפייה — נתוני תפעול',
+  view_operations_management: 'צפייה — ניהול תפעול',
   finance_access: 'גישה — כספים / גבייה',
   can_access_personal_reports: 'גישה — דוחות אישיים',
   view_contacts_instructors: 'צפייה — אנשי קשר מדריכים',


### PR DESCRIPTION
## Summary
This PR adds support for a new "operations management" permission flag that allows users with the appropriate permission to access the operations management route.

## Key Changes
- **Permission Flag**: Added `view_operations_management` to the list of recognized permission flags in `permissions.js`
- **Route Authorization**: Updated `buildBootstrapFromUser()` in `api.js` to include the 'operations-management' route when the user has the `view_operations_management` permission
- **UI Labels**: Added Hebrew translation for the new permission in `ui-hebrew.js` as "צפייה — ניהול תפעול" (View - Operations Management)
- **Build Artifact**: Updated the compiled bundle reference in `index.html` (transitive change from build process)

## Implementation Details
The new permission follows the existing pattern used for other management routes (e.g., israa-management). When a user has the `view_operations_management` permission flag set to true, the 'operations-management' route is automatically added to their allowed routes during bootstrap initialization.

https://claude.ai/code/session_01QSKoDiGYFxeoo8feJrykLg