### PR TITLE
חיווי אדום בסרגל צד להצעות מחיר מאושרות שממתינות לשליחה

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,7 @@
 import { api } from './api.js';
 import { config } from './config.js';
 import { state, setSession, defaultClientSettings } from './state.js';
-import { SCREEN_CACHE_STORAGE_PREFIX, persistCacheEntry, deletePersistedCacheEntry } from './cache-persist.js';
+import { SCREEN_CACHE_STORAGE_PREFIX, persistCacheEntry, deletePersistedCacheEntry, deletePersistedCacheByPrefixes } from './cache-persist.js';
 import { escapeHtml } from './screens/shared/html.js';
 import { hebrewRole, translateApiErrorForUser } from './screens/shared/ui-hebrew.js';
 import { createSharedInteractionLayer } from './screens/shared/interactions.js';
@@ -1157,8 +1157,28 @@ function screenCacheTtl() {
 const MEMORY_ONLY_CACHE_PREFIXES = [
   'activityDetail:',
   'operations:',
-  'proposals-agreements'
+  'proposals-agreements',
+  'contacts'
 ];
+
+const PROPOSALS_RELATED_CACHE_PREFIXES = ['proposals-agreements', 'contacts'];
+
+function purgeProposalsRelatedCaches() {
+  const deletedKeys = [];
+  Object.keys(state.screenDataCache || {}).forEach((key) => {
+    if (PROPOSALS_RELATED_CACHE_PREFIXES.some((prefix) => key === prefix || key.startsWith(`${prefix}:`))) {
+      delete state.screenDataCache[key];
+      deletedKeys.push(key);
+    }
+  });
+  const persistedKeys = deletePersistedCacheByPrefixes(PROPOSALS_RELATED_CACHE_PREFIXES);
+  deletedKeys.push(...persistedKeys.filter((key) => !deletedKeys.includes(key)));
+  deletedKeys.forEach((key) => persistCacheDelete(key));
+  if (deletedKeys.length) {
+    // eslint-disable-next-line no-console
+    console.info('[proposals-cache-purge]', { deletedKeys });
+  }
+}
 
 function purgeScreenCacheEntry(cacheKey) {
   if (!cacheKey) return;
@@ -1225,7 +1245,7 @@ async function loadScreenDataWithCache(screen) {
   const routePerfStart = routePerfEnabled ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0;
   const key = screenDataCacheKey();
   if (routeName === 'proposals-agreements') {
-    purgeScreenCacheEntry(key);
+    purgeProposalsRelatedCaches();
   }
   const hit = state.screenDataCache[key];
   const ttl = screenCacheTtl();
@@ -1280,11 +1300,12 @@ async function loadScreenDataWithCache(screen) {
         });
       }
       const entry = { data, t: Date.now() };
-      state.screenDataCache[key] = entry;
-      maybePersistScreenCacheEntry(key, entry);
       if (routeName === 'proposals-agreements') {
         logProposalsAgreementsContactOptions(data);
         syncPendingApprovedProposalsCountFromRows(data?.rows);
+      } else {
+        state.screenDataCache[key] = entry;
+        maybePersistScreenCacheEntry(key, entry);
       }
       if (key === 'exceptions') updateExceptionNavCount();
       inflightRequests.delete(key);
@@ -1319,8 +1340,10 @@ async function backgroundRefreshScreen(screen, cacheKey) {
     const data = await p;
     inflightRequests.delete(cacheKey);
     const entry = { data, t: Date.now() };
-    state.screenDataCache[cacheKey] = entry;
-    maybePersistScreenCacheEntry(cacheKey, entry);
+    if (cacheKey !== 'proposals-agreements') {
+      state.screenDataCache[cacheKey] = entry;
+      maybePersistScreenCacheEntry(cacheKey, entry);
+    }
     if (cacheKey === 'exceptions') updateExceptionNavCount();
     if (cacheKey === 'proposals-agreements') syncPendingApprovedProposalsCountFromRows(data?.rows);
     if (
@@ -1699,6 +1722,7 @@ function backgroundSyncBootstrap() {
       }
       refreshOpenEditRequestsCount().catch(() => {});
       refreshPendingApprovedProposalsCount().catch(() => {});
+      purgeProposalsRelatedCaches();
     })
     .catch(() => {
       state.permissionsReady = true;
@@ -1719,6 +1743,7 @@ async function restoreSession() {
   clearFinancePrefsIfUserChanged(state.user?.user_id);
   refreshOpenEditRequestsCount().catch(() => {});
   refreshPendingApprovedProposalsCount().catch(() => {});
+  purgeProposalsRelatedCaches();
 }
 
 async function mountScreen() {
@@ -1787,11 +1812,13 @@ async function mountScreen() {
   const cacheKey = screenDataCacheKey();
   const routeLoadStartMs = typeof performance !== 'undefined' ? performance.now() : Date.now();
   if (requestedRoute === 'proposals-agreements') {
-    purgeScreenCacheEntry(cacheKey);
+    purgeProposalsRelatedCaches();
   }
   // eslint-disable-next-line no-console
   console.info('[route-load:start]', { route: requestedRoute, cacheKey });
-  const rawEntry = screen.load ? state.screenDataCache[cacheKey] : null;
+  const rawEntry = (requestedRoute === 'proposals-agreements' || !screen.load)
+    ? null
+    : state.screenDataCache[cacheKey];
   const isStale = rawEntry && (Date.now() - rawEntry.t >= screenCacheTtl() || rawEntry.data?._is_stale === true);
 
   const shellExists = !!(state.token && document.querySelector('.app-shell #screenRoot'));
@@ -2099,6 +2126,7 @@ async function render() {
             });
             refreshOpenEditRequestsCount().catch(() => {});
             refreshPendingApprovedProposalsCount().catch(() => {});
+            purgeProposalsRelatedCaches();
             loginBootstrapDurationMs = performance.now() - bootstrapApplyStartMs;
             applyGlobalAccent(accentNameFromStorage(state.clientSettings));
             renderShellLoadingImmediately();

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -12,6 +12,7 @@ import { clearFinancePrefsIfUserChanged } from './screens/shared/finance-prefs-s
 import { applyGlobalAccent, accentNameFromStorage, bindAccentPickerOnce as bindAccentPickerListenerOnce } from './accent-picker.js';
 import { waitForSupabaseAuthSession } from './supabase-client.js';
 import { permissionFlagYes as permissionEnabled } from './permissions.js';
+import { countPendingApprovedProposals } from './screens/shared/proposals-pending-count.js';
 
 const app = document.getElementById('app');
 const loginLogoSrc  = new URL('../assets/logo1.png',      import.meta.url).href;
@@ -581,6 +582,38 @@ async function refreshOpenEditRequestsCount() {
   }
 }
 
+function setPendingApprovedProposalsCount(count) {
+  const normalized = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+  if (state.pendingApprovedProposalsCount !== normalized) {
+    state.pendingApprovedProposalsCount = normalized;
+    updateNavCountBadges();
+  }
+}
+
+function syncPendingApprovedProposalsCountFromRows(rows) {
+  enforceProposalsAgreementsRoute();
+  if (!isAllowedRoute('proposals-agreements')) {
+    setPendingApprovedProposalsCount(0);
+    return;
+  }
+  setPendingApprovedProposalsCount(countPendingApprovedProposals(rows));
+}
+
+async function refreshPendingApprovedProposalsCount() {
+  enforceProposalsAgreementsRoute();
+  if (!isAllowedRoute('proposals-agreements')) {
+    setPendingApprovedProposalsCount(0);
+    return;
+  }
+  try {
+    const data = await api.proposalsAgreements();
+    const rows = Array.isArray(data?.rows) ? data.rows : [];
+    setPendingApprovedProposalsCount(countPendingApprovedProposals(rows));
+  } catch {
+    // Keep existing count on transient failures.
+  }
+}
+
 const screenLoaders = {
   dashboard: () => import('./screens/dashboard.js').then((m) => m.dashboardScreen),
   activities: () => import('./screens/activities.js').then((m) => m.activitiesScreen),
@@ -838,6 +871,15 @@ function shellUserDisplayName() {
 }
 
 
+function proposalsNavCount() {
+  const stored = Number(state.pendingApprovedProposalsCount);
+  if (Number.isFinite(stored) && stored > 0) return stored;
+  const entry = state.screenDataCache?.['proposals-agreements'];
+  const rows = Array.isArray(entry?.data?.rows) ? entry.data.rows : [];
+  if (rows.length) return countPendingApprovedProposals(rows);
+  return Number.isFinite(stored) ? stored : 0;
+}
+
 function exceptionsNavCount() {
   const entry = state.screenDataCache?.exceptions;
   const instances = Array.isArray(entry?.data?.exceptionInstances) ? entry.data.exceptionInstances : [];
@@ -875,6 +917,13 @@ function navLabelHtmlForRoute(route) {
     const safeCount = escapeHtml(String(count));
     return `${label} <span class="ds-nav-count-badge ds-nav-count-badge--edit-requests" aria-label="${safeCount} בקשות עריכה פתוחות">${safeCount}</span>`;
   }
+  if (route === 'proposals-agreements') {
+    const count = proposalsNavCount();
+    const label = escapeHtml(baseLabel);
+    if (!Number.isFinite(count) || count <= 0) return label;
+    const safeCount = escapeHtml(String(count));
+    return `${label} <span class="ds-nav-count-badge ds-nav-count-badge--proposals-pending" aria-label="${safeCount} הצעות מחיר מאושרות ממתינות לשליחה">${safeCount}</span>`;
+  }
   const label = escapeHtml(navLabelForRoute(route));
   if (route !== 'exceptions') return label;
   const count = exceptionsNavCount();
@@ -885,7 +934,7 @@ function navLabelHtmlForRoute(route) {
 
 function updateNavCountBadges() {
   if (typeof document === 'undefined') return;
-  ['exceptions', 'edit-requests'].forEach((route) => {
+  ['exceptions', 'edit-requests', 'proposals-agreements'].forEach((route) => {
     document.querySelectorAll(`[data-route="${route}"] .ds-act-nav-item__label`).forEach((node) => {
       node.innerHTML = navLabelHtmlForRoute(route);
     });
@@ -1235,6 +1284,7 @@ async function loadScreenDataWithCache(screen) {
       maybePersistScreenCacheEntry(key, entry);
       if (routeName === 'proposals-agreements') {
         logProposalsAgreementsContactOptions(data);
+        syncPendingApprovedProposalsCountFromRows(data?.rows);
       }
       if (key === 'exceptions') updateExceptionNavCount();
       inflightRequests.delete(key);
@@ -1272,6 +1322,7 @@ async function backgroundRefreshScreen(screen, cacheKey) {
     state.screenDataCache[cacheKey] = entry;
     maybePersistScreenCacheEntry(cacheKey, entry);
     if (cacheKey === 'exceptions') updateExceptionNavCount();
+    if (cacheKey === 'proposals-agreements') syncPendingApprovedProposalsCountFromRows(data?.rows);
     if (
       activeNavigationToken === guardedToken &&
       state.route === guardedRoute &&
@@ -1647,6 +1698,7 @@ function backgroundSyncBootstrap() {
         if (state.route === 'personal-reports') render().catch(() => {});
       }
       refreshOpenEditRequestsCount().catch(() => {});
+      refreshPendingApprovedProposalsCount().catch(() => {});
     })
     .catch(() => {
       state.permissionsReady = true;
@@ -1666,6 +1718,7 @@ async function restoreSession() {
   consumePendingRouteFromUrlOrSession();
   clearFinancePrefsIfUserChanged(state.user?.user_id);
   refreshOpenEditRequestsCount().catch(() => {});
+  refreshPendingApprovedProposalsCount().catch(() => {});
 }
 
 async function mountScreen() {
@@ -1939,6 +1992,15 @@ function bindShell() {
     refreshOpenEditRequestsCount().catch(() => {});
   });
 
+  document.addEventListener('app:proposals-pending-updated', (e) => {
+    const rows = e?.detail?.rows;
+    if (Array.isArray(rows)) {
+      syncPendingApprovedProposalsCountFromRows(rows);
+      return;
+    }
+    refreshPendingApprovedProposalsCount().catch(() => {});
+  });
+
   document.querySelectorAll('[data-route]').forEach((button) => {
     button.addEventListener('click', () => {
       navigateToRoute(button.dataset.route);
@@ -2036,6 +2098,7 @@ async function render() {
               default_route: state.route
             });
             refreshOpenEditRequestsCount().catch(() => {});
+            refreshPendingApprovedProposalsCount().catch(() => {});
             loginBootstrapDurationMs = performance.now() - bootstrapApplyStartMs;
             applyGlobalAccent(accentNameFromStorage(state.clientSettings));
             renderShellLoadingImmediately();

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1,6 +1,9 @@
 import { escapeHtml } from './shared/html.js';
 import { dsCard, dsEmptyState, dsPageHeader, dsScreenStack, dsTableWrap } from './shared/layout.js';
 import { showToast } from './shared/toast.js';
+import { countPendingApprovedProposals, isProposalApprovedPendingSend } from './shared/proposals-pending-count.js';
+
+export { countPendingApprovedProposals, isProposalApprovedPendingSend };
 
 export const PROPOSALS_AGREEMENTS_ALLOWED_ROLES = new Set(['domain_manager', 'operation_manager', 'admin', 'business_development_manager']);
 export const PROPOSALS_AGREEMENTS_MANAGE_ROLES = new Set(['domain_manager', 'operation_manager', 'admin']);
@@ -27,6 +30,15 @@ const STATUS_ALIASES = { pending_approval: 'sent' };
 function normalizeProposalStatus(status) {
   const raw = text(status);
   return STATUS_ALIASES[raw] || raw;
+}
+
+function notifyPendingProposalsNav(rows) {
+  if (typeof document === 'undefined') return;
+  try {
+    document.dispatchEvent(new CustomEvent('app:proposals-pending-updated', {
+      detail: { rows: Array.isArray(rows) ? rows : [] }
+    }));
+  } catch { /* ignore */ }
 }
 
 const FIELD_LABELS = {
@@ -2374,6 +2386,7 @@ function replaceLocalRow(data, savedRow) {
   if (idx >= 0) rows[idx] = normalized;
   else rows.unshift(normalized);
   data.rows = dedupeById(sortRows(rows.map(normalizeProposalAgreementRow)));
+  notifyPendingProposalsNav(data.rows);
 }
 
 // ─── Catalog appendix PDF planning ─────────────────────────────────────────
@@ -2601,6 +2614,7 @@ export const proposalsAgreementsScreen = {
     data.rows = sortRows((Array.isArray(data.rows) ? data.rows : [])
       .map(normalizeProposalAgreementRow)
       .filter((r) => { const k = text(r.id); if (!k || seenIds.has(k)) return false; seenIds.add(k); return true; }));
+    notifyPendingProposalsNav(data.rows);
     const activityNameOptions = Array.from(new Set((Array.isArray(data?.activityNameOptions) ? data.activityNameOptions : []).map((v) => text(v)).filter(Boolean)));
     const proposalActivityPricing = Array.isArray(data?.proposalActivityPricing) ? data.proposalActivityPricing : [];
     setProposalGroupLookups(data, data.rows, proposalActivityPricing);

--- a/frontend/src/screens/shared/proposals-pending-count.js
+++ b/frontend/src/screens/shared/proposals-pending-count.js
@@ -1,0 +1,34 @@
+const STATUS_ALIASES = { pending_approval: 'sent' };
+
+function text(value) {
+  return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeProposalStatus(status) {
+  const raw = text(status);
+  return STATUS_ALIASES[raw] || raw;
+}
+
+function normalizeSignatureMeta(value) {
+  let raw = value;
+  if (typeof raw === 'string' && raw.trim()) {
+    try { raw = JSON.parse(raw); } catch { raw = null; }
+  }
+  const source = raw?.signature && typeof raw.signature === 'object' ? raw.signature : raw;
+  if (!source || typeof source !== 'object') return null;
+  return { signature: { image: text(source.image) } };
+}
+
+export function isProposalApprovedPendingSend(row) {
+  if (!row || typeof row !== 'object') return false;
+  const status = normalizeProposalStatus(row.status);
+  if (status === 'sent' || status === 'cancelled') return false;
+  const isApproved = status === 'approved';
+  const hasApprovedAt = Boolean(text(row.approved_at));
+  const hasSignature = normalizeSignatureMeta(row.signature_meta || row.approval_meta) !== null;
+  return isApproved || hasApprovedAt || hasSignature;
+}
+
+export function countPendingApprovedProposals(rows) {
+  return (Array.isArray(rows) ? rows : []).filter(isProposalApprovedPendingSend).length;
+}

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -109,6 +109,8 @@ export const state = {
   screenDataCache: {},
   /** Sidebar badge for open approval requests (null = not loaded yet). */
   openEditRequestsCount: null,
+  /** Sidebar badge for approved proposals awaiting send (null = not loaded yet). */
+  pendingApprovedProposalsCount: null,
   /** True once Supabase Auth session is available on the shared client. */
   authSessionReady: false,
   /** False while bootstrap/profile permission sync is in flight after reload. */
@@ -174,6 +176,7 @@ export function setSession(session) {
     state.clientSettings = defaultClientSettings();
     state.screenDataCache = {};
     state.openEditRequestsCount = null;
+    state.pendingApprovedProposalsCount = null;
     state.authSessionReady = false;
     state.permissionsReady = false;
     resetSupabaseAuthSessionWait();
@@ -218,6 +221,7 @@ export function setSession(session) {
   cleanupLegacyCalendarMonthLocalStorage(state.user.user_id);
   state.screenDataCache = {};
   state.openEditRequestsCount = null;
+  state.pendingApprovedProposalsCount = null;
   localStorage.setItem('dashboard_token', session.token);
   localStorage.setItem('dashboard_user', JSON.stringify(state.user));
   sessionStorage.setItem('ds_session_alive', '1');

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12957,6 +12957,22 @@ select.ds-input {
   font-weight: 800;
 }
 
+.ds-nav-count-badge--proposals-pending {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.35em;
+  height: 1.35em;
+  margin-inline-start: 0.35em;
+  padding: 0 0.42em;
+  border-radius: 999px;
+  background: #dc2626;
+  color: #fff;
+  font-size: 0.78em;
+  font-weight: 800;
+  vertical-align: middle;
+}
+
 /* Activities period tabs */
 .ds-activities-period-tabs {
   display: flex;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 797;
+const CACHE_VERSION = 798;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 796;
+const CACHE_VERSION = 797;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 796;
+const SW_ENTRY_VERSION = 797;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 797;
+const SW_ENTRY_VERSION = 798;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -60,7 +60,7 @@ const MIGRATION_FILE = new URL('../supabase/migrations/20260518_create_proposals
 const ROLE_UPDATE_MIGRATION_FILE = new URL('../supabase/migrations/20260602_add_business_development_manager_role.sql', import.meta.url);
 const APPROVAL_GUARD_MIGRATION_FILE = new URL('../supabase/migrations/20260616_proposals_agreements_approval_guard.sql', import.meta.url);
 
-const { proposalsAgreementsScreen, canAccessProposalsAgreements, canManageProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS, buildProposalCatalogPdfEntries, proposalPreviewBodyHtml } = await import('../frontend/src/screens/proposals-agreements.js');
+const { proposalsAgreementsScreen, canAccessProposalsAgreements, canManageProposalsAgreements, STATUS_LABELS, STATUS_OPTIONS, buildProposalCatalogPdfEntries, proposalPreviewBodyHtml, countPendingApprovedProposals, isProposalApprovedPendingSend } = await import('../frontend/src/screens/proposals-agreements.js');
 
 function stateFor(role) {
   return {
@@ -312,6 +312,42 @@ test('proposals-agreements route is registered and role-gated in route definitio
   assert.match(apiSource, /business_development_manager: \[[^\]]*'proposals-agreements'/);
   assert.doesNotMatch(apiSource, /authorized_user: \[[^\]]*'proposals-agreements'/);
   assert.doesNotMatch(apiSource, /instructor: \[[^\]]*'proposals-agreements'/);
+});
+
+test('pending approved proposals nav count includes approved unsigned sent excludes sent and cancelled', () => {
+  const approved = { id: '1', status: 'approved' };
+  const signed = { id: '2', status: 'draft', approved_at: '2026-06-01T10:00:00Z' };
+  const signatureOnly = { id: '3', status: 'draft', signature_meta: { signature: { image: 'proposals/signature-idan-nahum.png' } } };
+  const sent = { id: '4', status: 'sent', approved_at: '2026-06-01T10:00:00Z' };
+  const pendingAlias = { id: '5', status: 'pending_approval', approved_at: '2026-06-01T10:00:00Z' };
+  const cancelled = { id: '6', status: 'cancelled', approved_at: '2026-06-01T10:00:00Z' };
+  const draft = { id: '7', status: 'draft' };
+
+  assert.equal(isProposalApprovedPendingSend(approved), true);
+  assert.equal(isProposalApprovedPendingSend(signed), true);
+  assert.equal(isProposalApprovedPendingSend(signatureOnly), true);
+  assert.equal(isProposalApprovedPendingSend(sent), false);
+  assert.equal(isProposalApprovedPendingSend(pendingAlias), false);
+  assert.equal(isProposalApprovedPendingSend(cancelled), false);
+  assert.equal(isProposalApprovedPendingSend(draft), false);
+  assert.equal(countPendingApprovedProposals([approved, signed, sent, draft, signatureOnly]), 3);
+});
+
+test('sidebar proposals pending badge is wired in main shell nav', async () => {
+  const mainSource = await readFile(MAIN_FILE, 'utf8');
+  assert.match(mainSource, /ds-nav-count-badge--proposals-pending/);
+  assert.match(mainSource, /pendingApprovedProposalsCount/);
+  assert.match(mainSource, /refreshPendingApprovedProposalsCount/);
+  assert.match(mainSource, /app:proposals-pending-updated/);
+  assert.match(mainSource, /'proposals-agreements'/);
+  assert.match(mainSource, /navLabelHtmlForRoute[\s\S]*proposals-agreements/);
+});
+
+test('proposals screen dispatches pending nav updates on bind and local row changes', async () => {
+  const screenSource = await readFile(SCREEN_FILE, 'utf8');
+  assert.match(screenSource, /app:proposals-pending-updated/);
+  assert.match(screenSource, /notifyPendingProposalsNav\(data\.rows\)/);
+  assert.match(screenSource, /function replaceLocalRow[\s\S]*notifyPendingProposalsNav\(data\.rows\)/);
 });
 
 

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -506,8 +506,13 @@ test('proposals-agreements screen bypasses persistent and in-memory screen cache
   assert.match(mainSource, /'proposals-agreements': 0/);
   assert.match(mainSource, /'proposals-agreements'/);
   assert.match(mainSource, /MEMORY_ONLY_CACHE_PREFIXES[\s\S]*'proposals-agreements'/);
+  assert.match(mainSource, /MEMORY_ONLY_CACHE_PREFIXES[\s\S]*'contacts'/);
+  assert.match(mainSource, /purgeProposalsRelatedCaches/);
+  assert.match(mainSource, /PROPOSALS_RELATED_CACHE_PREFIXES[\s\S]*'contacts'/);
   assert.match(mainSource, /\[pa-data-contact-options\]/);
-  assert.match(mainSource, /routeName === 'proposals-agreements'[\s\S]*purgeScreenCacheEntry/);
+  assert.match(mainSource, /routeName === 'proposals-agreements'[\s\S]*purgeProposalsRelatedCaches/);
+  assert.match(mainSource, /requestedRoute === 'proposals-agreements'[\s\S]*\? null/);
+  assert.match(mainSource, /if \(routeName === 'proposals-agreements'\) \{[\s\S]*?\} else \{[\s\S]*maybePersistScreenCacheEntry/);
 });
 
 test('proposals agreements directory view uses only existing Supabase columns', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- מוסיף תג אדום עם מספר ליד **הצעות מחיר** בסרגל הצד, רק למשתמשים עם הרשאה למודול.
- החיווי מוצג כאשר קיימת לפחות הצעה שמאושרת/חתומה ועדיין לא נשלחה (`status !== 'sent'`).
- הספירה מתעדכנת בכניסה למערכת, רענון, טעינת מסך הצעות מחיר, ושינוי סטטוס מקומי (אישור / שליחה).

## תנאי ספירה
הצעה נספרת אם:
- `status === 'approved'`, או
- `approved_at` קיים, או
- `signature_meta` מכיל חתימה

ולא נספרת אם:
- `status === 'sent'` (כולל `pending_approval`)
- `status === 'cancelled'`

## קבצים עיקריים
- `frontend/src/screens/shared/proposals-pending-count.js` — לוגיקת ספירה משותפת
- `frontend/src/main.js` — תג בסרגל, רענון ב-login/bootstrap, מאזין לאירוע `app:proposals-pending-updated`
- `frontend/src/screens/proposals-agreements.js` — שידור עדכון אחרי `bind` ו-`replaceLocalRow`
- `frontend/src/styles/main.css` — `.ds-nav-count-badge--proposals-pending`
- `sw.js` / `frontend/sw.js` — גרסת cache **797**

## בדיקות
- `node --check` על הקבצים ששונו
- `node --test tests/proposals-agreements-screen.test.mjs` — 3 כשלונות קיימים שלא קשורים לשינוי (approval UI / status dropdown)
- `npm run check:build` — עבר

## אימות ידני מומלץ
1. התחברות עם משתמש בעל הרשאה להצעות מחיר + הצעה מאושרת שלא נשלחה → תג אדום עם מספר ליד **הצעות מחיר**
2. שינוי סטטוס ל־נשלח → התג נעלם
3. התחברות עם משתמש ללא הרשאה → אין תג
4. לוודא שהתג קטן ליד השם ולא צובע את כל הכפתור
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a91550a-578a-4632-8fda-24bd7c499eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a91550a-578a-4632-8fda-24bd7c499eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

