### PR TITLE
Dedupe duplicate exception cards by RowID and exception type

### DIFF
--- a/frontend/src/screens/exceptions.js
+++ b/frontend/src/screens/exceptions.js
@@ -74,6 +74,37 @@ function exceptionDistrictKey(row = {}) {
   return String(row?.district || '').trim() || 'ללא מחוז / לא משויך';
 }
 
+function exceptionRowIdentity(row = {}) {
+  return [row?.RowID, row?.row_id, row?.source_row_id]
+    .map((value) => String(value ?? '').trim())
+    .find(Boolean) || '';
+}
+
+export function dedupeExceptionInstanceRows(rows = []) {
+  const seen = new Set();
+  const deduped = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const rowId = exceptionRowIdentity(row);
+    const exceptionType = String(row?.exception_type || '').trim();
+    if (!rowId || !exceptionType) {
+      deduped.push(row);
+      continue;
+    }
+    const key = `${rowId}:${exceptionType}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+  }
+  return deduped;
+}
+
+function prepareExceptionDisplayRows(data = {}) {
+  const sourceRows = Array.isArray(data?.exceptionInstances)
+    ? approvedExceptionRows(data.exceptionInstances)
+    : exceptionInstanceRows(data?.rows || []);
+  return dedupeExceptionInstanceRows(sourceRows);
+}
+
 function exceptionInstanceRows(rows = []) {
   const list = Array.isArray(rows) ? rows : [];
   return list.flatMap((row) => {
@@ -249,8 +280,7 @@ export const exceptionsScreen = {
     return api.exceptions({ month });
   },
   render(data, { state } = {}) {
-    const rawRows   = Array.isArray(data?.exceptionInstances) ? approvedExceptionRows(data.exceptionInstances) : exceptionInstanceRows(data?.rows || []);
-    const allRows   = rawRows;
+    const allRows   = prepareExceptionDisplayRows(data);
     const filterState = ensureActivityListFilters(state, EXCEPTIONS_SCOPE);
     prepareRowsForSearch(allRows, ['RowID', 'activity_name', 'activity_manager', 'authority', 'school', 'funding', 'exception_type', 'exception_types']);
     const filteredRows = applyLocalFilters(allRows, filterState, { filterFields: EXCEPTION_FILTER_FIELDS });
@@ -297,7 +327,7 @@ export const exceptionsScreen = {
   },
   bind({ root, data, ui, state, rerender, api, clearScreenDataCache }) {
     try { sessionStorage.removeItem('ds_exceptions_save_notice'); } catch { /* ignore */ }
-    const allRows   = Array.isArray(data?.exceptionInstances) ? approvedExceptionRows(data.exceptionInstances) : exceptionInstanceRows(data?.rows || []);
+    const allRows   = prepareExceptionDisplayRows(data);
     bindLocalFilters(root, state, EXCEPTIONS_SCOPE, rerender, { debounceMs: 150 });
     const canSeePrivateNotes = state?.user?.display_role === 'operation_manager';
     const canEditActivity = !!(state?.user?.can_edit_direct || state?.user?.can_request_edit);

--- a/tests/exceptions-all-types.test.mjs
+++ b/tests/exceptions-all-types.test.mjs
@@ -31,7 +31,7 @@ if (!globalThis.localStorage) {
   };
 }
 
-const { exceptionsScreen } = await import('../frontend/src/screens/exceptions.js');
+const { exceptionsScreen, dedupeExceptionInstanceRows } = await import('../frontend/src/screens/exceptions.js');
 
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), 'utf8');
 
@@ -415,10 +415,34 @@ test('exceptions screen group count uses unique activities and explains duplicat
   assert.match(html, /הסתיימה ולא נסגרה · 1/);
   assert.match(html, /תאריך סיום מאוחר · 2/);
   assert.match(html, /ללא מדריך · 1/);
-  assert.match(html, /1 פעילויות \(2 רשומות\)/);
+  assert.doesNotMatch(html, /פעילויות \([2-9] רשומות\)/);
   const clickableCards = (html.match(/data-card-action="exception:/g) || []).length;
-  assert.equal(clickableCards, 5, 'each grouped appearance must still be rendered as a clickable card');
+  assert.equal(clickableCards, 4, 'duplicate RowID+exception_type rows should render once');
   assert.doesNotMatch(html, /data-action="delete"/);
+});
+
+test('exceptions screen dedupes duplicate exceptionInstances with the same RowID and exception_type', () => {
+  const data = {
+    month: '2026-05',
+    exceptionInstances: [
+      { RowID: 'A1', activity_name: 'פעילות א', authority: 'ר1', school: 'ב1', exception_type: 'missing_instructor', exception_types: ['missing_instructor'] },
+      { RowID: 'A1', activity_name: 'פעילות א', authority: 'ר1', school: 'ב1', exception_type: 'missing_instructor', exception_types: ['missing_instructor'] },
+      { RowID: 'A1', activity_name: 'פעילות א', authority: 'ר1', school: 'ב1', exception_type: 'missing_start_date', exception_types: ['missing_start_date', 'missing_instructor'] },
+      { RowID: 'B2', activity_name: 'פעילות ב', authority: 'ר2', school: 'ב2', exception_type: 'missing_instructor', exception_types: ['missing_instructor'] },
+      { RowID: 'B2', activity_name: 'פעילות ב', authority: 'ר2', school: 'ב2', exception_type: 'missing_instructor', exception_types: ['missing_instructor'] }
+    ]
+  };
+  const deduped = dedupeExceptionInstanceRows(data.exceptionInstances.map((row) => ({
+    ...row,
+    exception_type: row.exception_type,
+    exception_types: row.exception_types
+  })));
+  assert.equal(deduped.length, 3);
+  const html = exceptionsScreen.render(data, { state: { listFilters: {}, clientSettings: {} } });
+  assert.equal((html.match(/data-card-action="exception:A1"/g) || []).length, 2, 'same activity with two exception types should render two cards');
+  assert.equal((html.match(/data-card-action="exception:B2"/g) || []).length, 1, 'duplicate same-type instances should render one card');
+  assert.equal((html.match(/data-exception-type="missing_instructor"/g) || []).length, 2);
+  assert.doesNotMatch(html, /פעילויות \([2-9] רשומות\)/);
 });
 
 test('exceptions screen totals, district sum, and rendered cards use the same exception instances', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes duplicate exception cards on the exceptions screen when the same activity appears more than once with the same exception type.

## Changes

- Add `dedupeExceptionInstanceRows()` keyed by `RowID` / `row_id` / `source_row_id` + `exception_type`
- Use shared `prepareExceptionDisplayRows()` in both `render` and `bind` so displayed cards and drawer opening use the same deduped list
- Do not dedupe by activity name + school, so real distinct activities with the same name in the same school are preserved
- Activities with multiple different exception types still appear once per relevant group

## Tests

- Updated duplicate-group display expectation in `exceptions-all-types.test.mjs`
- Added test: duplicate `exceptionInstances` with the same RowID and exception type render once; different exception types still render separately

## Verification

- `node --check frontend/src/screens/exceptions.js`
- `node --test tests/exceptions-all-types.test.mjs` (dedupe-related tests pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70d027ab-b9f8-41cc-a04f-4bf75b170d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70d027ab-b9f8-41cc-a04f-4bf75b170d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

