### PR TITLE
Fix operations schedule time display to HH:MM

### DIFF
--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './shared/html.js';
 import { supabase } from '../supabase-client.js';
-import { formatDateHe, formatDateHeWithWeekday, formatTimeRangeShort } from './shared/format-date.js';
+import { formatDateHe, formatDateHeWithWeekday } from './shared/format-date.js';
 import {
   dsPageHeader,
   dsCard,
@@ -548,8 +548,8 @@ function buildScheduleRows(rows, state, directory) {
         date,
         activity,
         instructor,
-        time: getActivityTimeRange(activity) || formatTimeRangeShort(activity?.start_time, activity?.end_time),
-        hasTime: Boolean(getActivityTimeRange(activity) || activity?.start_time || activity?.StartTime)
+        time: getActivityTimeRange(activity),
+        hasTime: Boolean(getActivityTimeRange(activity))
       });
     });
   });
@@ -669,7 +669,7 @@ function getDetailDateForActivity(row) {
 }
 
 function getDetailTimeForActivity(row) {
-  return getActivityTimeRange(row) || formatTimeRangeShort(row?.start_time, row?.end_time) || '';
+  return getActivityTimeRange(row) || '';
 }
 
 function opsManagementStylesHtml() {

--- a/frontend/src/screens/shared/operations-activity-helpers.js
+++ b/frontend/src/screens/shared/operations-activity-helpers.js
@@ -1,4 +1,4 @@
-import { getActivityDateColumns } from './format-date.js';
+import { getActivityDateColumns, formatTimeRangeShort } from './format-date.js';
 import { isSummerActivity, normalizeActivitySeason, ACTIVITY_SEASON_SUMMER_2026, ACTIVITY_SEASON_SCHOOL_2027 } from './summer-activity.js';
 
 const INVALID_INSTRUCTOR_NAMES = new Set(['-', 'לא משויך', 'ללא שיוך']);
@@ -111,10 +111,10 @@ export function getActivityName(activity) {
 }
 
 export function getActivityTimeRange(activity) {
-  const start = String(activity?.start_time || activity?.StartTime || '').trim();
-  const end = String(activity?.end_time || activity?.EndTime || '').trim();
-  if (start && end) return `${start}-${end}`;
-  return start || end || '';
+  const start = activity?.start_time ?? activity?.StartTime;
+  const end = activity?.end_time ?? activity?.EndTime;
+  const formatted = formatTimeRangeShort(start, end);
+  return formatted === '—' ? '' : formatted;
 }
 
 export const WORKSHOP_ESTIMATE_PER_ACTIVITY = 25;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 779;
+const CACHE_VERSION = 780;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 779;
+const SW_ENTRY_VERSION = 780;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -7,6 +7,7 @@ import {
   getActivityInstructorName,
   getActivityPrimaryDate,
   getActivitySchoolNames,
+  getActivityTimeRange,
   isSummerOperationsException,
   buildWorkshopStockMapFromLists,
   buildWorkshopQuantityMetrics,
@@ -69,6 +70,14 @@ test('getActivityPrimaryDate uses start_date and meeting dates', () => {
   assert.equal(getActivityPrimaryDate({ date_1: '2026-05-02' }), '2026-05-02');
   assert.equal(getActivityPrimaryDate({ meeting_dates: ['2026-05-03'] }), '2026-05-03');
   assert.equal(getActivityPrimaryDate({}), '');
+});
+
+test('getActivityTimeRange formats HH:MM:SS to HH:MM for display and print', () => {
+  assert.equal(getActivityTimeRange({ start_time: '08:15:00', end_time: '09:00:00' }), '08:15-09:00');
+  assert.equal(getActivityTimeRange({ StartTime: '08:15:00', EndTime: '09:00:00' }), '08:15-09:00');
+  assert.equal(getActivityTimeRange({ start_time: '09:00', end_time: '12:30' }), '09:00-12:30');
+  assert.equal(getActivityTimeRange({ start_time: '08:15:00' }), '08:15');
+  assert.equal(getActivityTimeRange({}), '');
 });
 
 test('multi-school activity names are searchable and displayed', () => {
@@ -172,6 +181,23 @@ test('workshops tab shows inventory columns and print action', () => {
 test('actual participant count only uses existing activity fields', () => {
   assert.equal(getActivityActualParticipantCount({ participants_count: 25 }), 25);
   assert.equal(getActivityActualParticipantCount({ activity_name: 'סדנה' }), null);
+});
+
+test('operations management schedule shows HH:MM time range without seconds', () => {
+  const rows = [{
+    RowID: 'TIME-1',
+    status: 'פתוח',
+    authority: 'רשות א',
+    school: 'בית ספר',
+    activity_name: 'סדנה',
+    start_date: '2026-04-10',
+    start_time: '08:15:00',
+    end_time: '09:00:00',
+    instructor_name: 'דני'
+  }];
+  const html = operationsManagementScreen.render({ rows, workshopStockMap: new Map() }, { state: baseState() });
+  assert.match(html, />08:15-09:00</);
+  assert.doesNotMatch(html, />08:15:00-09:00:00</);
 });
 
 test('operations management render shows text-school activities without school_id', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Format activity time ranges in operations management via `formatTimeRangeShort` inside `getActivityTimeRange`, covering both `start_time`/`end_time` and legacy `StartTime`/`EndTime`.
- Simplify `operations-management.js` to rely on the shared helper for the schedule table and print views.
- Bump service worker cache version to `780` for the frontend asset refresh.

## Example
Supabase value `08:15:00`–`09:00:00` now displays as `08:15-09:00` in the schedule table and print window.

## Scope
- Code-only fix; no SQL or DB schema changes.
- Raw time values are unchanged for `input type="time"` and Supabase saves.

## Verification
- `npm run check:changed` passed
- `node --test tests/operations-management-screen.test.mjs` — new time-format tests pass
- Searched frontend for other raw `start_time`/`end_time` display paths in this screen; all schedule/print paths use `getActivityTimeRange`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ceb82c-490a-454c-80fa-891d6b236cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ceb82c-490a-454c-80fa-891d6b236cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

