### PR TITLE
Fix new proposal authority search and bypass stale screen cache

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CUe91_KR.js"></script>
+  <script type="module" crossorigin src="./assets/index-BMFYgTZJ.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BNCx56PA.css">
 </head>
 <body>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1098,6 +1098,7 @@ const SCREEN_CACHE_TTL_MS = {
   week: 8 * 60 * 1000,
   month: 8 * 60 * 1000,
   exceptions: 8 * 60 * 1000,
+  'proposals-agreements': 0,
 };
 const DEFAULT_CACHE_TTL_MS = 15 * 60 * 1000;
 
@@ -1106,8 +1107,26 @@ function screenCacheTtl() {
 }
 const MEMORY_ONLY_CACHE_PREFIXES = [
   'activityDetail:',
-  'operations:'
+  'operations:',
+  'proposals-agreements'
 ];
+
+function purgeScreenCacheEntry(cacheKey) {
+  if (!cacheKey) return;
+  delete state.screenDataCache[cacheKey];
+  persistCacheDelete(cacheKey);
+}
+
+function logProposalsAgreementsContactOptions(data) {
+  const options = Array.isArray(data?.contactOptions) ? data.contactOptions : [];
+  // eslint-disable-next-line no-console
+  console.info('[pa-data-contact-options]', {
+    total: options.length,
+    authorities: options.filter((c) => c._catalog_source === 'authorities').length,
+    schools: options.filter((c) => c._catalog_source === 'schools').length,
+    sampleAuthority: options.find((c) => c._catalog_source === 'authorities')
+  });
+}
 
 const MAX_PERSISTED_CACHE_ENTRY_BYTES = 80000;
 
@@ -1156,6 +1175,9 @@ async function loadScreenDataWithCache(screen) {
   const routePerfEnabled = routeName === 'dashboard' || routeName === 'activities' || routeName === 'week' || routeName === 'month';
   const routePerfStart = routePerfEnabled ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0;
   const key = screenDataCacheKey();
+  if (routeName === 'proposals-agreements') {
+    purgeScreenCacheEntry(key);
+  }
   const hit = state.screenDataCache[key];
   const ttl = screenCacheTtl();
   const age = hit ? Date.now() - hit.t : 0;
@@ -1211,6 +1233,9 @@ async function loadScreenDataWithCache(screen) {
       const entry = { data, t: Date.now() };
       state.screenDataCache[key] = entry;
       maybePersistScreenCacheEntry(key, entry);
+      if (routeName === 'proposals-agreements') {
+        logProposalsAgreementsContactOptions(data);
+      }
       if (key === 'exceptions') updateExceptionNavCount();
       inflightRequests.delete(key);
       return data;
@@ -1487,6 +1512,9 @@ function clearScreenDataCache() {
 
 function bindScreen(screen, screenRoot, data) {
   const routeAtBind = state.route;
+  if (routeAtBind === 'proposals-agreements') {
+    logProposalsAgreementsContactOptions(data);
+  }
   screen.bind?.({
     root: screenRoot,
     data,
@@ -1705,6 +1733,9 @@ async function mountScreen() {
 
   const cacheKey = screenDataCacheKey();
   const routeLoadStartMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  if (requestedRoute === 'proposals-agreements') {
+    purgeScreenCacheEntry(cacheKey);
+  }
   // eslint-disable-next-line no-console
   console.info('[route-load:start]', { route: requestedRoute, cacheKey });
   const rawEntry = screen.load ? state.screenDataCache[cacheKey] : null;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 794;
+const CACHE_VERSION = 795;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 794;
+const SW_ENTRY_VERSION = 795;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -465,6 +465,15 @@ test('screen and API source enforce authorization before API/Supabase calls', as
   assert.match(apiSource, /assertCanUseProposalsAgreementsApi\(\);[\s\S]*\.from\('proposals_agreements'\)/);
 });
 
+test('proposals-agreements screen bypasses persistent and in-memory screen cache', async () => {
+  const mainSource = await readFile(MAIN_FILE, 'utf8');
+  assert.match(mainSource, /'proposals-agreements': 0/);
+  assert.match(mainSource, /'proposals-agreements'/);
+  assert.match(mainSource, /MEMORY_ONLY_CACHE_PREFIXES[\s\S]*'proposals-agreements'/);
+  assert.match(mainSource, /\[pa-data-contact-options\]/);
+  assert.match(mainSource, /routeName === 'proposals-agreements'[\s\S]*purgeScreenCacheEntry/);
+});
+
 test('proposals agreements directory view uses only existing Supabase columns', async () => {
   const apiSource = await readFile(API_FILE, 'utf8');
   const columnsMatch = apiSource.match(/const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = '([^']+)'/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the **new proposal** screen (`+ הצעה חדשה`) authority search and stale-data issues.

### Flow fixes
- Removed "סוג גורם" — always starts with mandatory authority search
- Authority → optional school → contact flow
- Fixed Supabase column mappings (`authority_name`, `school_name`, `authority_district`, etc.)
- Support `active = 'yes'` in catalog filtering
- Temporary API logs: `[proposal-catalog-authorities]`, `[proposal-catalog-schools]`, `[proposal-contact-options]`

### Cache fix
Root cause for "אין תוצאה" after deploy: stale `screenDataCache` / persistent cache holding old `contactOptions` without `_catalog_source: 'authorities'` rows.

- `SCREEN_CACHE_TTL_MS['proposals-agreements'] = 0`
- Added `proposals-agreements` to `MEMORY_ONLY_CACHE_PREFIXES` (no localStorage restore)
- Purge in-memory cache on every proposals-agreements navigation
- Added UI debug log: `[pa-data-contact-options]` with authority/school counts
- Service Worker cache version **795**

## Acceptance test after deploy + hard refresh

1. Open new proposal
2. Search "אשכול" at authority step
3. Expected: **אשכול · מועצה אזורית · הדרום · קוד 5538**

If still failing, check console:
- `[proposal-catalog-authorities]`
- `[proposal-contact-options]`
- `[pa-data-contact-options]` — `authorities` must be > 0

## Verification
- `node --check` on changed files
- `tests/proposals-agreements-screen.test.mjs` — flow + cache tests pass
- `npm run check:build` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a91550a-578a-4632-8fda-24bd7c499eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a91550a-578a-4632-8fda-24bd7c499eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

