### PR TITLE
Contacts: add Hebrew alphabet selector, adjust labels and instructors grid

### DIFF
--- a/frontend/src/screens/contacts-full-directory.js
+++ b/frontend/src/screens/contacts-full-directory.js
@@ -11,7 +11,10 @@ const ENHANCED_ATTR = 'data-contacts-full-directory';
 
 let directoryPromise = null;
 let lastSearch = '';
+let activeLetter = '';
 let isRendering = false;
+
+const HEBREW_LETTERS = ['א','ב','ג','ד','ה','ו','ז','ח','ט','י','כ','ל','מ','נ','ס','ע','פ','צ','ק','ר','ש','ת'];
 
 function text(value) {
   return String(value == null ? '' : value).trim();
@@ -233,16 +236,19 @@ function ensureStyle() {
     .contacts-full-search:focus{outline:2px solid rgba(2,146,183,.18);border-color:var(--ds-accent,#0292b7)}
     .contacts-full-summary{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin:0 0 14px;color:#334155;font-size:14px}
     .contacts-full-summary__chip{display:inline-flex;align-items:center;gap:4px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:999px;padding:7px 12px;font-weight:700;color:#0f172a}
-    .contacts-full-list{display:grid;gap:10px}
+    .contacts-full-alphabet{display:flex;flex-wrap:wrap;justify-content:center;gap:8px;margin:0 auto 16px;max-width:760px}
+    .contacts-full-letter{min-width:34px;height:34px;border:1px solid #dbe6ee;border-radius:999px;background:#fff;color:#0f172a;font-weight:800;cursor:pointer}
+    .contacts-full-letter:hover,.contacts-full-letter.is-active{background:var(--ds-accent,#0292b7);border-color:var(--ds-accent,#0292b7);color:#fff}
+    .contacts-full-list{display:grid;gap:10px;width:min(920px,100%);margin:0 auto}
     .cfd-authority{border:1px solid #dbe6ee;border-radius:16px;background:#fff;box-shadow:0 6px 18px rgba(15,23,42,.045);overflow:hidden}
     .cfd-authority[open]{border-color:rgba(2,146,183,.34);box-shadow:0 8px 22px rgba(2,146,183,.08)}
-    .cfd-authority__head{cursor:pointer;list-style:none;display:grid;grid-template-columns:auto 1fr auto;gap:12px;align-items:center;padding:13px 16px;background:#fff}
+    .cfd-authority__head{cursor:pointer;list-style:none;display:flex;gap:10px;align-items:center;padding:12px 14px;background:#fff}
     .cfd-authority[open]>.cfd-authority__head{background:#f0fbff;border-bottom:1px solid #dbeafe}
     .cfd-authority__head::-webkit-details-marker,.cfd-card__head::-webkit-details-marker{display:none}
     .cfd-chevron{font-size:22px;line-height:1;color:#64748b;transform:rotate(180deg);transition:transform .18s ease}
     details[open]>.cfd-authority__head .cfd-chevron,details[open]>.cfd-card__head .cfd-chevron{transform:rotate(270deg)}
     .cfd-authority__name{font-weight:800;color:#0f172a;font-size:16px}
-    .cfd-authority__meta{display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;color:#475569;font-size:12px}
+    .cfd-authority__meta{display:flex;flex-wrap:wrap;gap:6px;color:#475569;font-size:12px;margin-inline-start:8px}
     .cfd-pill{background:#f8fafc;border:1px solid #e2e8f0;border-radius:999px;padding:4px 8px;white-space:nowrap}
     .cfd-authority__body{padding:12px 14px 16px;display:grid;gap:12px;background:#fbfdff}
     .cfd-group{border-radius:14px;border:1px solid #e2e8f0;background:#fff;overflow:hidden}
@@ -264,7 +270,7 @@ function ensureStyle() {
     .cfd-contact a{color:var(--ds-accent,#0292b7);text-decoration:none;font-weight:600}
     .cfd-empty{color:#94a3b8;font-size:13px;padding:8px 2px}
     .cfd-match{background:#fff3b0;border-radius:4px;padding-inline:2px}
-    @media (max-width: 760px){.cfd-authority__head,.cfd-card__head{grid-template-columns:auto 1fr}.cfd-authority__meta,.cfd-card__meta{grid-column:2}.cfd-contact{grid-template-columns:1fr}.contacts-full-search{width:100%}}
+    @media (max-width: 760px){.cfd-authority__head{align-items:flex-start}.cfd-authority__meta{margin-inline-start:0}.cfd-card__head{grid-template-columns:auto 1fr}.cfd-card__meta{grid-column:2}.cfd-contact{grid-template-columns:1fr}.contacts-full-search{width:100%}}
   `;
   document.head.appendChild(style);
 }
@@ -355,7 +361,7 @@ function authorityHtml(bucket, search) {
 
   const shouldOpen = Boolean(search);
   const schoolsHtml = schools.length ? `<section class="cfd-group cfd-group--schools">
-    <div class="cfd-group__title"><span>בתי ספר / מסגרות</span><span class="cfd-group__count">${schools.length}</span></div>
+    <div class="cfd-group__title"><span>בתי ספר</span><span class="cfd-group__count">${schools.length}</span></div>
     <div class="cfd-items">${schools.map((school) => schoolCardHtml(school, search)).join('')}</div>
   </section>` : '';
 
@@ -370,7 +376,7 @@ function authorityHtml(bucket, search) {
   </section>` : '';
 
   const meta = [
-    `${schools.length} בתי ספר / מסגרות`,
+    `${schools.length} בתי ספר`,
     bucket.authorityContacts.length ? `${bucket.authorityContacts.length} אנשי קשר ברשות` : '',
     otherGroups.length ? `${otherGroups.length} אחרים` : '',
     bucket._contactKeys.size ? `${bucket._contactKeys.size} אנשי קשר` : ''
@@ -386,16 +392,38 @@ function authorityHtml(bucket, search) {
   </details>`;
 }
 
+function firstHebrewLetter(value) {
+  const normalized = key(value).replace(/^[^א-ת]+/, '');
+  return normalized.charAt(0);
+}
+
+function alphabetHtml() {
+  return `<div class="contacts-full-alphabet" dir="rtl" aria-label="בחירת אות">${HEBREW_LETTERS.map((letter) => `<button type="button" class="contacts-full-letter${activeLetter === letter ? ' is-active' : ''}" data-contacts-letter="${letter}" aria-pressed="${activeLetter === letter ? 'true' : 'false'}">${letter}</button>`).join('')}</div>`;
+}
+
+function bindLetterButtons(listWrap, data) {
+  listWrap.querySelectorAll('[data-contacts-letter]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const letter = button.getAttribute('data-contacts-letter') || '';
+      activeLetter = activeLetter === letter ? '' : letter;
+      renderDirectory(listWrap, data);
+    });
+  });
+}
+
 function renderDirectory(listWrap, data) {
   const search = text(lastSearch);
-  const listHtml = data.authorities.map((bucket) => authorityHtml(bucket, search)).filter(Boolean).join('');
-  const emptyHtml = '<div class="cfd-empty">לא נמצאו תוצאות לחיפוש</div>';
-  listWrap.innerHTML = `<div class="contacts-full-summary" dir="rtl">
-    <span class="contacts-full-summary__chip"><strong>${data.authorityCount}</strong> רשויות</span>
-    <span class="contacts-full-summary__chip"><strong>${data.schoolCount}</strong> בתי ספר / מסגרות</span>
-  </div>
+  const filteredAuthorities = activeLetter
+    ? data.authorities.filter((bucket) => firstHebrewLetter(bucket.authority_name) === activeLetter)
+    : [];
+  const authoritiesForDisplay = search ? data.authorities : filteredAuthorities;
+  const listHtml = authoritiesForDisplay.map((bucket) => authorityHtml(bucket, search)).filter(Boolean).join('');
+  const hasDirectoryRequest = Boolean(activeLetter || search);
+  const emptyHtml = hasDirectoryRequest ? '<div class="cfd-empty">לא נמצאו תוצאות לחיפוש</div>' : '';
+  listWrap.innerHTML = `${alphabetHtml()}
   <div class="contacts-full-list" dir="rtl">${listHtml || emptyHtml}</div>`;
   listWrap.setAttribute(ENHANCED_ATTR, 'yes');
+  bindLetterButtons(listWrap, data);
 }
 
 function isSchoolContactsTabActive(root) {

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -25,7 +25,7 @@ const INSTR_SEARCH_FIELDS = [
 
 const SCHOOL_FILTER_FIELDS = [
   { key: 'authority', label: 'רשות' },
-  { key: 'school', label: 'בית ספר / מסגרת' },
+  { key: 'school', label: 'בית ספר' },
   { key: 'contact_role', label: 'תפקיד' }
 ];
 
@@ -366,13 +366,13 @@ function renderAuthorityAccordion(authority, bucket) {
 
   const { schoolCount, contactCount } = countAuthorityBucket(bucket);
   const badges = [
-    schoolCount > 0 ? `${schoolCount} בתי ספר / מסגרות` : '',
+    schoolCount > 0 ? `${schoolCount} בתי ספר` : '',
     contactCount > 0 ? `${contactCount} אנשי קשר` : ''
   ].filter(Boolean).join(' · ');
 
   const schoolsSection = schoolsHtml
     ? `<section class="sc-sub-group sc-sub-group--schools">
-        <div class="sc-sub-group__title"><span aria-hidden="true">🏫</span> בתי ספר / מסגרות <span class="sc-sub-group__count">${schoolCount}</span></div>
+        <div class="sc-sub-group__title"><span aria-hidden="true">🏫</span> בתי ספר <span class="sc-sub-group__count">${schoolCount}</span></div>
         <div class="sc-school-grid">${schoolsHtml}</div>
       </section>`
     : '';
@@ -490,7 +490,7 @@ function schoolTabHtml(rows, filters, activeLetter = '') {
   const summaryHtml = `<div class="sc-summary-bar contacts-summary-bar" dir="rtl">
     <span class="sc-summary-bar__item">רשויות: <strong>${stats.authorities}</strong></span>
     <span class="sc-summary-bar__sep" aria-hidden="true">·</span>
-    <span class="sc-summary-bar__item">בתי ספר / מסגרות: <strong>${stats.schools}</strong></span>
+    <span class="sc-summary-bar__item">בתי ספר: <strong>${stats.schools}</strong></span>
     <span class="sc-summary-bar__sep" aria-hidden="true">·</span>
     <span class="sc-summary-bar__item">אנשי קשר: <strong>${stats.contacts}</strong></span>
   </div>`;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -9922,12 +9922,12 @@ select.ds-input {
 }
 
 .instr-page .ci-list--instr-grid {
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 8px;
-  padding: 6px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 22px 24px;
+  padding: 14px;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .instr-page .ci-list--instr-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -9942,7 +9942,7 @@ select.ds-input {
 .instr-page .ci-list--instr-grid .instr-summary-row,
 .instr-page .instr-card .instr-summary-row {
   min-height: unset;
-  padding: 8px 8px 7px;
+  padding: 12px 12px 11px;
   background: #f7f7f8;
   border: 1px solid #ddd;
   border-top: 3px solid #888;


### PR DESCRIPTION
### Motivation

- Simplify the contacts directory initial view to avoid loading all authorities at once and to present an A–ת alphabet picker first. 
- Preserve the existing hierarchical display: authority → schools → authority contacts → other groups while keeping sections closed by default. 
- Reduce density on the instructors screen to improve readability by limiting wide-screen rows to four cards.

### Description

- Added an alphabet picker and per-letter filtering to `frontend/src/screens/contacts-full-directory.js` so the contacts page initially shows only the search and alphabet, and authorities are shown only after a letter is selected. 
- Kept the details/accordion structure and grouping (`בתי ספר`, `רשות`, `אחר`) and ensured authorities and groups render closed by default (details are opened only for search results). 
- Replaced occurrences of the label `"בית ספר / מסגרת"` and `"בתי ספר / מסגרות"` with `"בית ספר"` and `"בתי ספר"` in `frontend/src/screens/contacts.js` and updated the contacts directory wording accordingly. 
- Adjusted instructor grid styles in `frontend/src/styles/main.css` to display up to four instructor cards per row on wide screens and increased horizontal and vertical spacing for better breathing room.

### Testing

- Ran `node --check frontend/src/screens/contacts-full-directory.js` and `node --check frontend/src/screens/contacts.js` and they passed without syntax errors. 
- Executed focused verification with `npm run check:changed` which completed focused checks. 
- Ran `node --test tests/archive-local-search.test.mjs` and the suite passed (`2` tests passing). 
- Built the frontend with `npm run check:build` (Vite build) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ba7cf3c8832baa3a2fa1792d200c)