### PR TITLE
החזרת signature_meta ב‑view proposals_agreements_directory_view (migration)

### DIFF
--- a/supabase/migrations/20260616_proposals_agreements_directory_view_signature_meta.sql
+++ b/supabase/migrations/20260616_proposals_agreements_directory_view_signature_meta.sql
@@ -1,0 +1,28 @@
+-- Keep proposals_agreements_directory_view aligned with the fields selected by the proposals screen.
+-- signature_meta is stored on the source proposals_agreements row and is required to render
+-- the saved approval signature placement for approved proposals/agreements.
+do $$
+begin
+  if to_regclass('public.proposals_agreements_directory_view') is not null
+     and not exists (
+       select 1
+       from information_schema.columns
+       where table_schema = 'public'
+         and table_name = 'proposals_agreements_directory_view'
+         and column_name = 'signature_meta'
+     ) then
+    drop view if exists public.proposals_agreements_directory_view_without_signature_meta_20260616;
+
+    alter view public.proposals_agreements_directory_view
+      rename to proposals_agreements_directory_view_without_signature_meta_20260616;
+
+    create view public.proposals_agreements_directory_view as
+      select
+        directory_row.*,
+        coalesce(pa.signature_meta, '{}'::jsonb) as signature_meta
+      from public.proposals_agreements_directory_view_without_signature_meta_20260616 directory_row
+      left join public.proposals_agreements pa on pa.id = directory_row.id;
+
+    grant select on public.proposals_agreements_directory_view to authenticated;
+  end if;
+end $$;


### PR DESCRIPTION
### Motivation
- התקלה נגרמה מכך שה‑frontend מבקש את העמודה `signature_meta` מתוך `proposals_agreements_directory_view`, אך ה‑view בבסיס נתונים לא החזיר את העמודה ולכן נזרק השגיאה `[column proposals_agreements_directory_view.signature_meta does not exist]`.
- `signature_meta` נדרשת למסך הצעות מחיר כי היא מחזיקה מטא־דאטה של מיקום/הגדרות החתימה לאגירת אישור ההצעות, ולכן הפתרון צריך להחזיר את העמודה מהמקור במקום להסיר את השימוש בפרונטאנד.

### Description
- הוספתי migration חדש `supabase/migrations/20260616_proposals_agreements_directory_view_signature_meta.sql` שמבצע בדיקה ובמקרה הצורך עוטף את ה‑view הקיים, משנה את שמו ל`proposals_agreements_directory_view_without_signature_meta_20260616` ויוצר שוב את `proposals_agreements_directory_view` כ־`SELECT directory_row.*, coalesce(pa.signature_meta, '{}'::jsonb) as signature_meta FROM ... LEFT JOIN public.proposals_agreements pa ON pa.id = directory_row.id`.
- ה‑migration מעניק שוב `SELECT` על ה‑view ל־`authenticated` ומחזיר `signature_meta` מהטבלה המקורית מבלי לשנות קוד frontend או Service Worker.
- לא בוצעו שינויים בעמודי עיצוב, בקבצי frontend או בעדכון גרסת cache כי התיקון הוא SQL בלבד.

### Testing
- הורץ `node --check frontend/src/api.js` ועבר בהצלחה ללא שגיאות תחביריות. 
- הורץ `node --test tests/proposals-agreements-screen.test.mjs` שכלל 71 בדיקות והסתיים עם `pass 71, fail 0` בהצלחה. 
- הורץ `npm run check:changed` שהחזיר את ההודעה כי אין קבצי JS שדורשים בדיקה ממוקדת והבדיקה הממוקדת הושלמה בהצלחה.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30e19d030c832b92a557901285c679)