### PR TITLE
Fix proposal editor sidebar overflow

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,7 +14,7 @@
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
   <script type="module" crossorigin src="./assets/index-BhOCJcPJ.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-Df1ugFcT.css">
+  <link rel="stylesheet" crossorigin href="./assets/style-CEWh1CtR.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15983,21 +15983,99 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 .pa-editor-workspace {
   display: grid;
-  grid-template-columns: minmax(340px, 430px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 430px) minmax(0, 1fr);
   gap: 18px;
   align-items: start;
+  min-width: 0;
 }
 .pa-sidebar {
   position: sticky;
   top: 76px;
   max-height: calc(100vh - 96px);
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-width: 0;
+  max-width: 100%;
   padding: 12px;
   background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
   border: 1px solid #dbe7f3;
   border-radius: 18px;
   box-shadow: 0 14px 38px rgba(15, 23, 42, 0.08);
 }
+
+.pa-sidebar,
+.pa-sidebar * {
+  box-sizing: border-box;
+}
+.pa-sidebar .ds-pa-form-meta-panel,
+.pa-sidebar .ds-pa-form-type-panel,
+.pa-sidebar .ds-pa-form-bottom-panel,
+.pa-sidebar .ds-pa-form-activities-panel,
+.pa-sidebar .ds-pa-items-section,
+.pa-sidebar .ds-pa-items-list,
+.pa-sidebar .ds-pa-item-card,
+.pa-sidebar .ds-pa-form-field,
+.pa-sidebar .ds-pa-item-field,
+.pa-sidebar .ds-pa-client-search,
+.pa-sidebar .ds-pa-contact-manual-fields,
+.pa-sidebar .ds-pa-type-meta-grid,
+.pa-sidebar .ds-pa-type-meta-aux,
+.pa-sidebar .ds-pa-type-row {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+.pa-sidebar input,
+.pa-sidebar select,
+.pa-sidebar textarea,
+.pa-sidebar .ds-input,
+.pa-sidebar .ds-select,
+.pa-sidebar .ds-pa-activity-trigger {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+.pa-sidebar .ds-pa-form-field,
+.pa-sidebar .ds-pa-item-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+.pa-sidebar .ds-pa-form-field > span,
+.pa-sidebar .ds-pa-item-field > span,
+.pa-sidebar .ds-pa-field-label {
+  display: block;
+  min-width: 0;
+}
+.pa-sidebar .ds-pa-form-grid,
+.pa-sidebar .ds-pa-contact-manual-fields,
+.pa-sidebar .ds-pa-client-search,
+.pa-sidebar .ds-pa-client-row,
+.pa-sidebar .ds-pa-type-meta-grid,
+.pa-sidebar .ds-pa-type-meta-aux,
+.pa-sidebar .ds-pa-type-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+  align-items: end;
+}
+.pa-sidebar .ds-pa-client-row > *,
+.pa-sidebar .ds-pa-form-grid > *,
+.pa-sidebar .ds-pa-contact-manual-fields > *,
+.pa-sidebar .ds-pa-client-search > *,
+.pa-sidebar .ds-pa-type-meta-grid > *,
+.pa-sidebar .ds-pa-type-meta-aux > *,
+.pa-sidebar .ds-pa-type-row > *,
+.pa-sidebar .ds-pa-item-quick-row > * {
+  min-width: 0;
+  max-width: 100%;
+}
+.pa-sidebar .ds-pa-type-meta-grid > .ds-pa-form-field,
+.pa-sidebar .ds-pa-type-row .ds-pa-form-field {
+  flex: initial;
+  min-width: 0;
+}
+
 .pa-sidebar-heading {
   margin: 0 0 12px;
   padding-bottom: 10px;
@@ -16065,8 +16143,8 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 .pa-sidebar .ds-pa-item-quick-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 72px 92px;
-  gap: 7px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
   align-items: end;
 }
 .pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--select,
@@ -16075,9 +16153,15 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   grid-column: 1 / -1;
 }
 .pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--qty,
-.pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--price {
-  width: auto;
+.pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--price,
+.pa-sidebar .ds-pa-item-quick-row .ds-pa-item-field--total {
+  width: 100%;
   min-width: 0;
+}
+.pa-sidebar .ds-pa-line-total output,
+.pa-sidebar .ds-pa-form-actions-main .ds-btn {
+  width: 100%;
+  max-width: 100%;
 }
 .pa-sidebar .ds-pa-form-actions-main {
   display: grid;
@@ -16111,8 +16195,20 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 .pa-preview-canvas .proposal-document {
   transform-origin: top center;
 }
+@media (max-width: 1200px) {
+  .pa-sidebar .ds-pa-form-grid,
+  .pa-sidebar .ds-pa-contact-manual-fields,
+  .pa-sidebar .ds-pa-client-search,
+  .pa-sidebar .ds-pa-client-row,
+  .pa-sidebar .ds-pa-type-meta-grid,
+  .pa-sidebar .ds-pa-type-meta-aux,
+  .pa-sidebar .ds-pa-type-row,
+  .pa-sidebar .ds-pa-item-quick-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
 @media (max-width: 1180px) {
-  .pa-editor-workspace { grid-template-columns: 1fr; }
+  .pa-editor-workspace { grid-template-columns: minmax(0, 1fr); }
   .pa-sidebar { position: static; max-height: none; }
   .pa-preview { padding-inline: 4px; }
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 771;
+const CACHE_VERSION = 772;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 771;
+const SW_ENTRY_VERSION = 772;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation

- The proposal editor sidebar was causing horizontal overflow and field clipping due to rigid grid columns, `overflow: auto`, and fields with non-shrinking minimum widths. 
- The change aims to make the sidebar layout responsive and editable: no horizontal scroll, inputs/selects/textareas fill the panel, and grids can shrink to one column on narrow viewports. 

### Description

- Update CSS in `frontend/src/styles/main.css` to let columns shrink (use `minmax(0, 1fr)` / `minmax(0, 430px)`), set `min-width: 0`/`max-width: 100%`, hide x-scroll (`overflow-x: hidden`) and scope `box-sizing: border-box` under `.pa-sidebar` for consistent sizing; key classes touched include `.pa-sidebar`, `.pa-editor-workspace`, `.ds-pa-form-field`, `.ds-pa-client-row`, `.ds-pa-item-quick-row`, `.ds-pa-form-grid`, and `.ds-pa-type-meta-grid`. 
- Make form controls fill available width by forcing `width: 100%` / `max-width: 100%` / `min-width: 0` for `input`, `select`, `textarea`, `.ds-input`, and related controls inside the sidebar, and convert inner groups to grid with `minmax(0, 1fr)` so labels sit above fields and children can shrink. 
- Adjust `.ds-pa-item-quick-row` to a flexible two-column grid and ensure action buttons/line totals use full width to avoid clipping, and add a media breakpoint (`max-width: 1200px`) that collapses sidebar groups to a single column when space is limited. 
- Bump Service Worker cache/version from `771` to `772` in `frontend/sw.js` and `sw.js` and update the built stylesheet reference in `dist/index.html`; no A4/PDF/document structure changes were made. 

### Testing

- Ran `npm run check:changed`, which completed focused checks successfully. 
- Ran `npm run check:build` (Vite build) and the build completed successfully. 
- Ran `node --test tests/proposals-agreements-screen.test.mjs` and the focused test run passed (66 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b03d5a9c832b8b5a4fc10356101f)