### PR TITLE
Add `sent` proposal status and inline status dropdown in proposals table

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BhOCJcPJ.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-CEWh1CtR.css">
+  <script type="module" crossorigin src="./assets/index-Cy3OrP36.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BaCnB6xJ.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1917,7 +1917,8 @@ function normalizeProposalContactPhone(value) {
 
 const PA_STATUS_LABELS = {
   draft:                'טיוטה',
-  pending_approval:     'ממתין לאישור',
+  sent:                 'נשלח',
+  pending_approval:     'נשלח',
   returned_for_changes: 'הוחזר לתיקון',
   approved:             'מאושר',
   cancelled:            'בוטל'
@@ -1951,7 +1952,7 @@ function normalizeProposalAgreementActivityNames(value) {
 
 function normalizeProposalAgreementRow(row = {}) {
   const parsedNotes = parseActivityNamesFromNotes(row.notes);
-  const PA_VALID_STATUSES = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
+  const PA_VALID_STATUSES = new Set(['draft', 'sent', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
   const rawStatus = cleanProposalAgreementText(row.status);
   const authorityName = cleanProposalAgreementText(row.client_authority || row.authority_name || row.legacy_client_authority || row.authority);
   const schoolFramework = cleanProposalAgreementText(row.school_framework || row.school_name || row.contact_client_name || row.legacy_school_framework || row.school);
@@ -1980,7 +1981,7 @@ function normalizeProposalAgreementRow(row = {}) {
     phone:               cleanProposalAgreementText(row.phone),
     email:               cleanProposalAgreementText(row.email),
     notes:               parsedNotes.notes,
-    status:              PA_VALID_STATUSES.has(rawStatus) ? rawStatus : 'draft',
+    status:              PA_VALID_STATUSES.has(rawStatus) ? (rawStatus === 'pending_approval' ? 'sent' : rawStatus) : 'draft',
     approval_note:       cleanProposalAgreementText(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
     custom_document_sections: Array.isArray(row.custom_document_sections)
@@ -1997,7 +1998,7 @@ function normalizeProposalAgreementRow(row = {}) {
   return normalized;
 }
 
-const PA_VALID_STATUSES_SET = new Set(['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
+const PA_VALID_STATUSES_SET = new Set(['draft', 'sent', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled']);
 
 // Proposal group definitions and legacy-name aliases are business data and live in Supabase
 // (proposal_activity_groups / proposal_group_aliases). The lookup below is loaded from there
@@ -2109,7 +2110,7 @@ function sanitizeProposalAgreementPayload(payload = {}, groupLookup = proposalGr
     phone:               cleanProposalAgreementText(payload.phone),
     email:               cleanProposalAgreementText(payload.email),
     notes:               parseActivityNamesFromNotes(payload.notes).notes,
-    status:              PA_VALID_STATUSES_SET.has(rawStatus) ? rawStatus : 'draft',
+    status:              PA_VALID_STATUSES_SET.has(rawStatus) ? (rawStatus === 'pending_approval' ? 'sent' : rawStatus) : 'draft',
     approval_note:       cleanProposalAgreementText(payload.approval_note),
     total_amount:        payload.total_amount != null ? Number(payload.total_amount) || null : null,
     custom_document_sections: Array.isArray(payload.custom_document_sections) ? payload.custom_document_sections : [],

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1,5 +1,6 @@
 import { escapeHtml } from './shared/html.js';
 import { dsCard, dsEmptyState, dsPageHeader, dsScreenStack, dsTableWrap } from './shared/layout.js';
+import { showToast } from './shared/toast.js';
 
 export const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
 export const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
@@ -10,14 +11,20 @@ const SEARCH_DEBOUNCE_MS = 280;
 const TEST_HOURS_REGEX = /(?:שעות\s*)?בדיק(?:ה|ות)?/i;
 const PUBLIC_BASE = import.meta.env?.BASE_URL || './';
 
-export const STATUS_OPTIONS = ['draft', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'];
+export const STATUS_OPTIONS = ['draft', 'sent', 'returned_for_changes', 'approved', 'cancelled'];
 export const STATUS_LABELS = {
   draft:                'טיוטה',
-  pending_approval:     'ממתין לאישור',
+  sent:                 'נשלח',
+  pending_approval:     'נשלח',
   returned_for_changes: 'הוחזר לתיקון',
   approved:             'מאושר',
   cancelled:            'בוטל'
 };
+const STATUS_ALIASES = { pending_approval: 'sent' };
+function normalizeProposalStatus(status) {
+  const raw = text(status);
+  return STATUS_ALIASES[raw] || raw;
+}
 
 const FIELD_LABELS = {
   client_authority:    'רשות / מועצה / עירייה',
@@ -369,7 +376,7 @@ export function normalizeProposalAgreementRow(row = {}) {
     phone:               text(row.phone),
     email:               text(row.email),
     notes:               text(row.notes),
-    status:              STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft',
+    status:              STATUS_OPTIONS.includes(normalizeProposalStatus(row.status)) ? normalizeProposalStatus(row.status) : 'draft',
     approval_note:       text(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
     custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections.map(normalizeDocumentSection) : [],
@@ -428,7 +435,7 @@ function rowMatches(row, filters) {
   const q = normalizeSearch(filters.q);
   if (q && !normalizeSearch(row._searchText).includes(q)) return false;
   if (filters.activity_type_group && normalizeProposalGroup(row.activity_type_group) !== normalizeProposalGroup(filters.activity_type_group)) return false;
-  if (filters.status && text(row.status) !== filters.status) return false;
+  if (filters.status && normalizeProposalStatus(row.status) !== filters.status) return false;
   return true;
 }
 
@@ -458,16 +465,25 @@ function statusFilterHtml() {
 }
 
 function statusBadgeHtml(status) {
-  const label = STATUS_LABELS[status] || status || '—';
+  const normalizedStatus = normalizeProposalStatus(status);
+  const label = STATUS_LABELS[normalizedStatus] || STATUS_LABELS[status] || status || '—';
   const colorMap = {
     draft:                '#888',
-    pending_approval:     '#d97706',
+    sent:                 '#2563eb',
+    pending_approval:     '#2563eb',
     returned_for_changes: '#dc2626',
     approved:             '#16a34a',
     cancelled:            '#6b7280'
   };
-  const color = colorMap[status] || '#888';
+  const color = colorMap[normalizedStatus] || colorMap[status] || '#888';
   return `<span class="ds-pa-badge" style="display:inline-block;padding:1px 7px;border-radius:10px;font-size:0.78rem;background:${color};color:#fff;white-space:nowrap">${escapeHtml(label)}</span>`;
+}
+
+function statusSelectHtml(row, enabled) {
+  const currentStatus = STATUS_OPTIONS.includes(normalizeProposalStatus(row?.status)) ? normalizeProposalStatus(row.status) : 'draft';
+  const options = STATUS_OPTIONS.map((status) => optionHtml(status, currentStatus, STATUS_LABELS[status] || status)).join('');
+  const disabled = enabled ? '' : ' disabled aria-disabled="true"';
+  return `<select class="ds-pa-status-select" data-pa-row-status data-pa-status-id="${escapeHtml(row?.id || '')}" data-pa-previous-status="${escapeHtml(currentStatus)}" aria-label="עדכון סטטוס הצעה"${disabled}>${options}</select>`;
 }
 
 function detailRowsHtml(row) {
@@ -537,7 +553,7 @@ export function proposalsAgreementsTableRowsHtml(rows, state) {
       <td>${escapeHtml(row.school_framework || '—')}</td>
       <td>${escapeHtml(proposalGroupDisplayName(row.activity_type_group) || '—')}</td>
       <td>${escapeHtml(formatDateDisplay(row.proposal_date) || '')}</td>
-      <td>${statusBadgeHtml(row.status)}</td>
+      <td>${statusSelectHtml(row, canManage)}</td>
       <td>${row.total_amount != null ? `₪${escapeHtml(formatCurrency(row.total_amount))}` : ''}</td>
       <td class="ds-pa-actions-cell">${actionBtns.join('')}</td>
     </tr>`;
@@ -1908,7 +1924,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const title = mode === 'edit' ? 'עריכת הצעת מחיר' : 'יצירת הצעת מחיר';
   const normalizedActivityGroup = normalizeProposalGroup(row.activity_type_group);
   const filteredPricing = filterPricingByProposalType(pricingOptions, normalizedActivityGroup);
-  const currentStatus = STATUS_OPTIONS.includes(text(row.status)) ? text(row.status) : 'draft';
+  const currentStatus = STATUS_OPTIONS.includes(normalizeProposalStatus(row.status)) ? normalizeProposalStatus(row.status) : 'draft';
   const initAuth = text(row.client_authority);
   const initSchool = text(row.school_framework);
   const initContact = text(row.contact_name);
@@ -1923,7 +1939,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const hasCustomSections = Array.isArray(row.custom_document_sections) && row.custom_document_sections.length > 0;
   const canApproveDirectly = canApproveProposalsAgreements(state);
   const primaryActionLabel = canApproveDirectly ? 'אישור והפקת הצעה' : 'שליחה לאישור';
-  const primaryActionStatus = canApproveDirectly ? 'approved' : 'pending_approval';
+  const primaryActionStatus = canApproveDirectly ? 'approved' : 'sent';
 
   const initialPreviewRow = normalizeProposalAgreementRow({
     ...row,
@@ -2051,10 +2067,10 @@ function drawerActionButtons(row, state) {
     buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-edit-document="${escapeHtml(row.id)}">עריכת מסמך</button>`);
   }
   if (canManage && ['draft', 'returned_for_changes'].includes(status) && !isAdminRole) {
-    buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="pending_approval" data-pa-action-id="${escapeHtml(row.id)}">שליחה לאישור</button>`);
+    buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="sent" data-pa-action-id="${escapeHtml(row.id)}">שליחה לאישור</button>`);
   }
   if (isAdminRole) {
-    if (status === 'pending_approval') {
+    if (status === 'sent' || status === 'pending_approval') {
       buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="approved" data-pa-action-id="${escapeHtml(row.id)}">אישור</button>`);
       buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="returned_for_changes" data-pa-action-id="${escapeHtml(row.id)}">החזרה לתיקון</button>`);
     }
@@ -2214,7 +2230,7 @@ function payloadFromForm(form) {
 
 function validatePayload(payload, statusOverride) {
   const targetStatus = statusOverride || payload.status || 'draft';
-  const requiresCompleteProposal = targetStatus === 'pending_approval' || targetStatus === 'approved';
+  const requiresCompleteProposal = targetStatus === 'sent' || targetStatus === 'pending_approval' || targetStatus === 'approved';
   const requiredFields = requiresCompleteProposal
     ? REQUIRED_FIELDS_PENDING
     : REQUIRED_FIELDS_DRAFT;
@@ -3099,7 +3115,7 @@ export const proposalsAgreementsScreen = {
       // Always set status explicitly — 'draft' is the safe default
       const targetStatus = statusOverride || 'draft';
       payload.status = targetStatus;
-      const isPending = targetStatus === 'pending_approval';
+      const isPending = targetStatus === 'sent' || targetStatus === 'pending_approval';
 
       const validationErrors = validatePayload(payload, targetStatus);
       // No preview check here — the pending button handler manages the preview flow
@@ -3203,7 +3219,30 @@ export const proposalsAgreementsScreen = {
         }, rowGroup);
       }
     }, { signal });
-    root.addEventListener('change', (event) => {
+    root.addEventListener('change', async (event) => {
+
+      const rowStatusSelect = event.target.closest?.('[data-pa-row-status]');
+      if (rowStatusSelect) {
+        if (!canManage) return;
+        const id = text(rowStatusSelect.dataset.paStatusId);
+        const previousStatus = text(rowStatusSelect.dataset.paPreviousStatus) || 'draft';
+        const newStatus = text(rowStatusSelect.value);
+        if (!id || !newStatus || newStatus === previousStatus) return;
+        rowStatusSelect.disabled = true;
+        try {
+          const result = await api.updateProposalAgreementStatus(id, newStatus, '');
+          replaceLocalRow(data, result?.row || { id, status: newStatus, approval_note: '' });
+          refreshTable();
+          showToast('סטטוס ההצעה עודכן בהצלחה', 'success');
+        } catch (err) {
+          rowStatusSelect.value = previousStatus;
+          rowStatusSelect.disabled = false;
+          showToast('שגיאה בעדכון סטטוס ההצעה', 'error');
+          window.alert?.(`שגיאה בעדכון סטטוס: ${err?.message || err}`);
+        }
+        return;
+      }
+
       // ── Activity type filter ──────────────────────────────────────────────
       const activityTypeFilter = event.target.closest?.('[data-pa-activity-type-filter]');
       if (activityTypeFilter) {
@@ -3684,7 +3723,7 @@ export const proposalsAgreementsScreen = {
       if (savePendingBtn) {
         const form = savePendingBtn.closest('[data-pa-form]');
         if (!form) return;
-        const targetStatus = text(savePendingBtn.dataset.paTargetStatus) || 'pending_approval';
+        const targetStatus = text(savePendingBtn.dataset.paTargetStatus) || 'sent';
         if (form.dataset.paPreviewSeen !== 'yes') {
           // Preview not yet seen — open it automatically with a submit button inside
           const payload = payloadFromForm(form);

--- a/frontend/src/screens/shared/toast.js
+++ b/frontend/src/screens/shared/toast.js
@@ -13,8 +13,9 @@ export function showToast(message, kind = 'success', duration = 3000) {
 
   document.body.appendChild(el);
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => { el.classList.add('ds-toast--visible'); });
+  const raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : (callback) => setTimeout(callback, 0);
+  raf(() => {
+    raf(() => { el.classList.add('ds-toast--visible'); });
   });
 
   setTimeout(() => {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16471,3 +16471,23 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   }
   .pa-page-footer .pa-page-footer-logo { height: 18px !important; max-height: 18px !important; }
 }
+
+.ds-pa-status-select {
+  max-width: 112px;
+  min-width: 92px;
+  height: 28px;
+  padding: 2px 8px;
+  border: 1px solid var(--ds-border, #cbd5e1);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--ds-text, #0f172a);
+  font-size: 0.78rem;
+  line-height: 1.2;
+  direction: rtl;
+}
+
+.ds-pa-status-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+  background: var(--ds-status-neutral-soft, #e2e8f0);
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 772;
+const CACHE_VERSION = 773;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260616_proposals_agreements_sent_status.sql
+++ b/supabase/migrations/20260616_proposals_agreements_sent_status.sql
@@ -1,0 +1,7 @@
+-- Add the business "sent" status for proposals/agreements while preserving legacy statuses.
+ALTER TABLE public.proposals_agreements
+  DROP CONSTRAINT IF EXISTS proposals_agreements_status_check;
+
+ALTER TABLE public.proposals_agreements
+  ADD CONSTRAINT proposals_agreements_status_check
+  CHECK (status IN ('draft', 'sent', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'));

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 772;
+const SW_ENTRY_VERSION = 773;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -447,13 +447,13 @@ test('non-admin manager submits proposals for approval instead of approving dire
       const form = openNewProposalForm(root, dom);
       const primary = form.querySelector('[data-pa-save-pending]');
       assert.equal(primary.textContent.trim(), 'שליחה לאישור');
-      assert.equal(primary.dataset.paTargetStatus, 'pending_approval');
+      assert.equal(primary.dataset.paTargetStatus, 'sent');
       assert.doesNotMatch(form.innerHTML, /אישור והפקת הצעה/);
 
       fillPendingMinimum(form, dom, { unit_price: '650', quantity: '3' });
       primary.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
       await delay(30);
-      assert.equal(saves[0]?.status, 'pending_approval');
+      assert.equal(saves[0]?.status, 'sent');
     }
   );
 });
@@ -737,12 +737,44 @@ test('status filter shows only matching rows', async () => {
   );
 });
 
+test('table status dropdown updates status through the API and refreshes the row', async () => {
+  const localData = { rows: [{ ...sampleRows[0], status: 'draft' }] };
+  const saves = [];
+  await withJSDOM(
+    proposalsAgreementsScreen.render(localData, { state: stateFor('admin') }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: localData,
+        state: stateFor('admin'),
+        api: {
+          updateProposalAgreementStatus: async (id, status, note) => {
+            saves.push({ id, status, note });
+            return { ok: true, row: { ...localData.rows[0], id, status } };
+          }
+        }
+      });
+
+      const select = root.querySelector('[data-pa-row-status]');
+      assert.ok(select, 'status select should exist in the table row');
+      select.value = 'sent';
+      select.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      await delay(30);
+
+      assert.deepEqual(saves, [{ id: sampleRows[0].id, status: 'sent', note: '' }]);
+      assert.equal(localData.rows[0].status, 'sent');
+      assert.equal(root.querySelector('[data-pa-row-status]').value, 'sent');
+    }
+  );
+});
+
 test('status badge is rendered in table rows with correct labels', () => {
   const html = proposalsAgreementsScreen.render({ rows: sampleRows }, { state: stateFor('admin') });
   assert.match(html, /טיוטה/);
-  assert.match(html, /ממתין לאישור/);
-  // Badge markup
-  assert.match(html, /ds-pa-badge/);
+  assert.match(html, /נשלח/);
+  // Inline table status control
+  assert.match(html, /data-pa-row-status/);
+  assert.doesNotMatch(html, /נחתם/);
 });
 
 test('multiple proposal item names are preserved on save', async () => {
@@ -855,7 +887,8 @@ test('status constants exported and complete', () => {
     assert.ok(STATUS_LABELS[s], `${s} should have a Hebrew label`);
   }
   assert.ok(STATUS_OPTIONS.includes('draft'));
-  assert.ok(STATUS_OPTIONS.includes('pending_approval'));
+  assert.ok(STATUS_OPTIONS.includes('sent'));
+  assert.ok(STATUS_LABELS.pending_approval, 'legacy pending_approval rows should still have a label');
   assert.ok(STATUS_OPTIONS.includes('approved'));
   assert.ok(STATUS_OPTIONS.includes('cancelled'));
   assert.ok(STATUS_OPTIONS.includes('returned_for_changes'));


### PR DESCRIPTION
### Motivation
- Enable direct status changes from the main proposals table and introduce a business status `נשלח` (`sent`) while keeping `מאושר` as the final signed/approved state. 
- Preserve compatibility with legacy `pending_approval` rows (render as `נשלח`) and explicitly avoid adding a separate `נחתם` status.

### Description
- Add `sent` to the frontend `STATUS_OPTIONS`/`STATUS_LABELS`, add a small `STATUS_ALIASES` normalization so legacy `pending_approval` maps to `sent`, and update status normalization logic.  
- Replace the table status badge with a compact RTL-friendly `select` per row, wired to call `api.updateProposalAgreementStatus`, update local row on success, show toast notifications, and revert on failure.  
- Update API sanitization to accept `sent` (and treat legacy `pending_approval` as `sent`), add a Supabase migration that relaxes the `status` check constraint to include `sent`, and add minimal CSS for the compact select.  
- Bump Service Worker/cache version in `frontend/sw.js` and `sw.js` and update focused tests to cover the inline dropdown and `sent` behaviour.

### Testing
- Ran focused checks with `npm run check:changed` (all focused tests passed after adjustments).  
- Built the frontend via `npm run check:build` (Vite build completed successfully).  
- Executed the proposals screen unit tests with `node --test tests/proposals-agreements-screen.test.mjs` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b2241900832b8203d0982673183a)