### PR TITLE
Proposals: add two‑pane editor with live A4 preview, styles and tests

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1925,13 +1925,31 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const primaryActionLabel = canApproveDirectly ? 'אישור והפקת הצעה' : 'שליחה לאישור';
   const primaryActionStatus = canApproveDirectly ? 'approved' : 'pending_approval';
 
-  return `<form class="ds-pa-form ds-pa-form--compact" data-pa-form data-pa-mode="${escapeHtml(mode)}" data-pa-id="${escapeHtml(row.id || '')}" data-pa-original-type="${escapeHtml(normalizedActivityGroup)}" dir="rtl">
+  const initialPreviewRow = normalizeProposalAgreementRow({
+    ...row,
+    document_type: text(row.document_type) || 'הצעת מחיר',
+    activity_type_group: normalizedActivityGroup,
+    proposal_date: proposalDate
+  });
+  const initialTemplateKey = proposalGroupTemplateKey(normalizedActivityGroup);
+  const initialTemplateSections = resolveDocumentSections(row, [])
+    .filter((section) => !text(section.template_key) || text(section.template_key) === initialTemplateKey);
+  const initialPreviewHtml = proposalPreviewBodyHtml(initialPreviewRow, items, initialTemplateSections);
+
+  return `<form class="ds-pa-form ds-pa-form--compact pa-editor" data-pa-form data-pa-mode="${escapeHtml(mode)}" data-pa-id="${escapeHtml(row.id || '')}" data-pa-original-type="${escapeHtml(normalizedActivityGroup)}" dir="rtl">
     <div class="ds-pa-form-header">
       <h3 class="ds-pa-form-title">${escapeHtml(title)}</h3>
       <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-cancel-form>ביטול</button>
     </div>
 
+    <div class="pa-editor-workspace">
+      <aside class="pa-sidebar" aria-label="עריכת פרטי הצעת מחיר">
+        <div class="pa-sidebar-heading">
+          <span class="pa-sidebar-kicker">עורך הצעה</span>
+          <strong>${escapeHtml(title)}</strong>
+        </div>
     <div class="ds-pa-form-meta-panel">
+      <h4 class="pa-sidebar-section-title">פרטי נמען</h4>
       <div data-pa-step-panel="client">
         <div class="ds-pa-client-row" data-pa-client-search-row${isLocked ? ' hidden' : ''}>
           ${clientSearchHtml(contactOptions, row)}
@@ -1947,6 +1965,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
         </div>
       </div>
       <div data-pa-step-panel="contact">
+        <h4 class="pa-sidebar-section-title">איש קשר</h4>
         <div class="ds-pa-form-grid">
           <div data-pa-contact-picker-host>${initPickerHtml}</div>
           <div class="ds-pa-form-grid ds-pa-contact-manual-fields" data-pa-contact-manual-fields${isLocked ? ' hidden' : ''}>
@@ -1960,6 +1979,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
     </div>
 
     <div class="ds-pa-form-type-panel" data-pa-step-panel="proposal">
+      <h4 class="pa-sidebar-section-title">סוג ותאריך הצעה</h4>
       <div class="ds-pa-type-meta-grid">
         <div class="ds-pa-form-field">
           <span>${escapeHtml(FIELD_LABELS.activity_type_group)} *</span>
@@ -1975,10 +1995,12 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
     </div>
 
     <div class="ds-pa-form-activities-panel" data-pa-step-panel="activity">
+      <h4 class="pa-sidebar-section-title">פעילויות ומחירים</h4>
       <div data-pa-items-host>${itemsEditorHtml(items, filteredPricing, normalizedActivityGroup)}</div>
     </div>
 
     <div class="ds-pa-form-bottom-panel" data-pa-step-panel="summary">
+      <h4 class="pa-sidebar-section-title">סיכום והפקה</h4>
       <details class="ds-pa-notes-details"${text(row.notes) ? ' open' : ''}>
         <summary class="ds-pa-notes-summary">הערות</summary>
         <label class="ds-pa-form-field ds-pa-form-field--wide"><span>${escapeHtml(FIELD_LABELS.notes)}</span><textarea class="ds-input ds-input--sm ds-pa-notes-input" name="notes" rows="3">${escapeHtml(text(row.notes))}</textarea></label>
@@ -1993,6 +2015,17 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
           <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-cancel-form>ביטול</button>
         </div>
       </div>
+    </div>
+      </aside>
+      <section class="pa-preview" aria-label="תצוגת מסמך A4">
+        <div class="pa-preview-toolbar no-print">
+          <span>תצוגה מקדימה חיה</span>
+          <button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-preview-form>פתח לתצוגה / PDF</button>
+        </div>
+        <div class="pa-preview-canvas" data-pa-live-preview>
+          ${initialPreviewHtml}
+        </div>
+      </section>
     </div>
 
     <input type="hidden" name="status" data-pa-status-input value="${escapeHtml(currentStatus)}">
@@ -2605,6 +2638,7 @@ export const proposalsAgreementsScreen = {
           fillContactFields(form, contact);
           setContactSource(form, contact);
           lockClientFields(form, text(contact.authority), text(contact.school), text(contact.contact_name), text(contact.contact_role), text(contact.phone || contact.mobile || ''), text(contact.email || ''), text(contact.client_name) || text(contact.school) || text(contact.authority));
+          if (form) setTimeout(() => calcGrandTotal(form), 0);
         }
       }, { signal });
     };
@@ -2743,6 +2777,7 @@ export const proposalsAgreementsScreen = {
       const results = form.querySelector('[data-pa-client-results]');
       if (input) input.value = '';
       if (results) { results.hidden = true; results.innerHTML = ''; }
+      setTimeout(() => calcGrandTotal(form), 0);
     };
 
     const renderClientResults = (form) => {
@@ -2802,6 +2837,21 @@ export const proposalsAgreementsScreen = {
     };
 
 
+    const updateLivePreview = (container) => {
+      const form = container?.closest?.('[data-pa-form]') || (container?.matches?.('[data-pa-form]') ? container : null);
+      const previewHost = form?.querySelector?.('[data-pa-live-preview]');
+      if (!form || !previewHost) return;
+      const payload = payloadFromForm(form);
+      const row = normalizeProposalAgreementRow({
+        ...payload,
+        id: text(form.dataset.paId),
+        proposal_date: payload.proposal_date || localDateInputValue()
+      });
+      const templateKey = proposalGroupTemplateKey(row.activity_type_group);
+      const templateSections = proposalTemplateSections.filter((section) => text(section.template_key) === templateKey);
+      previewHost.innerHTML = proposalPreviewBodyHtml(row, payload._items || [], templateSections);
+    };
+
     // ── Items calc ────────────────────────────────────────────────────────────
     const calcItemRow = (rowEl) => {
       const qty = parseFloat(rowEl.querySelector('[data-pa-item-qty]')?.value || '0') || 0;
@@ -2838,6 +2888,7 @@ export const proposalsAgreementsScreen = {
         if (typeEl) typeEl.textContent = proposalGroupDisplayName(form.querySelector('[name="activity_type_group"]')?.value) || '—';
         const countEl = form.querySelector('[data-pa-summary-count]');
         if (countEl) countEl.textContent = String(form.querySelectorAll('[data-pa-item-row]').length) || '—';
+        updateLivePreview(form);
       }
       return sum;
     };

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1221,7 +1221,7 @@ function proposalCostTableHtml(items = []) {
     ? `<tr><td colspan="3">סה״כ לפני הנחה</td><td>${currencyAmountHtml(subtotal)}</td></tr>
        <tr><td colspan="3">הנחה</td><td>${currencyAmountHtml(-discount)}</td></tr>`
     : '';
-  return `<table class="pa-cost-table">
+  return `<table class="pa-cost-table pa-activities-table">
     <thead><tr><th>פעילות</th><th>כמות</th><th>מחיר יחידה</th><th>סה״כ שורה</th></tr></thead>
     <tbody>${rows.map((row) => `<tr>
         <td>${escapeHtml(row.name)}</td>
@@ -1246,7 +1246,7 @@ function proposalDiscountSummaryHtml(items = []) {
     return sum + (Number(total) || 0);
   }, 0);
   const payable = Math.max(subtotal - discount, 0);
-  return `<table class="pa-cost-table pa-discount-summary-table">
+  return `<table class="pa-cost-table pa-activities-table pa-discount-summary-table">
     <tbody>
       <tr><td>סה״כ לפני הנחה</td><td>${currencyAmountHtml(subtotal)}</td></tr>
       <tr><td>הנחה</td><td>${currencyAmountHtml(-discount)}</td></tr>
@@ -1292,7 +1292,7 @@ function proposalItemDetailsTableHtml(items = [], contextGroup = '') {
     return `<tr>${cells.map((cell) => `<td>${cell.html ? (cell.value || '—') : escapeHtml(cell.value || '—')}</td>`).join('')}</tr>`;
   }).filter(Boolean);
   if (!rows.length) return '';
-  return `<table class="pa-item-details-table">
+  return `<table class="pa-item-details-table pa-activities-table">
     <thead><tr><th>תוכנית / פעילות</th><th>מס׳ גפ״ן</th><th>מפגשים</th><th>שעות</th><th>עלות לשעה</th><th>כמות</th><th>מחיר לקורס / קבוצה אחת</th><th>סה״כ לפי כמות</th></tr></thead>
     <tbody>${rows.join('')}</tbody>
   </table>`;
@@ -1319,7 +1319,7 @@ function costsIntroBody(row = {}, items = []) {
 }
 
 function sectionHtml(title, body, className = '', options = {}) {
-  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3>${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body, options)}</section>`;
+  return `<section class="pa-section${className ? ` ${className}` : ''}"><h3 class="pa-section-heading">${escapeHtml(sectionHeadingText(title))}</h3>${sectionBodyHtml(body, options)}</section>`;
 }
 
 function recipientLineHtml(...values) {
@@ -1345,8 +1345,8 @@ function recipientBlockHtml(row = {}) {
   const contactLine = contactParts.length ? `<p>${contactParts.join(', ')}</p>` : '';
   const orgLine = recipientLineHtml(schoolName, authorityName);
   const lines = [contactLine, orgLine].filter(Boolean);
-  return `<div class="pa-doc-address">
-    <p><strong>לכבוד:</strong></p>
+  return `<div class="pa-doc-address pa-to-block">
+    <p class="pa-label-to"><strong>לכבוד:</strong></p>
     ${lines.join('\n    ')}
   </div>`;
 }
@@ -1442,11 +1442,11 @@ function renderProposalSectionBody(body, options = {}) {
   if (!groups.length) return '';
   const rendered = groups.map((group) => {
     if (group.type === 'ul') {
-      return `<ul>${group.items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
+      return `<ul class="pa-proposal-list">${group.items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
     }
     return group.items.map((lines) => `<p>${lines.map((line) => escapeHtml(line)).join('<br>')}</p>`).join('');
   }).join('');
-  return `<div class="pa-section-body${className ? ` ${className}` : ''}">${rendered}</div>`;
+  return `<div class="pa-section-body pa-section-text${className ? ` ${className}` : ''}">${rendered}</div>`;
 }
 
 function renderSectionBodyHtml(value, options = {}) {
@@ -1461,10 +1461,10 @@ function sectionLinesHtml(value, options = {}) {
 // The block renders inline after the document sections, under "בברכה," — never floated
 // or pushed above the footer. When Supabase has no signature, nothing is rendered.
 function signatureSectionHtml(_signatureBody = '') {
-  return `<section class="proposal-signature" aria-label="חתימה">
-    <p class="proposal-signature-greeting">בברכה,</p>
-    <div class="proposal-signature-block">
-      <div class="proposal-signature-line" aria-hidden="true"></div>
+  return `<section class="proposal-signature pa-footer-signature" aria-label="חתימה">
+    <p class="proposal-signature-greeting pa-blessing">בברכה,</p>
+    <div class="proposal-signature-block pa-signer-block">
+      <div class="proposal-signature-line pa-signer-line" aria-hidden="true"></div>
       <p class="proposal-signature-name">עידן נחום, סמנכ״ל כספים</p>
     </div>
   </section>`;
@@ -1516,9 +1516,9 @@ function documentSectionsEditorHtml(sections = [], isCustom = false) {
 function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText, sections, orgResponsibility, schoolResponsibility, paymentTerms, changesCancellation, remarks, signatureHtml, sectionLinesHtml: sectionLines }) {
   const title = text(documentTitle);
   return `
-    <div class="proposal-document" dir="rtl">
-      <div class="proposal-document-header">
-        <div class="proposal-header-brand">
+    <div class="proposal-document pa-document pa-a4-page" dir="rtl">
+      <div class="proposal-document-header pa-page-header">
+        <div class="proposal-header-brand pa-logo-area">
           <img
             src="${PUBLIC_BASE}proposals/proposal-header-logo.png"
             alt="לוגו תעשיידע"
@@ -1527,15 +1527,15 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
             decoding="async"
             onerror="this.style.display='none';"
           >
-          ${dateDisplay ? `<div class="pa-doc-date">${escapeHtml(dateDisplay)}</div>` : ''}
         </div>
-        ${recipientBlockHtml(row)}
       </div>
-      <hr class="pa-doc-divider">
+      ${recipientBlockHtml(row)}
+      <hr class="pa-doc-divider pa-divider">
+      ${dateDisplay ? `<div class="pa-doc-date pa-date-area">${escapeHtml(dateDisplay)}</div>` : ''}
       <div class="proposal-document-body">
         <div class="proposal-document-content">
-          ${title ? `<h1 class="pa-doc-subject">${escapeHtml(title)}</h1>` : ''}
-          ${introText ? sectionLines(introText, { className: 'pa-doc-intro' }) : ''}
+          ${title ? `<h1 class="pa-doc-subject pa-doc-title">${escapeHtml(title)}</h1>` : ''}
+          ${introText ? sectionLines(introText, { className: 'pa-doc-intro pa-intro-text' }) : ''}
           ${sections.join('')}
           ${orgResponsibility}
           ${schoolResponsibility}
@@ -1545,7 +1545,7 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
           ${signatureHtml}
         </div>
       </div>
-      <div class="proposal-document-footer">
+      <div class="proposal-document-footer pa-page-footer">
         <img
           src="${PUBLIC_BASE}proposals/proposal-footer-logo.png"
           alt="לוגו תחתון תעשיידע"
@@ -1554,6 +1554,7 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
           decoding="async"
           onerror="this.style.display='none';"
         >
+        <span><strong>תעשיידע</strong> — תעשייה למען חינוך מתקדם (ע״ר) &nbsp;|&nbsp; www.think.org.il</span>
       </div>
     </div>`;
 }
@@ -1591,7 +1592,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
   const renderActivitySection = (heading, body) => {
     const bodyHtml = body ? sectionBodyHtml(body) : '';
     if (!bodyHtml) return '';
-    return `<section class="pa-section">${heading ? `<h3>${escapeHtml(sectionHeadingText(heading))}</h3>` : ''}${bodyHtml}</section>`;
+    return `<section class="pa-section">${heading ? `<h3 class="pa-section-heading">${escapeHtml(sectionHeadingText(heading))}</h3>` : ''}${bodyHtml}</section>`;
   };
 
   const sections = [];
@@ -1636,7 +1637,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
     ? `<div class="pa-cost-table-block">${costsIntro ? `<p class="pa-costs-intro-heading">${escapeHtml(costsIntro)}</p>` : ''}${costTableHtml}</div>`
     : '';
   const paymentTerms = (paymentTermsBody || costTableBlock)
-    ? `<section class="pa-section pa-cost-section">${sectionTitle('payment_terms') ? `<h3>${escapeHtml(sectionHeadingText(sectionTitle('payment_terms')))}</h3>` : ''}${paymentTermsBody ? sectionBodyHtml(paymentTermsBody, { alwaysBullet: true }) : ''}${costTableBlock}</section>`
+    ? `<section class="pa-section pa-cost-section">${sectionTitle('payment_terms') ? `<h3 class="pa-section-heading">${escapeHtml(sectionHeadingText(sectionTitle('payment_terms')))}</h3>` : ''}${paymentTermsBody ? sectionBodyHtml(paymentTermsBody, { alwaysBullet: true }) : ''}${costTableBlock}</section>`
     : '';
 
   const signatureHtml = signatureSectionHtml(sectionBody('signature'));

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16131,3 +16131,244 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   .pa-preview { padding: 0 !important; background: transparent !important; border: 0 !important; }
   .pa-preview-canvas { padding: 0 !important; overflow: visible !important; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Proposals – A4 document styling adapted from Proposaleditor.html
+   Scoped aliases keep the dashboard isolated while matching the source document.
+   ═══════════════════════════════════════════════════════════════════ */
+.proposal-document.pa-document {
+  width: 794px;
+  max-width: 100%;
+  min-height: 1123px;
+  padding: 28px 67px 0;
+  background: #fff;
+  color: #111;
+  font-family: "Heebo", Arial, "Noto Sans Hebrew", sans-serif;
+  font-size: 11.5px;
+  line-height: 1.58;
+  letter-spacing: 0;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  border-radius: 0;
+}
+.proposal-document.pa-document .proposal-document-content {
+  max-width: none;
+  width: 100%;
+}
+.pa-page-header {
+  display: block !important;
+  min-height: 0 !important;
+  margin: 0 0 0 !important;
+  padding: 0 !important;
+  text-align: left !important;
+  max-width: none !important;
+}
+.pa-logo-area {
+  display: block !important;
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+  text-align: left !important;
+  direction: ltr !important;
+}
+.pa-logo-area .proposal-logo {
+  height: 58px;
+  max-height: 58px;
+  max-width: 220px;
+  width: auto;
+  display: inline-block;
+  object-fit: contain;
+}
+.pa-to-block {
+  position: static !important;
+  max-width: 100% !important;
+  margin: 0 0 2px !important;
+  font-size: 11.2px;
+  line-height: 1.5;
+  text-align: right !important;
+}
+.pa-to-block p { margin: 0; }
+.pa-label-to {
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: underline;
+  margin-bottom: 1px !important;
+}
+.pa-divider {
+  border: none !important;
+  border-top: 1px solid #bbb !important;
+  margin: 3px 0 !important;
+  width: 100% !important;
+  max-width: none !important;
+}
+.pa-date-area {
+  font-size: 10px;
+  color: #444;
+  margin: 3px 0 5px;
+  text-align: left !important;
+  direction: ltr;
+  width: 100%;
+}
+.pa-doc-title {
+  text-align: center;
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: underline;
+  margin: 0 0 5px;
+  color: #1a2d4a;
+  line-height: 1.45;
+}
+.pa-intro-text {
+  font-size: 11.2px;
+  line-height: 1.5;
+  margin: 0 0 5px;
+  text-align: center;
+}
+.pa-section { margin: 5px 0 4px; }
+.pa-section-heading {
+  display: block;
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  color: #2e5492 !important;
+  text-decoration: underline !important;
+  margin: 5px 0 2px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  line-height: 1.45 !important;
+}
+.pa-section-text {
+  font-size: 11.2px;
+  line-height: 1.5;
+  margin: 0 0 4px;
+}
+.pa-section-text p { margin: 0 0 4px !important; }
+.pa-proposal-list {
+  padding-right: 18px !important;
+  padding-left: 0 !important;
+  margin: 0 0 4px !important;
+  list-style: disc !important;
+}
+.proposal-document .pa-proposal-list li {
+  padding-inline-start: 0 !important;
+  font-size: 11.2px;
+  line-height: 1.5;
+}
+.proposal-document .pa-proposal-list li::before { content: none !important; }
+.pa-activities-table {
+  width: auto !important;
+  max-width: 100%;
+  border-collapse: collapse;
+  margin: 6px 0 8px !important;
+  font-size: 10.2px !important;
+  align-self: flex-start;
+  direction: rtl;
+}
+.pa-activities-table th {
+  background: #edf0f5 !important;
+  padding: 3px 14px !important;
+  border: 1px solid #ccc !important;
+  font-weight: 700;
+  text-align: center !important;
+  color: #1a2d4a !important;
+  white-space: nowrap;
+}
+.pa-activities-table th:first-child { text-align: right !important; }
+.pa-activities-table td {
+  padding: 3px 14px !important;
+  border: 1px solid #ccc !important;
+  text-align: center !important;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.pa-activities-table td:first-child { text-align: right !important; }
+.pa-activities-table tfoot td {
+  font-weight: 700;
+  background: #f5f7fa !important;
+}
+.pa-footer-signature {
+  margin: auto 0 14px !important;
+  padding-top: 14px;
+  text-align: left;
+  display: block !important;
+  width: 100%;
+  max-width: none;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.pa-footer-signature .pa-blessing {
+  font-size: 12.5px;
+  margin: 0 0 10px !important;
+  text-align: center !important;
+  width: auto !important;
+}
+.pa-signer-block {
+  margin-top: 4.4em;
+  display: block !important;
+  text-align: left;
+  direction: rtl !important;
+}
+.pa-signer-line {
+  display: inline-block !important;
+  width: auto !important;
+  min-width: 50mm;
+  border-top: 1px solid #555 !important;
+  padding-top: 1px;
+  margin: 0 !important;
+}
+.pa-signer-block .proposal-signature-name {
+  display: block;
+  width: auto !important;
+  margin: 2px 0 0 !important;
+  font-size: 10px !important;
+  white-space: nowrap;
+  text-align: left !important;
+  direction: rtl !important;
+}
+.pa-page-footer {
+  margin-top: auto !important;
+  border-top: 1px solid #bbb;
+  padding: 8px 0 10px !important;
+  font-size: 10px;
+  color: #666;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: center;
+}
+.pa-page-footer .proposal-footer-logo {
+  height: 18px;
+  max-height: 18px;
+  width: auto;
+  max-width: 80px;
+  margin: 0;
+}
+@media print {
+  * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  @page { size: A4 portrait; margin: 0; }
+  .proposal-document.pa-document {
+    width: 210mm !important;
+    min-height: 297mm !important;
+    padding: 10mm 17mm 0 !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    font-size: 11.5px !important;
+    line-height: 1.58 !important;
+  }
+  .proposal-preview-area,
+  .pa-preview-canvas { padding: 0 !important; }
+  .pa-page-header { text-align: left !important; }
+  .pa-logo-area .proposal-logo { height: 58px !important; max-height: 58px !important; }
+  .pa-activities-table { page-break-inside: auto; width: auto !important; }
+  .pa-activities-table tr { page-break-inside: avoid; }
+  .pa-activities-table thead { display: table-header-group; }
+  .pa-activities-table tfoot { display: table-footer-group; }
+  .pa-section-heading { page-break-after: avoid; }
+  .pa-footer-signature { break-inside: avoid; page-break-inside: avoid; }
+  .pa-page-footer {
+    margin-top: auto !important;
+    position: relative !important;
+    border-top: 1px solid #bbb !important;
+    padding: 5px 0 7px !important;
+  }
+  .pa-page-footer .proposal-footer-logo { height: 18px !important; max-height: 18px !important; }
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15971,3 +15971,163 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     white-space: nowrap !important;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Proposals – Proposaleditor-inspired official editor layout
+   Scoped to pa-editor/pa-sidebar/pa-preview so the dashboard stays isolated.
+   ═══════════════════════════════════════════════════════════════════ */
+.pa-editor.ds-pa-form--compact {
+  max-width: min(1760px, 100%);
+  margin-inline: auto;
+  padding: 12px;
+}
+.pa-editor-workspace {
+  display: grid;
+  grid-template-columns: minmax(340px, 430px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+.pa-sidebar {
+  position: sticky;
+  top: 76px;
+  max-height: calc(100vh - 96px);
+  overflow: auto;
+  padding: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  border: 1px solid #dbe7f3;
+  border-radius: 18px;
+  box-shadow: 0 14px 38px rgba(15, 23, 42, 0.08);
+}
+.pa-sidebar-heading {
+  margin: 0 0 12px;
+  padding-bottom: 10px;
+  border-bottom: 2px solid #1a2d4a;
+  color: #1a2d4a;
+}
+.pa-sidebar-heading strong {
+  display: block;
+  font-size: 0.95rem;
+  line-height: 1.25;
+}
+.pa-sidebar-kicker,
+.pa-sidebar-section-title {
+  display: block;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #1a2d4a;
+  text-transform: uppercase;
+}
+.pa-sidebar-section-title {
+  margin: 2px 0 9px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #c8d0dc;
+}
+.pa-sidebar .ds-pa-form-meta-panel,
+.pa-sidebar .ds-pa-form-type-panel,
+.pa-sidebar .ds-pa-form-bottom-panel,
+.pa-sidebar .ds-pa-item-card {
+  border-color: #d7e3ef;
+  box-shadow: none;
+}
+.pa-sidebar .ds-pa-form-meta-panel,
+.pa-sidebar .ds-pa-form-type-panel,
+.pa-sidebar .ds-pa-form-bottom-panel {
+  background: #f4f6f9;
+}
+.pa-sidebar .ds-pa-form-field span,
+.pa-sidebar .ds-pa-item-field span,
+.pa-sidebar .ds-pa-field-label {
+  color: #5a6a7a;
+  font-size: 0.72rem;
+}
+.pa-sidebar .ds-input {
+  background: #fff;
+  border-color: #c0cad6;
+  border-radius: 7px;
+}
+.pa-sidebar .ds-input:focus {
+  border-color: #1a2d4a;
+  box-shadow: 0 0 0 2px rgba(26, 45, 74, 0.1);
+}
+.pa-sidebar .ds-pa-type-card {
+  border-radius: 9px;
+  background: #fff;
+}
+.pa-sidebar .ds-pa-type-card.is-selected {
+  background: #eaf1fb;
+  border-color: #1a2d4a;
+  box-shadow: 0 0 0 1px rgba(26, 45, 74, 0.18) inset;
+}
+.pa-sidebar .ds-pa-item-card {
+  padding: 10px;
+  border-radius: 12px;
+}
+.pa-sidebar .ds-pa-item-quick-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 72px 92px;
+  gap: 7px;
+  align-items: end;
+}
+.pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--select,
+.pa-sidebar .ds-pa-line-total,
+.pa-sidebar .ds-pa-item-remove {
+  grid-column: 1 / -1;
+}
+.pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--qty,
+.pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--price {
+  width: auto;
+  min-width: 0;
+}
+.pa-sidebar .ds-pa-form-actions-main {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 7px;
+}
+.pa-preview {
+  min-width: 0;
+  padding: 14px 10px 26px;
+  border-radius: 22px;
+  background: radial-gradient(circle at top, #eef7ff 0%, #e2e8f0 42%, #d7dee8 100%);
+  border: 1px solid #d6e0eb;
+}
+.pa-preview-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin: 0 auto 12px;
+  max-width: 794px;
+  color: #334155;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+.pa-preview-canvas {
+  display: flex;
+  justify-content: center;
+  overflow-x: auto;
+  padding: 8px 4px 18px;
+}
+.pa-preview-canvas .proposal-document {
+  transform-origin: top center;
+}
+@media (max-width: 1180px) {
+  .pa-editor-workspace { grid-template-columns: 1fr; }
+  .pa-sidebar { position: static; max-height: none; }
+  .pa-preview { padding-inline: 4px; }
+}
+@media (max-width: 760px) {
+  .pa-editor.ds-pa-form--compact { padding: 8px 0; }
+  .pa-sidebar { border-radius: 14px; padding: 10px; }
+  .pa-preview { border-radius: 16px; margin-inline: -6px; }
+  .pa-preview-canvas { justify-content: flex-start; }
+  .pa-preview-canvas .proposal-document { min-width: 0; width: 100%; }
+}
+@media print {
+  .pa-editor-workspace,
+  .pa-sidebar,
+  .pa-preview-toolbar { display: contents; }
+  .pa-sidebar { display: none !important; }
+  .pa-preview { padding: 0 !important; background: transparent !important; border: 0 !important; }
+  .pa-preview-canvas { padding: 0 !important; overflow: visible !important; }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 767;
+const CACHE_VERSION = 769;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 769;
+const CACHE_VERSION = 770;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 743;
+const SW_ENTRY_VERSION = 745;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 745;
+const SW_ENTRY_VERSION = 746;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -350,6 +350,74 @@ test('new proposal tab opens compact form with preview and role-aware primary ac
   );
 });
 
+test('new proposal editor renders two-pane A4 layout and live preview updates key fields', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: {
+          rows: [],
+          activityNameOptions: [],
+          contactOptions: sampleContactOptions,
+          proposalActivityPricing: [{
+            activity_no: 'S1',
+            activity_name: 'סדנת מייקרים',
+            item_type: 'סדנה',
+            proposal_group: 'קיץ תשפ״ו',
+            unit_price: 450
+          }],
+          proposalActivityGroups: [{ group_key: 'קיץ תשפ״ו', display_name: 'קיץ תשפ״ו', template_key: 'summer' }],
+          proposalTemplateSections: [
+            { template_key: 'summer', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח להצעה' },
+            { template_key: 'summer', section_key: 'payment_terms', section_title: 'תנאי תשלום', section_body: 'תנאי תשלום' }
+          ]
+        },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      const form = openNewProposalForm(root, dom);
+      assert.ok(form.classList.contains('pa-editor'), 'form should use the official two-pane editor shell');
+      assert.ok(form.querySelector('.pa-sidebar'), 'editing sidebar should be present');
+      assert.ok(form.querySelector('[data-pa-live-preview] .proposal-document'), 'live A4 preview should be present');
+      assert.match(form.querySelector('.pa-sidebar')?.textContent || '', /פרטי נמען/);
+      assert.match(form.querySelector('.pa-sidebar')?.textContent || '', /פעילויות ומחירים/);
+
+      const searchInput = form.querySelector('[data-pa-client-search-input]');
+      searchInput.value = 'יוסי';
+      searchInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+      form.querySelector('[data-pa-client-result]')?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      const typeInput = form.querySelector('[name="activity_type_group"]');
+      typeInput.value = 'קיץ תשפ״ו';
+      typeInput.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      await delay(0);
+
+      const pricingSelect = form.querySelector('[data-pa-pricing-select]');
+      pricingSelect.value = pricingSelect.querySelectorAll('option')[1]?.value || '';
+      pricingSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      await delay(0);
+      const qtyInput = form.querySelector('[data-pa-item-qty]');
+      qtyInput.value = '2';
+      qtyInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+      const discountValue = form.querySelector('[data-pa-discount-value]');
+      discountValue.value = '100';
+      discountValue.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+      await delay(20);
+
+      const previewText = form.querySelector('[data-pa-live-preview]')?.textContent || '';
+      assert.match(previewText, /לכבוד/, 'recipient block should be visible in live preview');
+      assert.match(previewText, /מסגרת ב/, 'selected school should update in live preview');
+      assert.match(previewText, /יוסי קשר/, 'selected contact should update in live preview');
+      assert.match(previewText, /סדנת מייקרים/, 'selected item should update in live preview');
+      assert.match(previewText, /900/, 'quantity × price should update in live preview');
+      assert.match(previewText, /100/, 'discount should update in live preview');
+    }
+  );
+});
+
 
 test('non-admin manager submits proposals for approval instead of approving directly', async () => {
   const managerState = stateFor('operation_manager');

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -380,7 +380,13 @@ test('new proposal editor renders two-pane A4 layout and live preview updates ke
       const form = openNewProposalForm(root, dom);
       assert.ok(form.classList.contains('pa-editor'), 'form should use the official two-pane editor shell');
       assert.ok(form.querySelector('.pa-sidebar'), 'editing sidebar should be present');
-      assert.ok(form.querySelector('[data-pa-live-preview] .proposal-document'), 'live A4 preview should be present');
+      const liveDocument = form.querySelector('[data-pa-live-preview] .proposal-document');
+      assert.ok(liveDocument, 'live A4 preview should be present');
+      assert.ok(liveDocument.classList.contains('pa-document'), 'document should use the scoped Proposaleditor document class');
+      assert.ok(liveDocument.querySelector('.pa-page-header .pa-logo-area .proposal-logo'), 'document should render the Proposaleditor-style logo area');
+      assert.ok(liveDocument.querySelector('.pa-page-footer'), 'document should render the Proposaleditor-style footer');
+      assert.match(liveDocument.querySelector('.pa-page-footer')?.textContent || '', /www\.think\.org\.il/);
+      assert.ok(liveDocument.querySelector('.pa-footer-signature .pa-signer-line'), 'document should render the Proposaleditor-style signature line');
       assert.match(form.querySelector('.pa-sidebar')?.textContent || '', /פרטי נמען/);
       assert.match(form.querySelector('.pa-sidebar')?.textContent || '', /פעילויות ומחירים/);
 


### PR DESCRIPTION
### Motivation
- Replace the compact proposal form with a richer two‑pane editor to improve editing ergonomics and provide a live A4 preview while composing proposals.
- Keep the preview in sync with user edits (items, client, type and discounts) to reduce context switching and mistakes.
- Ship the UI with scoped styles and bump service worker cache versions to ensure clients pick up the new assets.

### Description
- Reworked the proposal form generation in `frontend/src/screens/proposals-agreements.js` to render a `pa-editor` two‑pane layout with a sticky sidebar (`.pa-sidebar`) and a live preview panel (`.pa-preview`) and to produce an initial preview HTML (`initialPreviewHtml`).
- Added `updateLivePreview` and integrated live preview updates into item/discount recalculation (`calcGrandTotal`) and contact selection flows, and ensured preview updates after contact/picker changes via deferred `calcGrandTotal` calls.
- Introduced CSS for the editor in `frontend/src/styles/main.css` scoped under `.pa-editor`, `.pa-sidebar` and `.pa-preview` to implement responsive two‑pane layout, toolbar and print rules.
- Bumped service worker cache/version identifiers in `frontend/sw.js` (`CACHE_VERSION`) and root `sw.js` (`SW_ENTRY_VERSION`) to ensure deployed clients refresh caches.
- Added an automated test in `tests/proposals-agreements-screen.test.mjs` that asserts the editor shell renders and the live preview updates when changing client, activity type, pricing, quantity and discount.

### Testing
- Added unit test `new proposal editor renders two-pane A4 layout and live preview updates key fields` in `tests/proposals-agreements-screen.test.mjs` and ran the test suite against the changed screen code.
- Ran the automated test suite (`npm test`) after the changes and all tests, including the new editor preview test, completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a0a05724832b866899ead36eb4af)