### PR TITLE
Unify general contacts via contacts_unified_view with source-aware editing

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -28,6 +28,7 @@ const MUTATING_ACTIONS = {
   addActivity: true,
   addContact: true,
   saveContact: true,
+  updateUnifiedContactRecord: true,
   submitEditRequest: true,
   submitCreateActivityRequest: true,
   reviewEditRequest: true,
@@ -426,6 +427,12 @@ async function selectActivitiesByDateRangeFromSupabase({
 
 const AUTHORITIES_CATALOG_COLUMNS = 'id,authority_name,authority_code,authority_type,hp_number,long_name,district,active';
 const SCHOOLS_CATALOG_COLUMNS = 'id,semel_mosad,school_name,authority,authority_id,district,city,active';
+const CONTACTS_UNIFIED_VIEW_COLUMNS = [
+  'contact_domain', 'client_type', 'client_name', 'authority_id', 'school_id', 'semel_mosad',
+  'authority_name', 'authority', 'school_name', 'school', 'contact_name', 'contact_role',
+  'phone', 'mobile', 'email', 'address', 'notes', 'authority_code', 'district', 'city',
+  'source_table', 'source_id'
+].join(',');
 
 function isCatalogActive(value) {
   if (value === false || value === 'no' || value === 0 || value === '0') return false;
@@ -835,9 +842,77 @@ function buildProposalClientSearchOptions(contactRows, authorityLookup, schoolLo
   return options;
 }
 
+function normalizeUnifiedContactRow(row) {
+  if (!row || typeof row !== 'object') return row;
+  const authorityName = normalizeCatalogText(row.authority_name || row.authority || row.client_name);
+  const schoolName = normalizeCatalogText(row.school_name || row.school);
+  return {
+    ...row,
+    authority_name: authorityName || null,
+    authority: authorityName || normalizeCatalogText(row.authority) || null,
+    school_name: schoolName || null,
+    school: schoolName || normalizeCatalogText(row.school) || null,
+    source_table: normalizeCatalogText(row.source_table) || null,
+    source_id: row.source_id != null ? String(row.source_id) : null,
+    contact_domain: normalizeCatalogText(row.contact_domain || row.client_type) || null
+  };
+}
+
+function compareUnifiedContactRows(a, b) {
+  const authCmp = normalizeCatalogText(a?.authority_name || a?.authority).localeCompare(
+    normalizeCatalogText(b?.authority_name || b?.authority),
+    'he'
+  );
+  if (authCmp !== 0) return authCmp;
+  const schoolCmp = normalizeCatalogText(a?.school_name || a?.school).localeCompare(
+    normalizeCatalogText(b?.school_name || b?.school),
+    'he'
+  );
+  if (schoolCmp !== 0) return schoolCmp;
+  const domainOrder = { school: 0, authority: 1, other: 2 };
+  const domainA = domainOrder[normalizeCatalogText(a?.contact_domain)] ?? 3;
+  const domainB = domainOrder[normalizeCatalogText(b?.contact_domain)] ?? 3;
+  if (domainA !== domainB) return domainA - domainB;
+  const sourceOrder = { schools: 0, contacts_schools: 1 };
+  const sourceA = sourceOrder[normalizeCatalogText(a?.source_table)] ?? 2;
+  const sourceB = sourceOrder[normalizeCatalogText(b?.source_table)] ?? 2;
+  if (sourceA !== sourceB) return sourceA - sourceB;
+  return normalizeCatalogText(a?.contact_name).localeCompare(normalizeCatalogText(b?.contact_name), 'he');
+}
+
 /**
- * Reads contacts_instructors + contacts_directory_view from Supabase.
- * Returns partial data when one source fails; contacts_directory_view falls back to contacts_schools.
+ * Reads general contacts from contacts_unified_view (contacts_schools + schools).
+ * Instructors are loaded separately via contacts_instructors.
+ *
+ * ⚠️ permissions table is intentionally excluded — login credentials must never be read client-side.
+ */
+async function readUnifiedContactsFromSupabase() {
+  if (!supabase) return [];
+  try {
+    const { data, error } = await supabase
+      .from('contacts_unified_view')
+      .select(CONTACTS_UNIFIED_VIEW_COLUMNS)
+      .order('authority_name', { ascending: true })
+      .order('school_name', { ascending: true })
+      .order('contact_domain', { ascending: true })
+      .order('contact_name', { ascending: true });
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.warn('[supabase] Failed to load contacts_unified_view:', error);
+      return [];
+    }
+    return (Array.isArray(data) ? data : [])
+      .map(normalizeUnifiedContactRow)
+      .sort(compareUnifiedContactRows);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('[supabase] Unexpected contacts_unified_view fetch error:', error);
+    return [];
+  }
+}
+
+/**
+ * Reads contacts_instructors + contacts_unified_view from Supabase.
  *
  * ⚠️ permissions table is intentionally excluded — login credentials must never be read client-side.
  */
@@ -854,38 +929,14 @@ async function readContactsFromSupabase() {
     return Array.isArray(result.data) ? result.data : [];
   };
 
-  const readSchoolContacts = async () => {
-    const viewResult = await supabase.from('contacts_directory_view').select('*');
-    if (!viewResult.error) return Array.isArray(viewResult.data) ? viewResult.data : [];
-
-    // eslint-disable-next-line no-console
-    console.warn('[supabase] Failed to load contacts_directory_view; falling back to contacts_schools:', viewResult.error);
-    const fallbackResult = await supabase.from('contacts_schools').select('*');
-    if (fallbackResult.error) {
-      // eslint-disable-next-line no-console
-      console.warn('[supabase] Failed to load contacts_schools fallback:', fallbackResult.error);
-      return [];
-    }
-    return Array.isArray(fallbackResult.data) ? fallbackResult.data : [];
-  };
-
   try {
-    const [instructor_rows, schoolRowsRaw, activityRows, catalog] = await Promise.all([
+    const [instructor_rows, schoolRowsRaw, catalog] = await Promise.all([
       readInstructors(),
-      readSchoolContacts(),
-      readAllActivitiesRowsSupabase().catch((error) => {
-        // eslint-disable-next-line no-console
-        console.warn('[supabase] Failed to load activities for contacts directory:', error);
-        return [];
-      }),
+      readUnifiedContactsFromSupabase(),
       readAuthoritySchoolCatalog()
     ]);
-    const school_rows = mergeActivityPlaceholdersIntoSchoolRows(
-      schoolRowsRaw,
-      activityRows,
-      catalog.authorityLookup,
-      catalog.schoolLookup
-    );
+    const school_rows = (Array.isArray(schoolRowsRaw) ? schoolRowsRaw : [])
+      .map((row) => enrichSchoolContactRow(row, catalog.authorityLookup, catalog.schoolLookup));
     return {
       instructor_rows,
       school_rows,
@@ -1881,6 +1932,7 @@ function invalidateScreenDataByAction(action) {
     savePermission: ['permissions'],
     addContact: ['contacts', 'instructor-contacts'],
     saveContact: ['contacts', 'instructor-contacts'],
+    updateUnifiedContactRecord: ['contacts', 'instructor-contacts'],
     saveSheetMapping: ['adminSettings', 'listSheets', 'dashboard:', 'activities:', 'week:', 'month:'],
     saveClientSetting: ['adminSettings', 'dashboard:', 'activities:', 'week:', 'month:'],
     addProposalAgreement: ['proposals-agreements'],
@@ -4433,6 +4485,57 @@ export const api = {
       return { ok: true };
     }
     throw new Error('invalid_contact_kind');
+  },
+  updateUnifiedContactRecord: async (payload) => {
+    const sourceTable = String(payload?.source_table || '').trim();
+    const sourceId = payload?.source_id != null ? String(payload.source_id).trim() : '';
+    const fields = payload?.fields && typeof payload.fields === 'object' ? payload.fields : {};
+    if (!sourceTable || !sourceId) throw new Error('missing_unified_contact_source');
+
+    const pickFields = (allowed) => {
+      const body = {};
+      for (const key of allowed) {
+        if (!Object.prototype.hasOwnProperty.call(fields, key)) continue;
+        const value = fields[key];
+        if (value === undefined) continue;
+        body[key] = typeof value === 'string' ? (value.trim() || null) : value;
+      }
+      return body;
+    };
+
+    if (sourceTable === 'contacts_schools') {
+      const updateBody = pickFields([
+        'client_type', 'client_name', 'authority_id', 'school_id', 'semel_mosad',
+        'authority', 'school', 'contact_name', 'contact_role',
+        'phone', 'mobile', 'email', 'address', 'notes'
+      ]);
+      if (!Object.keys(updateBody).length) throw new Error('no_fields_to_update');
+      const { data, error } = await supabase
+        .from('contacts_schools')
+        .update(updateBody)
+        .eq('id', sourceId)
+        .select()
+        .single();
+      if (error) throw new Error(error.message || 'update_unified_contact_failed');
+      return { ok: true, row: data, source_table: sourceTable, source_id: sourceId };
+    }
+
+    if (sourceTable === 'schools') {
+      const updateBody = pickFields([
+        'principal_name', 'school_phone', 'institution_address', 'city', 'district'
+      ]);
+      if (!Object.keys(updateBody).length) throw new Error('no_fields_to_update');
+      const { data, error } = await supabase
+        .from('schools')
+        .update(updateBody)
+        .eq('id', sourceId)
+        .select()
+        .single();
+      if (error) throw new Error(error.message || 'update_unified_contact_failed');
+      return { ok: true, row: data, source_table: sourceTable, source_id: sourceId };
+    }
+
+    throw new Error('invalid_unified_contact_source');
   },
   addProposalClient: async (payload) => {
     const clientType = String(payload.client_type || 'school').trim();

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'stabilization-fixes-20260620-v1'
+  HOTFIX_VERSION: 'contacts-unified-view-20260620-v1'
 };

--- a/frontend/src/screens/contacts-full-directory.js
+++ b/frontend/src/screens/contacts-full-directory.js
@@ -2,10 +2,7 @@ import { supabase, waitForSupabaseAuthSession } from '../supabase-client.js';
 import { escapeHtml } from './shared/html.js';
 
 const PAGE_SIZE = 1000;
-const CONTACTS_VIEW_TABLE = 'contacts_directory_view';
-const CONTACTS_FALLBACK_TABLE = 'contacts_schools';
-const AUTHORITIES_TABLE = 'authorities';
-const SCHOOLS_TABLE = 'schools';
+const CONTACTS_VIEW_TABLE = 'contacts_unified_view';
 const STYLE_ID = 'contacts-full-directory-style';
 const ENHANCED_ATTR = 'data-contacts-full-directory';
 
@@ -28,17 +25,21 @@ function key(value) {
   return text(value).toLowerCase().normalize('NFKC').replace(/[\u05F3\u05F4'"`´”“„״׳]/g, '').replace(/[\u2010-\u2015\u2212\-_/\\]+/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
-function isActive(value) {
-  const raw = text(value).toLowerCase();
-  return raw !== 'no' && raw !== '0' && raw !== 'false';
+function isSchoolProfileRow(row) {
+  return text(row?.source_table) === 'schools';
 }
 
 function hasContact(row) {
+  if (isSchoolProfileRow(row)) {
+    return Boolean(text(row?.contact_name) || text(row?.phone) || text(row?.address));
+  }
   return Boolean(text(row?.contact_name) || text(row?.mobile || row?.phone) || text(row?.email));
 }
 
 function contactKey(row) {
   return [
+    text(row?.source_table),
+    text(row?.source_id),
     key(row?.authority_id || row?.authority_name || row?.authority),
     key(row?.school_id || row?.semel_mosad || row?.school_name || row?.school),
     key(row?.client_type),
@@ -63,51 +64,52 @@ async function readAll(table, columns, orderColumn) {
   return rows;
 }
 
-async function readContactsRows() {
-  try {
-    return await readAll(CONTACTS_VIEW_TABLE, '*', 'authority_name');
-  } catch (error) {
-    console.warn('[contacts-full-directory] contacts_directory_view failed, using contacts_schools fallback', error);
-    return readAll(CONTACTS_FALLBACK_TABLE, '*', 'authority');
-  }
+function normalizeUnifiedRow(row) {
+  const authorityName = text(row.authority_name || row.authority || row.client_name);
+  const schoolName = text(row.school_name || row.school);
+  return {
+    id: text(row.source_id),
+    source_table: text(row.source_table),
+    source_id: text(row.source_id),
+    client_type: text(row.client_type || (schoolName ? 'school' : 'authority')),
+    client_name: text(row.client_name),
+    authority_id: text(row.authority_id),
+    authority_name: authorityName,
+    authority_code: text(row.authority_code),
+    school_id: text(row.school_id),
+    semel_mosad: text(row.semel_mosad),
+    school_name: schoolName,
+    contact_name: text(row.contact_name),
+    contact_role: text(row.contact_role),
+    phone: text(row.phone),
+    mobile: text(row.mobile),
+    email: text(row.email),
+    address: text(row.address),
+    notes: text(row.notes),
+    city: text(row.city),
+    district: text(row.district),
+    contact_domain: text(row.contact_domain || row.client_type),
+    _raw: row
+  };
 }
 
 async function loadDirectory() {
   if (!supabase) throw new Error('supabase_not_available');
   await waitForSupabaseAuthSession({ timeoutMs: 8000 }).catch(() => null);
 
-  const [authoritiesRaw, schoolsRaw, contactsRaw] = await Promise.all([
-    readAll(AUTHORITIES_TABLE, 'id,authority_code,authority_name,authority_type,hp_number,long_name,district,active', 'authority_name'),
-    readAll(SCHOOLS_TABLE, 'id,semel_mosad,school_name,authority,authority_id,city,district,sector,principal_name,school_phone,institution_address,active', 'authority'),
-    readContactsRows()
-  ]);
-
-  const authorities = authoritiesRaw
-    .filter((row) => text(row.authority_name))
-    .map((row) => ({
-      id: text(row.id),
-      authority_code: text(row.authority_code),
-      authority_name: text(row.authority_name),
-      authority_type: text(row.authority_type),
-      district: text(row.district),
-      active: text(row.active) || 'yes'
-    }))
-    .sort((a, b) => a.authority_name.localeCompare(b.authority_name, 'he'));
-
-  const authorityById = new Map(authorities.map((row) => [text(row.id), row]));
-  const authorityByName = new Map(authorities.map((row) => [key(row.authority_name), row]));
+  const contactsRaw = await readAll(CONTACTS_VIEW_TABLE, '*', 'authority_name');
+  const contacts = contactsRaw.map(normalizeUnifiedRow).filter(hasContact);
 
   const buckets = new Map();
-  const ensureBucket = (authority) => {
-    const name = text(authority?.authority_name || authority?.authority || authority?.client_name) || '—';
-    const id = text(authority?.id || authority?.authority_id);
-    const bucketKey = id || key(name);
+  const ensureBucket = (authorityName, authorityCode = '', authorityId = '') => {
+    const name = text(authorityName) || '—';
+    const bucketKey = text(authorityId) || key(name);
     if (!buckets.has(bucketKey)) {
       buckets.set(bucketKey, {
         key: bucketKey,
-        authority_id: id,
+        authority_id: text(authorityId),
         authority_name: name,
-        authority_code: text(authority?.authority_code),
+        authority_code: text(authorityCode),
         schools: new Map(),
         authorityContacts: [],
         otherGroups: new Map(),
@@ -115,117 +117,58 @@ async function loadDirectory() {
       });
     }
     const bucket = buckets.get(bucketKey);
-    if (!bucket.authority_code && authority?.authority_code) bucket.authority_code = text(authority.authority_code);
-    if (!bucket.authority_id && id) bucket.authority_id = id;
+    if (!bucket.authority_code && authorityCode) bucket.authority_code = text(authorityCode);
+    if (!bucket.authority_id && authorityId) bucket.authority_id = text(authorityId);
     return bucket;
   };
 
-  authorities.forEach((authority) => ensureBucket(authority));
+  contacts.forEach((contact) => {
+    const bucket = ensureBucket(contact.authority_name, contact.authority_code, contact.authority_id);
+    const cKey = contactKey(contact);
+    if (bucket._contactKeys.has(cKey)) return;
+    bucket._contactKeys.add(cKey);
 
-  const resolveAuthority = (row = {}) => {
-    const authorityId = text(row.authority_id);
-    const authorityName = text(row.authority_name || row.authority || row.client_name);
-    return (authorityId && authorityById.get(authorityId)) || authorityByName.get(key(authorityName)) || {
-      id: authorityId,
-      authority_name: authorityName || '—',
-      authority_code: text(row.authority_code)
-    };
-  };
+    const domain = key(contact.contact_domain || contact.client_type);
+    const schoolName = text(contact.school_name);
 
-  const schools = schoolsRaw
-    .filter((row) => text(row.school_name) && isActive(row.active))
-    .map((row) => {
-      const authority = resolveAuthority(row);
-      return {
-        id: text(row.id),
-        semel_mosad: text(row.semel_mosad),
-        school_name: text(row.school_name),
-        authority_id: text(row.authority_id || authority.id),
-        authority_name: text(row.authority || authority.authority_name),
-        city: text(row.city),
-        district: text(row.district),
-        sector: text(row.sector),
-        contacts: []
-      };
-    })
-    .sort((a, b) => a.school_name.localeCompare(b.school_name, 'he'));
+    if (domain === 'school' || schoolName) {
+      const schoolKey = contact.school_id || contact.semel_mosad || `${key(bucket.authority_name)}|${key(schoolName)}`;
+      if (!bucket.schools.has(schoolKey)) {
+        bucket.schools.set(schoolKey, {
+          id: contact.school_id,
+          semel_mosad: contact.semel_mosad,
+          school_name: schoolName,
+          authority_id: contact.authority_id,
+          authority_name: bucket.authority_name,
+          city: contact.city,
+          district: contact.district,
+          profile: null,
+          contacts: []
+        });
+      }
+      const school = bucket.schools.get(schoolKey);
+      if (isSchoolProfileRow(contact)) school.profile = contact;
+      else school.contacts.push(contact);
+      return;
+    }
 
-  const schoolById = new Map();
-  const schoolBySemel = new Map();
-  const schoolByAuthorityName = new Map();
+    if (domain === 'authority' || !contact.client_name || key(contact.client_name) === key(bucket.authority_name)) {
+      bucket.authorityContacts.push(contact);
+      return;
+    }
 
-  schools.forEach((school) => {
-    const authority = resolveAuthority({ authority_id: school.authority_id, authority: school.authority_name });
-    const bucket = ensureBucket(authority);
-    const schoolKey = school.id || school.semel_mosad || `${key(bucket.authority_name)}|${key(school.school_name)}`;
-    if (!bucket.schools.has(schoolKey)) bucket.schools.set(schoolKey, { ...school, contacts: [] });
-    const storedSchool = bucket.schools.get(schoolKey);
-    if (school.id) schoolById.set(school.id, storedSchool);
-    if (school.semel_mosad) schoolBySemel.set(school.semel_mosad, storedSchool);
-    schoolByAuthorityName.set(`${key(bucket.authority_name)}|${key(school.school_name)}`, storedSchool);
-    schoolByAuthorityName.set(`${key(school.authority_name)}|${key(school.school_name)}`, storedSchool);
+    const groupName = contact.client_name || contact.school_name || 'אחר';
+    const groupKey = key(groupName);
+    if (!bucket.otherGroups.has(groupKey)) bucket.otherGroups.set(groupKey, { name: groupName, contacts: [] });
+    bucket.otherGroups.get(groupKey).contacts.push(contact);
   });
 
-  const normalizeContact = (row) => {
-    const authority = resolveAuthority(row);
-    return {
-      id: text(row.id),
-      client_type: text(row.client_type || (text(row.school_name || row.school) ? 'school' : 'authority')),
-      client_name: text(row.client_name),
-      authority_id: text(row.authority_id || authority.id),
-      authority_name: text(row.authority_name || row.authority || authority.authority_name),
-      authority_code: text(row.authority_code || authority.authority_code),
-      school_id: text(row.school_id),
-      semel_mosad: text(row.semel_mosad),
-      school_name: text(row.school_name || row.school),
-      contact_name: text(row.contact_name),
-      contact_role: text(row.contact_role),
-      phone: text(row.phone),
-      mobile: text(row.mobile),
-      email: text(row.email),
-      notes: text(row.notes),
-      active: text(row.active) || 'yes',
-      _raw: row
-    };
-  };
-
-  contactsRaw
-    .map(normalizeContact)
-    .filter((row) => hasContact(row) && isActive(row.active))
-    .forEach((contact) => {
-      const bucket = ensureBucket(resolveAuthority(contact));
-      const cKey = contactKey(contact);
-      if (bucket._contactKeys.has(cKey)) return;
-      bucket._contactKeys.add(cKey);
-      const type = key(contact.client_type);
-
-      if (type === 'school' || contact.school_id || contact.semel_mosad || contact.school_name) {
-        const school = (contact.school_id && schoolById.get(contact.school_id))
-          || (contact.semel_mosad && schoolBySemel.get(contact.semel_mosad))
-          || schoolByAuthorityName.get(`${key(bucket.authority_name)}|${key(contact.school_name)}`)
-          || schoolByAuthorityName.get(`${key(contact.authority_name)}|${key(contact.school_name)}`);
-        if (school) {
-          school.contacts.push(contact);
-          return;
-        }
-      }
-
-      if (type === 'authority' || !contact.client_name || key(contact.client_name) === key(bucket.authority_name)) {
-        bucket.authorityContacts.push(contact);
-        return;
-      }
-
-      const groupName = contact.client_name || contact.school_name || 'אחר';
-      const groupKey = key(groupName);
-      if (!bucket.otherGroups.has(groupKey)) bucket.otherGroups.set(groupKey, { name: groupName, contacts: [] });
-      bucket.otherGroups.get(groupKey).contacts.push(contact);
-    });
-
   const bucketsList = [...buckets.values()].sort((a, b) => a.authority_name.localeCompare(b.authority_name, 'he'));
+  const schoolCount = bucketsList.reduce((sum, bucket) => sum + bucket.schools.size, 0);
   return {
     authorities: bucketsList,
-    authorityCount: authorities.length,
-    schoolCount: schools.length,
+    authorityCount: bucketsList.length,
+    schoolCount,
     contactCount: bucketsList.reduce((sum, bucket) => sum + bucket._contactKeys.size, 0)
   };
 }
@@ -293,11 +236,12 @@ function highlight(value, search) {
 }
 
 function contactSearchText(contact) {
-  return [contact.contact_name, contact.contact_role, contact.phone, contact.mobile, contact.email, contact.notes].map(text).join(' ');
+  return [contact.contact_name, contact.contact_role, contact.phone, contact.mobile, contact.email, contact.notes, contact.address, contact.city, contact.district].map(text).join(' ');
 }
 
 function schoolSearchText(school) {
-  return [school.school_name, school.semel_mosad, school.city, school.district, ...school.contacts.map(contactSearchText)].map(text).join(' ');
+  const profileText = school.profile ? contactSearchText(school.profile) : '';
+  return [school.school_name, school.semel_mosad, school.city, school.district, profileText, ...school.contacts.map(contactSearchText)].map(text).join(' ');
 }
 
 function groupSearchText(group) {
@@ -310,26 +254,32 @@ function matches(value, search) {
 }
 
 function contactHtml(contact, search) {
-  const phoneValue = contact.mobile || contact.phone;
-  const phoneHtml = phoneValue ? `<a href="tel:${escapeHtml(phoneValue)}" dir="ltr">${highlight(phoneValue, search)}</a>` : '<span class="cfd-contact__muted">—</span>';
-  const emailHtml = contact.email ? `<a href="mailto:${escapeHtml(contact.email)}" dir="ltr">${highlight(contact.email, search)}</a>` : '<span class="cfd-contact__muted">—</span>';
+  const phoneValue = text(contact.mobile || contact.phone);
+  const phoneHtml = phoneValue ? `<a href="tel:${escapeHtml(phoneValue)}" dir="ltr">${highlight(phoneValue, search)}</a>` : '';
+  const emailHtml = text(contact.email) ? `<a href="mailto:${escapeHtml(contact.email)}" dir="ltr">${highlight(contact.email, search)}</a>` : '';
+  const roleHtml = text(contact.contact_role) ? `<div class="cfd-contact__muted">${highlight(contact.contact_role, search)}</div>` : '';
+  const addressHtml = text(contact.address) ? `<div class="cfd-contact__muted">${highlight([contact.address, contact.city, contact.district].filter(Boolean).join(', '), search)}</div>` : '';
+  const name = text(contact.contact_name) || (isSchoolProfileRow(contact) ? 'פרטי בית ספר' : '—');
   return `<article class="cfd-contact">
-    <div class="cfd-contact__name">${highlight(contact.contact_name || '—', search)}</div>
-    <div class="cfd-contact__muted">${highlight(contact.contact_role || '—', search)}</div>
+    <div class="cfd-contact__name">${highlight(name, search)}</div>
+    ${roleHtml}
     <div>${phoneHtml}</div>
-    <div>${emailHtml}</div>
+    <div>${emailHtml || addressHtml}</div>
   </article>`;
 }
 
 function schoolCardHtml(school, search) {
   const shouldOpen = Boolean(search && matches(schoolSearchText(school), search));
-  const contactCount = school.contacts.length;
+  const items = [];
+  if (school.profile) items.push(school.profile);
+  items.push(...school.contacts);
+  const contactCount = items.length;
   const contactsHtml = contactCount
-    ? `<div class="cfd-contact-grid">${school.contacts.map((contact) => contactHtml(contact, search)).join('')}</div>`
-    : '<div class="cfd-empty">אין אנשי קשר משויכים</div>';
+    ? `<div class="cfd-contact-grid">${items.map((contact) => contactHtml(contact, search)).join('')}</div>`
+    : '';
   const meta = [
     school.semel_mosad ? `סמל מוסד ${escapeHtml(school.semel_mosad)}` : '',
-    contactCount ? `${contactCount} אנשי קשר` : 'אין אנשי קשר'
+    contactCount ? `${contactCount} אנשי קשר` : ''
   ].filter(Boolean).join(' · ');
   return `<details class="cfd-card"${shouldOpen ? ' open' : ''}>
     <summary class="cfd-card__head">
@@ -423,11 +373,6 @@ function alphabetHtml() {
   return `<div class="contacts-full-alphabet" dir="rtl" aria-label="בחירת אות">${HEBREW_LETTERS.map((letter) => `<button type="button" class="contacts-full-letter${activeLetter === letter ? ' is-active' : ''}" data-contacts-letter="${letter}" aria-pressed="${activeLetter === letter ? 'true' : 'false'}">${letter}</button>`).join('')}</div>`;
 }
 
-function bindLetterButtons(listWrap, data) {
-  void listWrap;
-  void data;
-}
-
 function renderDirectory(listWrap, data) {
   cachedDirectoryData = data;
   listWrapRef = listWrap;
@@ -493,6 +438,7 @@ async function enhanceContactsDirectory() {
   });
 
   if (!directoryPromise) directoryPromise = loadDirectory();
+  else if (listWrap.getAttribute(ENHANCED_ATTR) !== 'yes') directoryPromise = loadDirectory();
   if (listWrap.getAttribute(ENHANCED_ATTR) !== 'yes') {
     listWrap.innerHTML = '<div class="ds-empty" dir="rtl">טוען את מאגר אנשי הקשר המלא…</div>';
   }
@@ -530,6 +476,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     if (target?.closest?.('[data-contacts-tab]')) {
       activeLetter = '';
       lastSearch = '';
+      directoryPromise = null;
       scheduleEnhance();
     }
   }, true);

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -29,24 +29,41 @@ const SCHOOL_FILTER_FIELDS = [
   { key: 'contact_role', label: 'תפקיד' }
 ];
 
+function textValue(value) {
+  const raw = String(value == null ? '' : value).trim();
+  if (!raw || raw === 'null' || raw === 'undefined') return '';
+  return raw;
+}
+
+function isSchoolProfileRow(row) {
+  return String(row?.source_table || '') === 'schools';
+}
+
 function isValidContact(row) {
+  if (isSchoolProfileRow(row)) {
+    return Boolean(
+      textValue(row?.contact_name)
+      || textValue(row?.mobile || row?.phone)
+      || textValue(row?.email)
+      || textValue(row?.address)
+    );
+  }
   return Boolean(
-    String(row?.contact_name || '').trim()
-    || String(row?.mobile || row?.phone || '').trim()
-    || String(row?.email || '').trim()
+    textValue(row?.contact_name)
+    || textValue(row?.mobile || row?.phone)
+    || textValue(row?.email)
   );
 }
 
-function isActivityWithoutContact(row) {
-  return String(row?._source || '') === 'activity_without_contact';
-}
-
 function hasSchoolDirectoryEntry(rows) {
-  return (Array.isArray(rows) ? rows : []).some((row) => isValidContact(row) || isActivityWithoutContact(row));
+  const list = Array.isArray(rows) ? rows : [];
+  return list.some((row) => isValidContact(row) || isSchoolProfileRow(row));
 }
 
 function contactDedupeKey(row) {
   return [
+    String(row?.source_table || '').trim(),
+    String(row?.source_id || '').trim(),
     String(row?.authority || row?.client_name || '').trim().toLowerCase(),
     String(row?.school || '').trim().toLowerCase(),
     String(row?.contact_name || '').trim().toLowerCase(),
@@ -91,8 +108,8 @@ function computeSchoolTabStats(authorityMap, activeLetter = '') {
 
     bucket.schools.forEach((schoolRows, schoolName) => {
       if (!String(schoolName || '').trim()) return;
-      const valid = schoolRows.filter(isValidContact);
-      if (!valid.length && !schoolRows.some(isActivityWithoutContact)) return;
+      const valid = schoolRows.filter((row) => isValidContact(row) || isSchoolProfileRow(row));
+      if (!valid.length) return;
       schools += 1;
       hasContent = true;
       valid.forEach((row) => contactKeys.add(contactDedupeKey(row)));
@@ -116,8 +133,8 @@ function countAuthorityBucket(bucket) {
 
   bucket.schools.forEach((schoolRows, schoolName) => {
     if (!String(schoolName || '').trim()) return;
-    const valid = schoolRows.filter(isValidContact);
-    if (!valid.length && !schoolRows.some(isActivityWithoutContact)) return;
+    const valid = schoolRows.filter((row) => isValidContact(row) || isSchoolProfileRow(row));
+    if (!valid.length) return;
     schoolCount += 1;
     valid.forEach((row) => contactKeys.add(contactDedupeKey(row)));
   });
@@ -243,29 +260,70 @@ function instrTabHtml(rows, filters) {
 
 /* ─── School contacts ─── */
 
+function editPayload(row) {
+  return {
+    source_table: row?.source_table || '',
+    source_id: row?.source_id || '',
+    authority: row?.authority,
+    school: row?.school,
+    contact_name: row?.contact_name
+  };
+}
+
+function fieldLine(label, value, { copy = false, copyLabel = '', dir = 'rtl' } = {}) {
+  const safe = textValue(value);
+  if (!safe) return '';
+  const valueHtml = copy
+    ? `<span class="ci-dv">${escapeHtml(safe)}</span>${copyBtn(safe, copyLabel)}`
+    : escapeHtml(safe);
+  return `<div class="sc-person__field sc-person__field--${escapeHtml(label)}" dir="${dir}"><span class="sc-person__field-label">${escapeHtml(label)}:</span> ${valueHtml}</div>`;
+}
+
 function schoolPersonHtml(row) {
-  const name = row.contact_name ? escapeHtml(String(row.contact_name)) : '—';
-  const role = row.contact_role ? escapeHtml(String(row.contact_role)) : '—';
-  const mobile = row.mobile || row.phone;
-  const phone = mobile ? escapeHtml(String(mobile)) : '—';
-  const email = row.email ? escapeHtml(String(row.email)) : '—';
+  const name = textValue(row.contact_name);
+  const role = textValue(row.contact_role);
+  const phone = textValue(row.mobile || row.phone);
+  const mobileOnly = textValue(row.mobile);
+  const email = textValue(row.email);
+  const address = textValue(row.address);
+  const notes = textValue(row.notes);
   if (!isValidContact(row)) return '';
 
-  const editBtn = actionBtn('edit-school', {
-    _row_index: row._row_index,
-    authority: row.authority,
-    school: row.school,
-    contact_name: row.contact_name
-  }, '✎');
+  const editBtn = actionBtn('edit-unified', editPayload(row), '✎');
 
   return `<article class="sc-person sc-person--compact">
     <div class="sc-person__top">
-      <div class="sc-person__name">${name}</div>
+      ${name ? `<div class="sc-person__name">${escapeHtml(name)}</div>` : ''}
       <span class="sc-person__actions">${editBtn}</span>
     </div>
-    <div class="sc-person__role">${role}</div>
-    <div class="sc-person__field sc-person__field--phone" dir="ltr">${phone}</div>
-    <div class="sc-person__field sc-person__field--email" dir="ltr">${email === '—' ? '—' : `<span class="ci-dv">${email}</span>${copyBtn(row.email, 'העתק מייל')}`}</div>
+    ${role ? `<div class="sc-person__role">${escapeHtml(role)}</div>` : ''}
+    ${fieldLine('טלפון', phone, { dir: 'ltr' })}
+    ${mobileOnly && mobileOnly !== phone ? fieldLine('נייד', mobileOnly, { dir: 'ltr' }) : ''}
+    ${fieldLine('מייל', email, { copy: true, copyLabel: 'העתק מייל', dir: 'ltr' })}
+    ${fieldLine('כתובת', address)}
+    ${fieldLine('הערות', notes)}
+  </article>`;
+}
+
+function schoolProfileHtml(row) {
+  if (!isSchoolProfileRow(row) || !isValidContact(row)) return '';
+  const editBtn = actionBtn('edit-unified', editPayload(row), '✎');
+  const name = textValue(row.contact_name);
+  const role = textValue(row.contact_role);
+  const phone = textValue(row.phone);
+  const address = textValue(row.address);
+  const city = textValue(row.city);
+  const district = textValue(row.district);
+  const addressLine = [address, city, district].filter(Boolean).join(', ');
+
+  return `<article class="sc-person sc-person--compact sc-person--school-profile">
+    <div class="sc-person__top">
+      ${name ? `<div class="sc-person__name">${escapeHtml(name)}</div>` : '<div class="sc-person__name">פרטי בית ספר</div>'}
+      <span class="sc-person__actions">${editBtn}</span>
+    </div>
+    ${role ? `<div class="sc-person__role">${escapeHtml(role)}</div>` : ''}
+    ${fieldLine('טלפון', phone, { dir: 'ltr' })}
+    ${fieldLine('כתובת', addressLine)}
   </article>`;
 }
 
@@ -279,14 +337,15 @@ function firstHebrewLetter(str) {
 function groupByAuthorityStructured(rows) {
   const authMap = new Map();
   for (const row of rows) {
-    const authority = String(row.authority || row.client_name || '').trim() || '—';
+    const authority = textValue(row.authority || row.authority_name || row.client_name) || '—';
     if (!authMap.has(authority)) authMap.set(authority, { schools: new Map(), authority: [], other: [] });
     const bucket = authMap.get(authority);
-    const clientType = String(row.client_type || '').trim();
-    const schoolName = String(row.school || '').trim();
-    if (clientType === 'other') {
+    const clientType = textValue(row.client_type).toLowerCase();
+    const contactDomain = textValue(row.contact_domain).toLowerCase();
+    const schoolName = textValue(row.school || row.school_name);
+    if (contactDomain === 'other' || clientType === 'other') {
       bucket.other.push(row);
-    } else if (schoolName && clientType !== 'authority') {
+    } else if (schoolName && (contactDomain === 'school' || clientType === 'school' || isSchoolProfileRow(row))) {
       if (!bucket.schools.has(schoolName)) bucket.schools.set(schoolName, []);
       bucket.schools.get(schoolName).push(row);
     } else {
@@ -296,35 +355,16 @@ function groupByAuthorityStructured(rows) {
   return new Map([...authMap.entries()].sort((a, b) => a[0].localeCompare(b[0], 'he')));
 }
 
-function schoolWithoutContactHtml(row, schoolName) {
-  const addBtn = actionBtn('add-school-prefill', {
-    client_type: 'school',
-    authority: row?.authority,
-    school: row?.school || schoolName,
-    authority_id: row?.authority_id,
-    school_id: row?.school_id,
-    semel_mosad: row?.semel_mosad
-  }, 'הוסף איש קשר');
-  return `<article class="sc-person sc-person--compact sc-person--empty-contact">
-    <div class="sc-person__top">
-      <div class="sc-person__name">אין עדיין איש קשר לבית הספר הזה</div>
-      <span class="sc-person__actions">${addBtn}</span>
-    </div>
-    <div class="sc-person__role">בית הספר מופיע בפעילויות במערכת</div>
-  </article>`;
-}
-
 function renderSchoolAccordion(schoolName, rows) {
-  const validRows = rows.filter(isValidContact);
-  const activityRows = rows.filter(isActivityWithoutContact);
-  const noContactRow = activityRows[0] || rows[0] || {};
-  const personsHtml = validRows.length
-    ? validRows.map(schoolPersonHtml).filter(Boolean).join('')
-    : schoolWithoutContactHtml(noContactRow, schoolName);
-  if (!personsHtml) return '';
-  const contactCount = validRows.length;
-  const countLabel = contactCount === 0 ? 'אין איש קשר' : (contactCount === 1 ? '1 איש קשר' : `${contactCount} אנשי קשר`);
-  const semelMosad = rows.map((r) => String(r.semel_mosad || '').trim()).find(Boolean);
+  const profileRow = rows.find(isSchoolProfileRow);
+  const contactRows = rows.filter((row) => !isSchoolProfileRow(row) && isValidContact(row));
+  const profileHtml = schoolProfileHtml(profileRow);
+  const contactsHtml = contactRows.map(schoolPersonHtml).filter(Boolean).join('');
+  if (!profileHtml && !contactsHtml) return '';
+
+  const contactCount = contactRows.length + (profileHtml ? 1 : 0);
+  const countLabel = contactCount === 1 ? '1 איש קשר' : `${contactCount} אנשי קשר`;
+  const semelMosad = rows.map((r) => textValue(r.semel_mosad)).find(Boolean);
   const metaHtml = semelMosad
     ? `<div class="sc-school-meta"><span class="sc-school-meta__label">סמל מוסד:</span> <span class="sc-school-meta__val">${escapeHtml(semelMosad)}</span></div>`
     : '';
@@ -337,7 +377,7 @@ function renderSchoolAccordion(schoolName, rows) {
     </summary>
     <div class="sc-card__body">
       ${metaHtml}
-      <div class="sc-contact-list sc-contact-list--grid">${personsHtml}</div>
+      <div class="sc-contact-list sc-contact-list--grid">${profileHtml}${contactsHtml}</div>
     </div>
   </details>`;
 }
@@ -436,10 +476,28 @@ function instructorFormHtml(row = {}, managerOptions = []) {
   `;
 }
 
+function schoolDetailsFormHtml(row = {}) {
+  return `
+    <div class="ds-perm-edit-form ds-contact-edit-form" dir="rtl">
+      <input type="hidden" name="source_table" value="schools">
+      <input type="hidden" name="source_id" value="${escapeHtml(String(row.source_id || ''))}">
+      <div class="ds-perm-field"><span class="ds-muted">בית ספר</span><input class="ds-input ds-input--sm" value="${escapeHtml(String(row.school_name || row.school || ''))}" readonly></div>
+      <div class="ds-perm-field"><span class="ds-muted">מנהל/ת בית ספר</span><input class="ds-input ds-input--sm" name="principal_name" value="${escapeHtml(String(row.contact_name || ''))}"></div>
+      <div class="ds-perm-field"><span class="ds-muted">טלפון</span><input class="ds-input ds-input--sm" name="school_phone" value="${escapeHtml(String(row.phone || ''))}"></div>
+      <div class="ds-perm-field"><span class="ds-muted">כתובת</span><input class="ds-input ds-input--sm" name="institution_address" value="${escapeHtml(String(row.address || ''))}"></div>
+      <div class="ds-perm-field"><span class="ds-muted">עיר / יישוב</span><input class="ds-input ds-input--sm" name="city" value="${escapeHtml(String(row.city || ''))}"></div>
+      <div class="ds-perm-field"><span class="ds-muted">מחוז</span><input class="ds-input ds-input--sm" name="district" value="${escapeHtml(String(row.district || ''))}"></div>
+      <p class="ds-muted" data-contact-form-status role="status"></p>
+    </div>
+  `;
+}
+
 function schoolFormHtml(row = {}) {
   const clientType = String(row.client_type || 'school');
   return `
     <div class="ds-perm-edit-form ds-contact-edit-form" dir="rtl">
+      <input type="hidden" name="source_table" value="contacts_schools">
+      <input type="hidden" name="source_id" value="${escapeHtml(String(row.source_id || row.id || ''))}">
       <div class="ds-perm-field"><span class="ds-muted">סוג לקוח</span>
         <select class="ds-input ds-input--sm" name="client_type" data-school-client-type>
           <option value="school"${clientType === 'school' ? ' selected' : ''}>בית ספר</option>
@@ -457,6 +515,7 @@ function schoolFormHtml(row = {}) {
       <div class="ds-perm-field"><span class="ds-muted">טלפון</span><input class="ds-input ds-input--sm" name="phone" value="${escapeHtml(String(row.phone || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">נייד</span><input class="ds-input ds-input--sm" name="mobile" value="${escapeHtml(String(row.mobile || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">אימייל</span><input class="ds-input ds-input--sm" name="email" value="${escapeHtml(String(row.email || ''))}"></div>
+      <div class="ds-perm-field"><span class="ds-muted">כתובת</span><input class="ds-input ds-input--sm" name="address" value="${escapeHtml(String(row.address || ''))}"></div>
       <div class="ds-perm-field"><span class="ds-muted">הערות</span><textarea class="ds-input ds-input--sm" name="notes" rows="2">${escapeHtml(String(row.notes || ''))}</textarea></div>
       <p class="ds-muted" data-contact-form-status role="status"></p>
     </div>
@@ -557,9 +616,10 @@ export const contactsScreen = {
     ]);
     prepareRowsForSearch(schoolRows, [
       'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
-      'mobile', 'phone', 'email', 'authority', 'school',
-      'role', 'contact_role', 'position', 'active', 'notes', 'address',
-      'instructor_name', 'activity_name', 'activity_type', 'client_type', 'client_name', 'authority_id', 'school_id', 'semel_mosad', 'authority_code'
+      'mobile', 'phone', 'email', 'authority', 'authority_name', 'school', 'school_name',
+      'role', 'contact_role', 'position', 'active', 'notes', 'address', 'city', 'district',
+      'instructor_name', 'activity_name', 'activity_type', 'client_type', 'client_name',
+      'authority_id', 'school_id', 'semel_mosad', 'authority_code', 'source_table', 'source_id', 'contact_domain'
     ]);
     const filters = ensureActivityListFilters(state, CONTACTS_SCOPE);
     const canViewInstr  = data?.can_view_instructors !== false;
@@ -724,6 +784,98 @@ export const contactsScreen = {
       };
     };
 
+    const findUnifiedRow = (payload = {}) => {
+      const sourceTable = String(payload.source_table || '').trim();
+      const sourceId = String(payload.source_id || '').trim();
+      if (sourceTable && sourceId) {
+        const hit = schoolRows.find((row) =>
+          String(row.source_table || '') === sourceTable &&
+          String(row.source_id || '') === sourceId
+        );
+        if (hit) return hit;
+      }
+      return schoolRows.find((row) =>
+        String(row.authority || '') === String(payload.authority || '') &&
+        String(row.school || '') === String(payload.school || '') &&
+        String(row.contact_name || '') === String(payload.contact_name || '')
+      ) || null;
+    };
+
+    const openUnifiedEditor = (row) => {
+      if (!ui || !row) return;
+      const isSchoolRecord = String(row.source_table || '') === 'schools';
+      ui.openModal({
+        title: isSchoolRecord ? 'עריכת פרטי בית ספר' : 'עריכת לקוח / איש קשר',
+        content: isSchoolRecord ? schoolDetailsFormHtml(row) : schoolFormHtml(row),
+        actions: `<button type="button" class="ds-btn ds-btn--primary" data-save-contact="unified">שמירה</button>
+                  <button type="button" class="ds-btn" data-ui-close-modal>ביטול</button>`
+      });
+      const saveBtn = document.querySelector('[data-save-contact="unified"]');
+      if (!saveBtn) return;
+      const modalEl = document.querySelector('.ds-modal__content');
+      const clientTypeSelectEl = modalEl?.querySelector('[data-school-client-type]');
+      const schoolFieldEl = modalEl?.querySelector('[data-school-field]');
+      clientTypeSelectEl?.addEventListener('change', () => {
+        if (schoolFieldEl) schoolFieldEl.hidden = clientTypeSelectEl.value === 'authority';
+      });
+      saveBtn.onclick = async () => {
+        const modal = document.querySelector('.ds-modal__content');
+        if (!modal) return;
+        const statusEl = modal.querySelector('[data-contact-form-status]');
+        const get = (name) => String(modal.querySelector(`[name="${name}"]`)?.value || '').trim();
+        const sourceTable = get('source_table');
+        const sourceId = get('source_id');
+        if (!sourceTable || !sourceId) {
+          if (statusEl) statusEl.textContent = 'חסר מזהה מקור לעריכה';
+          return;
+        }
+
+        let fields = {};
+        if (sourceTable === 'schools') {
+          fields = {
+            principal_name: get('principal_name'),
+            school_phone: get('school_phone'),
+            institution_address: get('institution_address'),
+            city: get('city'),
+            district: get('district')
+          };
+        } else {
+          const clientType = get('client_type') || 'school';
+          const authority = get('authority');
+          const school = clientType === 'authority' ? '' : get('school');
+          fields = {
+            client_type: clientType,
+            client_name: clientType === 'school' ? school : (clientType === 'authority' ? authority : (school || authority)),
+            authority_id: get('authority_id') || null,
+            school_id: clientType === 'school' ? (get('school_id') || null) : null,
+            semel_mosad: clientType === 'school' ? (get('semel_mosad') || null) : null,
+            authority,
+            school: school || null,
+            contact_name: get('contact_name'),
+            contact_role: get('contact_role'),
+            phone: get('phone'),
+            mobile: get('mobile'),
+            email: get('email'),
+            address: get('address'),
+            notes: get('notes')
+          };
+        }
+
+        try {
+          saveBtn.disabled = true;
+          if (statusEl) statusEl.textContent = 'שומר...';
+          await api.updateUnifiedContactRecord({ source_table: sourceTable, source_id: sourceId, fields });
+          showToast('✅ נשמר בהצלחה', 'success', 1800);
+          ui.closeModal();
+          rerender();
+        } catch (err) {
+          if (statusEl) statusEl.textContent = `שגיאה: ${String(err?.message || '')}`;
+        } finally {
+          saveBtn.disabled = false;
+        }
+      };
+    };
+
     const openSchoolEditor = (row, isCreate = false) => {
       if (!ui) return;
       const target = row || {};
@@ -805,7 +957,9 @@ export const contactsScreen = {
       schoolRows,
       decodePayload,
       openInstructorEditor,
-      openSchoolEditor
+      openSchoolEditor,
+      openUnifiedEditor,
+      findUnifiedRow
     };
     if (!root._contactsActionBound) {
       root._contactsActionBound = true;
@@ -835,14 +989,16 @@ export const contactsScreen = {
           if (hit) ctx.openInstructorEditor?.(hit, false);
           return;
         }
+        if (action === 'edit-unified') {
+          const payload = ctx.decodePayload?.(btn) || {};
+          const hit = ctx.findUnifiedRow?.(payload);
+          if (hit) ctx.openUnifiedEditor?.(hit);
+          return;
+        }
         if (action === 'edit-school') {
           const payload = ctx.decodePayload?.(btn) || {};
-          const hit = (ctx.schoolRows || []).find((r) =>
-            String(r.authority || '') === String(payload.authority || '') &&
-            String(r.school || '') === String(payload.school || '') &&
-            String(r.contact_name || '') === String(payload.contact_name || '')
-          ) || null;
-          if (hit) ctx.openSchoolEditor?.(hit, false);
+          const hit = ctx.findUnifiedRow?.(payload);
+          if (hit) ctx.openUnifiedEditor?.(hit);
         }
       });
     }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 802;
+const CACHE_VERSION = 803;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
 </head>
 <body>
   <main id="app"></main>
-  <script type="module" src="./frontend/src/dashboard-kpi-corrections.js?v=20260620-stabilization-1"></script>
-  <script type="module" src="./frontend/src/main.js?v=20260620-stabilization-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-summer-training-matrix.js?v=20260620-stabilization-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-authorities-cleanup.js?v=20260620-stabilization-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-visual-tweaks.js?v=20260620-stabilization-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-inventory-polish.js?v=20260620-stabilization-1"></script>
+  <script type="module" src="./frontend/src/dashboard-kpi-corrections.js?v=20260620-contacts-unified-1"></script>
+  <script type="module" src="./frontend/src/main.js?v=20260620-contacts-unified-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-summer-training-matrix.js?v=20260620-contacts-unified-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-authorities-cleanup.js?v=20260620-contacts-unified-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-visual-tweaks.js?v=20260620-contacts-unified-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-inventory-polish.js?v=20260620-contacts-unified-1"></script>
 </body>
 </html>

--- a/supabase/migrations/20260620_contacts_unified_view.sql
+++ b/supabase/migrations/20260620_contacts_unified_view.sql
@@ -1,0 +1,79 @@
+-- Unified read-only view for general contacts (authorities, schools, school contacts).
+-- Instructors remain in contacts_instructors and are NOT included here.
+
+drop view if exists public.contacts_unified_view;
+
+create view public.contacts_unified_view as
+select
+  case
+    when lower(coalesce(cs.client_type, '')) = 'school'
+      or (nullif(trim(coalesce(cs.school, '')), '') is not null and lower(coalesce(cs.client_type, '')) <> 'authority')
+      then 'school'
+    when lower(coalesce(cs.client_type, '')) = 'authority' then 'authority'
+    else 'other'
+  end as contact_domain,
+  cs.client_type,
+  cs.client_name,
+  cs.authority_id,
+  cs.school_id,
+  cs.semel_mosad,
+  coalesce(a.authority_name, cs.authority) as authority_name,
+  cs.authority,
+  coalesce(s.school_name, cs.school) as school_name,
+  cs.school,
+  cs.contact_name,
+  cs.contact_role,
+  cs.phone,
+  cs.mobile,
+  cs.email,
+  cs.address,
+  cs.notes,
+  a.authority_code,
+  coalesce(s.district, a.district) as district,
+  s.city,
+  'contacts_schools'::text as source_table,
+  cs.id::text as source_id
+from public.contacts_schools cs
+left join public.authorities a on a.id = cs.authority_id
+left join public.schools s on s.id = cs.school_id
+where coalesce(lower(trim(cs.active::text)), 'yes') not in ('no', '0', 'false')
+
+union all
+
+select
+  'school'::text as contact_domain,
+  'school'::text as client_type,
+  sch.school_name as client_name,
+  sch.authority_id,
+  sch.id as school_id,
+  sch.semel_mosad,
+  coalesce(a.authority_name, sch.authority) as authority_name,
+  sch.authority,
+  sch.school_name,
+  sch.school_name as school,
+  nullif(trim(coalesce(sch.principal_name, '')), '') as contact_name,
+  case
+    when nullif(trim(coalesce(sch.principal_name, '')), '') is not null then 'מנהל/ת בית ספר'
+    else null
+  end as contact_role,
+  nullif(trim(coalesce(sch.school_phone, '')), '') as phone,
+  null::text as mobile,
+  null::text as email,
+  nullif(trim(coalesce(sch.institution_address, '')), '') as address,
+  null::text as notes,
+  a.authority_code,
+  coalesce(sch.district, a.district) as district,
+  sch.city,
+  'schools'::text as source_table,
+  sch.id::text as source_id
+from public.schools sch
+left join public.authorities a on a.id = sch.authority_id
+where coalesce(lower(trim(sch.active::text)), 'yes') not in ('no', '0', 'false')
+  and nullif(trim(coalesce(sch.school_name, '')), '') is not null
+  and (
+    nullif(trim(coalesce(sch.principal_name, '')), '') is not null
+    or nullif(trim(coalesce(sch.school_phone, '')), '') is not null
+    or nullif(trim(coalesce(sch.institution_address, '')), '') is not null
+  );
+
+grant select on public.contacts_unified_view to anon, authenticated;

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 802;
+const SW_ENTRY_VERSION = 803;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Creates `contacts_unified_view` SQL migration merging `contacts_schools` and `schools` with `source_table` / `source_id` for edit routing.
- Updates general contacts read path to use only `contacts_unified_view`; instructors remain separate via `contacts_instructors`.
- Adds `updateUnifiedContactRecord` API and edit buttons in contacts screens that update the underlying source table (`contacts_schools` or `schools`).
- Updates contacts display hierarchy (authority → schools → authority → other) and shows school profile data from `schools` without empty-state placeholders.
- Bumps Service Worker cache version to **803** and query-string versioning for changed assets.

## Changed files

- `supabase/migrations/20260620_contacts_unified_view.sql`
- `frontend/src/api.js`
- `frontend/src/screens/contacts.js`
- `frontend/src/screens/contacts-full-directory.js`
- `frontend/sw.js`, `sw.js`, `frontend/src/config.js`, `index.html`

## Verification

- `node --check` on changed JS files
- `npm run check:build` passed

## Deploy note

Run the new Supabase migration before relying on the unified view in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae26c2ad-6a8f-4b83-b331-62c62ba6598e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae26c2ad-6a8f-4b83-b331-62c62ba6598e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

