### PR TITLE
Fix proposal document header layout and SW cache bump

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -11692,13 +11692,14 @@ select.ds-input {
   box-sizing: border-box;
 }
 .proposal-document-header {
+  position: relative;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: flex-start;
-  gap: 16px;
   direction: rtl;
   width: 100%;
   max-width: 148mm;
+  min-height: 62px;
   margin-inline: auto;
   margin-bottom: 4pt;
   padding-top: 0;
@@ -11706,10 +11707,12 @@ select.ds-input {
 .proposal-header-brand {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   flex: 0 0 auto;
-  max-width: 42%;
+  max-width: 46%;
+  margin-inline: auto;
   direction: ltr;
+  text-align: center;
 }
 .proposal-logo {
   width: auto;
@@ -11799,23 +11802,24 @@ select.ds-input {
   text-align: left;
 }
 .pa-doc-date {
-  text-align: left;
+  width: 100%;
+  text-align: center;
   direction: ltr;
   font-size: 7pt;
   color: #6b7280;
   margin-top: 3pt;
 }
 .pa-doc-address {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
   direction: rtl;
   text-align: right;
   margin: 0;
-  margin-inline-start: auto;
   font-size: 9pt;
   line-height: 1.35;
-  flex: 0 1 auto;
   min-width: 0;
-  max-width: 55%;
-  align-self: flex-start;
+  max-width: 40%;
 }
 .pa-doc-address p {
   margin: 0 0 1pt;
@@ -12072,11 +12076,17 @@ select.ds-input {
   }
   .proposal-document-header {
     flex-direction: column;
-    align-items: stretch;
+    align-items: center;
     gap: 8px;
+    min-height: 0;
   }
   .proposal-header-brand {
     max-width: 100%;
+  }
+  .pa-doc-address {
+    position: static;
+    max-width: 100%;
+    align-self: stretch;
   }
   .proposal-logo {
     max-width: 140px;
@@ -12173,16 +12183,16 @@ select.ds-input {
     print-color-adjust: exact;
   }
 
-  /* Header — לכבוד ימין, לוגו+תאריך שמאל */
+  /* Header — centered logo/date, single recipient block on the right */
   .proposal-document-header {
-    position: static !important;
+    position: relative !important;
     display: flex !important;
-    justify-content: space-between !important;
+    justify-content: center !important;
     align-items: flex-start !important;
-    gap: 12px !important;
     direction: rtl !important;
     max-width: 148mm !important;
     width: 100% !important;
+    min-height: 17mm !important;
     margin-inline: auto !important;
     padding: 0 !important;
     margin-bottom: 3pt !important;
@@ -12191,9 +12201,11 @@ select.ds-input {
   .proposal-header-brand {
     display: flex !important;
     flex-direction: column !important;
-    align-items: flex-start !important;
-    max-width: 42% !important;
+    align-items: center !important;
+    max-width: 46% !important;
+    margin-inline: auto !important;
     direction: ltr !important;
+    text-align: center !important;
   }
   .proposal-logo {
     width: auto !important;
@@ -12254,23 +12266,24 @@ select.ds-input {
 
   /* ── Inner document content ───────────────────────────────────── */
   .pa-doc-date {
+    width: 100% !important;
     font-size: 7pt !important;
-    text-align: left !important;
+    text-align: center !important;
     direction: ltr !important;
     line-height: 1.3 !important;
     color: #6b7280 !important;
     margin-top: 2pt !important;
   }
   .pa-doc-address {
+    position: absolute !important;
+    inset-block-start: 0 !important;
+    inset-inline-start: 0 !important;
     direction: rtl !important;
     text-align: right !important;
     font-size: 9pt !important;
     line-height: 1.35 !important;
     margin: 0 !important;
-    margin-inline-start: auto !important;
-    flex: 0 1 auto !important;
-    max-width: 55% !important;
-    align-self: flex-start !important;
+    max-width: 40% !important;
     overflow-wrap: anywhere !important;
   }
   .pa-doc-address p {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 740;
+const CACHE_VERSION = 741;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/replit.md
+++ b/replit.md
@@ -6,7 +6,7 @@ Preserve: RTL, Hebrew, dark shell + light panels. Communication with user: Hebre
 ## Runtime
 - Static server: `npx serve dist -l 5000` (workflow: "Start application")
 - SW cache bump: edit `CACHE_VERSION` in `frontend/sw.js` after any JS/CSS change.
-- **Current versions**: SW v740 (frontend/sw.js + root sw.js)
+- **Current versions**: SW v741 (frontend/sw.js + root sw.js)
 
 ## Key identifiers
 - Supabase URL: `https://szinlhjuwyiyszdpsdop.supabase.co` (anon key in `frontend/src/supabase-client.js`)

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 740;
+const SW_ENTRY_VERSION = 741;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Ensure the proposal preview and printed/PDF output use a consistent header/layout: centered logo and date, a single right-aligned recipient block, correct currency direction in price tables, and stable signature/footer placement, and make sure clients pick up the updated CSS by bumping the service worker cache version.

### Description
- Adjusted `frontend/src/styles/main.css` to center the proposal logo and date, anchor the recipient block (`.pa-doc-address`) on the right, and align `@media print` rules with the regular preview rules so screen and PDF look consistent.
- Kept the signature and footer structure intact and preserved the existing `.pa-currency-amount` LTR/isolation styles to avoid currency placement or direction regressions.
- Bumped the service worker/cache version to `741` by updating `CACHE_VERSION` in `frontend/sw.js` and `SW_ENTRY_VERSION` in `sw.js`, and updated `replit.md` to reflect the new SW version.
- No changes were made to proposal text, data, calculations, Supabase logic, or business logic—only CSS and SW/version documentation were modified.

### Testing
- Ran `node --test tests/proposals-agreements-screen.test.mjs` (focused screen tests) and all tests passed (65 passed, 0 failed).
- Ran `npm run check:build` (production build) which completed successfully and produced `dist` assets.
- Ran `npm run check:changed` (focused checks) which completed with no errors.
- Modified files: `frontend/src/styles/main.css`, `frontend/sw.js`, `sw.js`, and `replit.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30576216b8832ba445523340ba7d8a)