### PR TITLE
Fix proposal form: catalog-only authority and school selection

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-XxoWVFMK.js"></script>
+  <script type="module" crossorigin src="./assets/index-BjU5IGqj.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BNCx56PA.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -424,7 +424,7 @@ async function selectActivitiesByDateRangeFromSupabase({
   return (Array.isArray(result.data) ? result.data : []).map(normalizeActivityRow);
 }
 
-const AUTHORITIES_CATALOG_COLUMNS = 'id,authority_name,authority_code,hp_number,district,active';
+const AUTHORITIES_CATALOG_COLUMNS = 'id,authority_name,authority_code,authority_type,hp_number,district,active';
 const SCHOOLS_CATALOG_COLUMNS = 'id,semel_mosad,school_name,authority,authority_id,active';
 
 function normalizeCatalogText(value) {
@@ -493,10 +493,12 @@ function buildAuthorityCatalogLookup(authorities = []) {
     const id = normalizeCatalogText(row.id);
     const authority_name = normalizeCatalogText(row.authority_name);
     const authority_code = normalizeCatalogText(row.authority_code);
+    const authority_type = normalizeCatalogText(row.authority_type);
     const entry = {
       id: id || null,
       authority_name,
       authority_code,
+      authority_type,
       hp_number: normalizeCatalogText(row.hp_number),
       district: normalizeCatalogText(row.district),
       active: normalizeCatalogText(row.active) || 'yes'
@@ -765,6 +767,7 @@ function buildProposalClientSearchOptions(contactRows, authorityLookup, schoolLo
       authority: auth.authority_name,
       school: '',
       authority_code: auth.authority_code,
+      authority_type: auth.authority_type,
       district: auth.district,
       contact_name: '',
       contact_role: '',

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -643,6 +643,10 @@ function textField(key, label, value, required) {
   return `<label class="ds-pa-form-field"><span>${escapeHtml(label)}${required ? ' *' : ''}</span><input class="ds-input ds-input--sm" name="${key}" value="${escapeHtml(value || '')}"${attrs}></label>`;
 }
 
+function hiddenField(key, value) {
+  return `<input type="hidden" name="${key}" value="${escapeHtml(value || '')}">`;
+}
+
 function activityPickerHtml(value, activityNameOptions) {
   const selectedValues = Array.isArray(value) ? value.map(text).filter(Boolean) : text(value).split(',').map(text).filter(Boolean);
   const allOptions = Array.from(new Set([...activityNameOptions, ...selectedValues])).filter(Boolean).sort((a, b) => a.localeCompare(b, 'he'));
@@ -671,8 +675,21 @@ function activityPickerHtml(value, activityNameOptions) {
 
 function clientTypeLabel(type = 'school') {
   if (type === 'authority') return 'רשות';
-  if (type === 'other') return 'אחר';
   return 'בית ספר';
+}
+
+function isCatalogContactRow(contact = {}) {
+  const source = text(contact._catalog_source);
+  return source === 'authorities' || source === 'schools';
+}
+
+function filterContactsForClient(contactOptions, { authorityId, schoolId, clientType } = {}) {
+  return (Array.isArray(contactOptions) ? contactOptions : []).filter((contact) => {
+    if (!text(contact.contact_name) || isCatalogContactRow(contact)) return false;
+    if (authorityId && text(contact.authority_id) !== authorityId) return false;
+    if (clientType === 'school' && schoolId && text(contact.school_id) !== schoolId) return false;
+    return true;
+  });
 }
 
 function clientSearchTypeFromRow(row = {}) {
@@ -690,7 +707,6 @@ function clientSearchHtml(_contactOptions, row = {}) {
       <select class="ds-input ds-input--sm" name="new_client_type" data-pa-new-client-type>
         <option value="school"${selectedType === 'school' ? ' selected' : ''}>בית ספר</option>
         <option value="authority"${selectedType === 'authority' ? ' selected' : ''}>רשות</option>
-        <option value="other"${selectedType === 'other' ? ' selected' : ''}>אחר</option>
       </select>
     </label>
     <div class="ds-pa-school-step-indicator" data-pa-school-step-indicator hidden>
@@ -705,11 +721,11 @@ function clientSearchHtml(_contactOptions, row = {}) {
   </div>`;
 }
 
-function contactPickerHtml(contactOptions, authority, school, selectedContactName, authorityId = null) {
-  const contacts = (Array.isArray(contactOptions) ? contactOptions : []).filter((c) => {
-    if (!text(c.contact_name)) return false;
-    if (authorityId && text(c.authority_id) && text(c.authority_id) !== authorityId) return false;
-    return text(c.authority) === authority && text(c.school) === school;
+function contactPickerHtml(contactOptions, authority, school, selectedContactName, authorityId = null, schoolId = null, clientType = 'school') {
+  const contacts = filterContactsForClient(contactOptions, {
+    authorityId,
+    schoolId: clientType === 'school' ? schoolId : null,
+    clientType
   });
   if (contacts.length <= 1) return '';
   const optionsHtml = ['<option value="">— בחרו איש קשר —</option>',
@@ -2005,7 +2021,15 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const isLocked = !!initAuth;
   const initContactSource = findContactForProposalRow(contactOptions, row) || buildContactSourceFromRow(row);
   const initAuthorityId = text(initContactSource?.authority_id) || null;
-  const initPickerHtml = initAuth ? contactPickerHtml(contactOptions, initAuth, initSchool, initContact, initAuthorityId) : '';
+  const initPickerHtml = initAuth ? contactPickerHtml(
+    contactOptions,
+    initAuth,
+    initSchool,
+    initContact,
+    initAuthorityId,
+    text(initContactSource?.school_id) || null,
+    text(initContactSource?.client_type) || clientSearchTypeFromRow(row)
+  ) : '';
   const initClientName = text(initContactSource?.client_name) || initSchool || initAuth;
   const proposalDate = mode === 'add' ? (text(row.proposal_date) || localDateInputValue()) : text(row.proposal_date);
   const hasCustomSections = Array.isArray(row.custom_document_sections) && row.custom_document_sections.length > 0;
@@ -2041,17 +2065,11 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
       <div data-pa-step-panel="client">
         <div class="ds-pa-client-search-block" data-pa-client-search-row${isLocked ? ' hidden' : ''}>
           ${clientSearchHtml(contactOptions, row)}
-          <div class="ds-pa-client-manual-row">
-            <button type="button" class="ds-btn ds-btn--sm ds-btn--ghost ds-pa-manual-client-btn" data-pa-new-client-toggle hidden>לא מצאת? הוסף ידנית</button>
-          </div>
         </div>
         <div data-pa-client-card${isLocked ? '' : ' hidden'}>${isLocked ? clientLockedBannerHtml(initAuth, initSchool, initContact, initRole, initPhone, initEmail, initClientName) : ''}</div>
-        <div class="ds-pa-new-client-hint" data-pa-new-client-hint hidden><span class="ds-pa-new-client-label">לקוח חדש / הזנה ידנית</span><button type="button" class="ds-btn ds-btn--xs ds-btn--ghost" data-pa-back-existing-client>חזרה לחיפוש</button></div>
-        <div class="ds-pa-form-grid" data-pa-client-fields${isLocked ? ' hidden' : ''}>
-          ${textField('client_authority', FIELD_LABELS.client_authority, row.client_authority, true)}
-          <div data-pa-school-field>
-            ${textField('school_framework', FIELD_LABELS.school_framework, row.school_framework, false)}
-          </div>
+        <div class="ds-pa-client-hidden-values" data-pa-client-fields hidden>
+          ${hiddenField('client_authority', row.client_authority)}
+          ${hiddenField('school_framework', row.school_framework)}
         </div>
       </div>
       <div data-pa-step-panel="contact">
@@ -2317,11 +2335,17 @@ function validatePayload(payload, statusOverride) {
   const errors = missing.map((key) => FIELD_LABELS[key] || key);
 
   const clientType = text(payload.client_type);
-  if (clientType !== 'other' && !text(payload.authority_id)) {
-    errors.push('יש לבחור רשות מתוך רשימת הרשויות המלאה.');
+  if (!text(payload.authority_id)) {
+    errors.push('יש לבחור רשות מתוך רשימת הרשויות.');
   }
   if (clientType === 'school' && !text(payload.school_id)) {
     errors.push('יש לבחור בית ספר מתוך רשימת בתי הספר של הרשות.');
+  }
+  const hasManualContact = Boolean(text(payload.contact_name) || text(payload.phone) || text(payload.email));
+  if (hasManualContact && !text(payload.contact_school_id)) {
+    if (!text(payload.authority_id) || (clientType === 'school' && !text(payload.school_id))) {
+      errors.push('ניתן להוסיף איש קשר רק לאחר בחירת רשות ובית ספר.');
+    }
   }
 
   if (requiresCompleteProposal) {
@@ -2689,7 +2713,6 @@ export const proposalsAgreementsScreen = {
     const lockClientFields = (form, auth, school, cName, cRole, phone, email, clientName = '') => {
       const cardEl = form?.querySelector('[data-pa-client-card]');
       const fieldsEl = form?.querySelector('[data-pa-client-fields]');
-      const hintEl = form?.querySelector('[data-pa-new-client-hint]');
       const searchRow = form?.querySelector('[data-pa-client-search-row]');
       const results = form?.querySelector('[data-pa-client-results]');
       if (cardEl) { cardEl.innerHTML = clientLockedBannerHtml(auth, school, cName, cRole, phone, email, clientName); cardEl.hidden = false; }
@@ -2698,20 +2721,14 @@ export const proposalsAgreementsScreen = {
       if (results) { results.hidden = true; results.innerHTML = ''; }
       const clientType = form?.querySelector('[data-pa-new-client-type]')?.value || 'school';
       const addContactRow = form?.querySelector('[data-pa-add-contact-row]');
-      if (clientType !== 'other') {
-        const roAuth = form?.querySelector('[data-pa-contact-ro-authority]');
-        const roSchoolEl = form?.querySelector('[data-pa-contact-ro-school]');
-        const roCtx = form?.querySelector('[data-pa-contact-ro-ctx]');
-        if (roAuth) roAuth.value = auth;
-        if (roSchoolEl) roSchoolEl.value = school;
-        if (roCtx) roCtx.hidden = false;
-        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
-        if (addContactRow) addContactRow.hidden = Boolean(cName);
-      } else {
-        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = Boolean(cName); });
-        if (addContactRow) addContactRow.hidden = true;
-      }
-      if (hintEl) hintEl.hidden = true;
+      const roAuth = form?.querySelector('[data-pa-contact-ro-authority]');
+      const roSchoolEl = form?.querySelector('[data-pa-contact-ro-school]');
+      const roCtx = form?.querySelector('[data-pa-contact-ro-ctx]');
+      if (roAuth) roAuth.value = auth;
+      if (roSchoolEl) roSchoolEl.value = school;
+      if (roCtx) roCtx.hidden = false;
+      form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+      if (addContactRow) addContactRow.hidden = Boolean(cName);
     };
 
     const unlockClientFields = (form) => {
@@ -2719,16 +2736,87 @@ export const proposalsAgreementsScreen = {
       const fieldsEl = form?.querySelector('[data-pa-client-fields]');
       const searchRow = form?.querySelector('[data-pa-client-search-row]');
       if (cardEl) cardEl.hidden = true;
-      if (fieldsEl) fieldsEl.hidden = false;
+      if (fieldsEl) fieldsEl.hidden = true;
       if (searchRow) searchRow.hidden = false;
-      form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = false; });
+      form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
       const addContactRow = form?.querySelector('[data-pa-add-contact-row]');
       if (addContactRow) addContactRow.hidden = true;
       const roCtx = form?.querySelector('[data-pa-contact-ro-ctx]');
       if (roCtx) roCtx.hidden = true;
     };
 
-    // ── Contact / client setup ────────────────────────────────────────────────
+    const applyContactSelectionAfterClient = (form, ctx = {}) => {
+      if (!form) return;
+      const {
+        authority = '',
+        school = '',
+        authorityId = '',
+        schoolId = '',
+        clientType = 'school',
+        clientName = ''
+      } = ctx;
+      const authInput = form.querySelector('input[name="client_authority"]');
+      const schoolInput = form.querySelector('input[name="school_framework"]');
+      if (authInput) authInput.value = authority;
+      if (schoolInput) schoolInput.value = school;
+
+      const contacts = filterContactsForClient(contactOptions, { authorityId, schoolId, clientType });
+      const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
+      const addContactRow = form.querySelector('[data-pa-add-contact-row]');
+      const baseSource = {
+        authority_id: authorityId || null,
+        school_id: schoolId || null,
+        client_type: clientType,
+        client_name: clientName || school || authority,
+        authority,
+        school,
+        contact_name: '',
+        contact_role: '',
+        phone: '',
+        mobile: '',
+        email: ''
+      };
+
+      if (contacts.length === 1) {
+        const contact = contacts[0];
+        fillContactFields(form, contact);
+        setContactSource(form, { ...baseSource, ...contact, id: contact.id });
+        if (pickerHost) pickerHost.innerHTML = '';
+        lockClientFields(
+          form,
+          authority,
+          school,
+          text(contact.contact_name),
+          text(contact.contact_role),
+          text(contact.phone || contact.mobile || ''),
+          text(contact.email || ''),
+          clientName || school || authority
+        );
+      } else {
+        fillContactFields(form, {});
+        setContactSource(form, baseSource);
+        if (pickerHost) {
+          pickerHost.innerHTML = contactPickerHtml(
+            contactOptions,
+            authority,
+            school,
+            '',
+            authorityId,
+            schoolId,
+            clientType
+          );
+          if (pickerHost.children.length) setupContactPicker(pickerHost, form);
+        }
+        lockClientFields(form, authority, school, '', '', '', '', clientName || school || authority);
+        if (addContactRow) addContactRow.hidden = contacts.length > 0;
+      }
+
+      const input = form.querySelector('[data-pa-client-search-input]');
+      const results = form.querySelector('[data-pa-client-results]');
+      if (input) input.value = '';
+      if (results) { results.hidden = true; results.innerHTML = ''; }
+      setTimeout(() => calcGrandTotal(form), 0);
+    };
     const fillContactFields = (form, contact) => {
       if (!form || !contact) return;
       const map = {
@@ -2818,19 +2906,24 @@ export const proposalsAgreementsScreen = {
         } else if (selectedType === 'school') {
           if (schoolStep === 'authority') {
             if (c._catalog_source !== 'authorities') return false;
-          } else {
-            if (!text(c.school)) return false;
-            if (c._catalog_source !== 'schools' && text(c.client_type) !== 'school') return false;
-            if (selectedAuthorityId && text(c.authority_id) !== selectedAuthorityId) return false;
+          } else if (c._catalog_source !== 'schools') {
+            return false;
+          } else if (selectedAuthorityId && text(c.authority_id) !== selectedAuthorityId) {
+            return false;
           }
-        } else {
-          const typeOk = text(c.school) || text(c.authority) || text(c.client_name) || text(c.semel_mosad);
-          if (!typeOk) return false;
         }
-        const haystack = [c.school, c.authority, c.client_name, c.contact_name, c.contact_role, c.phone, c.mobile, c.email, c.semel_mosad, c.authority_code]
-          .map(normalizeSearch).join(' ');
+        let haystack;
+        if (selectedType === 'authority' || (selectedType === 'school' && schoolStep === 'authority')) {
+          haystack = [c.authority, c.client_name, c.authority_code, c.district, c.authority_type]
+            .map(normalizeSearch).join(' ');
+        } else {
+          haystack = [c.school, c.client_name, c.semel_mosad]
+            .map(normalizeSearch).join(' ');
+        }
         if (!haystack.includes(q)) return false;
-        const key = [text(c.authority), text(c.school), text(c.contact_name), text(c.phone || c.mobile || ''), text(c.email)].join('||');
+        const key = selectedType === 'school' && schoolStep === 'school'
+          ? [text(c.school_id), text(c.school)].join('||')
+          : [text(c.authority_id), text(c.authority)].join('||');
         if (seen.has(key)) return false;
         seen.add(key);
         return true;
@@ -2840,20 +2933,13 @@ export const proposalsAgreementsScreen = {
     const clientResultLabel = (contact, selectedType, form) => {
       const school = text(contact.school);
       const authority = text(contact.authority);
-      const clientName = text(contact.client_name);
-      const contactName = text(contact.contact_name);
-      const role = text(contact.contact_role);
       const semel = text(contact.semel_mosad);
       const schoolStep = form?.dataset?.paSearchStep || 'authority';
       if (selectedType === 'authority' || (selectedType === 'school' && schoolStep === 'authority')) {
-        return authority || '';
+        return authority || text(contact.client_name) || '';
       }
-      const displayName = school || clientName || authority;
-      const parts = [displayName];
-      if (authority && authority !== displayName) parts.push(authority);
-      if (contactName) parts.push(role ? `${contactName} (${role})` : contactName);
-      if (semel) parts.push(`סמל: ${semel}`);
-      return parts.filter(Boolean).join(' — ');
+      const displayName = school || text(contact.client_name) || authority;
+      return semel ? `${displayName} (סמל: ${semel})` : displayName;
     };
 
     const applyClientTypeMode = (form) => {
@@ -2863,11 +2949,7 @@ export const proposalsAgreementsScreen = {
       const searchLabel = form?.querySelector('[data-pa-client-search-label]');
       const searchInput = form?.querySelector('[data-pa-client-search-input]');
       const results = form?.querySelector('[data-pa-client-results]');
-      const schoolField = form?.querySelector('[data-pa-school-field]');
-      const authorityInput = form?.querySelector('input[name="client_authority"]');
-      const schoolInput = form?.querySelector('input[name="school_framework"]');
       const stepIndicator = form?.querySelector('[data-pa-school-step-indicator]');
-      const isOther = type === 'other';
       if (type === 'school') {
         if (!form.dataset.paSearchStep) form.dataset.paSearchStep = 'authority';
       } else {
@@ -2876,37 +2958,21 @@ export const proposalsAgreementsScreen = {
         delete form.dataset.paAuthorityName;
         if (stepIndicator) stepIndicator.hidden = true;
       }
-      if (searchWrap) searchWrap.classList.toggle('is-manual-only', isOther);
-      if (searchField) searchField.hidden = isOther;
+      if (searchWrap) searchWrap.classList.remove('is-manual-only');
+      if (searchField) searchField.hidden = false;
       if (results) { results.hidden = true; results.innerHTML = ''; }
-      const manualSearchBtn = form?.querySelector('[data-pa-client-search-row] [data-pa-new-client-toggle]');
-      if (manualSearchBtn) manualSearchBtn.hidden = !isOther;
       const schoolStep = form?.dataset?.paSearchStep || 'authority';
       const searchLabelText = type === 'school'
         ? (schoolStep === 'school' ? 'בית ספר' : 'רשות (שלב 1 מתוך 2)')
         : clientTypeLabel(type);
       if (searchLabel) searchLabel.textContent = searchLabelText;
-      if (searchInput) searchInput.placeholder = isOther ? '' : `חיפוש לפי ${clientTypeLabel(type)}...`;
-      if (schoolField) schoolField.hidden = type === 'authority';
-      if (schoolInput) {
-        schoolInput.required = type === 'school';
-        schoolInput.setAttribute('aria-required', String(type === 'school'));
-        const label = schoolInput.closest('label')?.querySelector('span');
-        if (label) label.textContent = `${clientTypeLabel(type === 'authority' ? 'authority' : 'school')}${type === 'school' ? ' *' : ''}`;
-        if (type === 'authority') schoolInput.value = '';
-      }
-      if (authorityInput) {
-        const label = authorityInput.closest('label')?.querySelector('span');
-        if (label) label.textContent = `${isOther ? 'שם גוף' : 'רשות'} *`;
-      }
+      if (searchInput) searchInput.placeholder = `חיפוש לפי ${searchLabelText}...`;
       const clientFieldsEl = form?.querySelector('[data-pa-client-fields]');
       const clientCardEl = form?.querySelector('[data-pa-client-card]');
       const isLocked = clientCardEl && !clientCardEl.hidden && clientCardEl.children.length > 0;
-      if (!isLocked && clientFieldsEl) {
-        clientFieldsEl.hidden = !isOther;
-      }
+      if (clientFieldsEl) clientFieldsEl.hidden = true;
       if (!isLocked) {
-        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = !isOther; });
+        form?.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
         const addContactRowEl = form?.querySelector('[data-pa-add-contact-row]');
         if (addContactRowEl) addContactRowEl.hidden = true;
       }
@@ -2937,49 +3003,43 @@ export const proposalsAgreementsScreen = {
       }
 
       form.dataset.paNewClient = 'no';
-      let finalContact = contact;
+
       if (selectedType === 'school' && schoolStep === 'school') {
         const storedAuthorityId = form.dataset.paAuthorityId || '';
         const storedAuthorityName = form.dataset.paAuthorityName || '';
-        if (storedAuthorityId && !text(contact.authority_id)) {
-          finalContact = { ...contact, authority_id: storedAuthorityId, authority: storedAuthorityName || text(contact.authority) };
-        }
+        const authorityId = text(contact.authority_id) || storedAuthorityId;
+        const authority = storedAuthorityName || text(contact.authority);
+        const school = text(contact.school);
+        const schoolId = text(contact.school_id);
+        applyContactSelectionAfterClient(form, {
+          authority,
+          school,
+          authorityId,
+          schoolId,
+          clientType: 'school',
+          clientName: school || text(contact.client_name)
+        });
+        return;
       }
 
-      const authority = text(finalContact.authority);
-      const school = text(finalContact.school);
-      const authInput = form.querySelector('input[name="client_authority"]');
-      const schoolInput = form.querySelector('input[name="school_framework"]');
-      if (authInput) authInput.value = authority;
-      if (schoolInput) schoolInput.value = school;
-      fillContactFields(form, finalContact);
-      setContactSource(form, finalContact);
-      const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
-      const authorityId = text(finalContact.authority_id) || null;
-      if (pickerHost) {
-        pickerHost.innerHTML = contactPickerHtml(contactOptions, authority, school, text(finalContact.contact_name), authorityId);
-        if (pickerHost.children.length) setupContactPicker(pickerHost, form);
+      if (selectedType === 'authority') {
+        applyContactSelectionAfterClient(form, {
+          authority: text(contact.authority),
+          school: '',
+          authorityId: text(contact.authority_id),
+          schoolId: '',
+          clientType: 'authority',
+          clientName: text(contact.authority) || text(contact.client_name)
+        });
       }
-      const cName = text(finalContact.contact_name);
-      const cRole = text(finalContact.contact_role);
-      const phone = text(finalContact.phone || finalContact.mobile || '');
-      const email = text(finalContact.email || '');
-      lockClientFields(form, authority, school, cName, cRole, phone, email, text(finalContact.client_name) || school || authority);
-      const input = form.querySelector('[data-pa-client-search-input]');
-      const results = form.querySelector('[data-pa-client-results]');
-      if (input) input.value = '';
-      if (results) { results.hidden = true; results.innerHTML = ''; }
-      setTimeout(() => calcGrandTotal(form), 0);
     };
 
     const renderClientResults = (form) => {
       const type = form?.querySelector('[data-pa-new-client-type]')?.value || 'school';
       const input = form?.querySelector('[data-pa-client-search-input]');
       const results = form?.querySelector('[data-pa-client-results]');
-      if (!input || !results || type === 'other') return;
+      if (!input || !results) return;
       const matches = clientSearchMatches(input.value, type, form);
-      const manualBtn = form.querySelector('[data-pa-client-search-row] [data-pa-new-client-toggle]');
-      if (manualBtn) manualBtn.hidden = true;
       if (!text(input.value) || text(input.value).length < 2) {
         results.innerHTML = '<p class="ds-pa-client-results-empty">הקלידו לפחות שני תווים לחיפוש.</p>';
         results.hidden = true;
@@ -2987,13 +3047,8 @@ export const proposalsAgreementsScreen = {
       }
       if (!matches.length) {
         const schoolStep = form.dataset.paSearchStep || 'authority';
-        if (type === 'school' || type === 'authority') {
-          const stepLabel = (type === 'school' && schoolStep === 'school') ? 'בית ספר' : 'רשות';
-          results.innerHTML = `<p class="ds-pa-client-results-empty">לא נמצאה ${stepLabel} ברשימה. יש לחפש לפי שם מדויק.</p>`;
-        } else {
-          if (manualBtn) manualBtn.hidden = false;
-          results.innerHTML = '<p class="ds-pa-client-results-empty">לא נמצאו תוצאות.</p><button type="button" class="ds-pa-client-result ds-pa-client-result--manual" data-pa-new-client-toggle>לא מצאת? הוסף ידנית</button>';
-        }
+        const stepLabel = (type === 'school' && schoolStep === 'school') ? 'בית ספר' : 'רשות';
+        results.innerHTML = `<p class="ds-pa-client-results-empty">לא נמצאה ${stepLabel} ברשימה. יש לחפש לפי שם מדויק.</p>`;
         results.hidden = false;
         return;
       }
@@ -3002,15 +3057,13 @@ export const proposalsAgreementsScreen = {
       results.innerHTML = matches.map((contact, idx) => {
         let metaParts;
         if (_isAuthorityStep) {
+          const authorityType = text(contact.authority_type || '');
           const authorityCode = text(contact.authority_code || '');
           const district = text(contact.district || '');
-          metaParts = [authorityCode ? `מספר רשות ${authorityCode}` : '', district].filter(Boolean);
+          metaParts = [authorityType, district, authorityCode ? `קוד ${authorityCode}` : ''].filter(Boolean);
         } else {
-          const phone = text(contact.phone || contact.mobile || '');
-          const email = text(contact.email || '');
           const semel = text(contact.semel_mosad || '');
-          const authorityCode = text(contact.authority_code || '');
-          metaParts = [phone, email, semel ? `סמל ${semel}` : '', authorityCode ? `מספר רשות ${authorityCode}` : ''].filter(Boolean);
+          metaParts = [semel ? `סמל ${semel}` : ''].filter(Boolean);
         }
         return `<button type="button" class="ds-pa-client-result" data-pa-client-result="${idx}">
           <strong>${escapeHtml(clientResultLabel(contact, type, form))}</strong>
@@ -3032,18 +3085,15 @@ export const proposalsAgreementsScreen = {
       const initCard = form.querySelector('[data-pa-client-card]');
       const initIsLocked = initCard && !initCard.hidden && initCard.children.length > 0;
       if (initIsLocked) {
-        const initType = form.querySelector('[data-pa-new-client-type]')?.value || 'school';
-        if (initType !== 'other') {
-          const initCName = text(form.querySelector('input[name="contact_name"]')?.value || '');
-          const addContactRowInit = form.querySelector('[data-pa-add-contact-row]');
-          if (addContactRowInit) addContactRowInit.hidden = Boolean(initCName);
-          const roAuthInit = form.querySelector('[data-pa-contact-ro-authority]');
-          const roSchoolInit = form.querySelector('[data-pa-contact-ro-school]');
-          const roCtxInit = form.querySelector('[data-pa-contact-ro-ctx]');
-          if (roAuthInit) roAuthInit.value = text(form.querySelector('input[name="client_authority"]')?.value || '');
-          if (roSchoolInit) roSchoolInit.value = text(form.querySelector('input[name="school_framework"]')?.value || '');
-          if (roCtxInit) roCtxInit.hidden = false;
-        }
+        const initCName = text(form.querySelector('input[name="contact_name"]')?.value || '');
+        const addContactRowInit = form.querySelector('[data-pa-add-contact-row]');
+        if (addContactRowInit) addContactRowInit.hidden = Boolean(initCName);
+        const roAuthInit = form.querySelector('[data-pa-contact-ro-authority]');
+        const roSchoolInit = form.querySelector('[data-pa-contact-ro-school]');
+        const roCtxInit = form.querySelector('[data-pa-contact-ro-ctx]');
+        if (roAuthInit) roAuthInit.value = text(form.querySelector('input[name="client_authority"]')?.value || '');
+        if (roSchoolInit) roSchoolInit.value = text(form.querySelector('input[name="school_framework"]')?.value || '');
+        if (roCtxInit) roCtxInit.hidden = false;
       }
       form.querySelector('[data-pa-client-search-input]')?.addEventListener('input', () => renderClientResults(form), { signal });
       form.querySelector('[data-pa-new-client-type]')?.addEventListener('change', () => {
@@ -4143,47 +4193,39 @@ export const proposalsAgreementsScreen = {
       if (event.target.closest?.('[data-pa-unlock-client]')) {
         const form = event.target.closest('[data-pa-form]');
         const clientType = form?.querySelector('[data-pa-new-client-type]')?.value || 'school';
-        if (clientType === 'school' || clientType === 'authority') {
-          form.dataset.paNewClient = 'no';
-          if (clientType === 'school') {
-            form.dataset.paSearchStep = 'authority';
-            delete form.dataset.paAuthorityId;
-            delete form.dataset.paAuthorityName;
-            const stepIndicator = form.querySelector('[data-pa-school-step-indicator]');
-            if (stepIndicator) stepIndicator.hidden = true;
-          }
-          ['client_authority', 'school_framework', 'contact_name', 'contact_role', 'phone', 'email'].forEach((name) => {
-            const inp = form.querySelector(`input[name="${name}"]`);
-            if (inp) inp.value = '';
-          });
-          setContactSource(form, {});
-          const card = form.querySelector('[data-pa-client-card]');
-          if (card) { card.hidden = true; card.innerHTML = ''; }
-          const searchRow = form.querySelector('[data-pa-client-search-row]');
-          if (searchRow) searchRow.hidden = false;
-          const fields = form.querySelector('[data-pa-client-fields]');
-          if (fields) fields.hidden = true;
-          form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
-          const addContactRowUnlock = form.querySelector('[data-pa-add-contact-row]');
-          if (addContactRowUnlock) addContactRowUnlock.hidden = true;
-          const roCtxUnlock = form.querySelector('[data-pa-contact-ro-ctx]');
-          if (roCtxUnlock) roCtxUnlock.hidden = true;
-          const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
-          if (pickerHost) pickerHost.innerHTML = '';
-          const results = form.querySelector('[data-pa-client-results]');
-          if (results) { results.hidden = true; results.innerHTML = ''; }
-          const search = form.querySelector('[data-pa-client-search-input]');
-          if (search) { search.value = ''; }
-          applyClientTypeMode(form);
-          updateProposalStepper(form);
-          search?.focus();
-          return;
+        form.dataset.paNewClient = 'no';
+        if (clientType === 'school') {
+          form.dataset.paSearchStep = 'authority';
+          delete form.dataset.paAuthorityId;
+          delete form.dataset.paAuthorityName;
+          const stepIndicator = form.querySelector('[data-pa-school-step-indicator]');
+          if (stepIndicator) stepIndicator.hidden = true;
         }
-        unlockClientFields(form);
-        const hint = form?.querySelector('[data-pa-new-client-hint]');
-        if (hint) hint.hidden = true;
+        ['client_authority', 'school_framework', 'contact_name', 'contact_role', 'phone', 'email'].forEach((name) => {
+          const inp = form.querySelector(`input[name="${name}"]`);
+          if (inp) inp.value = '';
+        });
+        setContactSource(form, {});
+        const card = form.querySelector('[data-pa-client-card]');
+        if (card) { card.hidden = true; card.innerHTML = ''; }
+        const searchRow = form.querySelector('[data-pa-client-search-row]');
+        if (searchRow) searchRow.hidden = false;
+        const fields = form.querySelector('[data-pa-client-fields]');
+        if (fields) fields.hidden = true;
+        form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
+        const addContactRowUnlock = form.querySelector('[data-pa-add-contact-row]');
+        if (addContactRowUnlock) addContactRowUnlock.hidden = true;
+        const roCtxUnlock = form.querySelector('[data-pa-contact-ro-ctx]');
+        if (roCtxUnlock) roCtxUnlock.hidden = true;
+        const pickerHost = form.querySelector('[data-pa-contact-picker-host]');
+        if (pickerHost) pickerHost.innerHTML = '';
+        const results = form.querySelector('[data-pa-client-results]');
+        if (results) { results.hidden = true; results.innerHTML = ''; }
+        const search = form.querySelector('[data-pa-client-search-input]');
+        if (search) { search.value = ''; }
+        applyClientTypeMode(form);
         updateProposalStepper(form);
-        form?.querySelector('input[name="client_authority"]')?.focus();
+        search?.focus();
         return;
       }
 
@@ -4250,46 +4292,6 @@ export const proposalsAgreementsScreen = {
         const roCtx = form.querySelector('[data-pa-contact-ro-ctx]');
         if (roCtx) roCtx.hidden = false;
         form.querySelector('input[name="contact_name"]')?.focus();
-        return;
-      }
-
-      if (event.target.closest?.('[data-pa-new-client-toggle]')) {
-        const form = event.target.closest('[data-pa-form]');
-        const clientSearchInput = form?.querySelector('[data-pa-client-search-input]');
-        if (clientSearchInput) clientSearchInput.value = '';
-        if (form) form.dataset.paNewClient = 'yes';
-        const typeSelect = form?.querySelector('[data-pa-new-client-type]');
-        if (typeSelect) typeSelect.value = 'other';
-        unlockClientFields(form);
-        const sourceHost = form?.querySelector('[data-pa-contact-source]');
-        if (sourceHost) sourceHost.innerHTML = contactSourceInputsHtml({});
-        const hint = form?.querySelector('[data-pa-new-client-hint]');
-        if (hint) hint.hidden = false;
-        form?.querySelectorAll('[data-pa-new-client-only]').forEach((el) => { el.hidden = false; });
-        applyClientTypeMode(form);
-        ['client_authority', 'school_framework', 'contact_name', 'contact_role', 'phone', 'email'].forEach((name) => {
-          const inp = form?.querySelector(`input[name="${name}"]`);
-          if (inp) inp.value = '';
-        });
-        updateProposalStepper(form);
-        form?.querySelector('[data-pa-new-client-type]')?.focus?.();
-        return;
-      }
-      if (event.target.closest?.('[data-pa-back-existing-client]')) {
-        const form = event.target.closest('[data-pa-form]');
-        if (!form) return;
-        form.dataset.paNewClient = 'no';
-        const hint = form.querySelector('[data-pa-new-client-hint]');
-        if (hint) hint.hidden = true;
-        form.querySelectorAll('[data-pa-new-client-only]').forEach((el) => { el.hidden = true; });
-        form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = true; });
-        const fields = form.querySelector('[data-pa-client-fields]');
-        if (fields) fields.hidden = true;
-        const searchRow = form.querySelector('[data-pa-client-search-row]');
-        if (searchRow) searchRow.hidden = false;
-        applyClientTypeMode(form);
-        updateProposalStepper(form);
-        form.querySelector('[data-pa-client-search-input]')?.focus();
         return;
       }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 791;
+const CACHE_VERSION = 792;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 791;
+const SW_ENTRY_VERSION = 792;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -105,8 +105,32 @@ function fillPendingMinimum(form, dom, overrides = {}) {
   };
   set('input[name="client_authority"]', overrides.client_authority || 'רשות בדיקה');
   set('input[name="school_framework"]', overrides.school_framework || 'בית ספר בדיקה');
+  set('input[name="contact_source_authority_id"]', overrides.authority_id || 'auth-test');
+  set('input[name="contact_source_school_id"]', overrides.school_id || 'school-test');
+  set('input[name="contact_source_client_type"]', overrides.client_type || 'school');
   set('[name="activity_type_group"]', overrides.activity_type_group || 'קיץ תשפ״ו');
   fillLineItem(form, dom, overrides);
+}
+
+function setProposalCatalogIds(form, {
+  authority_id = 'auth-test',
+  school_id = 'school-test',
+  client_type = 'school'
+} = {}) {
+  const set = (name, value) => {
+    const el = form.querySelector(`input[name="${name}"]`);
+    if (el) el.value = value;
+  };
+  set('contact_source_authority_id', authority_id);
+  set('contact_source_school_id', school_id);
+  set('contact_source_client_type', client_type);
+}
+
+function selectClientResult(form, dom, query) {
+  const searchInput = form.querySelector('[data-pa-client-search-input]');
+  searchInput.value = query;
+  searchInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+  form.querySelector('[data-pa-client-result]')?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
 }
 
 const sampleRows = [
@@ -136,8 +160,81 @@ const sampleRows = [
   }
 ];
 
-const sampleContactOptions = [
+const sampleCatalogAuthorities = [
   {
+    _catalog_source: 'authorities',
+    client_type: 'authority',
+    client_name: 'רשות א',
+    authority_id: 'auth-a',
+    school_id: null,
+    authority: 'רשות א',
+    school: '',
+    authority_code: '101',
+    authority_type: 'עירייה',
+    district: 'מרכז',
+    contact_name: '',
+    contact_role: '',
+    phone: '',
+    email: '',
+    mobile: ''
+  },
+  {
+    _catalog_source: 'authorities',
+    client_type: 'authority',
+    client_name: 'רשות ב',
+    authority_id: 'auth-b',
+    school_id: null,
+    authority: 'רשות ב',
+    school: '',
+    authority_code: '102',
+    authority_type: 'מועצה',
+    district: 'דרום',
+    contact_name: '',
+    contact_role: '',
+    phone: '',
+    email: '',
+    mobile: ''
+  }
+];
+
+const sampleCatalogSchools = [
+  {
+    _catalog_source: 'schools',
+    client_type: 'school',
+    client_name: 'בית ספר א',
+    authority_id: 'auth-a',
+    school_id: 'school-a',
+    authority: 'רשות א',
+    school: 'בית ספר א',
+    semel_mosad: '11111',
+    contact_name: '',
+    contact_role: '',
+    phone: '',
+    email: '',
+    mobile: ''
+  },
+  {
+    _catalog_source: 'schools',
+    client_type: 'school',
+    client_name: 'מסגרת ב',
+    authority_id: 'auth-b',
+    school_id: 'school-b',
+    authority: 'רשות ב',
+    school: 'מסגרת ב',
+    semel_mosad: '22222',
+    contact_name: '',
+    contact_role: '',
+    phone: '',
+    email: '',
+    mobile: ''
+  }
+];
+
+const sampleContactRows = [
+  {
+    id: '1',
+    authority_id: 'auth-a',
+    school_id: 'school-a',
     authority: 'רשות א',
     school: 'בית ספר א',
     contact_name: 'דנה קשר',
@@ -146,6 +243,9 @@ const sampleContactOptions = [
     email: 'dana@example.com'
   },
   {
+    id: '2',
+    authority_id: 'auth-a',
+    school_id: 'school-a',
     authority: 'רשות א',
     school: 'בית ספר א',
     contact_name: 'מיכל כהן',
@@ -154,6 +254,9 @@ const sampleContactOptions = [
     email: 'michal@example.com'
   },
   {
+    id: '3',
+    authority_id: 'auth-b',
+    school_id: 'school-b',
     authority: 'רשות ב',
     school: 'מסגרת ב',
     contact_name: 'יוסי קשר',
@@ -162,6 +265,8 @@ const sampleContactOptions = [
     email: ''
   }
 ];
+
+const sampleContactOptions = [...sampleCatalogAuthorities, ...sampleCatalogSchools, ...sampleContactRows];
 
 test('screen authorization includes business development manager', () => {
   for (const role of ['domain_manager', 'operation_manager', 'admin', 'business_development_manager']) {
@@ -420,7 +525,7 @@ test('new proposal tab opens compact form with preview and role-aware primary ac
       assert.match(form.innerHTML, /אישור והפקת הצעה/);
       assert.doesNotMatch(form.innerHTML, /שליחה לאישור/);
       assert.match(form.innerHTML, /data-pa-client-search-input/);
-      assert.match(form.innerHTML, /הזנה ידנית/);
+      assert.match(form.innerHTML, /הוסף איש קשר ידנית/);
     }
   );
 });
@@ -468,10 +573,8 @@ test('new proposal editor renders two-pane A4 layout and live preview updates ke
       assert.match(form.querySelector('.pa-sidebar')?.textContent || '', /פרטי נמען/);
       assert.match(form.querySelector('.pa-sidebar')?.textContent || '', /פעילויות ומחירים/);
 
-      const searchInput = form.querySelector('[data-pa-client-search-input]');
-      searchInput.value = 'יוסי';
-      searchInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-      form.querySelector('[data-pa-client-result]')?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      selectClientResult(form, dom, 'רשות ב');
+      selectClientResult(form, dom, 'מסגרת');
       await delay(20);
 
       const typeInput = form.querySelector('[name="activity_type_group"]');
@@ -602,12 +705,10 @@ test('client selector auto-fills contact fields when existing client is chosen',
 
       const form = openNewProposalForm(root, dom);
       const typeSelect = form.querySelector('[data-pa-new-client-type]');
-      const searchInput = form.querySelector('[data-pa-client-search-input]');
       typeSelect.value = 'school';
       typeSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
-      searchInput.value = 'יוסי';
-      searchInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
-      form.querySelector('[data-pa-client-result]')?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      selectClientResult(form, dom, 'רשות ב');
+      selectClientResult(form, dom, 'מסגרת');
 
       const authorityInput = form.querySelector('input[name="client_authority"]');
       const schoolInput = form.querySelector('input[name="school_framework"]');
@@ -618,6 +719,8 @@ test('client selector auto-fills contact fields when existing client is chosen',
       assert.equal(schoolInput.value, 'מסגרת ב', 'school should be filled');
       assert.equal(contactInput.value, 'יוסי קשר', 'contact_name should be auto-filled');
       assert.equal(phoneInput.value, '050-2222222', 'phone should be auto-filled');
+      assert.equal(form.querySelector('input[name="contact_source_authority_id"]').value, 'auth-b');
+      assert.equal(form.querySelector('input[name="contact_source_school_id"]').value, 'school-b');
       assert.equal(form.querySelector('[data-pa-client-results]').hidden, true, 'results should close after selection');
       assert.equal(form.querySelector('[data-pa-client-search-row]').hidden, true, 'search row should close after selection');
       assert.match(form.querySelector('[data-pa-client-card]').textContent, /נבחר:.*מסגרת ב.*רשות ב.*יוסי קשר/, 'clear selected-client summary should be shown');
@@ -625,7 +728,7 @@ test('client selector auto-fills contact fields when existing client is chosen',
   );
 });
 
-test('multiple contacts for same client shows contact picker dropdown', async () => {
+test('authority search shows only catalog authorities without contact details', async () => {
   await withJSDOM(
     proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
     (root, dom) => {
@@ -643,15 +746,40 @@ test('multiple contacts for same client shows contact picker dropdown', async ()
 
       const results = form.querySelector('[data-pa-client-results]');
       assert.ok(results, 'results host should exist');
-      assert.match(results.innerHTML, /דנה קשר/, 'first contact should be in results');
-      assert.match(results.innerHTML, /מיכל כהן/, 'second contact should be in results');
+      assert.match(results.innerHTML, /רשות א/, 'authority should be in results');
+      assert.doesNotMatch(results.innerHTML, /דנה קשר/, 'contacts should not appear in authority search');
+      assert.doesNotMatch(results.innerHTML, /050-1111111/, 'phone should not appear in authority search');
+      assert.doesNotMatch(results.innerHTML, /הוסף ידנית/, 'manual add should not appear for authority search');
+    }
+  );
+});
+
+test('multiple contacts for same client shows contact picker dropdown', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      const form = openNewProposalForm(root, dom);
+      selectClientResult(form, dom, 'רשות א');
+      selectClientResult(form, dom, 'בית ספר');
+
+      const contactSelect = form.querySelector('[data-pa-contact-select]');
+      assert.ok(contactSelect, 'contact picker should appear when multiple contacts exist');
+      assert.match(contactSelect.innerHTML, /דנה קשר/, 'first contact should be in picker');
+      assert.match(contactSelect.innerHTML, /מיכל כהן/, 'second contact should be in picker');
     }
   );
 });
 
 test('contact picker fills fields and passes existing contact source on save', async () => {
   const savedPayloads = [];
-  const contacts = sampleContactOptions.map((contact, idx) => ({ ...contact, id: String(idx + 1) }));
+  const contacts = sampleContactRows;
   const mockApi = {
     addProposalAgreement: async (payload) => {
       savedPayloads.push({ ...payload });
@@ -660,22 +788,25 @@ test('contact picker fills fields and passes existing contact source on save', a
   };
 
   await withJSDOM(
-    proposalsAgreementsScreen.render({ rows: [], contactOptions: contacts }, { state: stateFor('admin') }),
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
     async (root, dom) => {
       proposalsAgreementsScreen.bind({
         root,
-        data: { rows: [], activityNameOptions: [], contactOptions: contacts },
+        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
         state: stateFor('admin'),
         api: mockApi
       });
 
       const form = openNewProposalForm(root, dom);
-      const searchInput = form.querySelector('[data-pa-client-search-input]');
-      searchInput.value = 'מיכל';
-      searchInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+      selectClientResult(form, dom, 'רשות א');
+      selectClientResult(form, dom, 'בית ספר');
 
       const contact = contacts.find((c) => c.contact_name === 'מיכל כהן');
-      form.querySelector('[data-pa-client-result]')?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      const contactSelect = form.querySelector('[data-pa-contact-select]');
+      const option = [...contactSelect.options].find((entry) => entry.textContent.includes('מיכל כהן'));
+      assert.ok(option, 'picker should include מיכל כהן');
+      contactSelect.value = option.value;
+      contactSelect.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
 
       assert.equal(form.querySelector('input[name="contact_name"]').value, 'מיכל כהן');
       assert.equal(form.querySelector('input[name="contact_source_id"]').value, contact.id);
@@ -694,30 +825,43 @@ test('contact picker fills fields and passes existing contact source on save', a
   );
 });
 
-test('new client toggle button shows hint and clears client selector', async () => {
+test('manual contact toggle appears when selected school has no contacts', async () => {
+  const catalogOnly = [
+    ...sampleCatalogAuthorities,
+    {
+      _catalog_source: 'schools',
+      client_type: 'school',
+      client_name: 'בית ספר ללא איש קשר',
+      authority_id: 'auth-b',
+      school_id: 'school-empty',
+      authority: 'רשות ב',
+      school: 'בית ספר ללא איש קשר',
+      semel_mosad: '99999',
+      contact_name: '',
+      contact_role: '',
+      phone: '',
+      email: '',
+      mobile: ''
+    }
+  ];
+
   await withJSDOM(
-    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: catalogOnly }, { state: stateFor('admin') }),
     (root, dom) => {
       proposalsAgreementsScreen.bind({
         root,
-        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        data: { rows: [], activityNameOptions: [], contactOptions: catalogOnly },
         state: stateFor('admin'),
         api: {}
       });
 
       const form = openNewProposalForm(root, dom);
-      const searchInput = form.querySelector('[data-pa-client-search-input]');
+      selectClientResult(form, dom, 'רשות ב');
+      selectClientResult(form, dom, 'ללא איש קשר');
 
-      // Pre-fill a search
-      searchInput.value = 'רשות ב';
-
-      // Click manual client toggle
-      form.querySelector('[data-pa-new-client-toggle]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
-
-      const hint = form.querySelector('[data-pa-new-client-hint]');
-      assert.equal(hint.hidden, false, 'hint should be visible after toggle');
-      assert.equal(searchInput.value, '', 'client search should be cleared');
-      assert.equal(form.dataset.paNewClient, 'yes', 'form should mark new client mode');
+      const addContactRow = form.querySelector('[data-pa-add-contact-row]');
+      assert.equal(addContactRow.hidden, false, 'manual contact row should appear when no contacts exist');
+      assert.match(addContactRow.textContent, /הוסף איש קשר ידנית/);
     }
   );
 });
@@ -790,8 +934,26 @@ test('pending flow preview has submit and back actions without draft save', asyn
   );
 });
 
-test('saving after new client toggle keeps manual contact fields in pending payload', async () => {
+test('saving manual contact keeps authority and school ids in pending payload', async () => {
   const savedPayloads = [];
+  const manualSchoolCatalog = [
+    ...sampleCatalogAuthorities,
+    {
+      _catalog_source: 'schools',
+      client_type: 'school',
+      client_name: 'בית ספר חדש',
+      authority_id: 'auth-b',
+      school_id: 'school-new',
+      authority: 'רשות ב',
+      school: 'בית ספר חדש',
+      semel_mosad: '33333',
+      contact_name: '',
+      contact_role: '',
+      phone: '',
+      email: '',
+      mobile: ''
+    }
+  ];
   const mockApi = {
     addProposalAgreement: async (payload) => {
       savedPayloads.push({ ...payload });
@@ -800,23 +962,22 @@ test('saving after new client toggle keeps manual contact fields in pending payl
   };
 
   await withJSDOM(
-    proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: manualSchoolCatalog }, { state: stateFor('admin') }),
     async (root, dom) => {
       proposalsAgreementsScreen.bind({
         root,
-        data: { rows: [], activityNameOptions: [], contactOptions: sampleContactOptions },
+        data: { rows: [], activityNameOptions: [], contactOptions: manualSchoolCatalog },
         state: stateFor('admin'),
         api: mockApi
       });
 
       const form = openNewProposalForm(root, dom);
-      form.querySelector('[data-pa-new-client-toggle]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      selectClientResult(form, dom, 'רשות ב');
+      selectClientResult(form, dom, 'בית ספר חדש');
+      form.querySelector('[data-pa-add-contact-toggle]').dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
 
-      form.querySelector('input[name="client_authority"]').value = 'רשות חדשה';
-      form.querySelector('input[name="school_framework"]').value = 'בית ספר חדש';
-      form.querySelector('input[name="document_type"]').value = 'הצעת מחיר';
-      form.querySelector('[name="activity_type_group"]').value = 'קיץ תשפ״ו';
       form.querySelector('input[name="contact_name"]').value = 'שרון חדש';
+      form.querySelector('[name="activity_type_group"]').value = 'קיץ תשפ״ו';
       form.dataset.paPreviewSeen = 'yes';
       fillLineItem(form, dom);
 
@@ -826,7 +987,10 @@ test('saving after new client toggle keeps manual contact fields in pending payl
       assert.equal(savedPayloads.length, 1);
       assert.equal(savedPayloads[0].status, 'approved');
       assert.equal(savedPayloads[0].contact_name, 'שרון חדש', 'manual contact name should be saved');
-      assert.equal(savedPayloads[0]._contact_original.client_type, 'other', 'manual client source metadata should be preserved');
+      assert.equal(savedPayloads[0].authority_id, 'auth-b');
+      assert.equal(savedPayloads[0].school_id, 'school-new');
+      assert.equal(savedPayloads[0].client_authority, 'רשות ב');
+      assert.equal(savedPayloads[0].school_framework, 'בית ספר חדש');
     }
   );
 });
@@ -920,6 +1084,7 @@ test('multiple proposal item names are preserved on save', async () => {
 
       form.querySelector('input[name="client_authority"]').value = 'רשות ג';
       form.querySelector('input[name="school_framework"]').value = 'בית ספר ג';
+      setProposalCatalogIds(form);
       form.querySelector('input[name="document_type"]').value = 'הצעת מחיר';
       form.querySelector('[name="activity_type_group"]').value = 'קיץ תשפ״ו ושנת הלימודים תשפ״ז';
 
@@ -1191,6 +1356,7 @@ test('save includes items via saveProposalAgreementItems', async () => {
 
       form.querySelector('input[name="client_authority"]').value = 'רשות הבדיקה';
       form.querySelector('input[name="school_framework"]').value = 'בית ספר הבדיקה';
+      setProposalCatalogIds(form);
       form.querySelector('input[name="document_type"]').value = 'הצעת מחיר';
       form.querySelector('[name="activity_type_group"]').value = 'קיץ תשפ״ו';
 
@@ -1336,6 +1502,7 @@ test('proposal form opens as a gated stepper flow', async () => {
       authInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
       schoolInput.value = 'בית ספר בדיקה';
       schoolInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+      setProposalCatalogIds(form);
 
       assert.equal(proposalStep.hidden, false, 'proposal step opens after required client fields');
       assert.equal(activityStep.hidden, false, 'activity step remains open while filling proposal type');
@@ -1510,6 +1677,7 @@ test('changing proposal type reloads relevant item areas and preview template', 
       const form = openNewProposalForm(root, dom);
       form.querySelector('input[name="client_authority"]').value = 'רשות הדוגמה';
       form.querySelector('input[name="school_framework"]').value = 'בית ספר הדוגמה';
+      setProposalCatalogIds(form);
       form.querySelector('input[name="contact_name"]').value = 'ישראל ישראלי';
       form.querySelector('input[name="contact_role"]').value = 'מנהל בית הספר';
 
@@ -2175,6 +2343,7 @@ test('proposal form has no catalog attach control and saves include_catalog fals
       await delay(20);
       const form = root.querySelector('[data-pa-form]');
       form.querySelector('input[name="client_authority"]').value = 'רשות הדוגמה';
+      setProposalCatalogIds(form, { school_id: '', client_type: 'authority' });
       form.querySelector('[name="activity_type_group"]').value = 'קיץ תשפ״ו';
       const pricingSelect = form.querySelector('[data-pa-pricing-select]');
       pricingSelect.selectedIndex = 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the **new proposal** screen so authority and school cannot be typed manually. Both must be selected from Supabase catalog tables; only contacts may be added manually, and only after a valid authority (and school, when applicable) is chosen.

## Changes

### UI (`frontend/src/screens/proposals-agreements.js`)
- Replaced visible `client_authority` / `school_framework` text inputs with hidden fields set only by catalog selection
- Removed **"אחר"** client type and all **"לא מצאת? הוסף ידנית"** paths for authority/school
- **School** flow: search `public.authorities` → search `public.schools` (filtered by `authority_id`) → contact picker / manual contact
- **Authority** flow: search `public.authorities` → contact picker filtered by `authority_id`
- Authority search results show only catalog metadata (`authority_type`, `district`, `authority_code`) — no phone/email/contact rows
- School search results show only school name and symbol — no contact details
- Manual contact add remains available via **"לא מצאת? הוסף איש קשר ידנית"** after catalog selection

### Validation
- Block save without `authority_id`: "יש לבחור רשות מתוך רשימת הרשויות."
- Block save without `school_id` for school client type: "יש לבחור בית ספר מתוך רשימת בתי הספר של הרשות."
- Block manual contact without prior catalog selection: "ניתן להוסיף איש קשר רק לאחר בחירת רשות ובית ספר."

### API (`frontend/src/api.js`)
- Include `authority_type` in authorities catalog loader for search result display

### Service Worker
- Bump cache version to **792** in `frontend/sw.js` and `sw.js`

## Verification
- `node --check` on changed JS files
- `node --test tests/proposals-agreements-screen.test.mjs` — **70/73 pass** (3 pre-existing unrelated failures: approval UI / status dropdown)
- `npm run check:build` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e54c325-3e62-4678-bd80-53df1c7ea01e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e54c325-3e62-4678-bd80-53df1c7ea01e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

