### PR TITLE
Fix proposal status handling and signature display logic

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2096,7 +2096,7 @@ function normalizeProposalAgreementRow(row = {}) {
     phone:               cleanProposalAgreementText(row.phone),
     email:               cleanProposalAgreementText(row.email),
     notes:               parsedNotes.notes,
-    status:              PA_VALID_STATUSES.has(rawStatus) ? (rawStatus === 'pending_approval' ? 'sent' : rawStatus) : 'draft',
+    status:              PA_VALID_STATUSES.has(rawStatus) ? rawStatus : 'draft',
     approval_note:       cleanProposalAgreementText(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
     custom_document_sections: Array.isArray(row.custom_document_sections)
@@ -2106,6 +2106,7 @@ function normalizeProposalAgreementRow(row = {}) {
       }))
       : [],
     include_catalog:     row.include_catalog === true || row.include_catalog === 'yes',
+    signature_meta:      (row.signature_meta && typeof row.signature_meta === 'object' && !Array.isArray(row.signature_meta)) ? row.signature_meta : null,
     approved_by:         cleanProposalAgreementText(row.approved_by),
     approved_at:         cleanProposalAgreementText(row.approved_at),
     created_at:          cleanProposalAgreementText(row.created_at),

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -18,7 +18,7 @@ export const STATUS_OPTIONS = ['draft', 'sent', 'returned_for_changes', 'approve
 export const STATUS_LABELS = {
   draft:                'טיוטה',
   sent:                 'נשלח',
-  pending_approval:     'נשלח',
+  pending_approval:     'ממתין לאישור',
   returned_for_changes: 'הוחזר לתיקון',
   approved:             'מאושר',
   cancelled:            'בוטל'
@@ -379,7 +379,7 @@ export function normalizeProposalAgreementRow(row = {}) {
     phone:               text(row.phone),
     email:               text(row.email),
     notes:               text(row.notes),
-    status:              STATUS_OPTIONS.includes(normalizeProposalStatus(row.status)) ? normalizeProposalStatus(row.status) : 'draft',
+    status:              (new Set(['draft', 'sent', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'])).has(text(row.status)) ? text(row.status) : 'draft',
     approval_note:       text(row.approval_note),
     total_amount:        row.total_amount != null ? Number(row.total_amount) || null : null,
     custom_document_sections: Array.isArray(row.custom_document_sections) ? row.custom_document_sections.map(normalizeDocumentSection) : [],
@@ -418,10 +418,9 @@ function formatDateDisplay(iso) {
 }
 
 function signatureSectionHtml(_signatureBody = '', row = {}, options = {}) {
-  const isApproved = normalizeProposalStatus(row?.status) === 'approved';
   const meta = normalizeSignatureMeta(row.signature_meta || row.approval_meta);
-  const hasStoredSignature = meta !== null && !!(text(row.approved_at) || text(row.approved_by));
-  const showSignatureImage = isApproved || hasStoredSignature || options.showSignatureImage === true;
+  const hasSavedSignature = Boolean(meta?.signature?.image);
+  const showSignatureImage = hasSavedSignature || options.showSignatureImage === true;
   const img = text(meta?.signature?.image) || PROPOSAL_SIGNATURE_IMAGE;
   const imageHtml = showSignatureImage
     ? `<img class="pa-signature-image" src="${PUBLIC_BASE}${escapeHtml(img)}" alt="חתימת עידן נחום" loading="eager" decoding="async" onerror="this.style.display='none';">`
@@ -517,16 +516,16 @@ function statusFilterHtml() {
 
 function statusBadgeHtml(status) {
   const normalizedStatus = normalizeProposalStatus(status);
-  const label = STATUS_LABELS[normalizedStatus] || STATUS_LABELS[status] || status || '—';
+  const label = STATUS_LABELS[status] || STATUS_LABELS[normalizedStatus] || status || '—';
   const colorMap = {
     draft:                '#888',
     sent:                 '#16a34a',
-    pending_approval:     '#16a34a',
+    pending_approval:     '#d97706',
     returned_for_changes: '#dc2626',
     approved:             '#16a34a',
     cancelled:            '#6b7280'
   };
-  const color = colorMap[normalizedStatus] || colorMap[status] || '#888';
+  const color = colorMap[status] || colorMap[normalizedStatus] || '#888';
   return `<span class="ds-pa-badge" style="display:inline-block;padding:1px 7px;border-radius:10px;font-size:0.78rem;background:${color};color:#fff;white-space:nowrap">${escapeHtml(label)}</span>`;
 }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 779;
+const CACHE_VERSION = 780;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -535,9 +535,13 @@ test('non-admin manager submits proposals for approval instead of approving dire
 });
 
 test('approved proposals render flow signature block inside the document', () => {
+  const savedSignatureMeta = { signature: { image: 'proposals/signature-idan-nahum.png' } };
   const draftHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'draft' }, [], []);
   const sentHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'sent' }, [], []);
-  const approvedHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'approved', approved_at: '2026-06-16T10:30:00.000Z' }, [], []);
+  // Approved row with signature_meta (signature is stored on approval)
+  const approvedHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'approved', approved_at: '2026-06-16T10:30:00.000Z', signature_meta: savedSignatureMeta }, [], []);
+  // Sent row that was previously approved — signature_meta persists even after status change
+  const sentAfterApprovalHtml = proposalPreviewBodyHtml({ ...sampleRows[0], status: 'sent', approved_at: '2026-06-16T10:30:00.000Z', signature_meta: savedSignatureMeta }, [], []);
 
   assert.doesNotMatch(draftHtml, /signature-idan-nahum\.png/);
   assert.doesNotMatch(sentHtml, /signature-idan-nahum\.png/);
@@ -546,6 +550,8 @@ test('approved proposals render flow signature block inside the document', () =>
   assert.doesNotMatch(approvedHtml, /אושר בתאריך/);
   assert.doesNotMatch(approvedHtml, /pa-signature-approval-line/);
   assert.match(approvedHtml, /proposals\/signature-idan-nahum\.png/);
+  // signature persists when status is changed to sent after approval
+  assert.match(sentAfterApprovalHtml, /proposals\/signature-idan-nahum\.png/);
   assert.doesNotMatch(approvedHtml, /pa-signature-layer/);
   assert.doesNotMatch(approvedHtml, /data-pa-signature-sticker/);
 


### PR DESCRIPTION
## Summary
This PR fixes several issues with proposal agreement status handling and signature display logic. The main changes involve properly supporting the `pending_approval` status throughout the application and refactoring signature display to be based on stored signature metadata rather than approval status.

## Key Changes

- **Status normalization**: Removed automatic conversion of `pending_approval` to `sent` status in the API layer, allowing the status to be preserved as-is. Updated frontend status validation to use a Set for cleaner status checking.

- **Status labels and colors**: 
  - Fixed Hebrew label for `pending_approval` from 'נשלח' (sent) to 'ממתין לאישור' (pending approval)
  - Changed `pending_approval` badge color from green (#16a34a) to amber (#d97706) to better distinguish it from approved status

- **Signature display logic**: Refactored `signatureSectionHtml()` to determine signature visibility based on the presence of stored signature metadata (`signature_meta.signature.image`) rather than approval status. This allows signatures to persist even if a proposal's status changes after approval.

- **Signature metadata handling**: Added proper normalization and preservation of `signature_meta` field in the API layer to ensure signature data persists across status changes.

- **Test updates**: Enhanced test coverage to verify that signatures persist when proposal status changes from `approved` to `sent` after approval.

- **Cache version bump**: Incremented service worker cache version to ensure clients pick up the updated logic.

## Implementation Details

The signature display logic now uses `hasSavedSignature` (checking for `meta?.signature?.image`) instead of checking the approval status directly. This decouples signature display from status, allowing previously approved proposals to maintain their signature display even if their status is changed back to `sent` or other statuses.

https://claude.ai/code/session_01VYCZLgC3wveRbjS7jFsFf4