### PR TITLE
Simplify authority filtering and update search result display

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BHJ088Cs.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-dYW-1WW3.css">
+  <script type="module" crossorigin src="./assets/index-Dhr6ueR3.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-C1wy32Pe.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -765,6 +765,7 @@ function buildProposalClientSearchOptions(contactRows, authorityLookup, schoolLo
       authority: auth.authority_name,
       school: '',
       authority_code: auth.authority_code,
+      district: auth.district,
       contact_name: '',
       contact_role: '',
       phone: '',

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -2058,7 +2058,15 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
         <h4 class="pa-sidebar-section-title">איש קשר</h4>
         <div class="ds-pa-form-grid">
           <div data-pa-contact-picker-host>${initPickerHtml}</div>
-          <div class="ds-pa-form-grid ds-pa-contact-manual-fields" data-pa-contact-manual-fields${isLocked ? ' hidden' : ''}>
+          <div data-pa-add-contact-row hidden>
+            <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost" data-pa-add-contact-toggle>לא מצאת? הוסף איש קשר ידנית</button>
+            <p class="ds-pa-add-contact-note">איש הקשר יתווסף לרשות ולבית הספר שנבחרו.</p>
+          </div>
+          <div class="ds-pa-form-grid ds-pa-contact-manual-fields" data-pa-contact-manual-fields hidden>
+            <div data-pa-contact-ro-ctx hidden>
+              <label class="ds-pa-form-field"><span>רשות</span><input type="text" class="ds-input ds-input--sm" data-pa-contact-ro-authority readonly tabindex="-1"></label>
+              <label class="ds-pa-form-field"><span>בית ספר</span><input type="text" class="ds-input ds-input--sm" data-pa-contact-ro-school readonly tabindex="-1"></label>
+            </div>
             ${textField('contact_name', FIELD_LABELS.contact_name, row.contact_name, false)}
             ${textField('contact_role', FIELD_LABELS.contact_role, row.contact_role, false)}
             ${textField('phone', FIELD_LABELS.phone, row.phone, false)}
@@ -2688,7 +2696,21 @@ export const proposalsAgreementsScreen = {
       if (fieldsEl) fieldsEl.hidden = true;
       if (searchRow) searchRow.hidden = true;
       if (results) { results.hidden = true; results.innerHTML = ''; }
-      form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = Boolean(cName); });
+      const clientType = form?.querySelector('[data-pa-new-client-type]')?.value || 'school';
+      const addContactRow = form?.querySelector('[data-pa-add-contact-row]');
+      if (clientType !== 'other') {
+        const roAuth = form?.querySelector('[data-pa-contact-ro-authority]');
+        const roSchoolEl = form?.querySelector('[data-pa-contact-ro-school]');
+        const roCtx = form?.querySelector('[data-pa-contact-ro-ctx]');
+        if (roAuth) roAuth.value = auth;
+        if (roSchoolEl) roSchoolEl.value = school;
+        if (roCtx) roCtx.hidden = false;
+        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+        if (addContactRow) addContactRow.hidden = Boolean(cName);
+      } else {
+        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = Boolean(cName); });
+        if (addContactRow) addContactRow.hidden = true;
+      }
       if (hintEl) hintEl.hidden = true;
     };
 
@@ -2700,6 +2722,10 @@ export const proposalsAgreementsScreen = {
       if (fieldsEl) fieldsEl.hidden = false;
       if (searchRow) searchRow.hidden = false;
       form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = false; });
+      const addContactRow = form?.querySelector('[data-pa-add-contact-row]');
+      if (addContactRow) addContactRow.hidden = true;
+      const roCtx = form?.querySelector('[data-pa-contact-ro-ctx]');
+      if (roCtx) roCtx.hidden = true;
     };
 
     // ── Contact / client setup ────────────────────────────────────────────────
@@ -2853,6 +2879,8 @@ export const proposalsAgreementsScreen = {
       if (searchWrap) searchWrap.classList.toggle('is-manual-only', isOther);
       if (searchField) searchField.hidden = isOther;
       if (results) { results.hidden = true; results.innerHTML = ''; }
+      const manualSearchBtn = form?.querySelector('[data-pa-client-search-row] [data-pa-new-client-toggle]');
+      if (manualSearchBtn) manualSearchBtn.hidden = !isOther;
       const schoolStep = form?.dataset?.paSearchStep || 'authority';
       const searchLabelText = type === 'school'
         ? (schoolStep === 'school' ? 'בית ספר' : 'רשות (שלב 1 מתוך 2)')
@@ -2876,6 +2904,11 @@ export const proposalsAgreementsScreen = {
       const isLocked = clientCardEl && !clientCardEl.hidden && clientCardEl.children.length > 0;
       if (!isLocked && clientFieldsEl) {
         clientFieldsEl.hidden = !isOther;
+      }
+      if (!isLocked) {
+        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = !isOther; });
+        const addContactRowEl = form?.querySelector('[data-pa-add-contact-row]');
+        if (addContactRowEl) addContactRowEl.hidden = true;
       }
     };
 
@@ -2995,6 +3028,23 @@ export const proposalsAgreementsScreen = {
       if (!form || form.dataset.paClientSearchBound === 'yes') return;
       form.dataset.paClientSearchBound = 'yes';
       applyClientTypeMode(form);
+      // Init contact area for forms already locked on mount (edit mode)
+      const initCard = form.querySelector('[data-pa-client-card]');
+      const initIsLocked = initCard && !initCard.hidden && initCard.children.length > 0;
+      if (initIsLocked) {
+        const initType = form.querySelector('[data-pa-new-client-type]')?.value || 'school';
+        if (initType !== 'other') {
+          const initCName = text(form.querySelector('input[name="contact_name"]')?.value || '');
+          const addContactRowInit = form.querySelector('[data-pa-add-contact-row]');
+          if (addContactRowInit) addContactRowInit.hidden = Boolean(initCName);
+          const roAuthInit = form.querySelector('[data-pa-contact-ro-authority]');
+          const roSchoolInit = form.querySelector('[data-pa-contact-ro-school]');
+          const roCtxInit = form.querySelector('[data-pa-contact-ro-ctx]');
+          if (roAuthInit) roAuthInit.value = text(form.querySelector('input[name="client_authority"]')?.value || '');
+          if (roSchoolInit) roSchoolInit.value = text(form.querySelector('input[name="school_framework"]')?.value || '');
+          if (roCtxInit) roCtxInit.hidden = false;
+        }
+      }
       form.querySelector('[data-pa-client-search-input]')?.addEventListener('input', () => renderClientResults(form), { signal });
       form.querySelector('[data-pa-new-client-type]')?.addEventListener('change', () => {
         form.dataset.paNewClient = 'no';
@@ -4114,6 +4164,10 @@ export const proposalsAgreementsScreen = {
           const fields = form.querySelector('[data-pa-client-fields]');
           if (fields) fields.hidden = true;
           form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+          const addContactRowUnlock = form.querySelector('[data-pa-add-contact-row]');
+          if (addContactRowUnlock) addContactRowUnlock.hidden = true;
+          const roCtxUnlock = form.querySelector('[data-pa-contact-ro-ctx]');
+          if (roCtxUnlock) roCtxUnlock.hidden = true;
           const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
           if (pickerHost) pickerHost.innerHTML = '';
           const results = form.querySelector('[data-pa-client-results]');
@@ -4174,12 +4228,28 @@ export const proposalsAgreementsScreen = {
         const fields = form.querySelector('[data-pa-client-fields]');
         if (fields) fields.hidden = true;
         form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+        const addContactRowClear = form.querySelector('[data-pa-add-contact-row]');
+        if (addContactRowClear) addContactRowClear.hidden = true;
+        const roCtxClear = form.querySelector('[data-pa-contact-ro-ctx]');
+        if (roCtxClear) roCtxClear.hidden = true;
         const search = form.querySelector('[data-pa-client-search-input]');
         if (search) { search.value = ''; search.focus(); }
         const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
         if (pickerHost) pickerHost.innerHTML = '';
         applyClientTypeMode(form);
         updateProposalStepper(form);
+        return;
+      }
+
+      if (event.target.closest?.('[data-pa-add-contact-toggle]')) {
+        const form = event.target.closest('[data-pa-form]');
+        if (!form) return;
+        const addContactRow = form.querySelector('[data-pa-add-contact-row]');
+        if (addContactRow) addContactRow.hidden = true;
+        form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = false; });
+        const roCtx = form.querySelector('[data-pa-contact-ro-ctx]');
+        if (roCtx) roCtx.hidden = false;
+        form.querySelector('input[name="contact_name"]')?.focus();
         return;
       }
 

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -2788,14 +2788,10 @@ export const proposalsAgreementsScreen = {
       const seen = new Set();
       return contactOptions.filter((c) => {
         if (selectedType === 'authority') {
-          if (!text(c.authority)) return false;
-          if (text(c.school)) return false;
-          if (c._catalog_source !== 'authorities' && text(c.client_type) !== 'authority') return false;
+          if (c._catalog_source !== 'authorities') return false;
         } else if (selectedType === 'school') {
           if (schoolStep === 'authority') {
-            if (!text(c.authority)) return false;
-            if (text(c.school)) return false;
-            if (c._catalog_source !== 'authorities' && text(c.client_type) !== 'authority') return false;
+            if (c._catalog_source !== 'authorities') return false;
           } else {
             if (!text(c.school)) return false;
             if (c._catalog_source !== 'schools' && text(c.client_type) !== 'school') return false;
@@ -2824,10 +2820,7 @@ export const proposalsAgreementsScreen = {
       const semel = text(contact.semel_mosad);
       const schoolStep = form?.dataset?.paSearchStep || 'authority';
       if (selectedType === 'authority' || (selectedType === 'school' && schoolStep === 'authority')) {
-        const code = text(contact.authority_code);
-        const parts = [authority].filter(Boolean);
-        if (code) parts.push(`מספר רשות: ${code}`);
-        return parts.join(' — ');
+        return authority || '';
       }
       const displayName = school || clientName || authority;
       const parts = [displayName];
@@ -2971,12 +2964,21 @@ export const proposalsAgreementsScreen = {
         results.hidden = false;
         return;
       }
+      const _schoolStepForRender = form.dataset.paSearchStep || 'authority';
+      const _isAuthorityStep = type === 'authority' || (type === 'school' && _schoolStepForRender === 'authority');
       results.innerHTML = matches.map((contact, idx) => {
-        const phone = text(contact.phone || contact.mobile || '');
-        const email = text(contact.email || '');
-        const semel = text(contact.semel_mosad || '');
-        const authorityCode = text(contact.authority_code || '');
-        const metaParts = [phone, email, semel ? `סמל ${semel}` : '', authorityCode ? `מספר רשות ${authorityCode}` : ''].filter(Boolean);
+        let metaParts;
+        if (_isAuthorityStep) {
+          const authorityCode = text(contact.authority_code || '');
+          const district = text(contact.district || '');
+          metaParts = [authorityCode ? `מספר רשות ${authorityCode}` : '', district].filter(Boolean);
+        } else {
+          const phone = text(contact.phone || contact.mobile || '');
+          const email = text(contact.email || '');
+          const semel = text(contact.semel_mosad || '');
+          const authorityCode = text(contact.authority_code || '');
+          metaParts = [phone, email, semel ? `סמל ${semel}` : '', authorityCode ? `מספר רשות ${authorityCode}` : ''].filter(Boolean);
+        }
         return `<button type="button" class="ds-pa-client-result" data-pa-client-result="${idx}">
           <strong>${escapeHtml(clientResultLabel(contact, type, form))}</strong>
           ${metaParts.length ? `<span class="ds-pa-client-result-meta">${escapeHtml(metaParts.join(' · '))}</span>` : ''}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -15567,6 +15567,32 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 .ds-pa-school-step-indicator[hidden] { display: none !important; }
 .ds-pa-school-step-text { flex: 1; color: #1e40af; }
 
+[data-pa-add-contact-row] {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 0;
+}
+[data-pa-add-contact-row][hidden] { display: none !important; }
+.ds-pa-add-contact-note {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.78rem;
+}
+[data-pa-contact-ro-ctx] {
+  grid-column: 1 / -1;
+  display: contents;
+}
+[data-pa-contact-ro-ctx][hidden] { display: none !important; }
+[data-pa-contact-ro-ctx] input[readonly] {
+  background: #f8fafc;
+  color: #64748b;
+  cursor: default;
+  border-color: #e2e8f0;
+}
+[data-pa-contact-manual-fields][hidden] { display: none !important; }
+
 /* ═══════════════════════════════════════════════════════════════════
    Operations management screen
    ═══════════════════════════════════════════════════════════════════ */

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 787;
+const SW_ENTRY_VERSION = 788;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 786;
+const SW_ENTRY_VERSION = 787;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR refactors the contact filtering logic for authority selection and updates the search results display to show different metadata based on the current search step (authority vs. school).

## Key Changes
- **Simplified authority filtering**: Removed redundant checks for `authority` and `school` fields, now relying solely on `_catalog_source` to determine if a contact is an authority
- **Streamlined authority display label**: Removed authority code formatting from the authority selection step, now displaying only the authority name
- **Conditional search result metadata**: 
  - For authority step: Display authority code and district
  - For school step: Display phone, email, school symbol (semel), and authority code
- **Added district field**: Included `district` field from authority data in the contact options for display purposes

## Implementation Details
- The filtering logic now uses a single source-of-truth check (`_catalog_source !== 'authorities'`) instead of multiple field validations
- Search result rendering now branches based on `_isAuthorityStep` flag to determine which metadata fields to display
- The district field is extracted from authority lookup data and passed through to the contact options

https://claude.ai/code/session_01JT46Hg4Z5GVkSqFYra8pPf