### PR TITLE
Unify activity type icons

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Dxl12qSl.js"></script>
+  <script type="module" crossorigin src="./assets/index-DxaCMC_g.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-D4jk2Orl.css">
 </head>
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-D2eFyNhO.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-BhYgHFzN.css">
+  <script type="module" crossorigin src="./assets/index-Dxl12qSl.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-D4jk2Orl.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'proposal-signature-flow-v2'
+  HOTFIX_VERSION: 'activity-icons-cache-refresh-v1'
 };

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -3,6 +3,7 @@ import { dsCard, dsScreenStack } from './shared/layout.js';
 import { computeOperationalExceptionsTotal } from './shared/exceptions-metrics.js';
 import { syncActivitiesGapQuery } from './shared/route-query.js';
 import { SUMMER_DEFAULT_MONTH_YM } from './shared/summer-activity.js';
+import { activityTypeIconSvg } from './shared/activity-type-icons.js';
 
 const HEBREW_MONTHS = [
   'ינואר',
@@ -70,10 +71,11 @@ const KPI_ICON_MAP = {
   'kpi|endings':            '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>',
   'kpi|missing_instructor': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="23" y2="12"/><line x1="23" y1="8" x2="19" y2="12"/></svg>',
   'kpi|missing_start_date': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="12" y1="14" x2="12" y2="18"/></svg>',
-  'kpi|active_courses':     '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
-  'kpi|active_workshops':   '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 010 14.14M4.93 4.93a10 10 0 000 14.14"/></svg>',
-  'kpi|active_tours':       '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>',
-  'kpi|active_after_school':'<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>',
+  'kpi|active_courses':     activityTypeIconSvg('course'),
+  'kpi|active_workshops':   activityTypeIconSvg('workshop'),
+  'kpi|active_tours':       activityTypeIconSvg('tour'),
+  'kpi|active_after_school':activityTypeIconSvg('after_school'),
+  'kpi|active_escape_room': activityTypeIconSvg('escape_room'),
   'kpi|summer':             '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="4.93" y1="4.93" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.07" y2="19.07"/><line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/><line x1="4.93" y1="19.07" x2="6.34" y2="17.66"/><line x1="17.66" y1="6.34" x2="19.07" y2="4.93"/></svg>'
 };
 

--- a/frontend/src/screens/instructors.js
+++ b/frontend/src/screens/instructors.js
@@ -10,6 +10,7 @@ import {
   bindLocalFilters,
   splitVisibleRows
 } from './shared/activity-list-filters.js';
+import { activityTypeIconSvg } from './shared/activity-type-icons.js';
 
 const INSTRUCTORS_SCOPE = 'instructors';
 const INSTRUCTOR_FILTER_FIELDS = [{
@@ -172,22 +173,12 @@ export function buildInstructorActivityDetailsForMonth(allRows, { empId, instrNa
   return items;
 }
 
-function instructorTypeIcon(icon) {
-  const S = (d) => `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${d}</svg>`;
-  const map = {
-    book:        S('<path d="M3 2.5C4.5 2 6.5 2 8 3V14C6.5 13 4.5 13 3 13.5V2.5z"/><path d="M13 2.5C11.5 2 9.5 2 8 3V14C9.5 13 11.5 13 13 13.5V2.5z"/>'),
-    pin:         S('<path d="M8 1.5a4 4 0 0 1 4 4c0 4-4 9-4 9s-4-5-4-9a4 4 0 0 1 4-4z"/><circle cx="8" cy="5.5" r="1.4"/>'),
-    bulb:        S('<path d="M8 2a4 4 0 0 1 2.8 6.8L11 10H5l.2-1.2A4 4 0 0 1 8 2z"/><line x1="6.5" y1="12" x2="9.5" y2="12"/><line x1="7" y1="14" x2="9" y2="14"/>'),
-    schoolClock: S('<circle cx="8" cy="8" r="6"/><polyline points="8 4.5 8 8 10.5 9.5"/>'),
-  };
-  return map[icon] || '';
-}
-
 const TYPE_ITEMS = [
-  { keys: ['course', 'קורס', 'קורסים'],                                                  label: 'קורסים',    icon: 'book'        },
-  { keys: ['tour', 'סיור', 'סיורים'],                                                     label: 'סיורים',    icon: 'pin'         },
-  { keys: ['workshop', 'סדנה', 'סדנאות'],                                                 label: 'סדנאות',    icon: 'bulb'        },
-  { keys: ['after_school', 'after school', 'afterschool', 'חוג אפטרסקול', 'אפטרסקול'], label: 'אפטרסקול', icon: 'schoolClock' },
+  { keys: ['course', 'קורס', 'קורסים'], label: 'קורסים', icon: 'course' },
+  { keys: ['workshop', 'סדנה', 'סדנאות'], label: 'סדנאות', icon: 'workshop' },
+  { keys: ['escape_room', 'escape room', 'escape-room', 'חדר בריחה', 'חדרי בריחה'], label: 'חדרי בריחה', icon: 'escape_room' },
+  { keys: ['tour', 'סיור', 'סיורים'], label: 'סיורים', icon: 'tour' },
+  { keys: ['after_school', 'after school', 'afterschool', 'חוג אפטרסקול', 'אפטרסקול'], label: 'אפטרסקול', icon: 'after_school' },
 ];
 
 function renderInstructorRow(row) {
@@ -197,7 +188,7 @@ function renderInstructorRow(row) {
 
   const statCells = TYPE_ITEMS.map(({ keys, label, icon }) => {
     const count = keys.reduce((sum, key) => sum + Number(typeCounts[key] || 0), 0);
-    return `<span class="instr-stat" title="${escapeHtml(label)}" aria-label="${escapeHtml(label)}: ${count}"><span class="instr-stat__icon">${instructorTypeIcon(icon)}</span><span class="instr-stat__num${count === 0 ? ' is-zero' : ''}">${count}</span></span>`;
+    return `<span class="instr-stat" title="${escapeHtml(label)}" aria-label="${escapeHtml(label)}: ${count}"><span class="instr-stat__icon">${activityTypeIconSvg(icon, 14)}</span><span class="instr-stat__num${count === 0 ? ' is-zero' : ''}">${count}</span></span>`;
   }).join('');
 
   return `<article class="instr-card" data-instructor-item="${escapeHtml(empId)}">

--- a/frontend/src/screens/shared/activity-type-icons.js
+++ b/frontend/src/screens/shared/activity-type-icons.js
@@ -1,0 +1,21 @@
+const ACTIVITY_TYPE_ICON_PATHS = {
+  course: '<path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/>',
+  workshop: '<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.8-3.8a6 6 0 0 1-7.9 7.9l-6.1 6.1a2.1 2.1 0 0 1-3-3l6.1-6.1a6 6 0 0 1 7.9-7.9z"/>',
+  escape_room: '<path d="M19.4 13.5a1.8 1.8 0 0 0 0-3l-1.9-1.1 1.9-1.1a1.8 1.8 0 0 0 0-3l-2-1.1a1.8 1.8 0 0 0-2.7 1.5v2.2h-2.4V5.7a1.8 1.8 0 0 0-2.7-1.5l-2 1.1a1.8 1.8 0 0 0 0 3l1.9 1.1-1.9 1.1a1.8 1.8 0 0 0 0 3l2 1.1a1.8 1.8 0 0 0 2.7-1.5v-2.2h2.4v2.2a1.8 1.8 0 0 0 2.7 1.5z"/><path d="M8 20h8"/>',
+  tour: '<path d="M8 6v12"/><path d="M16 6v12"/><path d="M3 10h18"/><path d="M6 20h12"/><path d="M6 4h12a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3z"/><circle cx="8" cy="14" r="1"/><circle cx="16" cy="14" r="1"/>',
+  after_school: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>'
+};
+
+export const ACTIVITY_TYPE_ICON_KEYS = {
+  course: 'course',
+  workshop: 'workshop',
+  escape_room: 'escape_room',
+  tour: 'tour',
+  after_school: 'after_school'
+};
+
+export function activityTypeIconSvg(typeKey, size = 15) {
+  const path = ACTIVITY_TYPE_ICON_PATHS[typeKey] || '';
+  if (!path) return '';
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${path}</svg>`;
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9980,7 +9980,7 @@ select.ds-input {
 
 .instr-page .instr-stats {
   display: grid !important;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 4px;
   width: 100%;
   margin-inline-start: 0;
@@ -9990,7 +9990,7 @@ select.ds-input {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 5px;
+  gap: 3px;
   height: 28px;
   min-height: unset;
   background: rgba(0,0,0,0.05);
@@ -16798,3 +16798,17 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 
 .pa-a4-page { position: relative; }
+
+@media (max-width: 420px) {
+  .instr-page .instr-stats {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .instr-page .instr-stat {
+    grid-column: span 2;
+  }
+
+  .instr-page .instr-stat:nth-child(4) {
+    grid-column-start: 2;
+  }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 782;
+const CACHE_VERSION = 799;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 798;
+const SW_ENTRY_VERSION = 799;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Provide a single, consistent visual mapping of the five activity types (קורסים, סדנאות, חדרי בריחה, סיורים, אפטרסקול) used both on the dashboard and in the instructors/guide cards to ensure identical icons everywhere and keep the change purely visual. 

### Description
- Added a shared helper `frontend/src/screens/shared/activity-type-icons.js` that exposes `activityTypeIconSvg()` and a fixed mapping for the five activity types. 
- Updated dashboard KPI icon entries in `frontend/src/screens/dashboard.js` to use the shared `activityTypeIconSvg()` for the five activity types (course, workshop, escape_room, tour, after_school) without changing any calculations or data flows. 
- Updated instructors/guide cards in `frontend/src/screens/instructors.js` to render exactly five compact statistic boxes (icon + count + tooltip/title) using the shared icons and kept existing data lookups untouched. 
- Adjusted layout styles in `frontend/src/styles/main.css` to present a compact row of 5 uniform boxes and added a responsive breakpoint that switches to a 3/2 centered grid on narrow screens; no logic, data fetching, field names or permissions were modified. 

### Testing
- Ran focused checks with `npm run check:changed` which invoked `node --check` on changed files and reported no syntax errors, and the check completed successfully. 
- Built the frontend with `npm run check:build` (which runs `vite build` and postbuild steps), and the production build completed successfully with assets updated in `dist/`.
- No additional unit/test-suite changes were required because this is a presentation-only update and no data logic was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ace3353c832bb4a0b325a45ad1d7)