### PR TITLE
Fix service worker cache entry version and update built assets

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-DE1h_Fm0.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BXfwD22H.css">
+  <script type="module" crossorigin src="./assets/index-bSAvKUAU.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BPoVLX8y.css">
 </head>
 <body>
   <main id="app"></main>

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 746;
+const SW_ENTRY_VERSION = 770;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation

- The root service worker entry used a different cache-busting query version than the frontend SW `CACHE_VERSION`, causing the SW/PWA cache consistency test to fail.
- Aligning the entry query version with the implementation ensures deployed clients fetch the correct frontend SW and precache set.
- The build output (`dist/index.html`) needed to be refreshed to reference the new production bundle names after the rebuild.

### Description

- Updated `SW_ENTRY_VERSION` in `sw.js` from `746` to `770` so it matches `CACHE_VERSION = 770` in `frontend/sw.js` and the import query string used by the root SW.
- Rebuilt the frontend which updated `dist/index.html` asset references to the new bundle names generated by the build.
- Verified the proposal/A4 document classes and relevant CSS for sidebar/preview remain present and unchanged (`pa-document`, `pa-a4-page`, `pa-page-header`, `pa-logo-area`, `pa-to-block`, `pa-doc-title`, `pa-activities-table`, `pa-footer-signature`, `pa-signer-line`, `pa-page-footer`).

### Testing

- Ran conflict-marker check `rg -n '^(<<<<<<<|=======|>>>>>>>)' frontend/src/screens/proposals-agreements.js frontend/src/styles/main.css frontend/sw.js sw.js` and found no conflict markers.
- Ran `git diff --check` and there were no whitespace/diff errors reported.
- Ran `npm run check:changed` which performed `node --check sw.js` and completed successfully.
- Ran `npm run check:build` which executed `vite build` and `postbuild-dist` successfully and regenerated `dist/index.html`.
- Ran `node --test tests/proposals-agreements-screen.test.mjs` which passed (66/66 tests passed).
- Ran `node --test tests/service-worker-pwa-cache.test.mjs`, observed an initial failure due to the version mismatch, updated `SW_ENTRY_VERSION` to match `CACHE_VERSION`, and re-ran the test which then passed (5/5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a8fe601c832b9e2d1a05d0d166a1)