### PR TITLE
Prevent internal proposal notes in customer preview

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1681,7 +1681,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = [], 
 
   const includeCatalog = false;
   const introText = sectionBody('intro');
-  const remarks = sectionBody('notes') || String(row.notes || '').replace(/\r\n?/g, '\n').trim();
+  const remarks = sectionBody('notes');
   const templateActivityIntro = filterCatalogContentFromBody(sectionBody('activity_intro'), false);
   const activityIntro = isSummerProposalGroup(activityTypeGroup)
     ? summerActivityProposalBody()

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2463,6 +2463,40 @@ test('catalog appendix entries skip non-course activities even when they have Ge
   });
 });
 
+test('proposal preview does not fall back to internal row notes for customer remarks', async () => {
+  const internalImportNote = 'ייבוא ידני מקובץ Word: ראנה הצעה. סטטוס טיוטה. רשות מג׳דל שמס לפי אישור המשתמש. ללא בית ספר.';
+  const row = {
+    ...sampleRows[0],
+    id: '8b9b2b40-eb01-4ee7-8741-e6ae3bced85e',
+    client_authority: 'מג׳דל שמס',
+    school_framework: '',
+    notes: internalImportNote
+  };
+
+  const htmlWithoutNotesSection = proposalPreviewBodyHtml(row, [], [
+    { template_key: '', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח ללקוח.' },
+    { template_key: '', section_key: 'notes', section_title: 'הערות', section_body: '' }
+  ]);
+
+  await withJSDOM(htmlWithoutNotesSection, async (_root, dom) => {
+    const doc = dom.window.document.querySelector('.proposal-document');
+    assert.ok(doc);
+    assert.doesNotMatch(doc.textContent, /ייבוא ידני מקובץ Word/);
+    assert.doesNotMatch(doc.textContent, /ראנה הצעה/);
+  });
+
+  const customerNote = 'הערה ללקוח מתוך סעיף המסמך בלבד.';
+  const htmlWithTemplateNote = proposalPreviewBodyHtml(row, [], [
+    { template_key: '', section_key: 'notes', section_title: 'הערות', section_body: customerNote }
+  ]);
+
+  await withJSDOM(htmlWithTemplateNote, async (_root, dom) => {
+    const docText = dom.window.document.querySelector('.proposal-document')?.textContent || '';
+    assert.match(docText, /הערה ללקוח מתוך סעיף המסמך בלבד/);
+    assert.doesNotMatch(docText, /ייבוא ידני מקובץ Word/);
+  });
+});
+
 test('workshop proposal preview removes catalog wording and keeps prices only in cost table', async () => {
   const row = {
     ...sampleRows[0],

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2463,13 +2463,15 @@ test('catalog appendix entries skip non-course activities even when they have Ge
   });
 });
 
-test('proposal preview does not fall back to internal row notes for customer remarks', async () => {
+test('approved proposal preview does not fall back to internal row notes for customer remarks', async () => {
   const internalImportNote = 'ייבוא ידני מקובץ Word: ראנה הצעה. סטטוס טיוטה. רשות מג׳דל שמס לפי אישור המשתמש. ללא בית ספר.';
   const row = {
     ...sampleRows[0],
     id: '8b9b2b40-eb01-4ee7-8741-e6ae3bced85e',
     client_authority: 'מג׳דל שמס',
     school_framework: '',
+    status: 'approved',
+    approved_at: '2026-06-16T10:30:00.000Z',
     notes: internalImportNote
   };
 


### PR DESCRIPTION
### Motivation
- Prevent internal/import notes stored in `row.notes` from being leaked into customer-facing proposal preview or PDF documents.
- Make sure customer-facing remarks only come from the document/template `notes` section or a dedicated customer-only field, and never from internal import metadata.

### Description
- Stop using `row.notes` as a fallback in `proposalPreviewBodyHtml` by changing `const remarks = sectionBody('notes') || String(row.notes ... )` to `const remarks = sectionBody('notes')` in `frontend/src/screens/proposals-agreements.js`.
- Add a focused regression test `proposal preview does not fall back to internal row notes for customer remarks` to `tests/proposals-agreements-screen.test.mjs` that verifies an internal import note is not rendered and that an explicit template `notes` value still appears.
- No other proposal sections, table structures, or customer-visible content were changed.

### Testing
- Ran `node --check frontend/src/screens/proposals-agreements.js` which succeeded.
- Ran the focused test with `node --test --test-name-pattern "proposal preview does not fall back" tests/proposals-agreements-screen.test.mjs` which passed.
- Ran `npm run check:changed` which exercised changed-file checks and the new test; the new focused test passed but the full `check:changed` report includes unrelated existing proposal screen test failures not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3335683f84832bab5ac06083966a95)