### PR TITLE
Remove approval date line from proposal signature block

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -417,17 +417,26 @@ function formatDateDisplay(iso) {
   return s;
 }
 
-function approvalDateDisplay(row = {}) {
-  const rawDate = row.approved_at || row.signed_at || row.updated_at || row.proposal_date;
-  const s = String(rawDate || '').trim();
-  if (!s) return '';
-  if (/^\d{4}-\d{2}-\d{2}/.test(s)) {
-    const [y, m, d] = s.slice(0, 10).split('-');
-    return `${d}/${m}/${y}`;
-  }
-  return formatDateDisplay(rawDate);
-}
+function signatureSectionHtml(_signatureBody = '', row = {}, options = {}) {
+  const isApproved = normalizeProposalStatus(row?.status) === 'approved';
+  const showSignatureImage = isApproved || options.showSignatureImage === true;
+  const meta = normalizeSignatureMeta(row.signature_meta || row.approval_meta);
+  const img = text(meta?.signature?.image) || PROPOSAL_SIGNATURE_IMAGE;
+  const imageHtml = showSignatureImage
+    ? `<img class="pa-signature-image" src="${PUBLIC_BASE}${escapeHtml(img)}" alt="חתימת עידן נחום" loading="eager" decoding="async" onerror="this.style.display='none';">`
+    : '';
 
+  return `<div class="pa-footer-signature" aria-label="חתימה">
+    <div class="pa-blessing">בברכה,</div>
+    <div class="pa-signer-block">
+      ${imageHtml}
+      <div class="pa-signer-name-block">
+        <div class="pa-signature-rule" aria-hidden="true"></div>
+        <div class="pa-signer-name">${DEFAULT_SIGNER_NAME}</div>
+      </div>
+    </div>
+  </div>`;
+}
 
 function clampNumber(value, min, max, fallback) {
   const n = Number(value);
@@ -448,35 +457,6 @@ function normalizeSignatureMeta(value) {
 
 function defaultSignatureMeta() {
   return { signature: { ...DEFAULT_SIGNATURE_META } };
-}
-
-// Signature is part of the fixed proposal document chrome and intentionally does not
-// render any legacy Supabase footer/signature markup. Keep this structure aligned with
-// Proposaleditor.html: blessing, optional image, signature rule, signer name.
-function signatureSectionHtml(_signatureBody = '', row = {}, options = {}) {
-  const isApproved = normalizeProposalStatus(row?.status) === 'approved';
-  const showSignatureImage = isApproved || options.showSignatureImage === true;
-  const meta = normalizeSignatureMeta(row.signature_meta || row.approval_meta);
-  const img = text(meta?.signature?.image) || PROPOSAL_SIGNATURE_IMAGE;
-  const approvedText = isApproved ? approvalDateDisplay(row) : '';
-  const imageHtml = showSignatureImage
-    ? `<img class="pa-signature-image" src="${PUBLIC_BASE}${escapeHtml(img)}" alt="חתימת עידן נחום" loading="eager" decoding="async" onerror="this.style.display='none';">`
-    : '';
-  const approvalHtml = isApproved && approvedText
-    ? `<div class="pa-signature-approval-line">אושר בתאריך: ${escapeHtml(approvedText)}</div>`
-    : '';
-
-  return `<div class="pa-footer-signature" aria-label="חתימה">
-    <div class="pa-blessing">בברכה,</div>
-    <div class="pa-signer-block">
-      ${imageHtml}
-      <div class="pa-signer-name-block">
-        <div class="pa-signature-rule" aria-hidden="true"></div>
-        <div class="pa-signer-name">${DEFAULT_SIGNER_NAME}</div>
-      </div>
-      ${approvalHtml}
-    </div>
-  </div>`;
 }
 
 function formatCurrency(num) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16649,13 +16649,6 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   object-fit: contain;
   margin: 0 0 6px;
 }
-.pa-footer-signature .pa-signature-approval-line {
-  margin: 4px 0 0;
-  font-size: 9px;
-  line-height: 1.25;
-  color: #666;
-  white-space: nowrap;
-}
 .pa-page-footer {
   margin-top: auto !important;
   border-top: 1px solid #bbb;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 781;
+const CACHE_VERSION = 782;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 781;
+const SW_ENTRY_VERSION = 782;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -543,10 +543,11 @@ test('approved proposals render flow signature block inside the document', () =>
   assert.doesNotMatch(sentHtml, /signature-idan-nahum\.png/);
   assert.doesNotMatch(draftHtml, /אושר בתאריך/);
   assert.doesNotMatch(sentHtml, /אושר בתאריך/);
+  assert.doesNotMatch(approvedHtml, /אושר בתאריך/);
+  assert.doesNotMatch(approvedHtml, /pa-signature-approval-line/);
   assert.match(approvedHtml, /proposals\/signature-idan-nahum\.png/);
   assert.doesNotMatch(approvedHtml, /pa-signature-layer/);
   assert.doesNotMatch(approvedHtml, /data-pa-signature-sticker/);
-  assert.doesNotMatch(approvedHtml, /style="left:/);
 
   const doc = new JSDOM(approvedHtml).window.document;
   const signature = doc.querySelector('.pa-footer-signature');
@@ -559,7 +560,7 @@ test('approved proposals render flow signature block inside the document', () =>
   assert.equal(signatureChildren[0], 'pa-signature-image', 'signature image should appear before the signer name block');
   assert.equal(signatureChildren[1], 'pa-signer-name-block', 'signer name block should follow the signature image');
   assert.ok(signature.compareDocumentPosition(doc.querySelector('.pa-page-footer')) & doc.defaultView.Node.DOCUMENT_POSITION_FOLLOWING, 'signature should appear before page footer');
-  assert.match(signature.textContent || '', /אושר בתאריך: 16\/06\/2026/);
+  assert.doesNotMatch(signature.textContent || '', /אושר בתאריך/);
   assert.doesNotMatch(signature.textContent || '', /אושר ונחתם דיגיטלית/);
 });
 


### PR DESCRIPTION
Show only the fixed signature layout (blessing, image, rule, signer name) without the extra 'אושר בתאריך' text. Bump SW cache to 782.