### PR TITLE
Fix bundle parent quantity in proposal print/PDF cost table

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1278,10 +1278,11 @@ function costTableRowsFromItem(item = {}) {
   const isBundleParent = displayMode === 'bundle_parent' || item.is_bundle_parent;
 
   if (isBundleParent && bundleItems.length) {
+    const parentQuantity = Number(item.quantity) || 1;
     const childRows = bundleItems.map((bundleItem) => {
       const name = publicActivityName(typeof bundleItem === 'object' ? bundleItem.activity_name : bundleItem);
       const unitPrice = numberValue(typeof bundleItem === 'object' ? bundleItem.unit_price : null);
-      const quantity = 1;
+      const quantity = parentQuantity;
       const total = unitPrice != null ? quantity * unitPrice : null;
       return costTableRowData(name, quantity, unitPrice, total);
     }).filter(Boolean);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1758,6 +1758,38 @@ test('summer proposal preview keeps prices out of activity section and expands b
 
 
 
+test('bundle parent cost table uses parent quantity in print preview', async () => {
+  const row = {
+    ...sampleRows[0],
+    activity_type_group: 'קיץ תשפ״ו',
+    proposal_date: '2026-06-01'
+  };
+  const items = [{
+    item_name: 'סדנאות STEM',
+    proposal_display_mode: 'bundle_parent',
+    quantity: 4,
+    unit_price: 450,
+    total_price: 1800,
+    proposal_group: 'קיץ תשפ״ו',
+    selected_bundle_items: [
+      { activity_name: 'רוטוקופטר', unit_price: 450 }
+    ]
+  }];
+
+  await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
+    const costTable = dom.window.document.querySelector('.pa-cost-table');
+    assert.ok(costTable, 'cost table should render');
+    const cells = [...costTable.querySelectorAll('tbody td')].map((td) => td.textContent.trim());
+    assert.equal(cells[0], 'רוטוקופטר');
+    assert.equal(cells[1], '4');
+    assert.match(cells[2], /^450\s*₪$/);
+    assert.match(cells[3], /^1,800\s*₪$/);
+    const grandTotal = costTable.querySelector('tfoot .pa-currency-amount');
+    assert.ok(grandTotal);
+    assert.equal(grandTotal.textContent.trim().replace(/\u00a0/g, ' '), '1,800 ₪');
+  });
+});
+
 test('catalog PDF appendices use fixed workshop/tour PDFs and specific selected course PDFs only', () => {
   const entries = buildProposalCatalogPdfEntries(
     { activity_type_group: 'הצעה משולבת' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When adding a proposal with a bundle parent activity/package and updating "כמות קבוצות" (group quantity), the editor UI calculated totals correctly, but print/PDF always showed quantity **1** for each bundle child row.

## Root cause

In `costTableRowsFromItem`, bundle parent items with `selected_bundle_items` expanded child rows with a hardcoded `quantity = 1`, ignoring `item.quantity` on the parent row.

## Fix

- Use `parentQuantity = Number(item.quantity) || 1` for bundle child rows in `costTableRowsFromItem`
- Apply parent quantity to each child row total: `quantity * unitPrice`
- `proposalCostTableHtml` already flows through this helper, so print/PDF now reflects the saved quantity
- `proposalItemDetailsTableHtml` already uses `itemQuantity(item)` on parent rows (no change needed)

## Test

Added `bundle parent cost table uses parent quantity in print preview`:
- `bundle_parent` item with `quantity: 4` and `selected_bundle_items`
- Asserts cost table shows quantity `4` and row total `450 × 4 = 1,800 ₪`

## Verification

- `node --check frontend/src/screens/proposals-agreements.js`
- `node --test tests/proposals-agreements-screen.test.mjs` (72/72 pass)

No changes to Supabase save logic (`saveProposalAgreementItems` already persists `quantity`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5eec8bf-eae4-4c50-9901-3a71f518e016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5eec8bf-eae4-4c50-9901-3a71f518e016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

