### PR TITLE
הצעות מחיר: מקור אנשי קשר מאוחד וביטול בחירה אוטומטית

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2493,53 +2493,36 @@ async function readProposalTemplateSectionsFromSupabase() {
 
 async function readContactsSchoolsForProposals() {
   try {
-    const directoryColumns = 'id,client_type,authority_id,authority_code,authority_name,authority_type,authority_district,school_id,semel_mosad,school_name,contact_name,contact_role,phone,mobile,email,active';
-    const legacyColumns = 'id,client_type,client_name,authority_id,school_id,semel_mosad,authority,school,contact_name,contact_role,phone,email,mobile';
-    const [catalog, contactsResult] = await Promise.all([
+    const [catalog, unifiedRows] = await Promise.all([
       readAuthoritySchoolCatalog(),
-      (async () => {
-        let { data, error } = await supabase
-          .from('contacts_directory_view')
-          .select(directoryColumns)
-          .order('authority_name', { ascending: true });
-        if (error) {
-          // eslint-disable-next-line no-console
-          console.warn('[supabase] Failed to load contacts_directory_view for proposals; falling back to contacts_schools:', error);
-          const fallback = await supabase
-            .from('contacts_schools')
-            .select(legacyColumns)
-            .order('authority', { ascending: true });
-          data = fallback.data;
-          error = fallback.error;
-        }
-        if (error) return [];
-        return (Array.isArray(data) ? data : []).map((c) => {
-          const authorityName = cleanProposalAgreementText(c.authority_name || c.authority || c.client_name);
-          const schoolName = cleanProposalAgreementText(c.school_name || c.school);
-          return {
-            id:           cleanProposalAgreementText(c.id),
-            client_type:  cleanProposalAgreementText(c.client_type),
-            client_name:  cleanProposalAgreementText(c.client_name) || schoolName || authorityName,
-            authority_id: c.authority_id ?? null,
-            school_id:    c.school_id ?? null,
-            semel_mosad:  cleanProposalAgreementText(c.semel_mosad),
-            authority_code: cleanProposalAgreementText(c.authority_code),
-            authority_type: cleanProposalAgreementText(c.authority_type),
-            authority_name: authorityName,
-            school_name:  schoolName,
-            district:     cleanProposalAgreementText(c.authority_district || c.district),
-            authority:    authorityName,
-            school:       schoolName,
-            contact_name: cleanProposalAgreementText(c.contact_name),
-            contact_role: cleanProposalAgreementText(c.contact_role),
-            phone:        cleanProposalAgreementText(c.phone || ''),
-            mobile:       cleanProposalAgreementText(c.mobile || ''),
-            email:        cleanProposalAgreementText(c.email || ''),
-            active:       c.active
-          };
-        }).filter((c) => c.authority_name || c.school_name || c.authority || c.school);
-      })()
+      readUnifiedContactsFromSupabase()
     ]);
+    const contactsResult = (Array.isArray(unifiedRows) ? unifiedRows : []).map((c) => {
+      const authorityName = cleanProposalAgreementText(c.authority_name || c.authority || c.client_name);
+      const schoolName = cleanProposalAgreementText(c.school_name || c.school);
+      return {
+        id:           cleanProposalAgreementText(c.source_id || c.id),
+        client_type:  cleanProposalAgreementText(c.client_type),
+        client_name:  cleanProposalAgreementText(c.client_name) || schoolName || authorityName,
+        authority_id: c.authority_id ?? null,
+        school_id:    c.school_id ?? null,
+        semel_mosad:  cleanProposalAgreementText(c.semel_mosad),
+        authority_code: cleanProposalAgreementText(c.authority_code),
+        authority_type: cleanProposalAgreementText(c.authority_type),
+        authority_name: authorityName,
+        school_name:  schoolName,
+        district:     cleanProposalAgreementText(c.district),
+        authority:    authorityName,
+        school:       schoolName,
+        contact_name: cleanProposalAgreementText(c.contact_name),
+        contact_role: cleanProposalAgreementText(c.contact_role),
+        phone:        cleanProposalAgreementText(c.phone || ''),
+        mobile:       cleanProposalAgreementText(c.mobile || ''),
+        email:        cleanProposalAgreementText(c.email || ''),
+        source_table: cleanProposalAgreementText(c.source_table),
+        active:       'yes'
+      };
+    }).filter((c) => c.authority_name || c.school_name || c.authority || c.school);
 
     // eslint-disable-next-line no-console
     console.info('[proposal-catalog-authorities]', {

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -736,7 +736,7 @@ function clientSearchHtml(_contactOptions, row = {}) {
 
 function contactPickerHtml(contactOptions, authority, school, selectedContactName, authorityId = null, schoolId = null) {
   const contacts = filterContactsForClient(contactOptions, { authorityId, schoolId });
-  if (contacts.length <= 1) return '';
+  if (contacts.length === 0) return '';
   const optionsHtml = ['<option value="">— בחרו איש קשר —</option>',
     ...contacts.map((c) => {
       const val = contactOptionKey(c);
@@ -2811,38 +2811,21 @@ export const proposalsAgreementsScreen = {
 
       setPanelOpen(form, 'contact', true);
 
-      if (contacts.length === 1) {
-        const contact = contacts[0];
-        fillContactFields(form, contact);
-        setContactSource(form, { ...baseSource, ...contact, id: contact.id });
-        if (pickerHost) pickerHost.innerHTML = '';
-        lockClientFields(
-          form,
+      fillContactFields(form, {});
+      setContactSource(form, baseSource);
+      if (pickerHost) {
+        pickerHost.innerHTML = contactPickerHtml(
+          contactOptions,
           authority,
           school,
-          text(contact.contact_name),
-          text(contact.contact_role),
-          text(contact.phone || contact.mobile || ''),
-          text(contact.email || ''),
-          clientName || school || authority
+          '',
+          authorityId,
+          schoolId || null
         );
-      } else {
-        fillContactFields(form, {});
-        setContactSource(form, baseSource);
-        if (pickerHost) {
-          pickerHost.innerHTML = contactPickerHtml(
-            contactOptions,
-            authority,
-            school,
-            '',
-            authorityId,
-            schoolId || null
-          );
-          if (pickerHost.children.length) setupContactPicker(pickerHost, form);
-        }
-        lockClientFields(form, authority, school, '', '', '', '', clientName || school || authority);
-        if (addContactRow) addContactRow.hidden = contacts.length > 0;
+        if (pickerHost.children.length) setupContactPicker(pickerHost, form);
       }
+      lockClientFields(form, authority, school, '', '', '', '', clientName || school || authority);
+      if (addContactRow) addContactRow.hidden = contacts.length > 0;
 
       const searchField = form.querySelector('[data-pa-client-search-field]');
       const schoolSearchPanel = form.querySelector('[data-pa-school-search-panel]');

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 804;
+const CACHE_VERSION = 805;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 804;
+const SW_ENTRY_VERSION = 805;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -764,7 +764,7 @@ test('admin sees approve and return actions for pending proposals', async () => 
   );
 });
 
-test('client selector auto-fills contact fields when existing client is chosen', async () => {
+test('client selector fills school fields without auto-selecting contact', async () => {
   await withJSDOM(
     proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
     (root, dom) => {
@@ -783,16 +783,21 @@ test('client selector auto-fills contact fields when existing client is chosen',
       const schoolInput = form.querySelector('input[name="school_framework"]');
       const contactInput = form.querySelector('input[name="contact_name"]');
       const phoneInput = form.querySelector('input[name="phone"]');
+      const contactSelect = form.querySelector('[data-pa-contact-select]');
 
       assert.equal(authorityInput.value, 'רשות ב', 'authority should be filled');
       assert.equal(schoolInput.value, 'מסגרת ב', 'school should be filled');
-      assert.equal(contactInput.value, 'יוסי קשר', 'contact_name should be auto-filled');
-      assert.equal(phoneInput.value, '050-2222222', 'phone should be auto-filled');
+      assert.equal(contactInput.value, '', 'contact_name should stay empty until user selects');
+      assert.equal(phoneInput.value, '', 'phone should stay empty until user selects');
+      assert.ok(contactSelect, 'contact picker should appear even for a single contact');
+      assert.match(contactSelect.innerHTML, /יוסי קשר/, 'single contact should appear in picker');
+      assert.equal(contactSelect.value, '', 'contact picker should default to placeholder');
       assert.equal(form.querySelector('input[name="contact_source_authority_id"]').value, 'auth-b');
       assert.equal(form.querySelector('input[name="contact_source_school_id"]').value, 'school-b');
       assert.equal(form.querySelector('[data-pa-client-results]').hidden, true, 'results should close after selection');
       assert.equal(form.querySelector('[data-pa-client-search-row]').hidden, true, 'search row should close after selection');
-      assert.match(form.querySelector('[data-pa-client-card]').textContent, /נבחר:.*מסגרת ב.*רשות ב.*יוסי קשר/, 'clear selected-client summary should be shown');
+      assert.match(form.querySelector('[data-pa-client-card]').textContent, /נבחר:.*מסגרת ב.*רשות ב/, 'selected-client summary should show school and authority');
+      assert.doesNotMatch(form.querySelector('[data-pa-client-card]').textContent, /יוסי קשר/, 'contact should not appear in summary before selection');
     }
   );
 });
@@ -954,7 +959,7 @@ test('authority search shows only catalog authorities without contact details', 
   );
 });
 
-test('multiple contacts for same client shows contact picker dropdown', async () => {
+test('multiple contacts for same client shows contact picker dropdown without preselection', async () => {
   await withJSDOM(
     proposalsAgreementsScreen.render({ rows: [], contactOptions: sampleContactOptions }, { state: stateFor('admin') }),
     (root, dom) => {
@@ -971,8 +976,10 @@ test('multiple contacts for same client shows contact picker dropdown', async ()
 
       const contactSelect = form.querySelector('[data-pa-contact-select]');
       assert.ok(contactSelect, 'contact picker should appear when multiple contacts exist');
+      assert.equal(contactSelect.value, '', 'contact picker should default to placeholder');
       assert.match(contactSelect.innerHTML, /דנה קשר/, 'first contact should be in picker');
       assert.match(contactSelect.innerHTML, /מיכל כהן/, 'second contact should be in picker');
+      assert.equal(form.querySelector('input[name="contact_name"]').value, '', 'contact fields should stay empty until selection');
     }
   );
 });
@@ -1025,7 +1032,70 @@ test('contact picker fills fields and passes existing contact source on save', a
   );
 });
 
-test('manual contact toggle appears when selected school has no contacts', async () => {
+test('proposals contact loader uses contacts_unified_view and not directory fallback', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const loaderBlock = apiSource.match(/async function readContactsSchoolsForProposals\(\) \{[\s\S]*?\n\}/);
+  assert.ok(loaderBlock, 'readContactsSchoolsForProposals should exist');
+  assert.match(loaderBlock[0], /readUnifiedContactsFromSupabase\(\)/);
+  assert.doesNotMatch(loaderBlock[0], /contacts_directory_view/);
+  assert.doesNotMatch(loaderBlock[0], /contacts_schools/);
+});
+
+test('school principal from schools source appears in proposal contact picker', async () => {
+  const schoolOnlyContactOptions = [
+    ...sampleCatalogAuthorities,
+    {
+      _catalog_source: 'schools',
+      client_type: 'school',
+      client_name: 'בית ספר מנהל',
+      authority_id: 'auth-a',
+      school_id: 'school-principal',
+      authority: 'רשות א',
+      school: 'בית ספר מנהל',
+      school_name: 'בית ספר מנהל',
+      semel_mosad: '33333',
+      contact_name: '',
+      contact_role: '',
+      phone: '',
+      email: '',
+      mobile: ''
+    },
+    {
+      id: 'school-principal',
+      source_table: 'schools',
+      authority_id: 'auth-a',
+      school_id: 'school-principal',
+      authority: 'רשות א',
+      school: 'בית ספר מנהל',
+      contact_name: 'רחל מנהלת',
+      contact_role: 'מנהל/ת בית ספר',
+      phone: '03-1234567',
+      email: ''
+    }
+  ];
+
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: schoolOnlyContactOptions }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: schoolOnlyContactOptions },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      const form = openNewProposalForm(root, dom);
+      selectClientResult(form, dom, 'רשות א');
+      selectClientResult(form, dom, 'בית ספר מנהל');
+
+      const contactSelect = form.querySelector('[data-pa-contact-select]');
+      assert.ok(contactSelect, 'school principal contact should appear in picker');
+      assert.match(contactSelect.innerHTML, /רחל מנהלת/);
+      assert.equal(contactSelect.value, '', 'school principal should not be preselected');
+    }
+  );
+});
+
   const catalogOnly = [
     ...sampleCatalogAuthorities,
     {

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1096,6 +1096,7 @@ test('school principal from schools source appears in proposal contact picker', 
   );
 });
 
+test('manual contact toggle appears when selected school has no contacts', async () => {
   const catalogOnly = [
     ...sampleCatalogAuthorities,
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## סיכום

תיקון ממוקד במסך הצעות מחיר כדי שאנשי הקשר ייטענו מאותו מקור כמו עמוד "אנשי קשר", ושהמשתמש יבחר איש קשר בעצמו.

## שינויים

### מקור אנשי קשר (`readContactsSchoolsForProposals`)
- טעינה דרך `readUnifiedContactsFromSupabase()` → `contacts_unified_view`
- הוסר שימוש ב-`contacts_directory_view` וב-fallback ל-`contacts_schools`
- נשמר מבנה `contactOptions` הקיים (כולל חיפוש לפי רשות ובית ספר)
- אנשי קשר מטבלת `schools` (מנהל/ת בית ספר) זמינים גם בהצעת מחיר חדשה

### ביטול בחירה אוטומטית (`applyContactSelectionAfterClient`)
- הוסרה ההתנהגות שמילאה אוטומטית פרטי איש קשר כש-`contacts.length === 1`
- לאחר בחירת רשות ובית ספר נשארים ריקים: `contact_name`, `contact_role`, `phone`, `email`
- ברירת מחדל ברשימת הבחירה: "— בחרו איש קשר —"

### תצוגת בוחר אנשי קשר (`contactPickerHtml`)
- הרשימה מוצגת גם כשיש איש קשר יחיד (במקום הסתרה והמילוי האוטומטי)

### Service Worker
- `CACHE_VERSION` / `SW_ENTRY_VERSION` עודכנו ל-**805**

## בדיקות

- `node --check` על `frontend/src/api.js` ו-`frontend/src/screens/proposals-agreements.js`
- `tests/proposals-agreements-screen.test.mjs` — כל בדיקות אנשי הקשר הרלוונטיות עברו
- `tests/service-worker-pwa-cache.test.mjs` — עבר

## לא שונה

מחירים, PDF, תבניות הצעת מחיר, עמוד אנשי קשר, `contacts_instructors`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2323394-e8f1-4131-b2ae-ac75aa6ac151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2323394-e8f1-4131-b2ae-ac75aa6ac151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

