### PR TITLE
Fix workshop inventory catalog rows

### DIFF
--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -746,6 +746,10 @@ function activityMatchesOfficialWorkshop(activity = {}, workshop = {}) {
   return normalizeWorkshopKey(getActivityName(activity)) === normalizeWorkshopKey(workshop.workshopName);
 }
 
+function activityMatchesAnyOfficialWorkshop(activity = {}, catalogRows = []) {
+  return catalogRows.some((workshop) => activityMatchesOfficialWorkshop(activity, workshop));
+}
+
 function workshopMetricsRows(rows, stockMap, catalogRows = []) {
   const groups = new Map();
   catalogRows.forEach((catalog) => {
@@ -785,6 +789,9 @@ function workshopMetricsRows(rows, stockMap, catalogRows = []) {
     return {
       stockGroupKey: group.stockGroupKey,
       workshopNo: group.linkedWorkshops.map((workshop) => workshop.workshopNo).filter(Boolean).join(', '),
+      workshopNoDisplay: group.linkedWorkshops.length > 1
+        ? group.linkedWorkshops.map((workshop) => [workshop.workshopNo, workshop.workshopName].filter(Boolean).join(' - ')).filter(Boolean).join(', ')
+        : group.linkedWorkshops.map((workshop) => workshop.workshopNo).filter(Boolean).join(', '),
       workshopName: group.workshopName,
       linkedWorkshops: group.linkedWorkshops,
       activities: group.activities,
@@ -1198,10 +1205,7 @@ function workshopsTabHtml(rows, state, stockMap, catalogRows = []) {
     activityCount: (row) => row.activityCount,
     estimatedQuantity: (row) => row.estimatedQuantity,
   });
-  const metrics = allMetrics.filter((row) => {
-    const stock = row.stockQuantity !== null && row.stockQuantity !== undefined && Number.isFinite(Number(row.stockQuantity)) ? Number(row.stockQuantity) : 0;
-    return row.activityCount > 0 || stock > 0;
-  });
+  const metrics = allMetrics;
 
   const table = metrics.length
     ? dsTableWrap(`<table class="ds-table ds-table--compact ds-ops-mgmt-data-table ds-ops-workshops-table"><thead><tr>
@@ -1223,12 +1227,13 @@ function workshopsTabHtml(rows, state, stockMap, catalogRows = []) {
         const stockValue = Number.isFinite(Number(shownStock)) ? Number(shownStock) : 0;
         const usageValue = normalizeInventoryUsage(row.actualQuantity);
         const remainderHtml = formatInventoryRemainder(stockValue, usageValue);
-        return `<tr>
-          <td>${escapeHtml(row.workshopNo || '—')}</td>
+        const stockAttr = hasDefaultStock ? ` value="${escapeHtml(String(shownStock))}"` : '';
+        return `<tr data-ops-stock-group="${escapeHtml(row.stockGroupKey || '')}">
+          <td>${escapeHtml(row.workshopNoDisplay || row.workshopNo || '—')}</td>
           <td>${escapeHtml(row.workshopName)}</td>
           <td>${row.activityCount}</td>
           <td>${requiredQuantity}</td>
-          <td>${escapeHtml(stockDisplay)}</td>
+          <td><span${stockAttr}>${escapeHtml(stockDisplay)}</span></td>
           <td class="ds-ops-usage-cell">${usageHtml}</td>
           <td>${remainderHtml}</td>
         </tr>`;
@@ -1366,7 +1371,8 @@ function renderTab(rows, state, data, allPreparedRows = []) {
     const catalogRows = extractWorkshopCatalogRows(data?.adminListsData, allPreparedRows);
     const summerRows = allPreparedRows.filter((row) =>
       activityMatchesPeriod(row, ACTIVITY_SEASON_SUMMER_2026) &&
-      activityOverlapsDateRange(row, SUMMER_2026_FROM, SUMMER_2026_TO)
+      activityOverlapsDateRange(row, SUMMER_2026_FROM, SUMMER_2026_TO) &&
+      activityMatchesAnyOfficialWorkshop(row, catalogRows)
     );
     return workshopsTabHtml(summerRows, state, stockMap, catalogRows);
   }
@@ -1397,8 +1403,11 @@ export const operationsManagementScreen = {
     const baseRows = applyBaseFilters(prepared, state);
     const filteredRows = applyAllFilters(baseRows, state);
     const ops = ensureOpsState(state);
+    const filterRows = ops.tab === TAB_WORKSHOPS
+      ? baseRows.filter((row) => activityMatchesAnyOfficialWorkshop(row, extractWorkshopCatalogRows(data?.adminListsData, prepared)))
+      : baseRows;
     return `<div class="ds-screen-stack ds-ops-mgmt-screen">${opsManagementStylesHtml()}${dsPageHeader('ניהול תפעול')}
-      ${topFiltersHtml(baseRows, state)}
+      ${topFiltersHtml(filterRows, state)}
       ${tabsHtml(ops.tab)}
       <div class="ds-ops-mgmt-content">${renderTab(filteredRows, state, data, prepared)}</div>
       <p class="ds-muted ds-ops-mgmt-count no-print" dir="rtl">מציג ${filteredRows.length} פעילויות מתוך ${allRows.length}</p>

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -344,12 +344,15 @@ test('workshops inventory tab includes catalog workshops outside selected date r
   ];
   const adminListsData = { categories: [{ category: 'activity_names', items: [
     { value: '001', label: 'סדנת מאי', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '001', activity_name: 'סדנת מאי', stock_quantity: 50 } },
-    { value: '0042', label: 'סדנת קטלוג', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '0042', activity_name: 'סדנת קטלוג', stock_quantity: 75 } }
+    { value: '0042', label: 'סדנת קטלוג', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '0042', activity_name: 'סדנת קטלוג', stock_quantity: 75 } },
+    { value: '0043', label: 'סדנת קטלוג ללא מלאי', _row: { category: 'activity_names', type: 'workshop', activity_type: 'workshop', active: true, activity_no: '0043', activity_name: 'סדנת קטלוג ללא מלאי', stock_quantity: 0 } }
   ] }] };
   const html = operationsManagementScreen.render({ rows, workshopStockMap: buildWorkshopStockMapFromLists(adminListsData), adminListsData }, { state });
   assert.match(html, /סדנת מאי/);
   assert.match(html, /סדנת קטלוג/);
   assert.match(html, /0042/);
+  assert.match(html, /סדנת קטלוג ללא מלאי/);
+  assert.match(html, /0043/);
   assert.doesNotMatch(html, /סדנת יולי/);
 });
 


### PR DESCRIPTION
### Motivation
- The operations "ציוד ומלאי" / workshops inventory tab was excluding official catalog workshops that had no in-range activity, causing the card to show 0 even when catalog rows exist.
- The inventory view was matching activities too broadly and could include non-catalog activity names, leaking unrelated rows into the inventory list.
- The fix must not change the catalog page itself and should preserve grouping by shared physical stock keys.

### Description
- Added `activityMatchesAnyOfficialWorkshop` and limited the inventory/activity selection to only match against official catalog workshop rows when computing the workshops tab.
- Kept catalog rows visible in the inventory metrics by removing the earlier metrics filter so catalog entries are shown even without matching in-range activities, and added `workshopNoDisplay` for multi-linked workshop label formatting.
- Marked workshop rows with `data-ops-stock-group` and wrapped stock cell values in a span to preserve grouped stock metadata and display for shared `stock_group_key` entries.
- Updated tests to cover a catalog workshop with zero stock and ensure non-catalog activities do not appear in the inventory tab; changed files: `frontend/src/screens/operations-management.js` and `tests/operations-management-screen.test.mjs`.

### Testing
- Ran `node --check frontend/src/screens/operations-management.js` and `node --check tests/operations-management-screen.test.mjs` with no syntax errors; success.
- Ran the focused suite with `node --test tests/operations-management-screen.test.mjs` which completed with all tests passing (25/25); success.
- Ran `npm run check:changed` (focused checks) which completed successfully; success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36f901f6c4832b8da50961f10483e5)