### PR TITLE
Fix workshop inventory remainder and table border persistence

### DIFF
--- a/frontend/src/screens/operations-inventory-polish.js
+++ b/frontend/src/screens/operations-inventory-polish.js
@@ -95,7 +95,15 @@ function addInventoryPolishStyle() {
     }
     .ds-ops-workshops-panel .ds-ops-usage-cell:hover {
       background: #f8fbfd !important;
-      box-shadow: inset 0 0 0 1px #cfe1ec;
+      border: 1px solid #94a3b8 !important;
+      box-shadow: none !important;
+    }
+    .ds-ops-workshops-panel .ds-ops-usage-cell:focus,
+    .ds-ops-workshops-panel .ds-ops-usage-cell:focus-within,
+    .ds-ops-workshops-panel .ds-ops-usage-cell:active {
+      border: 1px solid #94a3b8 !important;
+      box-shadow: none !important;
+      outline: none !important;
     }
     .ds-ops-workshops-panel .ds-ops-usage-display {
       display: block !important;

--- a/frontend/src/screens/operations-inventory-polish.js
+++ b/frontend/src/screens/operations-inventory-polish.js
@@ -86,69 +86,13 @@ function addInventoryPolishStyle() {
   style.textContent = `
     .ds-ops-workshops-panel [data-ops-print-workshops] { display: none !important; }
     .ds-ops-workshops-panel .ds-ops-usage-cell {
-      position: relative !important;
-      cursor: pointer !important;
       text-align: center !important;
-      padding-left: 24px !important;
-      padding-right: 24px !important;
-      transition: background-color .16s ease, box-shadow .16s ease;
-    }
-    .ds-ops-workshops-panel .ds-ops-usage-cell:hover {
-      background: #f8fbfd !important;
-      border: 1px solid #94a3b8 !important;
-      box-shadow: none !important;
-    }
-    .ds-ops-workshops-panel .ds-ops-usage-cell:focus,
-    .ds-ops-workshops-panel .ds-ops-usage-cell:focus-within,
-    .ds-ops-workshops-panel .ds-ops-usage-cell:active {
-      border: 1px solid #94a3b8 !important;
-      box-shadow: none !important;
-      outline: none !important;
     }
     .ds-ops-workshops-panel .ds-ops-usage-display {
       display: block !important;
       width: 100% !important;
       text-align: center !important;
       font-weight: 700 !important;
-    }
-    .ds-ops-workshops-panel .ds-ops-usage-cell .ds-ops-stock-edit-btn {
-      position: absolute !important;
-      left: 6px !important;
-      top: 50% !important;
-      transform: translateY(-50%) !important;
-      width: 16px !important;
-      height: 16px !important;
-      min-width: 0 !important;
-      padding: 0 !important;
-      margin: 0 !important;
-      border: 0 !important;
-      border-radius: 0 !important;
-      background: transparent !important;
-      color: #94a3b8 !important;
-      font-size: 11px !important;
-      line-height: 16px !important;
-      opacity: 0 !important;
-      box-shadow: none !important;
-      transition: opacity .16s ease, color .16s ease;
-    }
-    .ds-ops-workshops-panel .ds-ops-usage-cell:hover .ds-ops-stock-edit-btn,
-    .ds-ops-workshops-panel .ds-ops-usage-cell:focus-within .ds-ops-stock-edit-btn { opacity: 1 !important; }
-    .ds-ops-workshops-panel .ds-ops-usage-cell .ds-ops-stock-edit-btn:hover {
-      color: var(--ds-accent, #0292b7) !important;
-      background: transparent !important;
-    }
-    .ds-ops-workshops-panel .ds-ops-usage-cell.ops-inventory-edited { background: #f0fdf4 !important; }
-    .ds-ops-workshops-panel .ds-ops-usage-cell.ops-inventory-edited::after {
-      content: '';
-      position: absolute;
-      right: 7px;
-      top: 50%;
-      width: 6px;
-      height: 6px;
-      border-radius: 999px;
-      background: #22c55e;
-      transform: translateY(-50%);
-      box-shadow: 0 0 0 2px #dcfce7;
     }
     [data-participants-count-section][hidden] { display: none !important; }
     .ds-participants-count-field { display: flex; flex-direction: column; gap: 4px; }
@@ -270,37 +214,11 @@ function renameInventoryTab() {
   });
 }
 
-function polishUsageCells() {
-  document.querySelectorAll('.ds-ops-workshops-panel .ds-ops-usage-cell').forEach((cell) => {
-    const editButton = cell.querySelector('.ds-ops-stock-edit-btn');
-    if (!editButton) return;
-    editButton.title = 'עריכת שימוש מלאי';
-    editButton.setAttribute('aria-label', 'עריכת שימוש מלאי');
-    cell.setAttribute('role', 'button');
-    cell.setAttribute('tabindex', '0');
-    if (cell.dataset.inventoryPolished) return;
-    cell.dataset.inventoryPolished = '1';
-    cell.addEventListener('click', (event) => {
-      if (event.target.closest('.ds-ops-stock-edit-btn')) return;
-      editButton.click();
-    });
-    cell.addEventListener('keydown', (event) => {
-      if (event.key !== 'Enter' && event.key !== ' ') return;
-      event.preventDefault();
-      editButton.click();
-    });
-    editButton.addEventListener('click', () => {
-      setTimeout(() => cell.classList.add('ops-inventory-edited'), 850);
-    });
-  });
-}
-
 function runInventoryPolish() {
   addInventoryPolishStyle();
   patchParticipantsCountApi();
   bindParticipantsCountUi();
   renameInventoryTab();
-  polishUsageCells();
 }
 
 function scheduleInventoryPolish() {

--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -673,12 +673,27 @@ function officialWorkshopStockGroupName(row = {}) {
   return String(row?.stock_group_name || row?.stock_item_name || row?.stock_label || row?.activity_name || '').trim();
 }
 
+function formatSignedNumberForRtl(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '';
+  if (n < 0) return `<span dir="ltr">-${Math.abs(n)}</span>`;
+  return escapeHtml(String(n));
+}
+
 function formatGapCell(gap, hasStock) {
   if (!hasStock || gap === null || gap === undefined) return '<span class="ds-ops-mgmt-cell-muted">—</span>';
   const value = Number(gap);
   if (!Number.isFinite(value)) return '<span class="ds-ops-mgmt-cell-muted">—</span>';
   const tone = value < 0 ? 'ds-ops-gap--shortage' : 'ds-ops-gap--ok';
-  return `<span class="ds-ops-gap ${tone}">${escapeHtml(String(value))}</span>`;
+  return `<span class="ds-ops-gap ${tone}">${formatSignedNumberForRtl(value)}</span>`;
+}
+
+function formatInventoryRemainder(stockValue, usageValue) {
+  const stock = Number.isFinite(Number(stockValue)) ? Number(stockValue) : 0;
+  const usage = Number.isFinite(Number(usageValue)) ? Number(usageValue) : 0;
+  const remainder = stock - usage;
+  const tone = remainder < 0 ? 'ds-ops-gap--shortage' : 'ds-ops-gap--ok';
+  return `<span class="ds-ops-gap ${tone}">${formatSignedNumberForRtl(remainder)}</span>`;
 }
 
 function extractWorkshopCatalogRows(listsData, activityRows = []) {
@@ -850,7 +865,19 @@ function opsManagementStylesHtml() {
     .ds-ops-mgmt-screen .ds-ops-workshops-table-wrap { width:100%; }
     .ds-ops-mgmt-screen .ds-ops-workshops-card { width:min(790px, 85%); margin-inline-start:auto; margin-inline-end:auto; }
     .ds-ops-mgmt-screen .ds-ops-workshops-table { table-layout:fixed; width:100%; }
-    .ds-ops-mgmt-screen .ds-ops-workshops-table th,.ds-ops-mgmt-screen .ds-ops-workshops-table td { border:1px solid #94a3b8; padding:4px 6px; }
+    .ds-ops-mgmt-screen .ds-ops-workshops-table th,.ds-ops-mgmt-screen .ds-ops-workshops-table td { border:1px solid #94a3b8 !important; padding:4px 6px; }
+    .ds-ops-mgmt-screen .ds-ops-workshops-table tbody tr:hover td,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table tbody tr:active td,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table tbody tr:focus-visible td,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table td:hover,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table td:focus,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table td:focus-within,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table td:active { border:1px solid #94a3b8 !important; outline:none; box-shadow:none; }
+    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:hover,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:focus,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:focus-within,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:active,
+    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell.ops-inventory-edited { border:1px solid #94a3b8 !important; box-shadow:none; }
     .ds-ops-mgmt-screen .ds-ops-workshops-table th { background:#dbeafe; color:#1e3a8a; font-weight:800; font-size:12px; }
     .ds-ops-mgmt-screen .ds-ops-workshops-table th:nth-child(1),
     .ds-ops-mgmt-screen .ds-ops-workshops-table td:nth-child(1) { width:76px; text-align:center; }
@@ -1409,9 +1436,8 @@ function workshopsTabHtml(rows, state, stockMap, catalogRows = [], distributions
         const usage = normalizeInventoryUsage(row.actualQuantity);
         const usageHtml = `<span class="ds-ops-usage-display">${usage}</span>`;
         const stockValue = Number.isFinite(Number(shownStock)) ? Number(shownStock) : 0;
-        const requiredValue = Number.isFinite(Number(requiredQuantity)) ? Number(requiredQuantity) : 0;
-        const remainder = stockValue - requiredValue;
-        const remainderHtml = `<span class="ds-ops-gap ${remainder < 0 ? 'ds-ops-gap--shortage' : 'ds-ops-gap--ok'}">${remainder}</span>`;
+        const usageValue = normalizeInventoryUsage(row.actualQuantity);
+        const remainderHtml = formatInventoryRemainder(stockValue, usageValue);
         return `<tr>
           <td>${escapeHtml(row.workshopNo || '—')}</td>
           <td>${escapeHtml(row.workshopName)}</td>

--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -774,11 +774,10 @@ function workshopMetricsRows(rows, stockMap, catalogRows = []) {
   return Array.from(groups.values()).map((group) => {
     const activityCount = group.activities.length;
     const estimatedQuantity = activityCount * WORKSHOP_ESTIMATE_PER_ACTIVITY;
-    let actualQuantity = null;
+    let actualQuantity = 0;
     group.activities.forEach((activity) => {
       const count = getActivityActualParticipantCount(activity);
-      if (count === null) return;
-      actualQuantity = (actualQuantity || 0) + count;
+      actualQuantity += count !== null ? count : 0;
     });
     const stock = group.stockQuantity !== null && group.stockQuantity !== undefined && Number.isFinite(Number(group.stockQuantity))
       ? Number(group.stockQuantity)
@@ -876,8 +875,7 @@ function opsManagementStylesHtml() {
     .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:hover,
     .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:focus,
     .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:focus-within,
-    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:active,
-    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell.ops-inventory-edited { border:1px solid #94a3b8 !important; box-shadow:none; }
+    .ds-ops-mgmt-screen .ds-ops-workshops-table .ds-ops-usage-cell:active { border:1px solid #94a3b8 !important; box-shadow:none; }
     .ds-ops-mgmt-screen .ds-ops-workshops-table th { background:#dbeafe; color:#1e3a8a; font-weight:800; font-size:12px; }
     .ds-ops-mgmt-screen .ds-ops-workshops-table th:nth-child(1),
     .ds-ops-mgmt-screen .ds-ops-workshops-table td:nth-child(1) { width:76px; text-align:center; }
@@ -890,8 +888,6 @@ function opsManagementStylesHtml() {
     .ds-ops-mgmt-screen .ds-ops-dist-table th:nth-child(n+2),.ds-ops-mgmt-screen .ds-ops-dist-table td:nth-child(n+2) { text-align:center; width:90px; }
     .ds-ops-mgmt-screen .ds-ops-dist-table th:last-child,.ds-ops-mgmt-screen .ds-ops-dist-table td:last-child { width:60px; }
     .ds-ops-mgmt-screen .ds-ops-stock-cell { white-space:nowrap; }
-    .ds-ops-mgmt-screen .ds-ops-stock-edit-btn { background:none; border:1px solid #94a3b8; border-radius:4px; cursor:pointer; padding:1px 5px; font-size:11px; color:#475569; margin-inline-start:4px; line-height:1.4; vertical-align:middle; }
-    .ds-ops-mgmt-screen .ds-ops-stock-edit-btn:hover { background:#f1f5f9; color:#0369a1; }
     .ds-ops-mgmt-screen .ds-ops-stock-input { width:64px; text-align:center; font-size:12px; padding:2px 4px; border:1px solid #94a3b8; border-radius:4px; background:#fff; }
     .ds-ops-mgmt-screen .ds-ops-stock-save-btn { background:#0369a1; color:#fff; border:none; border-radius:4px; padding:2px 6px; cursor:pointer; font-size:11px; margin-inline-start:2px; }
     .ds-ops-mgmt-screen .ds-ops-stock-cancel-btn { background:#94a3b8; color:#fff; border:none; border-radius:4px; padding:2px 6px; cursor:pointer; font-size:11px; margin-inline-start:2px; }
@@ -928,7 +924,6 @@ function opsManagementStylesHtml() {
 
 let _schedulePrintContext = null;
 let _schoolsPrintContext = null;
-let _workshopsDistContext = null;
 
 function openOpsPrintWindow({ title = 'הדפסה', bodyHtml = '' } = {}) {
   const printWindow = window.open('', '_blank');
@@ -1148,216 +1143,6 @@ function printSchoolsSchedule() {
   setTimeout(() => printWindow.print(), 250);
 }
 
-async function saveWorkshopDistribution(stockGroupKey, instructorName, quantityReceived) {
-  if (!supabase) throw new Error('Supabase client is not configured');
-  const payload = {
-    stock_group_key: String(stockGroupKey || '').trim(),
-    instructor_name: String(instructorName || '').trim(),
-    quantity_received: quantityReceived !== null && Number.isFinite(Number(quantityReceived)) ? Number(quantityReceived) : null,
-    period_start: SUMMER_2026_FROM,
-    period_end: SUMMER_2026_TO,
-    updated_at: new Date().toISOString()
-  };
-  const { error } = await supabase.from('workshop_stock_distributions').upsert(payload, { onConflict: 'stock_group_key,instructor_name,period_start' });
-  if (error) throw error;
-}
-
-async function saveWorkshopDistributionWithNotes(stockGroupKey, instructorName, quantityReceived, notes = '') {
-  if (!supabase) throw new Error('Supabase client is not configured');
-  const payload = {
-    stock_group_key: String(stockGroupKey || '').trim(),
-    instructor_name: String(instructorName || '').trim(),
-    quantity_received: quantityReceived !== null && Number.isFinite(Number(quantityReceived)) ? Number(quantityReceived) : null,
-    period_start: SUMMER_2026_FROM,
-    period_end: SUMMER_2026_TO,
-    notes: String(notes || '').trim() || null,
-    updated_at: new Date().toISOString()
-  };
-  const { error } = await supabase.from('workshop_stock_distributions').upsert(payload, { onConflict: 'stock_group_key,instructor_name,period_start' });
-  if (error) throw error;
-}
-
-function openWorkshopDistModal(workshopName, rerender) {
-  const ctx = _workshopsDistContext;
-  if (!ctx) return;
-  const row = ctx.metrics.find((m) => m.workshopName === workshopName);
-  if (!row) return;
-
-  const instructorGroups = new Map();
-  (row.activities || []).forEach((activity) => {
-    const name = getActivityInstructorName(activity);
-    if (!name) return;
-    if (!instructorGroups.has(name)) instructorGroups.set(name, { name, count: 0 });
-    instructorGroups.get(name).count++;
-  });
-  const instructorList = Array.from(instructorGroups.values()).sort((a, b) => b.count - a.count);
-
-  const stockDisplay = row.stockQuantity !== null && row.stockQuantity !== undefined ? String(row.stockQuantity) : '—';
-
-  if (!document.getElementById('ds-ops-dist-modal-style')) {
-    const style = document.createElement('style');
-    style.id = 'ds-ops-dist-modal-style';
-    style.textContent = [
-      '.ds-dist-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:9000;display:flex;align-items:center;justify-content:center}',
-      '.ds-dist-modal{background:#fff;border-radius:12px;box-shadow:0 8px 32px rgba(0,0,0,.22);padding:20px 24px 16px;min-width:320px;max-width:560px;width:96vw;max-height:88vh;overflow-y:auto;direction:rtl;font-family:Assistant,Arial,sans-serif;font-size:13px;color:#111;position:relative}',
-      '.ds-dist-modal h3{margin:0 0 10px;font-size:15px;color:#0f172a;border-bottom:1px solid #e2e8f0;padding-bottom:8px;padding-left:28px}',
-      '.ds-dist-modal__info{font-size:12px;color:#475569;margin-bottom:8px}',
-      '.ds-dist-modal__summary{display:flex;gap:18px;background:#f1f5f9;border-radius:8px;padding:8px 12px;margin-bottom:12px;font-size:13px;flex-wrap:wrap}',
-      '.ds-dist-modal__summary b{color:#0f172a}',
-      '.ds-dist-modal__summary .ds-rem-shortage{color:#dc2626;font-weight:700}',
-      '.ds-dist-modal__summary .ds-rem-ok{color:#16a34a;font-weight:700}',
-      '.ds-dist-modal table{width:100%;border-collapse:collapse;font-size:12px}',
-      '.ds-dist-modal th,.ds-dist-modal td{border:1px solid #cbd5e1;padding:5px 7px;text-align:right}',
-      '.ds-dist-modal th{background:#dbeafe;color:#1e3a8a;font-weight:700}',
-      '.ds-dist-modal input[type=number]{width:68px;padding:3px 4px;border:1px solid #94a3b8;border-radius:4px;text-align:center;font-size:12px}',
-      '.ds-dist-modal input[type=text]{width:120px;padding:3px 4px;border:1px solid #94a3b8;border-radius:4px;font-size:12px}',
-      '.ds-dist-modal__footer{display:flex;gap:8px;justify-content:flex-start;margin-top:14px;border-top:1px solid #e2e8f0;padding-top:12px}',
-      '.ds-dist-modal__close-btn{position:absolute;top:14px;left:14px;background:none;border:none;font-size:18px;cursor:pointer;color:#64748b;line-height:1;padding:0 4px}',
-      '.ds-dist-modal__close-btn:hover{color:#111}'
-    ].join('');
-    document.head.appendChild(style);
-  }
-
-  const instrRowsHtml = instructorList.map((ig) => {
-    const dist = ctx.distributions.find((d) => d.stock_group_key === row.stockGroupKey && d.instructor_name === ig.name);
-    const qty = dist?.quantity_received !== null && dist?.quantity_received !== undefined ? String(dist.quantity_received) : '';
-    const notes = dist?.notes || '';
-    return `<tr>
-      <td>${escapeHtml(ig.name)}<small style="color:#94a3b8;margin-right:4px">(${ig.count} סדנאות)</small></td>
-      <td><input type="number" class="ds-dist-qty-input" data-instructor="${escapeHtml(ig.name)}" value="${escapeHtml(qty)}" min="0" placeholder="—"></td>
-      <td><input type="text" class="ds-dist-notes-input" data-instructor="${escapeHtml(ig.name)}" value="${escapeHtml(notes)}" placeholder="הערה..."></td>
-    </tr>`;
-  }).join('');
-
-  const calcUsage = () => {
-    let total = 0;
-    ctx.distributions.filter((d) => d.stock_group_key === row.stockGroupKey).forEach((d) => {
-      const v = Number(d.quantity_received);
-      if (Number.isFinite(v)) total += v;
-    });
-    return total;
-  };
-
-  const initUsage = calcUsage();
-  const initRemainder = row.stockQuantity !== null ? row.stockQuantity - initUsage : null;
-  const remClass = (v) => (v !== null && v < 0 ? 'ds-rem-shortage' : 'ds-rem-ok');
-
-  const overlay = document.createElement('div');
-  overlay.className = 'ds-dist-overlay';
-  overlay.innerHTML = `
-    <div class="ds-dist-modal">
-      <button type="button" class="ds-dist-modal__close-btn" title="סגור">✕</button>
-      <h3>עדכון שימוש מלאי לפי מדריכים</h3>
-      <div class="ds-dist-modal__info"><strong>${escapeHtml(row.workshopName)}</strong>${row.workshopNo ? ` · מס׳ ${escapeHtml(row.workshopNo)}` : ''}</div>
-      <div class="ds-dist-modal__summary">
-        <div>כמות מלאי: <b>${escapeHtml(stockDisplay)}</b></div>
-        <div>שימוש נוכחי: <b class="ds-dist-usage-sum">${initUsage}</b></div>
-        <div>יתרה: <b class="ds-dist-remainder ${remClass(initRemainder)}">${initRemainder !== null ? String(initRemainder) : '—'}</b></div>
-      </div>
-      <table>
-        <thead><tr><th>מדריך</th><th>כמות שחולקה</th><th>הערות</th></tr></thead>
-        <tbody>${instrRowsHtml || '<tr><td colspan="3" style="text-align:center;color:#94a3b8;padding:10px">לא נמצאו מדריכים בסדנאות אלה</td></tr>'}</tbody>
-      </table>
-      <div class="ds-dist-modal__footer">
-        <button type="button" class="ds-btn ds-btn--primary ds-dist-save-btn">שמירה</button>
-        <button type="button" class="ds-btn ds-dist-cancel-btn">ביטול</button>
-      </div>
-    </div>`;
-  document.body.appendChild(overlay);
-
-  function updateSummary() {
-    let total = 0;
-    overlay.querySelectorAll('.ds-dist-qty-input').forEach((inp) => {
-      const v = Number(inp.value);
-      if (Number.isFinite(v) && v >= 0) total += v;
-    });
-    overlay.querySelector('.ds-dist-usage-sum').textContent = String(total);
-    const rem = row.stockQuantity !== null ? row.stockQuantity - total : null;
-    const remEl = overlay.querySelector('.ds-dist-remainder');
-    remEl.textContent = rem !== null ? String(rem) : '—';
-    remEl.className = `ds-dist-remainder ${remClass(rem)}`;
-  }
-  overlay.querySelectorAll('.ds-dist-qty-input').forEach((inp) => inp.addEventListener('input', updateSummary));
-
-  function hasChanges() {
-    let changed = false;
-    overlay.querySelectorAll('.ds-dist-qty-input').forEach((inp) => {
-      const name = inp.getAttribute('data-instructor');
-      const dist = ctx.distributions.find((d) => d.stock_group_key === row.stockGroupKey && d.instructor_name === name);
-      const saved = dist?.quantity_received !== null && dist?.quantity_received !== undefined ? String(dist.quantity_received) : '';
-      if (inp.value !== saved) changed = true;
-    });
-    overlay.querySelectorAll('.ds-dist-notes-input').forEach((inp) => {
-      const name = inp.getAttribute('data-instructor');
-      const dist = ctx.distributions.find((d) => d.stock_group_key === row.stockGroupKey && d.instructor_name === name);
-      const saved = dist?.notes || '';
-      if (inp.value !== saved) changed = true;
-    });
-    return changed;
-  }
-
-  function closeModal() { overlay.remove(); }
-
-  function confirmClose() {
-    if (hasChanges() && !confirm('יש שינויים שלא נשמרו. לצאת בלי לשמור?')) return;
-    closeModal();
-  }
-
-  overlay.querySelector('.ds-dist-modal__close-btn').addEventListener('click', confirmClose);
-  overlay.querySelector('.ds-dist-cancel-btn').addEventListener('click', confirmClose);
-  overlay.addEventListener('click', (e) => { if (e.target === overlay) confirmClose(); });
-
-  const saveBtn = overlay.querySelector('.ds-dist-save-btn');
-  saveBtn.addEventListener('click', async () => {
-    saveBtn.disabled = true;
-    saveBtn.textContent = 'שומר...';
-    try {
-      const saves = [];
-      overlay.querySelectorAll('.ds-dist-qty-input').forEach((inp) => {
-        const instructorName = inp.getAttribute('data-instructor');
-        const notesInput = overlay.querySelector(`.ds-dist-notes-input[data-instructor="${CSS.escape(instructorName)}"]`);
-        const rawQty = inp.value.trim();
-        const qty = rawQty !== '' && Number.isFinite(Number(rawQty)) ? Number(rawQty) : null;
-        const notesVal = notesInput ? notesInput.value.trim() : '';
-        saves.push(
-          saveWorkshopDistributionWithNotes(row.stockGroupKey, instructorName, qty, notesVal).then(() => {
-            const idx = ctx.distributions.findIndex((d) => d.stock_group_key === row.stockGroupKey && d.instructor_name === instructorName);
-            const entry = { stock_group_key: row.stockGroupKey, instructor_name: instructorName, quantity_received: qty, notes: notesVal, period_start: SUMMER_2026_FROM };
-            if (idx >= 0) ctx.distributions[idx] = { ...ctx.distributions[idx], ...entry };
-            else ctx.distributions.push(entry);
-          })
-        );
-      });
-      await Promise.all(saves);
-      saveBtn.textContent = '✓ נשמר!';
-      setTimeout(() => { closeModal(); rerender?.(); }, 850);
-    } catch (err) {
-      console.error('[operations-management] Failed to save distributions:', err);
-      alert('שמירה נכשלה. יש לנסות שוב.');
-      saveBtn.disabled = false;
-      saveBtn.textContent = 'שמירה';
-    }
-  });
-}
-
-async function updateWorkshopStockGroup(stockGroupKey, stockQuantity) {
-  if (!supabase) throw new Error('Supabase client is not configured');
-  const cleanKey = String(stockGroupKey || '').trim();
-  const query = supabase
-    .from('lists')
-    .update({ stock_quantity: stockQuantity })
-    .eq('category', 'activity_names')
-    .eq('type', 'workshop')
-    .eq('activity_type', 'workshop');
-  if (cleanKey.startsWith('activity_')) {
-    query.eq('activity_no', cleanKey.replace(/^activity_/, ''));
-  } else {
-    query.eq('stock_group_key', cleanKey);
-  }
-  const { error } = await query;
-  if (error) throw error;
-}
-
 function instructorsTabHtml(rows, state, data = {}, directory = buildSchoolsDirectory([]), contactsIndex = new Map()) {
   const ops = ensureOpsState(state);
   const filters = ensureActivityListFilters(state, SCOPE);
@@ -1405,7 +1190,7 @@ function instructorsTabHtml(rows, state, data = {}, directory = buildSchoolsDire
   </section>`;
 }
 
-function workshopsTabHtml(rows, state, stockMap, catalogRows = [], distributions = []) {
+function workshopsTabHtml(rows, state, stockMap, catalogRows = []) {
   const ops = ensureOpsState(state);
   const allMetrics = sortByConfig(workshopMetricsRows(rows, stockMap, catalogRows), state, TAB_WORKSHOPS, {
     workshopNo: (row) => row.workshopNo || row.workshopName,
@@ -1419,7 +1204,7 @@ function workshopsTabHtml(rows, state, stockMap, catalogRows = [], distributions
   });
 
   const table = metrics.length
-    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table"><thead><tr>
+    ? dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"><thead><tr>
         ${sortableTh(state, TAB_WORKSHOPS, 'workshopNo', 'מס׳ / קבוצה')}
         ${sortableTh(state, TAB_WORKSHOPS, 'workshopName', 'שם פריט מלאי')}
         ${sortableTh(state, TAB_WORKSHOPS, 'activityCount', 'כמות סדנאות')}
@@ -1444,13 +1229,11 @@ function workshopsTabHtml(rows, state, stockMap, catalogRows = [], distributions
           <td>${row.activityCount}</td>
           <td>${requiredQuantity}</td>
           <td>${escapeHtml(stockDisplay)}</td>
-          <td class="ds-ops-usage-cell">${usageHtml}<button type="button" class="ds-ops-stock-edit-btn" data-ops-dist-edit="${escapeHtml(row.workshopName)}" title="ערוך חלוקת מלאי למדריכים">✎</button></td>
+          <td class="ds-ops-usage-cell">${usageHtml}</td>
           <td>${remainderHtml}</td>
         </tr>`;
       }).join('')}</tbody></table>`)
     : dsEmptyState('לא נמצאו סדנאות בתקופת הקיץ');
-
-  _workshopsDistContext = { metrics, distributions };
 
   return `<section class="ds-ops-mgmt-panel ds-ops-workshops-panel" dir="rtl">
     <div class="ds-ops-mgmt-panel__toolbar no-print">
@@ -1585,8 +1368,7 @@ function renderTab(rows, state, data, allPreparedRows = []) {
       activityMatchesPeriod(row, ACTIVITY_SEASON_SUMMER_2026) &&
       activityOverlapsDateRange(row, SUMMER_2026_FROM, SUMMER_2026_TO)
     );
-    const distributions = Array.isArray(data?.workshopDistributions) ? data.workshopDistributions : [];
-    return workshopsTabHtml(summerRows, state, stockMap, catalogRows, distributions);
+    return workshopsTabHtml(summerRows, state, stockMap, catalogRows);
   }
   return instructorsTabHtml(rows, state, data, directory, contactsIndex);
 }
@@ -1599,22 +1381,13 @@ export const operationsManagementScreen = {
       readOperationsSchoolsDirectory(),
       readContactsSchools()
     ]);
-    let workshopDistributions = [];
-    try {
-      const { data, error } = await supabase.from('workshop_stock_distributions').select('*');
-      if (error) throw error;
-      workshopDistributions = Array.isArray(data) ? data : [];
-    } catch (err) {
-      console.warn('[operations-management] Failed to load workshop_stock_distributions:', err);
-    }
     return {
       ...activities,
       schoolsDirectoryRows: schoolsDirectory.rows,
       schoolsDirectorySource: schoolsDirectory.source,
       workshopStockMap: buildWorkshopStockMapFromLists(lists),
       adminListsData: lists,
-      contactsSchoolsRows,
-      workshopDistributions
+      contactsSchoolsRows
     };
   },
   render(data, { state } = {}) {
@@ -1702,14 +1475,6 @@ export const operationsManagementScreen = {
     root.querySelector('[data-ops-print]')?.addEventListener('click', () => printInstructorSchedule());
     root.querySelector('[data-ops-print-workshops]')?.addEventListener('click', () => printWorkshopsFromDom(root));
     root.querySelector('[data-ops-print-schools]')?.addEventListener('click', () => printSchoolsSchedule());
-
-
-    root.querySelectorAll('[data-ops-dist-edit]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const name = btn.getAttribute('data-ops-dist-edit') || '';
-        openWorkshopDistModal(name, rerender);
-      });
-    });
 
     root.querySelectorAll('[data-ops-school]').forEach((btn) => {
       btn.addEventListener('click', () => {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 806;
+const CACHE_VERSION = 807;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 805;
+const CACHE_VERSION = 806;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 805;
+const SW_ENTRY_VERSION = 806;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 806;
+const SW_ENTRY_VERSION = 807;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -174,6 +174,8 @@ test('workshops tab shows inventory columns and print action', () => {
   assert.match(html, /יתרת מלאי/);
   assert.match(html, /הדפס כמויות סדנאות/);
   assert.match(html, /ds-ops-gap--ok/);
+  assert.doesNotMatch(html, /data-ops-dist-edit/);
+  assert.doesNotMatch(html, /ds-ops-stock-edit-btn/);
   assert.match(html, />50</);
   assert.match(html, />238</);
   assert.match(html, />62</);
@@ -197,11 +199,46 @@ test('workshops inventory remainder uses existing stock minus usage', () => {
     workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
     adminListsData
   }, { state });
-  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"'));
   assert.match(tableHtml, />2500<[^]*>194<[^]*>2306</);
   assert.match(tableHtml, />100<[^]*>100<[^]*><span class="ds-ops-gap ds-ops-gap--ok">0<\/span>/);
   assert.match(tableHtml, />390<[^]*>450<[^]*><span class="ds-ops-gap ds-ops-gap--shortage"><span dir="ltr">-60<\/span><\/span>/);
   assert.match(html, /ds-ops-workshops-table td:active \{ border:1px solid #94a3b8 !important;/);
+});
+
+test('workshops inventory usage is read-only and sums participants_count from activities', () => {
+  const state = baseState();
+  state.operationsManagement.tab = 'workshops';
+  const adminListsData = { categories: [{ category: 'activity_names', items: [
+    { value: '201', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '201', activity_name: 'סדנת סיכום', stock_quantity: 500 } }
+  ] }] };
+  const baseRows = [
+    { RowID: 'U-1', status: 'פתוח', activity_name: 'סדנת סיכום', start_date: '2026-07-10', activity_season: 'summer_2026', activity_type: 'workshop', participants_count: 80 },
+    { RowID: 'U-2', status: 'פתוח', activity_name: 'סדנת סיכום', start_date: '2026-07-11', activity_season: 'summer_2026', activity_type: 'workshop', participants_count: null },
+    { RowID: 'U-3', status: 'פתוח', activity_name: 'סדנת סיכום', start_date: '2026-07-12', activity_season: 'summer_2026', activity_type: 'workshop' }
+  ];
+  const html = operationsManagementScreen.render({
+    rows: baseRows,
+    workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
+    adminListsData
+  }, { state });
+  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  assert.match(tableHtml, />3</);
+  assert.match(tableHtml, />75</);
+  assert.match(tableHtml, />80</);
+  assert.match(tableHtml, />420</);
+  assert.doesNotMatch(tableHtml, /data-ops-dist-edit/);
+  assert.doesNotMatch(tableHtml, /ds-ops-stock-edit-btn/);
+  assert.doesNotMatch(tableHtml, /role="button"/);
+
+  const updatedHtml = operationsManagementScreen.render({
+    rows: baseRows.map((row) => row.RowID === 'U-3' ? { ...row, participants_count: 40 } : row),
+    workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
+    adminListsData
+  }, { state });
+  const updatedTableHtml = updatedHtml.slice(updatedHtml.indexOf('<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  assert.match(updatedTableHtml, />120</);
+  assert.match(updatedTableHtml, />380</);
 });
 
 
@@ -216,7 +253,7 @@ test('workshops inventory uses x25 required quantity and shows missing participa
     workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
     adminListsData
   }, { state });
-  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"'));
   assert.match(tableHtml, />25</);
   assert.match(tableHtml, />0</);
   assert.doesNotMatch(tableHtml, /לא עודכן/);
@@ -241,7 +278,7 @@ test('workshops inventory tab excludes courses and after-school catalog rows', (
     workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
     adminListsData
   }, { state });
-  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"'));
   assert.match(tableHtml, /סדנה אמיתית/);
   assert.doesNotMatch(tableHtml, /קורס רובוטיקה/);
   assert.doesNotMatch(tableHtml, /אפטר סקול מדעים/);
@@ -331,7 +368,7 @@ test('workshops inventory groups physical stock by stock_group_key', () => {
     workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
     adminListsData
   }, { state });
-  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"'));
   assert.equal((tableHtml.match(/data-ops-stock-group="magic_box"/g) || []).length, 1);
   assert.match(tableHtml, /024 - קופת קסם/);
   assert.match(tableHtml, /029 - קופת קסם/);

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -174,10 +174,34 @@ test('workshops tab shows inventory columns and print action', () => {
   assert.match(html, /יתרת מלאי/);
   assert.match(html, /הדפס כמויות סדנאות/);
   assert.match(html, /ds-ops-gap--ok/);
-  assert.match(html, />250</);
-  assert.match(html, />238</);
   assert.match(html, />50</);
+  assert.match(html, />238</);
+  assert.match(html, />62</);
   assert.match(html, />300</);
+});
+
+test('workshops inventory remainder uses existing stock minus usage', () => {
+  const state = baseState();
+  state.operationsManagement.tab = 'workshops';
+  const adminListsData = { categories: [{ category: 'activity_names', items: [
+    { value: '101', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '101', activity_name: 'סדנת חיובית', stock_quantity: 2500 } },
+    { value: '102', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '102', activity_name: 'סדנת אפס', stock_quantity: 100 } },
+    { value: '103', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '103', activity_name: 'סדנת חוסר', stock_quantity: 390 } }
+  ] }] };
+  const html = operationsManagementScreen.render({
+    rows: [
+      { RowID: 'P-1', status: 'פתוח', activity_name: 'סדנת חיובית', start_date: '2026-07-10', activity_season: 'summer_2026', activity_type: 'workshop', participants_count: 194 },
+      { RowID: 'Z-1', status: 'פתוח', activity_name: 'סדנת אפס', start_date: '2026-07-10', activity_season: 'summer_2026', activity_type: 'workshop', participants_count: 100 },
+      { RowID: 'N-1', status: 'פתוח', activity_name: 'סדנת חוסר', start_date: '2026-07-10', activity_season: 'summer_2026', activity_type: 'workshop', participants_count: 450 }
+    ],
+    workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
+    adminListsData
+  }, { state });
+  const tableHtml = html.slice(html.indexOf('<table class="ds-table ds-table--compact ds-table--interactive ds-ops-mgmt-data-table ds-ops-workshops-table"'));
+  assert.match(tableHtml, />2500<[^]*>194<[^]*>2306</);
+  assert.match(tableHtml, />100<[^]*>100<[^]*><span class="ds-ops-gap ds-ops-gap--ok">0<\/span>/);
+  assert.match(tableHtml, />390<[^]*>450<[^]*><span class="ds-ops-gap ds-ops-gap--shortage"><span dir="ltr">-60<\/span><\/span>/);
+  assert.match(html, /ds-ops-workshops-table td:active \{ border:1px solid #94a3b8 !important;/);
 });
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes **יתרת מלאי** in the operations management workshops inventory table (`מלאי סדנאות — קיץ 2026`) to calculate as `מלאי קיים - שימוש מלאי` instead of subtracting **כמות נדרשת**.
- Formats negative remainders with an LTR-wrapped minus sign (e.g. `-60`) for correct RTL display.
- Keeps workshop table cell borders visible on hover, focus, active, and click states.
- Bumps service worker cache version to **806** for GitHub Pages deployment.

## Example
| מלאי קיים | שימוש מלאי | יתרת מלאי (before) | יתרת מלאי (after) |
|---|---:|---:|---:|
| 2500 | 194 | 450 | **2306** |

## Changed files
- `frontend/src/screens/operations-management.js`
- `frontend/src/screens/operations-inventory-polish.js`
- `frontend/sw.js`
- `sw.js`
- `tests/operations-management-screen.test.mjs`

## Verification
- `npm run check:changed` — passed
- `npm run check:build` — passed
- `node --test tests/operations-management-screen.test.mjs` — focused inventory tests passed (tests 10–12); two pre-existing unrelated failures remain in tests 17–18
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfab9137-676f-43d8-a230-f59c4c9a9916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfab9137-676f-43d8-a230-f59c4c9a9916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

