### PR TITLE
Filter end-dates tab to courses and after-school only

### DIFF
--- a/frontend/src/screens/end-dates.js
+++ b/frontend/src/screens/end-dates.js
@@ -2,7 +2,14 @@ import { escapeHtml } from './shared/html.js';
 import { dsCard, dsScreenStack, dsEmptyState } from './shared/layout.js';
 import { formatDateHe } from './shared/format-date.js';
 import { triggerExcelDownload } from './shared/excel-export.js';
-import { activityManagerDisplayName } from './shared/activity-options.js';
+import { activityManagerDisplayName, normalizeActivityTypeKey } from './shared/activity-options.js';
+
+const END_DATES_ACTIVITY_TYPES = new Set(['course', 'after_school']);
+
+function isLongProgramActivity(row) {
+  const type = normalizeActivityTypeKey(row?.activity_type || row?.item_type || row?.type);
+  return END_DATES_ACTIVITY_TYPES.has(type);
+}
 
 function asIso(value) {
   const text = String(value || '').trim().slice(0, 10);
@@ -45,6 +52,7 @@ function normalizeRows(rows, managerFilter = '') {
   const today = localTodayIso();
   return rows
     .map((row) => {
+      if (!isLongProgramActivity(row)) return null;
       const endDate = asIso(row?.end_date) || asIso(row?.date_end);
       if (!endDate) return null;
       if (isClosedStatus(row?.status)) return null;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 807;
+const CACHE_VERSION = 808;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 807;
+const SW_ENTRY_VERSION = 808;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/end-dates-screen.test.mjs
+++ b/tests/end-dates-screen.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { endDatesScreen } = await import('../frontend/src/screens/end-dates.js');
+
+const futureEndDate = '2099-12-31';
+
+const rows = [
+  {
+    activity_name: 'קורס רובוטיקה',
+    activity_type: 'course',
+    school: 'בית ספר א',
+    authority: 'רשות א',
+    end_date: futureEndDate,
+    status: 'פעיל'
+  },
+  {
+    activity_name: 'חוג מייקרים',
+    activity_type: 'אפטרסקול',
+    school: 'בית ספר ב',
+    authority: 'רשות ב',
+    end_date: futureEndDate,
+    status: 'פעיל'
+  },
+  {
+    activity_name: 'סדנת מדע',
+    activity_type: 'workshop',
+    school: 'בית ספר ג',
+    authority: 'רשות ג',
+    end_date: futureEndDate,
+    status: 'פעיל'
+  },
+  {
+    activity_name: 'חדר בריחה',
+    activity_type: 'escape_room',
+    school: 'בית ספר ד',
+    authority: 'רשות ד',
+    end_date: futureEndDate,
+    status: 'פעיל'
+  },
+  {
+    activity_name: 'סיור חלל',
+    activity_type: 'tour',
+    school: 'בית ספר ה',
+    authority: 'רשות ה',
+    end_date: futureEndDate,
+    status: 'פעיל'
+  }
+];
+
+test('end-dates screen shows only courses and after-school programs', () => {
+  const html = endDatesScreen.render({ rows }, { state: {} });
+  assert.match(html, /קורס רובוטיקה/);
+  assert.match(html, /חוג מייקרים/);
+  assert.doesNotMatch(html, /סדנת מדע/);
+  assert.doesNotMatch(html, /חדר בריחה/);
+  assert.doesNotMatch(html, /סיור חלל/);
+});
+
+test('end-dates screen accepts Hebrew course type label', () => {
+  const html = endDatesScreen.render({
+    rows: [{
+      activity_name: 'קורס ביומימיקרי',
+      activity_type: 'קורסים',
+      school: 'בית ספר',
+      authority: 'רשות',
+      end_date: futureEndDate,
+      status: 'פעיל'
+    }]
+  }, { state: {} });
+  assert.match(html, /קורס ביומימיקרי/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restricts the **תאריכי סיום** tab to long programs only: **קורסים** (`course`) and **אפטרסקול** (`after_school`).
- Excludes workshops, escape rooms, tours, and other short/one-day activity types from display.
- Display-only change in `frontend/src/screens/end-dates.js`; no data or API mutations.
- Bumps Service Worker cache version to **808** for GitHub Pages deploy.

## Test plan
- [x] `node --check frontend/src/screens/end-dates.js`
- [x] `node --test tests/end-dates-screen.test.mjs` — courses and after-school appear; workshop/escape room/tour excluded
- [x] `node --test tests/service-worker-pwa-cache.test.mjs` — SW cache version aligned (808)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf679b63-069a-46b1-88f3-06929b2c69e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf679b63-069a-46b1-88f3-06929b2c69e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

