### PR TITLE
Use course item-details table for course proposals

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1380,10 +1380,16 @@ function proposalItemDetailsTableHtml(items = [], contextGroup = '') {
   const visibleItems = (Array.isArray(items) ? items : []).filter((item) =>
     !isTestHoursItem(item) && text(item.proposal_display_mode) !== 'bundle_child');
   const rows = visibleItems.map((item) => {
-    const hasPedagogicPricingData = Boolean(
-      text(item.gefen_number) || item.meetings_count != null || item.hours_count != null || item.hourly_price != null
+    const hasCourseRowData = Boolean(
+      text(item.item_name)
+      || text(item.gefen_number)
+      || item.meetings_count != null
+      || item.hours_count != null
+      || item.hourly_price != null
+      || item.unit_price != null
+      || item.total_price != null
     );
-    if (!hasPedagogicPricingData) return '';
+    if (!hasCourseRowData) return '';
     const quantity = itemQuantity(item);
     const quantityTotal = itemQuantityTotal(item);
     const cells = [
@@ -1723,7 +1729,10 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = [], 
   // Payment section: general terms text comes from Supabase, while the price
   // breakdown is always built dynamically from proposal_agreement_items.
   const paymentTermsBody = sectionBody('payment_terms');
-  const costTableHtml = proposalCostTableHtml(items);
+  const proposalKind = proposalActivityKind(row, items);
+  const costTableHtml = proposalKind === 'course'
+    ? proposalItemDetailsTableHtml(items, activityTypeGroup)
+    : proposalCostTableHtml(items);
   const costsIntro = costsIntroBody(row, items);
   const costTableBlock = (costsIntro || costTableHtml)
     ? `<div class="pa-cost-table-block">${costsIntro ? `<p class="pa-costs-intro-heading">${escapeHtml(costsIntro)}</p>` : ''}${costTableHtml}</div>`

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2203,40 +2203,65 @@ test('catalog PDF appendices use fixed workshop/tour PDFs and specific selected 
 });
 
 
-test('course preview renders one cost table with quantity, unit group price, and quantity total', async () => {
+test('course preview renders the course item details table instead of the workshop cost table', async () => {
   const row = {
     ...sampleRows[0],
     id: 'course-price-breakdown-row',
-    activity_type_group: 'שנת הלימודים תשפ״ז',
+    activity_type_group: 'שנה הבאה',
     proposal_date: '2026-06-01'
   };
   const items = [{
-    item_name: 'קורס רובוטיקה',
+    item_name: 'סודות הבינה המלאכותית',
     item_type: 'קורס',
-    proposal_group: 'שנת הלימודים תשפ״ז',
+    proposal_group: 'שנה הבאה',
     gefen_number: '9545',
-    meetings_count: 10,
-    hours_count: 20,
-    hourly_price: 450,
+    meetings_count: 8,
     quantity: 2,
-    unit_price: 9000,
-    total_price: 18000
+    hours_count: 16,
+    unit_price: 7500,
+    hourly_price: 468.75,
+    total_price: 15000
   }];
 
   await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
-    assert.equal(dom.window.document.querySelectorAll('.pa-cost-table').length, 1);
-    assert.equal(dom.window.document.querySelector('.pa-item-details-table'), null);
+    const courseTable = dom.window.document.querySelector('.pa-item-details-table');
+    assert.ok(courseTable, 'course details table should render');
+    assert.equal(dom.window.document.querySelector('.pa-cost-table'), null);
+    const headers = [...courseTable.querySelectorAll('thead th')].map((th) => th.textContent.trim());
+    assert.ok(headers.includes('קורס / תוכנית'));
+    assert.ok(headers.includes('מס׳ גפ״ן'));
+    assert.ok(headers.includes('מפגשים'));
+    assert.ok(headers.includes('מחיר לשעה'));
+    assert.ok(courseTable.textContent.includes('סודות הבינה המלאכותית'));
+    assert.ok(!headers.includes('פעילות'));
+    assert.ok(!headers.includes('מחיר יחידה'));
+    assert.ok(!headers.includes('סה״כ שורה'));
+  });
+});
+
+test('summer preview keeps the workshop cost table instead of the course details table', async () => {
+  const row = {
+    ...sampleRows[0],
+    id: 'summer-price-breakdown-row',
+    activity_type_group: 'פעילויות קיץ',
+    proposal_date: '2026-06-01'
+  };
+  const items = [{
+    item_name: 'סדנת רובוטיקה',
+    item_type: 'סדנה',
+    proposal_group: 'פעילויות קיץ',
+    quantity: 3,
+    unit_price: 450,
+    total_price: 1350
+  }];
+
+  await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
     const costTable = dom.window.document.querySelector('.pa-cost-table');
-    assert.ok(costTable, 'cost table should render');
+    assert.ok(costTable, 'workshop cost table should render');
+    assert.equal(dom.window.document.querySelector('.pa-item-details-table'), null);
     const headers = [...costTable.querySelectorAll('thead th')].map((th) => th.textContent.trim());
     assert.deepEqual(headers, ['פעילות', 'כמות', 'מחיר יחידה', 'סה״כ שורה']);
-    const cells = [...costTable.querySelectorAll('tbody td')].map((td) => td.textContent.trim());
-    assert.equal(cells.at(-3), '2');
-    assert.match(cells.at(-2), /^9,000\s*₪$/);
-    assert.match(cells.at(-1), /^18,000\s*₪$/);
-    const unitPriceCell = costTable.querySelector('tbody td:nth-child(3) .pa-currency-amount');
-    assert.ok(unitPriceCell, 'unit price should use isolated currency span');
-    assert.equal(unitPriceCell.getAttribute('dir'), 'ltr');
+    assert.ok(!headers.includes('קורס / תוכנית'));
   });
 });
 
@@ -2266,31 +2291,29 @@ test('proposal cost table renders currency with consistent LTR direction', async
   });
 });
 
-test('course cost table calculates quantity total when total price is empty', async () => {
+test('course item details table keeps a row when only name and pricing fields exist', async () => {
   const row = {
     ...sampleRows[0],
     id: 'course-price-breakdown-fallback-row',
-    activity_type_group: 'שנת הלימודים תשפ״ז',
+    activity_type_group: 'שנה הבאה',
     proposal_date: '2026-06-01'
   };
   const items = [{
     item_name: 'קורס רובוטיקה',
     item_type: 'קורס',
-    proposal_group: 'שנת הלימודים תשפ״ז',
-    gefen_number: '9545',
-    meetings_count: 10,
+    proposal_group: 'שנה הבאה',
     quantity: 2,
     unit_price: 9000,
     total_price: ''
   }];
 
   await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
-    assert.equal(dom.window.document.querySelectorAll('.pa-cost-table').length, 1);
-    assert.equal(dom.window.document.querySelector('.pa-item-details-table'), null);
-    const cells = [...dom.window.document.querySelectorAll('.pa-cost-table tbody td')].map((td) => td.textContent.trim());
-    assert.equal(cells.at(-3), '2');
-    assert.match(cells.at(-2), /^9,000\s*₪$/);
-    assert.match(cells.at(-1), /^18,000\s*₪$/);
+    const courseTable = dom.window.document.querySelector('.pa-item-details-table');
+    assert.ok(courseTable, 'course details table should render even without pedagogic fields');
+    const cells = [...courseTable.querySelectorAll('tbody td')].map((td) => td.textContent.trim());
+    assert.equal(cells[0], 'קורס רובוטיקה');
+    assert.equal(cells[3], '2');
+    assert.match(cells[6], /^18,000\s*₪$/);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Course proposals were rendering the workshop/activities cost table because `proposalPreviewBodyHtml` always used `proposalCostTableHtml(items)` regardless of proposal kind. 
- Course rows were hidden when pedagogic fields (gefən, meetings, hours, hourly price) were missing even though name or pricing existed, producing empty course tables.

### Description
- Change `proposalPreviewBodyHtml` to choose the table by kind: when `proposalActivityKind(row, items) === 'course'` it uses `proposalItemDetailsTableHtml(items, activityTypeGroup)`, otherwise it keeps `proposalCostTableHtml(items)`. 
- Broaden the visibility condition in `proposalItemDetailsTableHtml` so a course row is kept when at least one of `item_name`, `gefen_number`, `meetings_count`, `hours_count`, `hourly_price`, `unit_price`, or `total_price` is present, allowing rows with only name/price to render with empty pedagogic columns. 
- Do not change `proposalCostTableHtml`, workshop/summer table structure, Supabase templates, or other document text/footers/signature assets. 
- Update `tests/proposals-agreements-screen.test.mjs` with three focused tests covering: a course (`שנה הבאה`) renders the course details table, a summer proposal keeps the workshop cost table, and a sparse-course item still renders a course row.

### Testing
- Ran the focused triple-test command `node --test --test-name-pattern "course preview renders the course item details table|summer preview keeps the workshop cost table|course item details table keeps a row" tests/proposals-agreements-screen.test.mjs` and all three focused tests passed. 
- Ran the full file `node --test tests/proposals-agreements-screen.test.mjs` which showed the new tests passing but unrelated existing tests failed (approval/status/include_catalog areas) and thus the full suite did not pass. 
- Ran build verification with `npm run check:build` which completed successfully (Vite build succeeded with existing chunk-size warnings). 
- Changed files: `frontend/src/screens/proposals-agreements.js` and `tests/proposals-agreements-screen.test.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3331bc8ab8832b98fcdd5eaa576ae6)