### PR TITLE
Add 'חתום ואשר' proposal approval & signing flow

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1828,8 +1828,8 @@ function normalizeData(data) {
 
 const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
 const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
-const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
-const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = 'id,authority_id,authority_code,school_id,contact_school_id,authority_name,legacy_client_authority,contact_client_type,contact_client_name,school_name,legacy_school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,approved_by,approved_at,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = 'id,authority_id,authority_code,school_id,contact_school_id,authority_name,legacy_client_authority,contact_client_type,contact_client_name,school_name,legacy_school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,approved_by,approved_at,created_at,updated_at';
 const PROPOSALS_AGREEMENTS_WRITABLE_COLUMNS = new Set([
   'authority_id', 'school_id', 'contact_school_id', 'client_authority', 'school_framework',
   'document_type', 'activity_type_group', 'proposal_date', 'activity_names', 'contact_name',
@@ -1881,6 +1881,11 @@ function canManageProposalsAgreementsApi() {
 
 function assertCanUseProposalsAgreementsApi() {
   if (!canUseProposalsAgreementsApi()) throw new Error('proposals_agreements_forbidden');
+}
+
+function canApproveProposalsAgreementsApi() {
+  const role = String(state?.user?.display_role || state?.user?.role || '').trim();
+  return role === 'admin' || permissionFlagYes(state?.user?.approve_proposals_agreements);
 }
 
 function assertCanManageProposalsAgreementsApi() {
@@ -1991,6 +1996,8 @@ function normalizeProposalAgreementRow(row = {}) {
       }))
       : [],
     include_catalog:     row.include_catalog === true || row.include_catalog === 'yes',
+    approved_by:         cleanProposalAgreementText(row.approved_by),
+    approved_at:         cleanProposalAgreementText(row.approved_at),
     created_at:          cleanProposalAgreementText(row.created_at),
     updated_at:          cleanProposalAgreementText(row.updated_at)
   };
@@ -3933,7 +3940,12 @@ export const api = {
     const cleanStatus = cleanProposalAgreementText(status);
     if (!rowId) throw new Error('missing_proposal_agreement_id');
     if (!PA_VALID_STATUSES_SET.has(cleanStatus)) throw new Error('invalid_proposal_agreement_status');
+    if (cleanStatus === 'approved' && !canApproveProposalsAgreementsApi()) throw new Error('proposals_agreements_approval_forbidden');
     const patch = { status: cleanStatus, approval_note: cleanProposalAgreementText(approvalNote) };
+    if (cleanStatus === 'approved') {
+      patch.approved_by = state?.user?.auth_user_id || state?.user?.user_id || state?.user?.id || null;
+      patch.approved_at = new Date().toISOString();
+    }
     const { data, error } = await supabase
       .from('proposals_agreements')
       .update(patch)

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -69,7 +69,7 @@ export function canManageProposalsAgreements(state) {
 }
 
 function canApproveProposalsAgreements(state) {
-  return userRole(state) === 'admin';
+  return userRole(state) === 'admin' || permFlag(state?.user?.approve_proposals_agreements);
 }
 
 function text(value) {
@@ -382,6 +382,8 @@ export function normalizeProposalAgreementRow(row = {}) {
     custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections.map(normalizeDocumentSection) : [],
     include_catalog:     false,
     created_at:          text(row.created_at),
+    approved_by:         text(row.approved_by),
+    approved_at:         text(row.approved_at),
     updated_at:          text(row.updated_at)
   };
   normalized._searchText = buildProposalsAgreementsSearchText(normalized);
@@ -404,7 +406,15 @@ function formatDateDisplay(iso) {
     const [y, m, d] = s.split('-');
     return `${d}/${m}/${y}`;
   }
+  const parsed = new Date(s);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleDateString('he-IL', { timeZone: 'Asia/Jerusalem' });
+  }
   return s;
+}
+
+function approvalDateDisplay(row = {}) {
+  return formatDateDisplay(row.approved_at || row.signed_at || row.updated_at || row.proposal_date);
 }
 
 function formatCurrency(num) {
@@ -479,9 +489,10 @@ function statusBadgeHtml(status) {
   return `<span class="ds-pa-badge" style="display:inline-block;padding:1px 7px;border-radius:10px;font-size:0.78rem;background:${color};color:#fff;white-space:nowrap">${escapeHtml(label)}</span>`;
 }
 
-function statusSelectHtml(row, enabled) {
+function statusSelectHtml(row, enabled, canApprove = false) {
   const currentStatus = STATUS_OPTIONS.includes(normalizeProposalStatus(row?.status)) ? normalizeProposalStatus(row.status) : 'draft';
-  const options = STATUS_OPTIONS.map((status) => optionHtml(status, currentStatus, STATUS_LABELS[status] || status)).join('');
+  const selectableStatuses = canApprove ? STATUS_OPTIONS : STATUS_OPTIONS.filter((status) => status !== 'approved');
+  const options = selectableStatuses.map((status) => optionHtml(status, currentStatus, STATUS_LABELS[status] || status)).join('');
   const disabled = enabled ? '' : ' disabled aria-disabled="true"';
   return `<select class="ds-pa-status-select" data-pa-row-status data-pa-status-id="${escapeHtml(row?.id || '')}" data-pa-previous-status="${escapeHtml(currentStatus)}" aria-label="עדכון סטטוס הצעה"${disabled}>${options}</select>`;
 }
@@ -538,6 +549,9 @@ export function proposalsAgreementsTableRowsHtml(rows, state) {
     if (canManage && (['draft', 'returned_for_changes'].includes(status) || (isAdmin && status !== 'approved'))) {
       actionBtns.push(`<button type="button" class="ds-btn ds-btn--xs ds-pa-row-action" data-pa-edit-row="${escapeHtml(row.id)}" title="עריכה">עריכה</button>`);
     }
+    if (isAdmin && normalizeProposalStatus(status) === 'sent') {
+      actionBtns.push(`<button type="button" class="ds-btn ds-btn--xs ds-btn--primary ds-pa-row-action" data-pa-status-action="approved" data-pa-action-id="${escapeHtml(row.id)}" title="חתום ואשר">חתום ואשר</button>`);
+    }
     if (canManage && status === 'approved') {
       actionBtns.push(`<button type="button" class="ds-btn ds-btn--xs ds-btn--ghost ds-pa-row-action" data-pa-clone-row="${escapeHtml(row.id)}" title="שכפול להצעה חדשה">שכפול</button>`);
     }
@@ -553,7 +567,7 @@ export function proposalsAgreementsTableRowsHtml(rows, state) {
       <td>${escapeHtml(row.school_framework || '—')}</td>
       <td>${escapeHtml(proposalGroupDisplayName(row.activity_type_group) || '—')}</td>
       <td>${escapeHtml(formatDateDisplay(row.proposal_date) || '')}</td>
-      <td>${statusSelectHtml(row, canManage)}</td>
+      <td>${statusSelectHtml(row, canManage, isAdmin)}</td>
       <td>${row.total_amount != null ? `₪${escapeHtml(formatCurrency(row.total_amount))}` : ''}</td>
       <td class="ds-pa-actions-cell">${actionBtns.join('')}</td>
     </tr>`;
@@ -1476,11 +1490,16 @@ function sectionLinesHtml(value, options = {}) {
 // Signature is part of the fixed proposal document chrome and intentionally does not
 // render any legacy Supabase footer/signature markup. Keep this structure aligned with
 // Proposaleditor.html so the signer name sits on the signature line above the page footer.
-function signatureSectionHtml(_signatureBody = '') {
+function signatureSectionHtml(_signatureBody = '', row = {}) {
+  const isApproved = normalizeProposalStatus(row?.status) === 'approved';
+  const signedMeta = isApproved
+    ? `<div class="pa-signed-meta">אושר ונחתם דיגיטלית בתאריך: ${escapeHtml(approvalDateDisplay(row))}</div>`
+    : '';
   return `<div class="pa-footer-signature" aria-label="חתימה">
     <div class="pa-blessing">בברכה,</div>
     <div class="pa-signer-block">
-      <div class="pa-signer-line">עידן נחום, סמנכ״ל כספים</div>
+      <div class="pa-signer-line">עידן נחום, סמנכ״ל כספים ותפעול</div>
+      ${signedMeta}
     </div>
   </div>`;
 }
@@ -1655,7 +1674,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = []) 
     ? `<section class="pa-section pa-cost-section">${sectionTitle('payment_terms') ? `<h3 class="pa-section-heading">${escapeHtml(sectionHeadingText(sectionTitle('payment_terms')))}</h3>` : ''}${paymentTermsBody ? sectionBodyHtml(paymentTermsBody, { alwaysBullet: true }) : ''}${costTableBlock}</section>`
     : '';
 
-  const signatureHtml = signatureSectionHtml(sectionBody('signature'));
+  const signatureHtml = signatureSectionHtml(sectionBody('signature'), row);
 
   return buildProposalDocumentHtml({
     dateDisplay,
@@ -2071,7 +2090,7 @@ function drawerActionButtons(row, state) {
   }
   if (isAdminRole) {
     if (status === 'sent' || status === 'pending_approval') {
-      buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="approved" data-pa-action-id="${escapeHtml(row.id)}">אישור</button>`);
+      buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="approved" data-pa-action-id="${escapeHtml(row.id)}">חתום ואשר</button>`);
       buttons.push(`<button type="button" class="ds-btn ds-btn--sm" data-pa-status-action="returned_for_changes" data-pa-action-id="${escapeHtml(row.id)}">החזרה לתיקון</button>`);
     }
     if (!['cancelled', 'approved'].includes(status)) {
@@ -3228,6 +3247,15 @@ export const proposalsAgreementsScreen = {
         const previousStatus = text(rowStatusSelect.dataset.paPreviousStatus) || 'draft';
         const newStatus = text(rowStatusSelect.value);
         if (!id || !newStatus || newStatus === previousStatus) return;
+        if (newStatus === 'approved' && !canApproveProposalsAgreements(state)) {
+          rowStatusSelect.value = previousStatus;
+          showToast('אין הרשאה לאשר ולחתום הצעות מחיר', 'error');
+          return;
+        }
+        if (newStatus === 'approved' && !window.confirm?.('האם לאשר ולחתום את הצעת המחיר?')) {
+          rowStatusSelect.value = previousStatus;
+          return;
+        }
         rowStatusSelect.disabled = true;
         try {
           const result = await api.updateProposalAgreementStatus(id, newStatus, '');
@@ -3596,6 +3624,13 @@ export const proposalsAgreementsScreen = {
         const newStatus = text(statusActionBtn.dataset.paStatusAction);
         const id = text(statusActionBtn.dataset.paActionId);
         if (!newStatus || !id) return;
+        if (newStatus === 'approved') {
+          if (!canApproveProposalsAgreements(state)) {
+            showToast('אין הרשאה לאשר ולחתום הצעות מחיר', 'error');
+            return;
+          }
+          if (!window.confirm?.('האם לאשר ולחתום את הצעת המחיר?')) return;
+        }
         if (newStatus === 'returned_for_changes') {
           const drawer = root.querySelector('[data-pa-drawer]');
           const inlineFormHost = drawer?.querySelector('[data-pa-inline-form]');

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 773;
+const CACHE_VERSION = 774;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 773;
+const SW_ENTRY_VERSION = 774;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -466,7 +466,7 @@ test('admin sees approve and return actions for pending proposals', async () => 
       proposalsAgreementsScreen.bind({ root, data: { rows: [pendingRow] }, state: stateFor('admin'), api: {} });
       root.querySelector(`[data-pa-row-id="${pendingRow.id}"]`)?.click();
       const drawerText = root.querySelector('[data-pa-drawer]')?.textContent || '';
-      assert.match(drawerText, /אישור/);
+      assert.match(drawerText, /חתום ואשר/);
       assert.match(drawerText, /החזרה לתיקון/);
     }
   );


### PR DESCRIPTION
### Motivation

- Add an admin-gated approval-and-signing flow so proposals moved to `נשלח` can be approved and digitally signed, persisting audit data and rendering the signature on the A4 document.
- Ensure only properly authorized users can set proposals to `מאושר` and that approval is recorded with who and when.

### Description

- UI: added a quick-action `חתום ואשר` button in the proposals table for `sent` rows and the same action in the drawer for admins/approvers, shown only to users with approval permission. (frontend/src/screens/proposals-agreements.js)
- UI: status selector no longer exposes `approved` to users without approval permission and both the inline status change and action-button flows show a confirmation prompt before approving. (frontend/src/screens/proposals-agreements.js)
- API/frontend persistence: when status is set to `approved` the client code includes `approved_by` and `approved_at` in the patch, and the API layer prevents non-authorized users from approving. Normalizers/loaders now surface `approved_by` and `approved_at` so the state persists after refresh. (frontend/src/api.js, frontend/src/screens/proposals-agreements.js)
- Document rendering: the existing signature block (`.pa-footer-signature`) now renders the approved signature metadata (signer line + "אושר ונחתם דיגיטלית בתאריך: DD/MM/YYYY") only when the proposal is `approved`, and nothing is rendered in the footer or duplicated. (frontend/src/screens/proposals-agreements.js)
- Service Worker: bumped cache entry/version to ensure clients pick up JS changes. (frontend/sw.js, sw.js)
- Tests: updated the focused screen test to expect the new action label. (tests/proposals-agreements-screen.test.mjs)

### Testing

- Ran focused checks: `npm run check:changed` — passed.
- Built the frontend: `npm run check:build` (Vite build + postbuild) — passed.
- Ran focused unit/screen tests: `node --test tests/proposals-agreements-screen.test.mjs` — all focused tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30bffdadd4832b806ac39bc45260c2)