### PR TITLE
Normalize activity statuses and human display names

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -33,6 +33,7 @@ import {
   getManagerUsers,
   getFilterOptionOverrides,
   cleanUnique,
+  humanDisplayText,
   NO_ACTIVITY_MANAGER_LABEL,
   resolveGradeOptions
 } from './shared/activity-options.js';
@@ -121,7 +122,10 @@ function isInactiveActivityStatus(row = {}) {
 }
 
 function normalizedActivityStatus(row = {}) {
-  return String(row?.status || '').trim();
+  const status = String(row?.status || '').trim();
+  if (status === 'פעיל' || status.toLowerCase() === 'active' || status.toLowerCase() === 'open') return 'פתוח';
+  if (status.toLowerCase() === 'closed') return 'סגור';
+  return status;
 }
 
 function isDeletedActivity(row = {}) {
@@ -344,7 +348,7 @@ function logActivitiesAccess(state) {
 }
 
 function normalizeAdminSummaryText(value) {
-  return String(value == null ? '' : value).trim();
+  return humanDisplayText(value);
 }
 
 function normalizeAdminSummarySearchText(value) {
@@ -492,14 +496,14 @@ function parseLinkedSchoolsJson(row) {
 function getActivitySchoolNames(row) {
   const names = new Set();
   parseLinkedSchoolsJson(row).forEach((s) => {
-    const n = String(s?.school_name || '').trim();
+    const n = humanDisplayText(s?.school_name);
     if (n) names.add(n);
   });
-  const lsn = String(row?.linked_school_names || '').trim();
-  if (lsn) lsn.split(/\s*\+\s*|\s*[,،]\s*/).forEach((n) => { const t = n.trim(); if (t) names.add(t); });
-  const ssn = String(row?.single_school_name || '').trim();
+  const lsn = humanDisplayText(row?.linked_school_names);
+  if (lsn) lsn.split(/\s*\+\s*|\s*[,،]\s*/).forEach((n) => { const t = humanDisplayText(n); if (t) names.add(t); });
+  const ssn = humanDisplayText(row?.single_school_name);
   if (ssn) names.add(ssn);
-  const ls = String(row?.legacy_school || row?.school || '').trim();
+  const ls = humanDisplayText(row?.legacy_school || row?.school);
   if (ls) names.add(ls);
   return Array.from(names);
 }
@@ -510,19 +514,19 @@ function getActivitySchoolNames(row) {
  * אין לסנן לפי school_id — פעילות עם school טקסטואלי בלבד תוצג כרגיל.
  */
 function getActivitySchoolDisplayName(row) {
-  const lsn = String(row?.linked_school_names || '').trim();
+  const lsn = humanDisplayText(row?.linked_school_names);
   if (lsn) return lsn;
-  const ssn = String(row?.single_school_name || '').trim();
+  const ssn = humanDisplayText(row?.single_school_name);
   if (ssn) return ssn;
-  const ls = String(row?.school || row?.legacy_school || '').trim();
+  const ls = humanDisplayText(row?.school || row?.legacy_school);
   return ls || 'לא משויך';
 }
 
 const ACTIVITY_FILTER_FIELDS = [
   { key: 'activity_manager', label: 'מנהל פעילות', getValues: (row) => [activityManagerDisplayName(row?.activity_manager)] },
-  { key: 'instructor', label: 'מדריך', getValues: (row) => [row?.instructor_name, row?.instructor_name_2] },
-  { key: 'activity_name', label: 'תוכנית' },
-  { key: 'authority', label: 'רשות' },
+  { key: 'instructor', label: 'מדריך', getValues: (row) => [humanDisplayText(row?.instructor_name), humanDisplayText(row?.instructor_name_2)] },
+  { key: 'activity_name', label: 'תוכנית', getValues: (row) => [humanDisplayText(row?.activity_name)] },
+  { key: 'authority', label: 'רשות', getValues: (row) => [humanDisplayText(row?.authority)] },
   { key: 'funding', label: 'מימון' },
   { key: 'school', label: 'בית ספר', getValues: getActivitySchoolNames },
   { key: 'activity_type', label: 'סוג הפעילות', getOptionLabel: (value) => visibleActivityCategoryLabel(value) }
@@ -547,8 +551,8 @@ const ACTIVITY_SEARCH_FIELDS = [
 function activityInstructorMeta(row, opts = {}) {
   const hideEmpIds = !!opts.hideEmpIds;
   const instructorByEmpId = opts.instructorByEmpId || {};
-  const n1 = String(row?.instructor_name ?? row?.Instructor ?? row?.Employee ?? '').trim();
-  const n2 = String(row?.instructor_name_2 ?? row?.Instructor2 ?? row?.Employee2 ?? '').trim();
+  const n1 = humanDisplayText(row?.instructor_name ?? row?.Instructor ?? row?.Employee);
+  const n2 = humanDisplayText(row?.instructor_name_2 ?? row?.Instructor2 ?? row?.Employee2);
   const e1 = String(row?.emp_id ?? row?.EmployeeID ?? row?.employee_id ?? '').trim();
   const e2 = String(row?.emp_id_2 ?? row?.EmployeeID2 ?? row?.employee_id_2 ?? '').trim();
   const names = [
@@ -649,7 +653,7 @@ function mergeOptions(settings, keys) {
   keys.forEach((k) => {
     const arr = Array.isArray(map[k]) ? map[k] : [];
     arr.forEach((v) => {
-      const s = String(v || '').trim();
+      const s = humanDisplayText(v);
       if (!s || seen.has(s)) return;
       seen.add(s);
       out.push(s);
@@ -2430,10 +2434,10 @@ export const activitiesScreen = {
       const get = (k) => String(fd.get(k) || '').trim();
       const authorityCustom = get('authority_custom');
       const schoolCustom = get('school_custom');
-      const authorityValue = authorityCustom || get('authority');
-      const schoolValue = schoolCustom || get('school');
+      const authorityValue = humanDisplayText(authorityCustom || get('authority'));
+      const schoolValue = humanDisplayText(schoolCustom || get('school'));
       const selectedSchool = !schoolCustom ? schoolRecords.find((school) => {
-        const label = String(school?.name || school?.value || '').trim();
+        const label = humanDisplayText(school?.name || school?.value);
         return label && label === schoolValue;
       }) : null;
       const selectedName = get('activity_name');
@@ -2470,30 +2474,30 @@ export const activitiesScreen = {
       const payload = {
         source: isOneDay ? 'short' : 'long',
         activity_family: isOneDay ? 'one_day' : 'program',
-        activity_manager: get('activity_manager'),
+        activity_manager: humanDisplayText(get('activity_manager')),
         authority_id: String(selectedSchool?.authority_id || '').trim() || null,
         school_id: String(selectedSchool?.school_id || '').trim() || null,
-        authority: authorityValue || String(selectedSchool?.authority || '').trim(),
+        authority: authorityValue || humanDisplayText(selectedSchool?.authority),
         school: schoolValue,
         grade: get('grade'),
         class_group: get('class_group'),
         activity_type: selectedType || get('activity_type'),
         item_type: selectedType || get('activity_type'),
         activity_season: normalizeActivitySeason(get('activity_season')),
-        activity_name: selectedName,
+        activity_name: humanDisplayText(selectedName),
         activity_no: String(hit?.activity_no || get('activity_no') || ''),
         sessions: isOneDay ? '1' : sessionsValue,
         price: get('price'),
         funding: get('funding'),
         start_time: get('start_time'),
         end_time: get('end_time'),
-        instructor_name: get('instructor_name'),
+        instructor_name: humanDisplayText(get('instructor_name')),
         emp_id: pickEmp(get('instructor_name')),
-        instructor_name_2: get('instructor_name_2'),
+        instructor_name_2: humanDisplayText(get('instructor_name_2')),
         emp_id_2: pickEmp(get('instructor_name_2')),
         start_date: isOneDay ? oneDayDate : get('start_date'),
         end_date: isOneDay ? oneDayDate || null : get('end_date') || null,
-        status: isOneDay ? 'פתוח' : 'פעיל',
+        status: 'פתוח',
         notes: get('notes')
       };
       if (isOneDay) {

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatDateHeWithWeekday, formatTimeShort, formatTimeRangeShort, formatActivityDateColumnsHe } from './format-date.js';
-import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName, resolveGradeOptions } from './activity-options.js';
+import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, humanDisplayText, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName, resolveGradeOptions } from './activity-options.js';
 import { ACTIVITY_SEASON_OPTIONS, activitySeasonLabel, normalizeActivitySeason } from './summer-activity.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
@@ -32,7 +32,7 @@ function activityNameLabel(type) {
 }
 
 function fallback(v) {
-  return String(v || '').trim() || '—';
+  return humanDisplayText(v) || '—';
 }
 
 function managerFallback(v) {
@@ -110,7 +110,7 @@ function buildInstructorLookup(settings) {
 }
 
 function resolveInstructorDisplayName(name, empId, lookup) {
-  const direct = String(name || '').trim();
+  const direct = humanDisplayText(name);
   if (direct) return direct;
   const emp = String(empId || '').trim();
   if (emp && lookup?.[emp]) return lookup[emp];
@@ -127,7 +127,7 @@ function normalizeActivityNameOptions(raw) {
       return;
     }
     if (o && typeof o === 'object') {
-      const label = String(o.label || o.activity_name || o.value || '').trim();
+      const label = humanDisplayText(o.label || o.activity_name || o.value);
       if (!label) return;
       out.push({
         label,
@@ -141,8 +141,17 @@ function normalizeActivityNameOptions(raw) {
 }
 
 function selectHtml({ name, value, options, klass = 'ds-input', placeholder = '—', attrs = '' }) {
-  const safeValue = normalizeActivityTypeKey(value) || String(value || '').trim();
-  const normalized = toOptions(options).map((option) => normalizeActivityTypeKey(option) || option);
+  const isActivityTypeField = name === 'activity_type' || name === 'item_type';
+  const safeValue = isActivityTypeField
+    ? (normalizeActivityTypeKey(value) || String(value || '').trim())
+    : (['authority', 'school', 'instructor_name', 'instructor_name_2', 'activity_manager', 'activity_name', 'program_name', 'name', 'title'].includes(name)
+      ? humanDisplayText(value)
+      : String(value || '').trim());
+  const normalized = toOptions(options).map((option) => {
+    if (isActivityTypeField) return normalizeActivityTypeKey(option) || option;
+    if (['authority', 'school', 'instructor_name', 'instructor_name_2', 'activity_manager', 'activity_name', 'program_name', 'name', 'title'].includes(name)) return humanDisplayText(option);
+    return option;
+  });
   const seen = new Set();
   const unique = normalized.filter((option) => {
     if (!option || seen.has(option)) return false;
@@ -154,7 +163,8 @@ function selectHtml({ name, value, options, klass = 'ds-input', placeholder = '�
     .concat(
       all.map((o) => {
         const selected = o === safeValue ? ' selected' : '';
-        return `<option value="${escapeHtml(o)}"${selected}>${escapeHtml(activityTypeDisplayLabel(o) || o)}</option>`;
+        const label = isActivityTypeField ? (activityTypeDisplayLabel(o) || o) : o;
+        return `<option value="${escapeHtml(o)}"${selected}>${escapeHtml(label)}</option>`;
       })
     )
     .join('');
@@ -210,7 +220,10 @@ function activitySeasonSelectHtml(settings = {}, selected = 'regular') {
 }
 
 function inputHtml({ name, value, type = 'text', klass = 'ds-input', attrs = '' }) {
-  return `<input class="${escapeHtml(klass)}" name="${escapeHtml(name)}" type="${escapeHtml(type)}" value="${escapeHtml(String(value || ''))}" ${attrs}>`;
+  const safeValue = ['authority', 'school', 'instructor_name', 'instructor_name_2', 'activity_manager', 'activity_name', 'program_name', 'name', 'title'].includes(name)
+    ? humanDisplayText(value)
+    : String(value || '');
+  return `<input class="${escapeHtml(klass)}" name="${escapeHtml(name)}" type="${escapeHtml(type)}" value="${escapeHtml(safeValue)}" ${attrs}>`;
 }
 
 function textareaHtml({ name, value, klass = 'ds-input', rows = 3, attrs = '' }) {
@@ -374,8 +387,8 @@ function blockActivityDetails(row, { settings = {} } = {}) {
     console.warn('[activity-edit] activity name options missing from client settings');
   }
   const isOneDay = Boolean(normalizeOneDayActivityType(activityType));
-  const statusOptions = isOneDay ? ['פתוח', 'סגור', 'נמחק'] : ['פעיל', 'סגור'];
-  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : (isOneDay ? 'פתוח' : 'פעיל');
+  const statusOptions = ['פתוח', 'סגור'];
+  const normalizedStatus = normStatus(row.status) === 'closed' ? 'סגור' : 'פתוח';
 
   return `
     <section class="activity-drawer__section activity-drawer__section--edit-group" data-mode="edit" hidden>
@@ -392,7 +405,7 @@ function blockActivityDetails(row, { settings = {} } = {}) {
         )}
         ${fieldEditOnly(
           'סטטוס',
-          selectHtml({ name: 'status', value: normalizedStatus, options: statusOptions, placeholder: 'פעיל' })
+          selectHtml({ name: 'status', value: normalizedStatus, options: statusOptions, placeholder: 'פתוח' })
         )}
         ${fieldEditOnly(
           'עונת פעילות',
@@ -840,6 +853,7 @@ function singleForm(row, { settings = {}, privateNote = null, canEdit = false, c
       data-row-id="${escapeHtml(String(row.RowID || row.row_id || row.source_row_id || ''))}"
       data-can-direct-edit="${canDirectEdit ? 'yes' : 'no'}"
       data-can-request-edit="${canRequestEdit ? 'yes' : 'no'}"
+      data-original-status="${escapeHtml(String(row.status || ''))}"
       data-auto-end-date="${escapeHtml(computedEnd)}"
       data-is-once="${ONCE_TYPES.includes(activityType) ? 'yes' : 'no'}">
       ${editReqBadge}

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -112,8 +112,12 @@ function text(value) {
   return String(value == null ? '' : value).trim();
 }
 
+export function humanDisplayText(value) {
+  return text(value).replace(/\u00A0/g, ' ').replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
 export function cleanActivityManagerName(value) {
-  const clean = text(value);
+  const clean = humanDisplayText(value);
   const upper = clean.toUpperCase();
   if (!clean || clean === 'ללא' || clean === 'ללא מנהל' || upper === 'NULL' || upper === 'UNDEFINED' || upper === 'NONE' || upper === 'N/A' || upper === 'UNASSIGNED' || clean === '-') return '';
   return clean;
@@ -186,10 +190,10 @@ export function getActivityCatalog(settings) {
   const seen = new Set();
   return rows
     .map((row) => ({
-      label: text(row?.label || row?.activity_name || row?.value),
-      label_he: text(row?.label_he || row?.label || row?.activity_name || row?.value),
-      value: text(row?.value || row?.activity_name || row?.label),
-      activity_name: text(row?.activity_name || row?.value || row?.label),
+      label: humanDisplayText(row?.label || row?.activity_name || row?.value),
+      label_he: humanDisplayText(row?.label_he || row?.label || row?.activity_name || row?.value),
+      value: humanDisplayText(row?.value || row?.activity_name || row?.label),
+      activity_name: humanDisplayText(row?.activity_name || row?.value || row?.label),
       activity_no: text(row?.activity_no),
       activity_type: normalizeActivityTypeKey(row?.activity_type || row?.parent_value || row?.type),
       parent_value: normalizeActivityTypeKey(row?.parent_value || row?.activity_type || row?.type),
@@ -240,7 +244,7 @@ export function getRosterUsers(settings) {
     : [];
   const seen = new Set();
   return raw
-    .map((user) => ({ name: text(user?.name), emp_id: text(user?.emp_id) }))
+    .map((user) => ({ name: humanDisplayText(user?.name), emp_id: text(user?.emp_id) }))
     .filter((user) => user.name)
     .filter((user) => {
       if (seen.has(user.name)) return false;

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -2,7 +2,7 @@ import { translateApiErrorForUser } from './ui-hebrew.js';
 import { showToast } from './toast.js';
 import { formatDateHe } from './format-date.js';
 import { escapeHtml } from './html.js';
-import { activityTypeMatches, normalizeActivityTypeKey, normalizeOneDayActivityType } from './activity-options.js';
+import { activityTypeMatches, humanDisplayText, normalizeActivityTypeKey, normalizeOneDayActivityType } from './activity-options.js';
 import { state } from '../../state.js';
 
 function setEditMode(form, editing) {
@@ -22,6 +22,26 @@ function setStatus(statusEl, kind, text) {
   statusEl.textContent = text;
   statusEl.classList.remove('is-pending', 'is-error', 'is-success', 'is-warning');
   if (kind) statusEl.classList.add(kind);
+}
+
+const HUMAN_DISPLAY_FIELDS = new Set([
+  'instructor_name',
+  'instructor_name_2',
+  'activity_manager',
+  'previous_activity_manager',
+  'school',
+  'school_name',
+  'authority',
+  'activity_name',
+  'program_name',
+  'name',
+  'title'
+]);
+
+function normalizeActivityStatusForSave(value) {
+  const clean = String(value || '').trim();
+  if (clean === 'סגור' || clean.toLowerCase() === 'closed') return 'סגור';
+  return 'פתוח';
 }
 
 const GENERIC_ONE_DAY_ACTIVITY_NAMES = new Set(['סדנה', 'סדנאות', 'סיור', 'סיורים', 'חדר בריחה', 'חדרי בריחה']);
@@ -275,11 +295,18 @@ export function bindActivityEditForm(contentRoot, {
       if (el.closest('[hidden]')) return;
       const rawValue = el.value;
       if (rawValue === undefined || rawValue === null) return;
-      const nextValue = String(rawValue).trim();
+      const rawNextValue = String(rawValue).trim();
+      const nextValue = name === 'status'
+        ? normalizeActivityStatusForSave(rawNextValue)
+        : (HUMAN_DISPLAY_FIELDS.has(name) ? humanDisplayText(rawNextValue) : rawNextValue);
       const prevValue = String(initialValues[name] ?? '').trim();
       if (nextValue === prevValue) return;
       changes[name] = nextValue;
     });
+
+    if (String(form.dataset.originalStatus || '').trim() === 'פעיל' && !Object.prototype.hasOwnProperty.call(changes, 'status')) {
+      changes.status = 'פתוח';
+    }
 
     if (hasMeetingDatesChanged(form, initialValues)) {
       const snapshot = buildMeetingDatesSnapshot(form);

--- a/frontend/src/screens/shared/excel-export.js
+++ b/frontend/src/screens/shared/excel-export.js
@@ -1,6 +1,12 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatActivityDateColumnsHe } from './format-date.js';
-import { activityManagerDisplayName } from './activity-options.js';
+import { activityManagerDisplayName, humanDisplayText } from './activity-options.js';
+
+function activityStatusDisplay(status) {
+  const clean = String(status || '').trim();
+  if (clean === 'סגור' || clean.toLowerCase() === 'closed') return 'סגור';
+  return 'פתוח';
+}
 
 function safeFilePart(value, fallback = 'export') {
   const clean = String(value || fallback).replace(/[\\/?%*:|"<>]/g, '_').trim();
@@ -37,16 +43,16 @@ export function activityExportRow(row = {}) {
       : Array.from({ length: 35 }, (_, idx) => row[`date_${idx + 1}`] || row[`Date${idx + 1}`]).filter(Boolean);
   return {
     'מספר שורה': row.RowID || row.row_id || '',
-    'שם פעילות': row.activity_name || '',
+    'שם פעילות': humanDisplayText(row.activity_name),
     'סוג פעילות': row.activity_type || '',
-    'סטטוס': row.status || '',
-    'בית ספר': row.school || '',
-    'רשות': row.authority || '',
+    'סטטוס': activityStatusDisplay(row.status),
+    'בית ספר': humanDisplayText(row.school),
+    'רשות': humanDisplayText(row.authority),
     'שכבה': row.grade || '',
     'קבוצה / כיתה': row.class_group || '',
     'מנהל פעילות': activityManagerDisplayName(row.activity_manager),
-    'מדריך 1': row.instructor_name || row.emp_id || '',
-    'מדריך 2': row.instructor_name_2 || row.emp_id_2 || '',
+    'מדריך 1': humanDisplayText(row.instructor_name) || row.emp_id || '',
+    'מדריך 2': humanDisplayText(row.instructor_name_2) || row.emp_id_2 || '',
     'תאריך התחלה': formatDateHe(row.start_date) || row.start_date || '',
     'תאריך סיום': formatDateHe(row.end_date) || row.end_date || '',
     'תאריכי מפגשים': meetingDates.map((d) => formatDateHe(d) || d).join(', ') || formatActivityDateColumnsHe(row),


### PR DESCRIPTION
### Motivation
- Present a single canonical activity status to users: `פתוח` (open) and `סגור` (closed), hiding internal/soft-delete statuses like `נמחק` and avoiding the duplicate `פעיל` label.
- Avoid showing or saving underscores in human-readable names (instructors, schools, authorities, activity names) while preserving technical identifiers (e.g. `escape_room`, slugs, activity_type).
- Apply display and save-time normalization only, without performing any bulk DB changes or altering external activity table schemas.

### Description
- Added `humanDisplayText` in `shared/activity-options.js` and used it to clean underscores/nbspaces for human fields and catalog/roster labels while leaving technical keys untouched.
- Normalized status handling in `frontend/src/screens/activities.js` so legacy values like `פעיל`, `active`, `open` are treated as `פתוח` for display and logic, and `נמחק`/`deleted` remain hidden from normal views.
- Limited status dropdowns and edit flows (in `shared/activity-detail-html.js` and `shared/bind-activity-edit-form.js`) to show only `פתוח` and `סגור`, and normalize `פעיל` → `פתוח` on save (including adding `data-original-status` to the edit form for correct handling).
- Applied `humanDisplayText` across filters, add/edit forms and Excel export (`activities.js`, `activity-detail-html.js`, `bind-activity-edit-form.js`, `excel-export.js`) so displayed and newly saved human names use spaces, and exported status shows `פתוח`/`סגור`.

### Testing
- Ran focused syntax/checks with `npm run check:changed`, which completed successfully for the modified files.
- Ran the focused screen test `node --test tests/activities-screen.test.mjs`, which reported `33` passed and `3` failing tests; the three failures are about summer-month initialization and view-switcher label expectations (`2026-07` vs `2026-06` and longer button labels) and appear unrelated to the focused status/name normalization changes.
- Did not run the full legacy test suite per the agent testing policy; no Service Worker or cache/version changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b151d658832ba7a027f87897c8ba)