### PR TITLE
Embed A4 proposal editor preview

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1925,12 +1925,25 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const primaryActionLabel = canApproveDirectly ? 'אישור והפקת הצעה' : 'שליחה לאישור';
   const primaryActionStatus = canApproveDirectly ? 'approved' : 'pending_approval';
 
-  return `<form class="ds-pa-form ds-pa-form--compact" data-pa-form data-pa-mode="${escapeHtml(mode)}" data-pa-id="${escapeHtml(row.id || '')}" data-pa-original-type="${escapeHtml(normalizedActivityGroup)}" dir="rtl">
+  const initialPreviewRow = normalizeProposalAgreementRow({
+    ...row,
+    document_type: text(row.document_type) || 'הצעת מחיר',
+    activity_type_group: normalizedActivityGroup,
+    proposal_date: proposalDate
+  });
+  const initialTemplateKey = proposalGroupTemplateKey(normalizedActivityGroup);
+  const initialTemplateSections = resolveDocumentSections(row, [])
+    .filter((section) => !text(section.template_key) || text(section.template_key) === initialTemplateKey);
+  const initialPreviewHtml = proposalPreviewBodyHtml(initialPreviewRow, items, initialTemplateSections);
+
+  return `<form class="ds-pa-form ds-pa-form--compact pa-editor" data-pa-form data-pa-mode="${escapeHtml(mode)}" data-pa-id="${escapeHtml(row.id || '')}" data-pa-original-type="${escapeHtml(normalizedActivityGroup)}" dir="rtl">
     <div class="ds-pa-form-header">
       <h3 class="ds-pa-form-title">${escapeHtml(title)}</h3>
       <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-cancel-form>ביטול</button>
     </div>
 
+    <div class="pa-editor-workspace">
+      <aside class="pa-sidebar" aria-label="עריכת פרטי הצעת מחיר">
     <div class="ds-pa-form-meta-panel">
       <div data-pa-step-panel="client">
         <div class="ds-pa-client-row" data-pa-client-search-row${isLocked ? ' hidden' : ''}>
@@ -1993,6 +2006,17 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
           <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-cancel-form>ביטול</button>
         </div>
       </div>
+    </div>
+      </aside>
+      <section class="pa-preview" aria-label="תצוגת מסמך A4">
+        <div class="pa-preview-toolbar no-print">
+          <span>תצוגה מקדימה חיה</span>
+          <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-preview-form>פתח לתצוגה / PDF</button>
+        </div>
+        <div class="pa-preview-canvas" data-pa-live-preview>
+          ${initialPreviewHtml}
+        </div>
+      </section>
     </div>
 
     <input type="hidden" name="status" data-pa-status-input value="${escapeHtml(currentStatus)}">
@@ -2802,6 +2826,21 @@ export const proposalsAgreementsScreen = {
     };
 
 
+    const updateLivePreview = (container) => {
+      const form = container?.closest?.('[data-pa-form]') || (container?.matches?.('[data-pa-form]') ? container : null);
+      const previewHost = form?.querySelector?.('[data-pa-live-preview]');
+      if (!form || !previewHost) return;
+      const payload = payloadFromForm(form);
+      const row = normalizeProposalAgreementRow({
+        ...payload,
+        id: text(form.dataset.paId),
+        proposal_date: payload.proposal_date || localDateInputValue()
+      });
+      const templateKey = proposalGroupTemplateKey(row.activity_type_group);
+      const templateSections = proposalTemplateSections.filter((section) => text(section.template_key) === templateKey);
+      previewHost.innerHTML = proposalPreviewBodyHtml(row, payload._items || [], templateSections);
+    };
+
     // ── Items calc ────────────────────────────────────────────────────────────
     const calcItemRow = (rowEl) => {
       const qty = parseFloat(rowEl.querySelector('[data-pa-item-qty]')?.value || '0') || 0;
@@ -2838,6 +2877,7 @@ export const proposalsAgreementsScreen = {
         if (typeEl) typeEl.textContent = proposalGroupDisplayName(form.querySelector('[name="activity_type_group"]')?.value) || '—';
         const countEl = form.querySelector('[data-pa-summary-count]');
         if (countEl) countEl.textContent = String(form.querySelectorAll('[data-pa-item-row]').length) || '—';
+        updateLivePreview(form);
       }
       return sum;
     };

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15971,3 +15971,84 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     white-space: nowrap !important;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Proposals – Proposaleditor-inspired official editor layout
+   Scoped to pa-editor/pa-sidebar/pa-preview so the dashboard stays isolated.
+   ═══════════════════════════════════════════════════════════════════ */
+.pa-editor.ds-pa-form--compact {
+  max-width: min(1760px, 100%);
+  margin-inline: auto;
+  padding: 12px;
+}
+.pa-editor-workspace {
+  display: grid;
+  grid-template-columns: minmax(340px, 430px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+.pa-sidebar {
+  position: sticky;
+  top: 76px;
+  max-height: calc(100vh - 96px);
+  overflow: auto;
+  padding: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  border: 1px solid #dbe7f3;
+  border-radius: 18px;
+  box-shadow: 0 14px 38px rgba(15, 23, 42, 0.08);
+}
+.pa-sidebar .ds-pa-form-meta-panel,
+.pa-sidebar .ds-pa-form-type-panel,
+.pa-sidebar .ds-pa-form-bottom-panel,
+.pa-sidebar .ds-pa-item-card {
+  border-color: #d7e3ef;
+  box-shadow: none;
+}
+.pa-preview {
+  min-width: 0;
+  padding: 14px 10px 26px;
+  border-radius: 22px;
+  background: radial-gradient(circle at top, #eef7ff 0%, #e2e8f0 42%, #d7dee8 100%);
+  border: 1px solid #d6e0eb;
+}
+.pa-preview-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin: 0 auto 12px;
+  max-width: 794px;
+  color: #334155;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+.pa-preview-canvas {
+  display: flex;
+  justify-content: center;
+  overflow-x: auto;
+  padding: 8px 4px 18px;
+}
+.pa-preview-canvas .proposal-document {
+  transform-origin: top center;
+}
+@media (max-width: 1180px) {
+  .pa-editor-workspace { grid-template-columns: 1fr; }
+  .pa-sidebar { position: static; max-height: none; }
+  .pa-preview { padding-inline: 4px; }
+}
+@media (max-width: 760px) {
+  .pa-editor.ds-pa-form--compact { padding: 8px 0; }
+  .pa-sidebar { border-radius: 14px; padding: 10px; }
+  .pa-preview { border-radius: 16px; margin-inline: -6px; }
+  .pa-preview-canvas { justify-content: flex-start; }
+  .pa-preview-canvas .proposal-document { min-width: 720px; }
+}
+@media print {
+  .pa-editor-workspace,
+  .pa-sidebar,
+  .pa-preview-toolbar { display: contents; }
+  .pa-sidebar { display: none !important; }
+  .pa-preview { padding: 0 !important; background: transparent !important; border: 0 !important; }
+  .pa-preview-canvas { padding: 0 !important; overflow: visible !important; }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 767;
+const CACHE_VERSION = 768;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 743;
+const SW_ENTRY_VERSION = 744;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation

- Replace the compact/new-form editing UX with the Proposaleditor-style two-pane editor so creation/editing/preview/PDF feel like the new design while preserving all existing Supabase-backed behavior and permissions. 
- Keep all existing API hooks, save/update/delete/clone/status workflows, and document templates as the single source of truth and avoid adding new data sources or iframes.

### Description

- Render a two-pane editor inside the existing `proposals-agreements` screen by adding a scoped editor wrapper and sidebar while keeping the existing form fields and save/update flows (`frontend/src/screens/proposals-agreements.js`).
- Generate an initial live A4 preview HTML using the existing template rendering helpers (`proposalPreviewBodyHtml`, `resolveDocumentSections`, etc.) and wire a new `updateLivePreview` function to refresh the preview on form/item changes so the preview uses the real payload/items/templates.
- Add scoped CSS for the editor layout and print behavior with dedicated prefixes (`pa-editor`, `pa-sidebar`, `pa-preview`) to avoid global style leakage (`frontend/src/styles/main.css`).
- Bump frontend service-worker cache entry/version constants so new JS/CSS are picked up on deploy (`frontend/sw.js` and `sw.js`).

### Testing

- Ran the focused screen test `node --test tests/proposals-agreements-screen.test.mjs`, which completed successfully (`65` tests passing, `0` failures).
- Built the frontend with `npm run check:build`, which completed successfully (production build emitted a chunk-size warning only).
- Ran focused checks with `npm run check:changed` (includes `node --check` on changed files) and they passed.
- Verified `node --check` (syntax check) on modified JS files and confirmed no syntax errors; service-worker cache versions were updated as part of the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a0a05724832b866899ead36eb4af)