### PR TITLE
Guard proposal approval permissions

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1834,8 +1834,9 @@ const PROPOSALS_AGREEMENTS_WRITABLE_COLUMNS = new Set([
   'authority_id', 'school_id', 'contact_school_id', 'client_authority', 'school_framework',
   'document_type', 'activity_type_group', 'proposal_date', 'activity_names', 'contact_name',
   'contact_role', 'phone', 'email', 'notes', 'status', 'approval_note', 'total_amount',
-  'custom_document_sections', 'include_catalog', 'signature_meta'
+  'custom_document_sections', 'include_catalog'
 ]);
+const PROPOSALS_AGREEMENTS_APPROVAL_COLUMNS = new Set(['approved_by', 'approved_at', 'signature_position', 'signature_meta']);
 const PA_ACTIVITY_NAMES_MARKER = '\u001ePA_ACTIVITY_NAMES:';
 
 function parseActivityNamesFromNotes(notes) {
@@ -2095,7 +2096,16 @@ function enrichProposalPricingRows(rows = [], groupLookup = proposalGroupLookupC
   });
 }
 
+function assertProposalAgreementApprovalPayloadAllowed(payload = {}) {
+  const requestedStatus = cleanProposalAgreementText(payload.status);
+  const touchesApprovalField = Object.keys(payload || {}).some((key) => PROPOSALS_AGREEMENTS_APPROVAL_COLUMNS.has(key));
+  if ((requestedStatus === 'approved' || touchesApprovalField) && !canApproveProposalsAgreementsApi()) {
+    throw new Error('proposals_agreements_approval_forbidden');
+  }
+}
+
 function sanitizeProposalAgreementPayload(payload = {}, groupLookup = proposalGroupLookupCache) {
+  assertProposalAgreementApprovalPayloadAllowed(payload);
   const activity_names = normalizeProposalAgreementActivityNames(payload.activity_names);
   const rawStatus = cleanProposalAgreementText(payload.status);
   const rawGroup = cleanProposalAgreementText(payload.activity_type_group);
@@ -2360,7 +2370,7 @@ async function readProposalsAgreementsFromSupabase() {
   };
 }
 
-const USER_PUBLIC_COLUMNS = 'user_id,username,email,name,role,display_role,is_active,permissions,auth_user_id,can_review_requests,view_proposals_agreements,manage_proposals_agreements';
+const USER_PUBLIC_COLUMNS = 'user_id,username,email,name,role,display_role,is_active,permissions,auth_user_id,can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements';
 const PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_reports';
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 
@@ -2536,6 +2546,7 @@ function flattenUserRow(userRow = {}) {
   if (userRow.can_review_requests != null) flat.can_review_requests = userRow.can_review_requests;
   if (userRow.view_proposals_agreements != null) flat.view_proposals_agreements = userRow.view_proposals_agreements;
   if (userRow.manage_proposals_agreements != null) flat.manage_proposals_agreements = userRow.manage_proposals_agreements;
+  if (userRow.approve_proposals_agreements != null) flat.approve_proposals_agreements = userRow.approve_proposals_agreements;
   return flat;
 }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 777;
+const CACHE_VERSION = 778;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260616_proposals_agreements_approval_guard.sql
+++ b/supabase/migrations/20260616_proposals_agreements_approval_guard.sql
@@ -1,0 +1,51 @@
+-- Enforce proposal/agreement approval permissions at the database layer.
+-- UI checks are not sufficient because the frontend talks directly to Supabase.
+
+alter table public.users
+  add column if not exists approve_proposals_agreements boolean;
+
+create or replace function public.app_can_approve_proposals_agreements()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(
+    public.app_current_role() = 'admin'
+    or public.app_has_permission('approve_proposals_agreements'),
+    false
+  )
+$$;
+
+revoke all on function public.app_can_approve_proposals_agreements() from public;
+grant execute on function public.app_can_approve_proposals_agreements() to authenticated;
+
+create or replace function public.guard_proposals_agreements_approval_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.app_can_approve_proposals_agreements() and (
+    new.status = 'approved'
+    or new.approved_by is distinct from old.approved_by
+    or new.approved_at is distinct from old.approved_at
+    or new.signature_meta is distinct from old.signature_meta
+  ) then
+    raise exception 'proposals_agreements_approval_forbidden'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.guard_proposals_agreements_approval_update() from public;
+
+drop trigger if exists trg_guard_proposals_agreements_approval_update on public.proposals_agreements;
+create trigger trg_guard_proposals_agreements_approval_update
+before update on public.proposals_agreements
+for each row
+execute function public.guard_proposals_agreements_approval_update();

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 777;
+const SW_ENTRY_VERSION = 778;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -58,6 +58,7 @@ const ACT_NAV_FILE = new URL('../frontend/src/screens/shared/act-nav-grid.js', i
 const SCREEN_FILE = new URL('../frontend/src/screens/proposals-agreements.js', import.meta.url);
 const MIGRATION_FILE = new URL('../supabase/migrations/20260518_create_proposals_agreements.sql', import.meta.url);
 const ROLE_UPDATE_MIGRATION_FILE = new URL('../supabase/migrations/20260602_add_business_development_manager_role.sql', import.meta.url);
+const APPROVAL_GUARD_MIGRATION_FILE = new URL('../supabase/migrations/20260616_proposals_agreements_approval_guard.sql', import.meta.url);
 
 const { proposalsAgreementsScreen, canAccessProposalsAgreements, canManageProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS, buildProposalCatalogPdfEntries, proposalPreviewBodyHtml } = await import('../frontend/src/screens/proposals-agreements.js');
 
@@ -201,6 +202,80 @@ test('role update migration allows business development manager for login and pr
   assert.match(migration, /app_can_manage_proposals_agreements[\s\S]*app_current_role\(\) in \('domain_manager', 'operation_manager', 'admin'\)/);
   assert.match(migration, /for insert[\s\S]*with check \(public\.app_can_manage_proposals_agreements\(\)\)/);
   assert.match(migration, /for update[\s\S]*using \(public\.app_can_manage_proposals_agreements\(\)\)/);
+});
+
+
+
+test('proposal approval UI is limited to admin or approve permission users', async () => {
+  const sentRow = { ...sampleRows[0], status: 'sent' };
+  const draftRow = { ...sampleRows[0], status: 'draft' };
+  const regularManager = stateFor('operation_manager');
+  regularManager.user.manage_proposals_agreements = true;
+  const privilegedManager = stateFor('operation_manager');
+  privilegedManager.user.manage_proposals_agreements = true;
+  privilegedManager.user.approve_proposals_agreements = true;
+
+  const regularHtml = proposalsAgreementsScreen.render({ rows: [sentRow] }, { state: regularManager });
+  assert.doesNotMatch(regularHtml, /חתום ואשר/, 'unprivileged manager should not see sign-and-approve action');
+  const regularTable = regularHtml.match(/<tbody data-pa-table-body>[\s\S]*?<\/tbody>/)?.[0] || '';
+  assert.doesNotMatch(regularTable, /<option value="approved"/, 'unprivileged manager should not be able to select approved status');
+
+  const privilegedDraftHtml = proposalsAgreementsScreen.render({ rows: [draftRow] }, { state: privilegedManager });
+  assert.doesNotMatch(privilegedDraftHtml, /חתום ואשר/, 'privileged user should only see sign-and-approve for sent proposals');
+
+  const privilegedSentHtml = proposalsAgreementsScreen.render({ rows: [sentRow] }, { state: privilegedManager });
+  assert.match(privilegedSentHtml, /חתום ואשר/, 'approve permission should reveal sign-and-approve for sent proposals');
+  const privilegedTable = privilegedSentHtml.match(/<tbody data-pa-table-body>[\s\S]*?<\/tbody>/)?.[0] || '';
+  assert.match(privilegedTable, /<option value="approved"/, 'approve permission should allow selecting approved status');
+});
+
+test('unprivileged users cannot open signature mode or save signature from forged approve actions', async () => {
+  const sentRow = { ...sampleRows[0], status: 'sent' };
+  const managerState = stateFor('operation_manager');
+  managerState.user.manage_proposals_agreements = true;
+  let updateCalls = 0;
+  let readCalls = 0;
+
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [sentRow] }, { state: managerState }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [sentRow], activityNameOptions: [], contactOptions: [] },
+        state: managerState,
+        api: {
+          readProposalAgreementItems: async () => { readCalls += 1; return []; },
+          updateProposalAgreementStatus: async () => { updateCalls += 1; return { ok: true }; }
+        }
+      });
+      const forged = dom.window.document.createElement('button');
+      forged.type = 'button';
+      forged.dataset.paStatusAction = 'approved';
+      forged.dataset.paActionId = sentRow.id;
+      root.appendChild(forged);
+      forged.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await delay(20);
+
+      assert.equal(dom.window.document.getElementById('pa-preview-overlay'), null, 'signature placement overlay should not open');
+      assert.equal(readCalls, 0, 'signature flow should not load proposal items');
+      assert.equal(updateCalls, 0, 'signature save/update should not be called');
+    }
+  );
+});
+
+test('proposal approval API and RLS guard direct approval writes', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const migration = await readFile(APPROVAL_GUARD_MIGRATION_FILE, 'utf8');
+
+  assert.match(apiSource, /function canApproveProposalsAgreementsApi\(\)[\s\S]*role === 'admin'[\s\S]*approve_proposals_agreements/);
+  assert.match(apiSource, /assertProposalAgreementApprovalPayloadAllowed[\s\S]*PROPOSALS_AGREEMENTS_APPROVAL_COLUMNS[\s\S]*requestedStatus === 'approved'/);
+  assert.match(apiSource, /PROPOSALS_AGREEMENTS_APPROVAL_COLUMNS = new Set\(\['approved_by', 'approved_at', 'signature_position', 'signature_meta'\]\)/);
+  assert.match(apiSource, /updateProposalAgreementStatus[\s\S]*cleanStatus === 'approved' && !canApproveProposalsAgreementsApi\(\)[\s\S]*proposals_agreements_approval_forbidden/);
+
+  assert.match(migration, /app_can_approve_proposals_agreements[\s\S]*app_current_role\(\) = 'admin'[\s\S]*app_has_permission\('approve_proposals_agreements'\)/);
+  assert.match(migration, /guard_proposals_agreements_approval_update[\s\S]*new\.status = 'approved'[\s\S]*new\.approved_by is distinct from old\.approved_by[\s\S]*new\.approved_at is distinct from old\.approved_at[\s\S]*new\.signature_meta is distinct from old\.signature_meta/);
+  assert.match(migration, /raise exception 'proposals_agreements_approval_forbidden'/);
+  assert.match(migration, /create trigger trg_guard_proposals_agreements_approval_update/);
 });
 
 test('table structure includes all required columns including status', () => {


### PR DESCRIPTION
### Motivation

- Ensure only admin or users with the `approve_proposals_agreements` permission can approve and sign proposals, and prevent clients or forged requests from setting approval/audit/signature fields directly.
- UI-only hiding is not sufficient because the frontend talks directly to Supabase, so the database must also block unauthorized approval writes.

### Description

- Added API-side approval guard in `frontend/src/api.js` by treating `approved_by`, `approved_at`, `signature_position` and `signature_meta` as approval-only fields and rejecting payloads that set them unless `canApproveProposalsAgreementsApi()` is true via `assertProposalAgreementApprovalPayloadAllowed` and `PROPOSALS_AGREEMENTS_APPROVAL_COLUMNS`.
- Added Supabase migration `supabase/migrations/20260616_proposals_agreements_approval_guard.sql` which creates `app_can_approve_proposals_agreements()` and a `BEFORE UPDATE` trigger `trg_guard_proposals_agreements_approval_update` that raises `proposals_agreements_approval_forbidden` when an unauthorized user attempts to set `status = 'approved'` or change approval/signature fields.
- Exposed `approve_proposals_agreements` in the frontend bootstrap/user columns and flattened user row so non-admin approvers are recognized, and kept UI controls gated (status dropdown and "חתום ואשר" action) to only show/enable approval flows for authorized users.
- Bumped service worker versions in `frontend/sw.js` and `sw.js` because frontend JS changed, and added focused tests in `tests/proposals-agreements-screen.test.mjs` covering UI visibility, forged actions, API guard checks, and the new migration presence.

### Testing

- Ran `npm run check:changed` and it completed without errors.
- Ran `npm run check:build` (full frontend build) and it completed successfully producing updated `dist` assets.
- Ran `node --test tests/proposals-agreements-screen.test.mjs` and the suite passed (all added and existing focused tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d45dcc80832b9fa2a1cb86a72858)