### PR TITLE
Add "Other" option to proposal contact picker and manual-contact save flow

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'dashboard-performance-hotfix-20260620-v2'
+  HOTFIX_VERSION: 'dashboard-performance-hotfix-20260620-v3'
 };

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -736,14 +736,15 @@ function clientSearchHtml(_contactOptions, row = {}) {
 
 function contactPickerHtml(contactOptions, authority, school, selectedContactName, authorityId = null, schoolId = null) {
   const contacts = filterContactsForClient(contactOptions, { authorityId, schoolId });
-  if (contacts.length === 0) return '';
+  if (!authorityId || !schoolId) return '';
   const optionsHtml = ['<option value="">— בחרו איש קשר —</option>',
     ...contacts.map((c) => {
       const val = contactOptionKey(c);
       const contactName = text(c.contact_name);
       const label = c.contact_role ? `${contactName} (${text(c.contact_role)})` : contactName;
       return `<option value="${escapeHtml(val)}"${text(c.contact_name) === selectedContactName || val === selectedContactName ? ' selected' : ''}>${escapeHtml(label)}</option>`;
-    })
+    }),
+    '<option value="__pa_other_contact__">אחר</option>'
   ].join('');
   return `<label class="ds-pa-form-field"><span>איש קשר</span>
     <select class="ds-input ds-input--sm" data-pa-contact-select>${optionsHtml}</select>
@@ -2105,6 +2106,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
               <label class="ds-pa-form-field"><span>רשות</span><input type="text" class="ds-input ds-input--sm" data-pa-contact-ro-authority readonly tabindex="-1"></label>
               <label class="ds-pa-form-field"><span>בית ספר</span><input type="text" class="ds-input ds-input--sm" data-pa-contact-ro-school readonly tabindex="-1"></label>
             </div>
+            <input type="hidden" name="contact_selection_mode" value="">
             ${textField('contact_name', FIELD_LABELS.contact_name, row.contact_name, false)}
             ${textField('contact_role', FIELD_LABELS.contact_role, row.contact_role, false)}
             ${textField('phone', FIELD_LABELS.phone, row.phone, false)}
@@ -2329,6 +2331,7 @@ function payloadFromForm(form) {
   payload.authority_id = text(formData.get('contact_source_authority_id')) || null;
   payload.school_id = text(formData.get('contact_source_school_id')) || null;
   payload.client_type = text(formData.get('contact_source_client_type')) || (payload.school_id ? 'school' : 'authority');
+  payload._contact_selection_mode = text(formData.get('contact_selection_mode'));
   payload._contact_original = {
     id:           text(formData.get('contact_source_id')),
     client_type:  payload.client_type,
@@ -2361,7 +2364,11 @@ function validatePayload(payload, statusOverride) {
   if (!text(payload.school_id)) {
     errors.push('יש לבחור בית ספר מתוך רשימת בתי הספר של הרשות.');
   }
-  const hasManualContact = Boolean(text(payload.contact_name) || text(payload.phone) || text(payload.email));
+  const hasManualContact = Boolean(text(payload.contact_name) || text(payload.contact_role) || text(payload.phone) || text(payload.email));
+  const isOtherContact = text(payload._contact_selection_mode) === 'other';
+  if (isOtherContact && !text(payload.contact_name)) {
+    errors.push('יש להזין שם איש קשר חדש.');
+  }
   if (hasManualContact && !text(payload.contact_school_id)) {
     if (!text(payload.authority_id) || !text(payload.school_id)) {
       errors.push('ניתן להוסיף איש קשר רק לאחר בחירת רשות ובית ספר.');
@@ -2859,14 +2866,58 @@ export const proposalsAgreementsScreen = {
       if (host) host.innerHTML = contactSourceInputsHtml(contact || {});
     };
 
+    const setContactSelectionMode = (form, mode = '') => {
+      const input = form?.querySelector('input[name="contact_selection_mode"]');
+      if (input) input.value = mode;
+    };
+
+    const contactSourceFromForm = (form) => ({
+      id: '',
+      authority_id: text(form?.querySelector('input[name="contact_source_authority_id"]')?.value) || null,
+      school_id: text(form?.querySelector('input[name="contact_source_school_id"]')?.value) || null,
+      school_required: text(form?.querySelector('input[name="contact_source_school_required"]')?.value) || 'yes',
+      client_type: text(form?.querySelector('input[name="contact_source_client_type"]')?.value) || 'school',
+      client_name: text(form?.querySelector('input[name="contact_source_client_name"]')?.value),
+      authority: text(form?.querySelector('input[name="contact_source_authority"]')?.value),
+      school: text(form?.querySelector('input[name="contact_source_school"]')?.value),
+      contact_name: '',
+      contact_role: '',
+      phone: '',
+      mobile: '',
+      email: ''
+    });
+
+    const showManualContactFields = (form) => {
+      if (!form) return;
+      form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = false; });
+      const roCtx = form.querySelector('[data-pa-contact-ro-ctx]');
+      if (roCtx) roCtx.hidden = false;
+      setContactSelectionMode(form, 'other');
+      setContactSource(form, contactSourceFromForm(form));
+      fillContactFields(form, {});
+      form.querySelector('input[name="contact_name"]')?.focus();
+    };
+
     const setupContactPicker = (container, form) => {
       const contactSelect = container?.querySelector?.('[data-pa-contact-select]');
       if (!contactSelect) return;
       contactSelect.addEventListener('change', () => {
         const key = contactSelect.value;
+        if (key === '__pa_other_contact__') {
+          lockClientFields(
+            form,
+            text(form.querySelector('input[name="contact_source_authority"]')?.value),
+            text(form.querySelector('input[name="contact_source_school"]')?.value),
+            '', '', '', '',
+            text(form.querySelector('input[name="contact_source_client_name"]')?.value)
+          );
+          showManualContactFields(form);
+          return;
+        }
         if (!key) return;
         const contact = contactOptions.find((c) => contactOptionKey(c) === key);
         if (contact) {
+          setContactSelectionMode(form, '');
           fillContactFields(form, contact);
           setContactSource(form, contact);
           lockClientFields(form, text(contact.authority), text(contact.school), text(contact.contact_name), text(contact.contact_role), text(contact.phone || contact.mobile || ''), text(contact.email || ''), text(contact.client_name) || text(contact.school) || text(contact.authority));
@@ -4308,10 +4359,7 @@ export const proposalsAgreementsScreen = {
         if (!form) return;
         const addContactRow = form.querySelector('[data-pa-add-contact-row]');
         if (addContactRow) addContactRow.hidden = true;
-        form.querySelectorAll('[data-pa-contact-manual-fields]').forEach((el) => { el.hidden = false; });
-        const roCtx = form.querySelector('[data-pa-contact-ro-ctx]');
-        if (roCtx) roCtx.hidden = false;
-        form.querySelector('input[name="contact_name"]')?.focus();
+        showManualContactFields(form);
         return;
       }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 811;
+const CACHE_VERSION = 812;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 811;
+const SW_ENTRY_VERSION = 812;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Allow users to choose an explicit "אחר" (Other) contact when creating a new proposal and then enter a new contact inline. 
- Ensure the new contact is persisted and associated with the selected authority and school using the existing contact persistence flow, without changing other proposal flows or UI.

### Description
- Added an "אחר" option to the contact picker in the proposal form and wired a change handler to reveal manual contact inputs (name, role, phone, email) when selected; implemented in `frontend/src/screens/proposals-agreements.js` (`contactPickerHtml`, `setupContactPicker`, `showManualContactFields`, hidden `contact_selection_mode` input and payload wiring).
- Track the manual selection mode via a hidden `contact_selection_mode` form field and include it in the payload so validation can require a name when "Other" is chosen (`payloadFromForm` and `validatePayload`).
- Keep authority/school source metadata when showing manual fields so the existing server-side routine `ensure_contact_school_from_proposal` can create/find a `contacts_schools` record and return a `contact_school_id` to attach to the proposal (frontend uses the existing API in `frontend/src/api.js`).
- Bumped service-worker/cache and hotfix version: `frontend/sw.js` (`CACHE_VERSION`), `sw.js` (`SW_ENTRY_VERSION`), and `frontend/src/config.js` (`HOTFIX_VERSION`).

### Testing
- Ran `node --check frontend/src/screens/proposals-agreements.js`, `node --check frontend/src/config.js`, `node --check frontend/sw.js`, and `node --check sw.js` and they succeeded.
- Built the frontend with `npm run check:build` and the build succeeded.
- Ran the focused checks via `npm run check:changed` which runs the proposal screen tests; the manual-contact related test (`manual contact toggle appears when selected school has no contacts`) passed, but the test run included unrelated failing proposal-screen assertions (6 failing tests) that are pre-existing and not caused by this focused change.
- Service worker / cache versions updated in `frontend/sw.js` and `sw.js` and hotfix version updated in `frontend/src/config.js`.

Changed files
- `frontend/src/screens/proposals-agreements.js`
- `frontend/sw.js`
- `sw.js`
- `frontend/src/config.js`

Where "אחר" was added
- In the proposal contact picker UI rendered by `contactPickerHtml` in `frontend/src/screens/proposals-agreements.js`.

Where the new contact is saved
- Persistence uses the existing RPC/API path `ensure_contact_school_from_proposal` (server-side RPC) invoked by the frontend API flow and ultimately records/returns a `contact_school_id` for the proposal; the underlying contact record is stored/managed within the existing `contacts_schools` (contacts by school) source via the existing API (`frontend/src/api.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fb7a2634832b9abaab68f1ce5e6d)