### PR TITLE
Fix proposal signature flow layout

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'proposal-manual-signature-v1'
+  HOTFIX_VERSION: 'proposal-signature-flow-v2'
 };

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -430,10 +430,8 @@ function signatureSectionHtml(_signatureBody = '', row = {}, options = {}) {
     <div class="pa-blessing">בברכה,</div>
     <div class="pa-signer-block">
       ${imageHtml}
-      <div class="pa-signer-name-block">
-        <div class="pa-signature-rule" aria-hidden="true"></div>
-        <div class="pa-signer-name">${DEFAULT_SIGNER_NAME}</div>
-      </div>
+      <div class="pa-signature-rule" aria-hidden="true"></div>
+      <div class="pa-signer-name">${DEFAULT_SIGNER_NAME}</div>
     </div>
   </div>`;
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16609,7 +16609,7 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   font-weight: 700;
   background: #f5f7fa !important;
 }
-/* Footer text signature — aligned with Proposaleditor.html .footer-signature */
+/* Footer signature: one in-flow block (blessing, image, rule, signer). */
 .pa-footer-signature {
   margin-top: 14px;
   text-align: left;
@@ -16617,20 +16617,24 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   page-break-inside: avoid;
 }
 .pa-footer-signature .pa-blessing {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  margin: 0 0 10px auto;
   font-size: 12.5px;
-  margin-bottom: 10px;
-  text-align: center;
+  text-align: right;
 }
 .pa-signer-block {
-  margin-top: 4.4em;
-}
-.pa-signer-name-block {
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
   max-width: 100%;
   text-align: left;
+  vertical-align: top;
 }
 .pa-signature-rule {
   display: block;
+  width: 100%;
   border-top: 1px solid #555;
   margin: 0;
   height: 0;
@@ -16644,6 +16648,8 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 .pa-footer-signature .pa-signature-image {
   display: block;
+  align-self: center;
+  width: auto;
   max-width: 140px;
   max-height: 64px;
   object-fit: contain;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 784;
+const CACHE_VERSION = 785;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 784;
+const SW_ENTRY_VERSION = 785;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -556,9 +556,14 @@ test('approved proposals render flow signature block inside the document', () =>
   assert.equal(signature.querySelectorAll('.pa-signature-image').length, 1);
   assert.equal(signature.querySelectorAll('.pa-signature-rule').length, 1);
   assert.equal(signature.querySelectorAll('.pa-signer-name').length, 1);
-  const signatureChildren = [...signature.querySelector('.pa-signer-block').children].map((node) => node.className);
-  assert.equal(signatureChildren[0], 'pa-signature-image', 'signature image should appear before the signer name block');
-  assert.equal(signatureChildren[1], 'pa-signer-name-block', 'signer name block should follow the signature image');
+  const signatureChildren = [...signature.children].map((node) => node.className);
+  assert.deepEqual(signatureChildren, ['pa-blessing', 'pa-signer-block'], 'signature area should be one normal document-flow block');
+  const signerChildren = [...signature.querySelector('.pa-signer-block').children].map((node) => node.className);
+  assert.deepEqual(
+    signerChildren,
+    ['pa-signature-image', 'pa-signature-rule', 'pa-signer-name'],
+    'signature image, rule, and signer name should render in fixed vertical order'
+  );
   assert.ok(signature.compareDocumentPosition(doc.querySelector('.pa-page-footer')) & doc.defaultView.Node.DOCUMENT_POSITION_FOLLOWING, 'signature should appear before page footer');
   assert.doesNotMatch(signature.textContent || '', /אושר בתאריך/);
   assert.doesNotMatch(signature.textContent || '', /אושר ונחתם דיגיטלית/);


### PR DESCRIPTION
### Motivation

- The signature image was positioned unstably and could move independently of the signature area, causing layout and PDF/print issues.
- The signature must always appear above the signer name line (`עידן נחום, סמנכ״ל כספים ותפעול`) and move as a single in-flow block with the document content.
- Avoid absolute/floating/transform/percent-based placement so the signature is stable in normal view, print, and PDF export.

### Description

- Render the signature as a single normal document-flow block in `signatureSectionHtml` so the structure is: blessing, image, rule, signer name, all inside `.pa-footer-signature` (file: `frontend/src/screens/proposals-agreements.js`).
- Replace manual spacing/float-like layout with an inline-flex/column flow and related sizing tweaks in `frontend/src/styles/main.css` to keep the image, rule and signer name vertically ordered without using `position`, `top`, `left`, `transform`, percent-based placement, or floating layers.
- Strengthen the focused screen test to assert the new in-flow block and exact child order; updated file: `tests/proposals-agreements-screen.test.mjs`.
- Files changed: `frontend/src/screens/proposals-agreements.js`, `frontend/src/styles/main.css`, `tests/proposals-agreements-screen.test.mjs`.

### Testing

- Ran `node --check frontend/src/screens/proposals-agreements.js` and it passed with no syntax errors.
- Ran `node --check tests/proposals-agreements-screen.test.mjs` and `node --test tests/proposals-agreements-screen.test.mjs`, the focused tests completed successfully (72 tests passed, 0 failed).
- Ran the recommended focused checks `npm run check:changed` and full frontend build check `npm run check:build`, both completed successfully and the production build completed without test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a324ba398bc832ba26c48853db85784)