### PR TITLE
Signature: show image and `אושר בתאריך` for approved proposals

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -414,7 +414,14 @@ function formatDateDisplay(iso) {
 }
 
 function approvalDateDisplay(row = {}) {
-  return formatDateDisplay(row.approved_at || row.signed_at || row.updated_at || row.proposal_date);
+  const rawDate = row.approved_at || row.signed_at || row.updated_at || row.proposal_date;
+  const s = String(rawDate || '').trim();
+  if (!s) return '';
+  if (/^\d{4}-\d{2}-\d{2}/.test(s)) {
+    const [y, m, d] = s.slice(0, 10).split('-');
+    return `${d}/${m}/${y}`;
+  }
+  return formatDateDisplay(rawDate);
 }
 
 function formatCurrency(num) {
@@ -1492,11 +1499,11 @@ function sectionLinesHtml(value, options = {}) {
 // Proposaleditor.html so the signer name sits on the signature line above the page footer.
 function signatureSectionHtml(_signatureBody = '', row = {}) {
   const isApproved = normalizeProposalStatus(row?.status) === 'approved';
-;;;  const signatureImage = isApproved
+  const signatureImage = isApproved
     ? `<img src="${PUBLIC_BASE}proposals/signature-idan-nahum.png" alt="חתימת עידן נחום" class="pa-signature-image" loading="eager" decoding="async" onerror="this.style.display='none';">`
     : '';
   const signedMeta = isApproved
-    ? `<div class="pa-signed-meta">אושר ונחתם דיגיטלית בתאריך: ${escapeHtml(approvalDateDisplay(row))}</div>`
+    ? `<div class="pa-signed-meta">אושר בתאריך: ${escapeHtml(approvalDateDisplay(row))}</div>`
     : '';
   return `<div class="pa-footer-signature" aria-label="חתימה">
     <div class="pa-blessing">בברכה,</div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16418,9 +16418,9 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 .pa-signed-meta {
   display: block;
   margin-top: 2px;
-  font-size: 8.5px;
+  font-size: 9px;
   line-height: 1.25;
-  color: #444;
+  color: #666;
   white-space: nowrap;
   text-align: left !important;
   direction: rtl !important;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 775;
+const CACHE_VERSION = 776;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 775;
+const SW_ENTRY_VERSION = 776;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -465,6 +465,8 @@ test('approved proposals render signature image only inside the signature block'
 
   assert.doesNotMatch(draftHtml, /signature-idan-nahum\.png/);
   assert.doesNotMatch(sentHtml, /signature-idan-nahum\.png/);
+  assert.doesNotMatch(draftHtml, /אושר בתאריך/);
+  assert.doesNotMatch(sentHtml, /אושר בתאריך/);
   assert.match(approvedHtml, /proposals\/signature-idan-nahum\.png/);
 
   const doc = new JSDOM(approvedHtml).window.document;
@@ -473,7 +475,8 @@ test('approved proposals render signature image only inside the signature block'
   assert.equal(doc.querySelectorAll('.pa-signature-image').length, 1);
   assert.equal(doc.querySelectorAll('.pa-footer-signature .pa-signature-image').length, 1);
   assert.equal(doc.querySelectorAll('.pa-footer-signature .pa-signer-line').length, 1);
-  assert.match(doc.querySelector('.pa-footer-signature')?.textContent || '', /אושר ונחתם דיגיטלית בתאריך/);
+  assert.match(doc.querySelector('.pa-footer-signature')?.textContent || '', /אושר בתאריך: 16\/06\/2026/);
+  assert.doesNotMatch(doc.querySelector('.pa-footer-signature')?.textContent || '', /אושר ונחתם דיגיטלית/);
 });
 
 test('admin sees approve and return actions for pending proposals', async () => {


### PR DESCRIPTION
### Motivation
- Remove the duplicated/verbose signature wording and ensure the signature image is the single visual signature for approved proposals. 
- Display a concise approval line `אושר בתאריך: DD/MM/YYYY` (no “נחתם דיגיטלית”) and make it visually secondary. 
- Bump Service Worker cache versions because JS/CSS changed so clients will pick up the new assets.

### Description
- Replace the long phrase `אושר ונחתם דיגיטלית בתאריך: ...` with the shorter `אושר בתאריך: ${approvalDate}` in the signature block and ensure the signer name and signature image remain as identification and the only signature visual (`frontend/src/screens/proposals-agreements.js`).
- Ensure approved dates render as `DD/MM/YYYY` for ISO date inputs by enhancing `approvalDateDisplay` to format `YYYY-MM-DD`/ISO correctly (`frontend/src/screens/proposals-agreements.js`).
- Make the approval meta visually subtler by updating `.pa-signed-meta` sizing/color (`frontend/src/styles/main.css`).
- Update focused tests to assert no signature image or approval line for `draft`/`sent`, and to validate the approved state shows one signature block, image, signer line and the new `אושר בתאריך` wording while rejecting the old digital-signature phrase (`tests/proposals-agreements-screen.test.mjs`).
- Bump Service Worker cache/version constants in `frontend/sw.js` and root `sw.js` (incremented 775 -> 776) to invalidate old caches after deploy.

### Testing
- Ran focused checks with `npm run check:changed`, which exercised `node --test tests/proposals-agreements-screen.test.mjs`, and all focused tests passed (68 passed, 0 failed). 
- Built the frontend with `npm run check:build` (Vite build) and the build completed successfully. 
- Ran the proposal screen test directly with `node --test tests/proposals-agreements-screen.test.mjs` and it passed. 
- Note: Service Worker versions were bumped in both `frontend/sw.js` and `sw.js`; users may need `Ctrl+Shift+R` after deploy to clear cached app shell.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30c904480c832b95020715a1216d37)