### PR TITLE
Manual proposal signature placement (drag-to-place + persist signature_meta)

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Cy3OrP36.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BaCnB6xJ.css">
+  <script type="module" crossorigin src="./assets/index-CEensn6D.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-D65HtmMm.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1828,13 +1828,13 @@ function normalizeData(data) {
 
 const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
 const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
-const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,approved_by,approved_at,created_at,updated_at';
-const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = 'id,authority_id,authority_code,school_id,contact_school_id,authority_name,legacy_client_authority,contact_client_type,contact_client_name,school_name,legacy_school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,approved_by,approved_at,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_COLUMNS = 'id,authority_id,school_id,contact_school_id,client_authority,school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,signature_meta,approved_by,approved_at,created_at,updated_at';
+const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = 'id,authority_id,authority_code,school_id,contact_school_id,authority_name,legacy_client_authority,contact_client_type,contact_client_name,school_name,legacy_school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,signature_meta,approved_by,approved_at,created_at,updated_at';
 const PROPOSALS_AGREEMENTS_WRITABLE_COLUMNS = new Set([
   'authority_id', 'school_id', 'contact_school_id', 'client_authority', 'school_framework',
   'document_type', 'activity_type_group', 'proposal_date', 'activity_names', 'contact_name',
   'contact_role', 'phone', 'email', 'notes', 'status', 'approval_note', 'total_amount',
-  'custom_document_sections', 'include_catalog'
+  'custom_document_sections', 'include_catalog', 'signature_meta'
 ]);
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
@@ -3934,7 +3934,7 @@ export const api = {
     if (error) throw new Error(error.message || 'proposals_agreement_delete_failed');
     return { ok: true, id: rowId };
   },
-  updateProposalAgreementStatus: async (id, status, approvalNote = '') => {
+  updateProposalAgreementStatus: async (id, status, approvalNote = '', signatureMeta = null) => {
     assertCanManageProposalsAgreementsApi();
     const rowId = cleanProposalAgreementText(id);
     const cleanStatus = cleanProposalAgreementText(status);
@@ -3945,6 +3945,7 @@ export const api = {
     if (cleanStatus === 'approved') {
       patch.approved_by = state?.user?.auth_user_id || state?.user?.user_id || state?.user?.id || null;
       patch.approved_at = new Date().toISOString();
+      if (signatureMeta && typeof signatureMeta === 'object') patch.signature_meta = signatureMeta;
     }
     const { data, error } = await supabase
       .from('proposals_agreements')

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'proposal-footer-signature-v2'
+  HOTFIX_VERSION: 'proposal-manual-signature-v1'
 };

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -10,6 +10,8 @@ const SEARCH_DEBOUNCE_MS = 280;
 // This frontend keeps only UI logic and derives options from the loader payload.
 const TEST_HOURS_REGEX = /(?:שעות\s*)?בדיק(?:ה|ות)?/i;
 const PUBLIC_BASE = import.meta.env?.BASE_URL || './';
+const PROPOSAL_SIGNATURE_IMAGE = 'proposals/signature-idan-nahum.png';
+const DEFAULT_SIGNATURE_META = Object.freeze({ image: PROPOSAL_SIGNATURE_IMAGE, xPercent: 68, yPercent: 78, widthPercent: 18 });
 
 export const STATUS_OPTIONS = ['draft', 'sent', 'returned_for_changes', 'approved', 'cancelled'];
 export const STATUS_LABELS = {
@@ -381,6 +383,7 @@ export function normalizeProposalAgreementRow(row = {}) {
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
     custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections.map(normalizeDocumentSection) : [],
     include_catalog:     false,
+    signature_meta:      normalizeSignatureMeta(row.signature_meta || row.approval_meta),
     created_at:          text(row.created_at),
     approved_by:         text(row.approved_by),
     approved_at:         text(row.approved_at),
@@ -422,6 +425,56 @@ function approvalDateDisplay(row = {}) {
     return `${d}/${m}/${y}`;
   }
   return formatDateDisplay(rawDate);
+}
+
+
+function clampNumber(value, min, max, fallback) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+function normalizeSignatureMeta(value) {
+  let raw = value;
+  if (typeof raw === 'string' && raw.trim()) {
+    try { raw = JSON.parse(raw); } catch { raw = null; }
+  }
+  const source = raw?.signature && typeof raw.signature === 'object' ? raw.signature : raw;
+  if (!source || typeof source !== 'object') return null;
+  const xPercent = clampNumber(source.xPercent, 0, 100, null);
+  const yPercent = clampNumber(source.yPercent, 0, 100, null);
+  const widthPercent = clampNumber(source.widthPercent, 6, 35, DEFAULT_SIGNATURE_META.widthPercent);
+  if (xPercent == null || yPercent == null) return null;
+  return {
+    signature: {
+      image: text(source.image) || PROPOSAL_SIGNATURE_IMAGE,
+      xPercent,
+      yPercent,
+      widthPercent
+    }
+  };
+}
+
+function signatureMetaForRow(row = {}) {
+  return normalizeSignatureMeta(row.signature_meta || row.approval_meta) || DEFAULT_SIGNATURE_META && { signature: { ...DEFAULT_SIGNATURE_META } };
+}
+
+function signatureLayerHtml(row = {}, { editable = false } = {}) {
+  const isApproved = normalizeProposalStatus(row?.status) === 'approved';
+  if (!isApproved && !editable) return '';
+  const meta = normalizeSignatureMeta(row.signature_meta || row.approval_meta) || { signature: { ...DEFAULT_SIGNATURE_META } };
+  const sig = meta.signature;
+  const x = clampNumber(sig.xPercent, 0, 100, DEFAULT_SIGNATURE_META.xPercent);
+  const y = clampNumber(sig.yPercent, 0, 100, DEFAULT_SIGNATURE_META.yPercent);
+  const w = clampNumber(sig.widthPercent, 6, 35, DEFAULT_SIGNATURE_META.widthPercent);
+  const img = text(sig.image) || PROPOSAL_SIGNATURE_IMAGE;
+  const approvedText = isApproved ? approvalDateDisplay(row) : '';
+  return `<div class="pa-signature-layer${editable ? ' is-editing' : ''}" data-pa-signature-layer>
+    <div class="pa-signature-sticker${editable ? ' is-draggable' : ''}" data-pa-signature-sticker style="left:${x}%;top:${y}%;width:${w}%;" ${editable ? 'tabindex="0" role="button" aria-label="גרירת חתימה למיקום במסמך"' : ''}>
+      <img class="pa-signature-image" src="${PUBLIC_BASE}${escapeHtml(img)}" alt="חתימת עידן נחום" loading="eager" decoding="async" draggable="false" onerror="this.style.display='none';">
+      <div class="pa-signature-approval-line">${isApproved && approvedText ? `אושר בתאריך: ${escapeHtml(approvedText)}` : 'מקם את החתימה כאן'}</div>
+    </div>
+  </div>`;
 }
 
 function formatCurrency(num) {
@@ -1497,20 +1550,11 @@ function sectionLinesHtml(value, options = {}) {
 // Signature is part of the fixed proposal document chrome and intentionally does not
 // render any legacy Supabase footer/signature markup. Keep this structure aligned with
 // Proposaleditor.html so the signer name sits on the signature line above the page footer.
-function signatureSectionHtml(_signatureBody = '', row = {}) {
-  const isApproved = normalizeProposalStatus(row?.status) === 'approved';
-  const signatureImage = isApproved
-    ? `<img src="${PUBLIC_BASE}proposals/signature-idan-nahum.png" alt="חתימת עידן נחום" class="pa-signature-image" loading="eager" decoding="async" onerror="this.style.display='none';">`
-    : '';
-  const signedMeta = isApproved
-    ? `<div class="pa-signed-meta">אושר בתאריך: ${escapeHtml(approvalDateDisplay(row))}</div>`
-    : '';
+function signatureSectionHtml(_signatureBody = '', _row = {}) {
   return `<div class="pa-footer-signature" aria-label="חתימה">
     <div class="pa-blessing">בברכה,</div>
     <div class="pa-signer-block">
-      ${signatureImage}
       <div class="pa-signer-line">עידן נחום, סמנכ״ל כספים ותפעול</div>
-      ${signedMeta}
     </div>
   </div>`;
 }
@@ -1562,6 +1606,7 @@ function buildProposalDocumentHtml({ dateDisplay, documentTitle, row, introText,
   const title = text(documentTitle);
   return `
     <div class="proposal-document pa-document pa-a4-page" dir="rtl">
+      ${signatureLayerHtml(row)}
       <div class="proposal-document-header pa-page-header">
         <div class="proposal-header-brand pa-logo-area">
           <img
@@ -3096,6 +3141,7 @@ export const proposalsAgreementsScreen = {
       overlay.setAttribute('dir', 'rtl');
       const clientLabel = [freshRow.client_authority, freshRow.school_framework].filter(Boolean).map(escapeHtml).join(' — ');
       const saveBtnHtml = '';
+      const signingMode = options.signatureMode === true;
       const submitBtnHtml = options.onSubmit ? `<button type="button" class="ds-btn ds-btn--primary ds-btn--sm no-print" id="pa-preview-submit">${escapeHtml(options.submitLabel || 'שליחה לאישור')}</button>` : '';
       const hasCustomSections = Array.isArray(freshRow.custom_document_sections) && freshRow.custom_document_sections.length > 0;
       const missingTemplateNotice = (!templateSections.length && !hasCustomSections)
@@ -3110,16 +3156,49 @@ export const proposalsAgreementsScreen = {
           <button type="button" class="ds-btn ds-btn--sm no-print" id="pa-preview-close">← חזרה לעריכה</button>
           ${saveBtnHtml}
           ${submitBtnHtml}
+          ${signingMode ? '<button type="button" class="ds-btn ds-btn--primary ds-btn--sm no-print" id="pa-signature-confirm">אשר מיקום וחתום</button><button type="button" class="ds-btn ds-btn--sm ds-btn--ghost no-print" id="pa-signature-cancel">ביטול</button>' : ''}
           <button type="button" class="ds-btn ds-btn--sm no-print" id="pa-print-btn">הדפסה / שמירה כ-PDF</button>
           <span class="ds-pa-preview-client no-print">${clientLabel}</span>
           ${missingTemplateNotice}
           ${missingItemsNotice}
         </div>
         <div class="proposal-preview-area">
-          ${proposalPreviewBodyHtml(freshRow, items, templateSections)}
+          ${signingMode ? proposalPreviewBodyHtml({ ...freshRow, status: 'draft' }, items, templateSections).replace('<div class="proposal-document pa-document pa-a4-page" dir="rtl">', '<div class="proposal-document pa-document pa-a4-page" dir="rtl">' + signatureLayerHtml({ ...freshRow, status: 'draft' }, { editable: true })) : proposalPreviewBodyHtml(freshRow, items, templateSections)}
         </div>`;
       document.body.appendChild(overlay);
       document.body.classList.add('is-print-preview');
+      const signatureSticker = signingMode ? overlay.querySelector('[data-pa-signature-sticker]') : null;
+      const signaturePage = signatureSticker?.closest('.pa-a4-page');
+      const readSignatureMeta = () => {
+        if (!signatureSticker || !signaturePage) return { signature: { ...DEFAULT_SIGNATURE_META } };
+        const pageRect = signaturePage.getBoundingClientRect();
+        const stickerRect = signatureSticker.getBoundingClientRect();
+        const widthPercent = clampNumber((stickerRect.width / pageRect.width) * 100, 6, 35, DEFAULT_SIGNATURE_META.widthPercent);
+        const xPercent = clampNumber(((stickerRect.left - pageRect.left) / pageRect.width) * 100, 0, 100 - widthPercent, DEFAULT_SIGNATURE_META.xPercent);
+        const yPercent = clampNumber(((stickerRect.top - pageRect.top) / pageRect.height) * 100, 0, 96, DEFAULT_SIGNATURE_META.yPercent);
+        return { signature: { image: PROPOSAL_SIGNATURE_IMAGE, xPercent: Math.round(xPercent * 100) / 100, yPercent: Math.round(yPercent * 100) / 100, widthPercent: Math.round(widthPercent * 100) / 100 } };
+      };
+      if (signatureSticker && signaturePage) {
+        let dragState = null;
+        signatureSticker.addEventListener('pointerdown', (e) => {
+          const pageRect = signaturePage.getBoundingClientRect();
+          const stickerRect = signatureSticker.getBoundingClientRect();
+          dragState = { dx: e.clientX - stickerRect.left, dy: e.clientY - stickerRect.top, pageRect };
+          signatureSticker.setPointerCapture?.(e.pointerId);
+          e.preventDefault();
+        });
+        signatureSticker.addEventListener('pointermove', (e) => {
+          if (!dragState) return;
+          const pageRect = signaturePage.getBoundingClientRect();
+          const stickerRect = signatureSticker.getBoundingClientRect();
+          const leftPx = Math.min(pageRect.width - stickerRect.width, Math.max(0, e.clientX - pageRect.left - dragState.dx));
+          const topPx = Math.min(pageRect.height - stickerRect.height, Math.max(0, e.clientY - pageRect.top - dragState.dy));
+          signatureSticker.style.left = `${(leftPx / pageRect.width) * 100}%`;
+          signatureSticker.style.top = `${(topPx / pageRect.height) * 100}%`;
+        });
+        signatureSticker.addEventListener('pointerup', () => { dragState = null; });
+        signatureSticker.addEventListener('pointercancel', () => { dragState = null; });
+      }
       if (options.form) options.form.dataset.paPreviewSeen = 'yes';
       const printButton = overlay.querySelector('#pa-print-btn');
       printButton?.addEventListener('click', () => {
@@ -3127,6 +3206,8 @@ export const proposalsAgreementsScreen = {
       });
       const closeOverlay = () => { overlay.remove(); document.body.classList.remove('is-print-preview'); };
       overlay.querySelector('#pa-preview-close')?.addEventListener('click', closeOverlay);
+      overlay.querySelector('#pa-signature-cancel')?.addEventListener('click', closeOverlay);
+      overlay.querySelector('#pa-signature-confirm')?.addEventListener('click', () => options.onSignatureConfirm?.(readSignatureMeta(), closeOverlay));
       if (options.onSubmit) overlay.querySelector('#pa-preview-submit')?.addEventListener('click', () => { closeOverlay(); options.onSubmit(); });
       overlay.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeOverlay(); });
 
@@ -3263,8 +3344,29 @@ export const proposalsAgreementsScreen = {
           showToast('אין הרשאה לאשר ולחתום הצעות מחיר', 'error');
           return;
         }
-        if (newStatus === 'approved' && !window.confirm?.('האם לאשר ולחתום את הצעת המחיר?')) {
+        if (newStatus === 'approved') {
           rowStatusSelect.value = previousStatus;
+          const row = data.rows.find((r) => text(r.id) === id);
+          if (!row) return;
+          let items = [];
+          try { if (typeof api.readProposalAgreementItems === 'function') items = await api.readProposalAgreementItems(id); } catch { items = []; }
+          await openPreview(row, items, {
+            signatureMode: true,
+            onSignatureConfirm: async (signatureMeta, closeOverlay) => {
+              rowStatusSelect.disabled = true;
+              try {
+                const result = await api.updateProposalAgreementStatus(id, 'approved', '', signatureMeta);
+                replaceLocalRow(data, result?.row || { id, status: 'approved', approval_note: '', signature_meta: signatureMeta });
+                refreshTable();
+                closeOverlay?.();
+                showToast('ההצעה אושרה ונחתמה במיקום שנבחר', 'success');
+              } catch (err) {
+                rowStatusSelect.disabled = false;
+                showToast('שגיאה בעדכון סטטוס ההצעה', 'error');
+                window.alert?.(`שגיאה בעדכון סטטוס: ${err?.message || err}`);
+              }
+            }
+          });
           return;
         }
         rowStatusSelect.disabled = true;
@@ -3640,7 +3742,30 @@ export const proposalsAgreementsScreen = {
             showToast('אין הרשאה לאשר ולחתום הצעות מחיר', 'error');
             return;
           }
-          if (!window.confirm?.('האם לאשר ולחתום את הצעת המחיר?')) return;
+          const row = data.rows.find((r) => text(r.id) === id);
+          if (!row) return;
+          let items = [];
+          try { if (typeof api.readProposalAgreementItems === 'function') items = await api.readProposalAgreementItems(id); } catch { items = []; }
+          await openPreview(row, items, {
+            signatureMode: true,
+            onSignatureConfirm: async (signatureMeta, closeOverlay) => {
+              statusActionBtn.disabled = true;
+              try {
+                const result = await api.updateProposalAgreementStatus(id, 'approved', '', signatureMeta);
+                replaceLocalRow(data, result?.row || { id, status: 'approved', approval_note: '', signature_meta: signatureMeta });
+                refreshTable();
+                const updated = data.rows.find((item) => text(item.id) === id);
+                const drawer = root.querySelector('[data-pa-drawer]');
+                if (drawer && updated) drawer.outerHTML = drawerHtml(updated, activityNameOptions, state);
+                closeOverlay?.();
+                showToast('ההצעה אושרה ונחתמה במיקום שנבחר', 'success');
+              } catch (err) {
+                statusActionBtn.disabled = false;
+                window.alert?.(`שגיאה באישור וחתימה: ${err?.message || err}`);
+              }
+            }
+          });
+          return;
         }
         if (newStatus === 'returned_for_changes') {
           const drawer = root.querySelector('[data-pa-drawer]');

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16509,3 +16509,44 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   opacity: 0.72;
   background: var(--ds-status-neutral-soft, #e2e8f0);
 }
+
+.pa-a4-page { position: relative; overflow: hidden; }
+.pa-signature-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+.pa-signature-sticker {
+  position: absolute;
+  max-width: 35%;
+  cursor: default;
+  pointer-events: auto;
+  user-select: none;
+  touch-action: none;
+  transform: translate(0, 0);
+}
+.pa-signature-sticker.is-draggable {
+  cursor: move;
+  border: 1px dashed rgba(37, 99, 235, 0.55);
+  border-radius: 10px;
+  padding: 5px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+}
+.pa-signature-sticker img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  -webkit-user-drag: none;
+}
+.pa-signature-approval-line {
+  margin-top: 2px;
+  font-size: 9px;
+  line-height: 1.25;
+  color: #666;
+  text-align: center;
+  white-space: nowrap;
+}
+.pa-signature-layer.is-editing .pa-signature-approval-line { color: #2563eb; }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 776;
+const CACHE_VERSION = 777;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260616_proposals_agreements_signature_meta.sql
+++ b/supabase/migrations/20260616_proposals_agreements_signature_meta.sql
@@ -1,0 +1,6 @@
+-- Store admin-selected proposal signature placement as JSON percentages relative to the A4 page.
+ALTER TABLE public.proposals_agreements
+  ADD COLUMN IF NOT EXISTS signature_meta jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.proposals_agreements.signature_meta IS
+  'Proposal approval signature metadata, including image path and x/y/width percentages relative to the A4 page.';

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 776;
+const SW_ENTRY_VERSION = 777;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -458,7 +458,7 @@ test('non-admin manager submits proposals for approval instead of approving dire
   );
 });
 
-test('approved proposals render signature image only inside the signature block', () => {
+test('approved proposals render signature sticker once inside the A4 document', () => {
   const draftHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'draft' }, [], []);
   const sentHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'sent' }, [], []);
   const approvedHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'approved', approved_at: '2026-06-16T10:30:00.000Z' }, [], []);
@@ -473,10 +473,10 @@ test('approved proposals render signature image only inside the signature block'
   assert.equal(doc.querySelectorAll('.pa-footer-signature').length, 1);
   assert.equal(doc.querySelectorAll('.pa-page-footer').length, 1);
   assert.equal(doc.querySelectorAll('.pa-signature-image').length, 1);
-  assert.equal(doc.querySelectorAll('.pa-footer-signature .pa-signature-image').length, 1);
+  assert.equal(doc.querySelectorAll('.pa-signature-layer .pa-signature-image').length, 1);
   assert.equal(doc.querySelectorAll('.pa-footer-signature .pa-signer-line').length, 1);
-  assert.match(doc.querySelector('.pa-footer-signature')?.textContent || '', /אושר בתאריך: 16\/06\/2026/);
-  assert.doesNotMatch(doc.querySelector('.pa-footer-signature')?.textContent || '', /אושר ונחתם דיגיטלית/);
+  assert.match(doc.querySelector('.pa-signature-layer')?.textContent || '', /אושר בתאריך: 16\/06\/2026/);
+  assert.doesNotMatch(doc.querySelector('.pa-signature-layer')?.textContent || '', /אושר ונחתם דיגיטלית/);
 });
 
 test('admin sees approve and return actions for pending proposals', async () => {


### PR DESCRIPTION
### Motivation
- Allow authorized approvers to position the proposal signature manually on the A4 document instead of always using a fixed footer image. 
- Persist the chosen placement so the preview and PDF/print show the signature exactly where the admin placed it.
- Keep the approval flow explicit: entering a signing mode and confirming placement is required before the status becomes `approved`.

### Description
- UI: Add a draggable signature "sticker" layer over the A4 document in the preview and a signing mode opened from `חתום ואשר` / `approved` actions; the sticker is constrained to the A4 page and shows a subtle editing border while draggable (`signatureLayerHtml`, drag handlers inside `openPreview`).
- Data: Introduce a new JSONB column `signature_meta` (migration `supabase/migrations/20260616_proposals_agreements_signature_meta.sql`) that stores `{ signature: { image, xPercent, yPercent, widthPercent } }` with percentages relative to the A4 page.
- API: Extend `api.updateProposalAgreementStatus` to accept an optional `signatureMeta` argument and persist `signature_meta` when approving, alongside `approved_by` and `approved_at`.
- Rendering: Move signature rendering into an absolute `.pa-signature-layer` inside the A4 document so approved signatures appear at the stored relative position and not duplicated in the footer; the footer keeps the signer name and the approval date line remains near the signature sticker.
- Styles / SW: Add scoped CSS for `.pa-signature-layer` and `.pa-signature-sticker` (in `frontend/src/styles/main.css`) and bump service worker cache version (`frontend/sw.js` and `sw.js`) and `HOTFIX_VERSION` in config.
- Safety: Signature placement is saved in percentages (not pixels) to ensure consistent rendering in preview and PDF/print across viewports.

### Testing
- Ran focused verification: `npm run check:changed` (JS checks + focused tests) — passed.
- Frontend build verified: `npm run check:build` (`vite build`) — passed and assets updated.
- Focused screen test executed: `node --test tests/proposals-agreements-screen.test.mjs` — all tests passed (focused assertions include signature placement rendering and no duplicate footer signature).
- Note: a Playwright screenshot attempt failed because `playwright` is not installed in the environment; manual UI screenshot not produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d20525d8832ba165359bde86cf52)