### PR TITLE
Fix workshop inventory catalog source

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-HQOghq2Q.js"></script>
+  <script type="module" crossorigin src="./assets/index-CULty5ig.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DymUQe6d.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -91,7 +91,7 @@ const DASHBOARD_ACTIVITY_COLUMNS = [
 ].join(',');
 const DASHBOARD_ACTIVITY_MIN_COLUMNS = 'row_id,activity_family,activity_manager,activity_name,authority,school,instructor_name,instructor_name_2,emp_id,emp_id_2,start_date,end_date,status,activity_type';
 const SETTINGS_BOOTSTRAP_COLUMNS = 'key,value,description';
-const LISTS_BOOTSTRAP_COLUMNS = 'category,value,label,group,item_value,item_label,val,display,is_active,active,category_order,sort_order';
+const LISTS_BOOTSTRAP_COLUMNS = 'category,value,label,active,category_order,sort_order';
 let settingsRowsCache = null;
 let settingsRowsPromise = null;
 let listsRowsCache = null;
@@ -1064,13 +1064,13 @@ async function readListsFromSupabase() {
     const rows = Array.isArray(result.data) ? result.data : [];
     const catMap = new Map();
     for (const row of rows) {
-      const cat = String(row.category || row.group || '').trim();
+      const cat = String(row.category || '').trim();
       if (!cat) continue;
-      const value = String(row.value ?? row.item_value ?? row.val ?? '').trim();
-      const label = String(row.label ?? row.item_label ?? row.display ?? value).trim() || value;
+      const value = String(row.value ?? '').trim();
+      const label = String(row.label ?? value).trim() || value;
       if (!value) continue;
       if (!catMap.has(cat)) catMap.set(cat, []);
-      catMap.get(cat).push({ label, value, _row: row, is_active: row.is_active, active: row.active });
+      catMap.get(cat).push({ label, value, _row: row, active: row.active });
     }
     const categories = [...catMap.entries()].map(([category, items]) => ({ category, items }));
     listsRowsCache = { categories, _source: 'supabase' };

--- a/frontend/src/screens/operations-management.js
+++ b/frontend/src/screens/operations-management.js
@@ -657,9 +657,12 @@ function isWorkshopInventoryRequired(workshopName) {
 
 function isOfficialWorkshopListRow(row = {}, category = '') {
   const cat = String(category || row?.category || '').trim().toLowerCase();
+  if (cat !== 'activity_names') return false;
   const type = String(row?.type || '').trim().toLowerCase();
   const activityType = String(row?.activity_type || '').trim().toLowerCase();
-  return cat === 'activity_names' && type === 'workshop' && activityType === 'workshop';
+  if (type && type !== 'workshop') return false;
+  if (activityType && activityType !== 'workshop') return false;
+  return true;
 }
 
 function officialWorkshopStockGroupKey(row = {}) {
@@ -699,6 +702,26 @@ function formatInventoryRemainder(stockValue, usageValue) {
 function extractWorkshopCatalogRows(listsData, activityRows = []) {
   const rows = [];
   const seen = new Set();
+  const categories = Array.isArray(listsData?.categories) ? listsData.categories : [];
+  const activityNamesByKey = new Map();
+  const addNameMapping = (key, row = {}, item = {}) => {
+    const cleanKey = normalizeWorkshopKey(key);
+    if (!cleanKey || activityNamesByKey.has(cleanKey)) return;
+    activityNamesByKey.set(cleanKey, { row, item });
+  };
+  categories.forEach(({ category, items }) => {
+    const cat = String(category || '').trim().toLowerCase();
+    if (cat !== 'activity_names') return;
+    (Array.isArray(items) ? items : []).forEach((item) => {
+      const row = item?._row && typeof item._row === 'object' ? item._row : item;
+      if (!isOfficialWorkshopListRow(row, cat) || row?.active === false || !isTruthyListValue(row?.active)) return;
+      addNameMapping(row?.activity_name, row, item);
+      addNameMapping(row?.label, row, item);
+      addNameMapping(row?.value, row, item);
+      addNameMapping(item?.label, row, item);
+      addNameMapping(item?.value, row, item);
+    });
+  });
   const add = ({ no = '', name = '', stock = null, stockGroupKey = '', stockGroupName = '' } = {}) => {
     const cleanName = String(name || '').trim();
     if (!cleanName || !isWorkshopInventoryRequired(cleanName)) return;
@@ -713,22 +736,41 @@ function extractWorkshopCatalogRows(listsData, activityRows = []) {
       stockGroupName: String(stockGroupName || cleanName).trim()
     });
   };
-  (Array.isArray(listsData?.categories) ? listsData.categories : []).forEach(({ category, items }) => {
+  categories.forEach(({ category, items }) => {
     const cat = String(category || '').trim().toLowerCase();
     const list = Array.isArray(items) ? items : [];
-    if (cat !== 'activity_names') return;
+    if (cat !== 'workshop_stock') return;
     list.forEach((item) => {
       const row = item?._row && typeof item._row === 'object' ? item._row : item;
-      if (!isOfficialWorkshopListRow(row, cat) || !isTruthyListValue(row?.active)) return;
+      if (row?.active === false || !isTruthyListValue(row?.active)) return;
+      const name = String(row?.label || item?.label || row?.value || item?.value || '').trim();
+      const match = activityNamesByKey.get(normalizeWorkshopKey(name)) || activityNamesByKey.get(normalizeWorkshopKey(row?.value || item?.value));
       add({
-        no: row?.activity_no,
-        name: row?.activity_name,
+        no: match?.row?.activity_no || row?.value || item?.value,
+        name,
         stock: stockMapValue(row),
-        stockGroupKey: officialWorkshopStockGroupKey(row),
-        stockGroupName: officialWorkshopStockGroupName(row)
+        stockGroupKey: String(row?.value || item?.value || normalizeWorkshopKey(name)).trim(),
+        stockGroupName: name
       });
     });
   });
+  if (!rows.length) {
+    categories.forEach(({ category, items }) => {
+      const cat = String(category || '').trim().toLowerCase();
+      if (cat !== 'activity_names') return;
+      (Array.isArray(items) ? items : []).forEach((item) => {
+        const row = item?._row && typeof item._row === 'object' ? item._row : item;
+        if (!isOfficialWorkshopListRow(row, cat) || row?.active === false || !isTruthyListValue(row?.active)) return;
+        add({
+          no: row?.activity_no || row?.value || item?.value,
+          name: row?.activity_name || row?.label || item?.label || row?.value || item?.value,
+          stock: stockMapValue(row),
+          stockGroupKey: officialWorkshopStockGroupKey(row),
+          stockGroupName: officialWorkshopStockGroupName(row)
+        });
+      });
+    });
+  }
   return rows.sort((a, b) => compareValues(a.workshopNo || a.workshopName, b.workshopNo || b.workshopName, 'asc'));
 }
 

--- a/frontend/src/screens/shared/operations-activity-helpers.js
+++ b/frontend/src/screens/shared/operations-activity-helpers.js
@@ -167,16 +167,20 @@ export function parseStockQuantityFromRow(row = {}) {
   return null;
 }
 
-const ACTIVITY_NAME_LIST_CATEGORIES = new Set([
-  'activity_names'
+const WORKSHOP_STOCK_LIST_CATEGORIES = new Set([
+  'workshop_stock'
 ]);
 
-function isOfficialWorkshopListRow(row = {}, category = '') {
+function isActivityNameWorkshopListRow(row = {}, category = '') {
   const cat = String(category || row?.category || '').trim().toLowerCase();
+  if (cat !== 'activity_names') return false;
   const type = String(row?.type || '').trim().toLowerCase();
   const activityType = String(row?.activity_type || '').trim().toLowerCase();
-  return cat === 'activity_names' && type === 'workshop' && activityType === 'workshop';
+  if (type && type !== 'workshop') return false;
+  if (activityType && activityType !== 'workshop') return false;
+  return true;
 }
+
 
 function addStockToMap(map, names, stock) {
   if (stock === null) return;
@@ -188,18 +192,34 @@ function addStockToMap(map, names, stock) {
 export function buildWorkshopStockMapFromLists(listsData) {
   const map = new Map();
   const categories = Array.isArray(listsData?.categories) ? listsData.categories : [];
+  let sawWorkshopStock = false;
   categories.forEach(({ category, items }) => {
     const cat = String(category || '').trim().toLowerCase();
-    if (!ACTIVITY_NAME_LIST_CATEGORIES.has(cat)) return;
+    if (!WORKSHOP_STOCK_LIST_CATEGORIES.has(cat)) return;
+    sawWorkshopStock = true;
     const list = Array.isArray(items) ? items : [];
     list.forEach((item) => {
       const row = item?._row && typeof item._row === 'object' ? item._row : item;
-      if (!isOfficialWorkshopListRow(row, cat)) return;
+      if (row?.active === false) return;
       const stock = parseStockQuantityFromRow(row);
       if (stock === null) return;
-      addStockToMap(map, [row?.activity_name, row?.label_he, item?.label], stock);
+      addStockToMap(map, [row?.label, row?.value, item?.label, item?.value], stock);
     });
   });
+  if (!sawWorkshopStock) {
+    categories.forEach(({ category, items }) => {
+      const cat = String(category || '').trim().toLowerCase();
+      if (cat !== 'activity_names') return;
+      const list = Array.isArray(items) ? items : [];
+      list.forEach((item) => {
+        const row = item?._row && typeof item._row === 'object' ? item._row : item;
+        if (!isActivityNameWorkshopListRow(row, cat) || row?.active === false) return;
+        const stock = parseStockQuantityFromRow(row);
+        if (stock === null) return;
+        addStockToMap(map, [row?.activity_name, row?.label, row?.value, item?.label, item?.value], stock);
+      });
+    });
+  }
   return map;
 }
 

--- a/tests/operations-management-screen.test.mjs
+++ b/tests/operations-management-screen.test.mjs
@@ -333,6 +333,34 @@ test('authorities tab renders schools, dates and activities in fixed grouped ord
   assert.equal((groupedHtml.match(/פעילות ראשונה/g) || []).length, 1);
 });
 
+test('workshops inventory tab uses workshop_stock as inventory source without requiring matching activities', () => {
+  const state = baseState();
+  state.operationsManagement.tab = 'workshops';
+  state.operationsManagement.dateFrom = '2026-07-01';
+  state.operationsManagement.dateTo = '2026-07-31';
+  const adminListsData = { categories: [
+    { category: 'workshop_stock', items: [
+      { value: 'frog', label: 'פרוגי המקפצת', _row: { category: 'workshop_stock', value: 'frog', label: 'פרוגי המקפצת', active: true } },
+      { value: 'bird', label: 'ציפור שיווי משקל', _row: { category: 'workshop_stock', value: 'bird', label: 'ציפור שיווי משקל', active: true } },
+      { value: 'inactive', label: 'מלאי לא פעיל', _row: { category: 'workshop_stock', value: 'inactive', label: 'מלאי לא פעיל', active: false } }
+    ] },
+    { category: 'activity_names', items: [
+      { value: '001', label: 'פרוגי המקפצת', _row: { category: 'activity_names', value: '001', label: 'פרוגי המקפצת', active: true } }
+    ] }
+  ] };
+  const html = operationsManagementScreen.render({
+    rows: [
+      { RowID: 'FROG-1', status: 'פתוח', activity_name: 'פרוגי המקפצת', start_date: '2026-07-10', activity_season: 'summer_2026' }
+    ],
+    workshopStockMap: buildWorkshopStockMapFromLists(adminListsData),
+    adminListsData
+  }, { state });
+  assert.match(html, /מלאי סדנאות — קיץ 2026/);
+  assert.match(html, /פרוגי המקפצת/);
+  assert.match(html, /ציפור שיווי משקל/);
+  assert.doesNotMatch(html, /מלאי לא פעיל/);
+});
+
 test('workshops inventory tab includes catalog workshops outside selected date range', () => {
   const state = baseState();
   state.operationsManagement.tab = 'workshops';


### PR DESCRIPTION
### Motivation

- Resolve a bug where the Operations > Equipment & Stock screen showed "מלאי סדנאות — 0" due to failing `lists` parsing and overly-strict catalog filtering. 
- Ensure the UI reads real columns from `public.lists` and uses `workshop_stock` as the primary inventory source while preserving backward compatibility with `activity_names`.

### Description

- Restrict `LISTS_BOOTSTRAP_COLUMNS` to actual `public.lists` columns by setting it to `category,value,label,active,category_order,sort_order`, and stop selecting non-existent aliases such as `group,item_value,item_label,val,display,is_active` in `readListsFromSupabase`. (`frontend/src/api.js`)
- Change `extractWorkshopCatalogRows` so `workshop_stock` is used as the primary source of inventory items and `activity_names` is used only for name/value matching or as a fallback when `workshop_stock` is absent; do not require `type`/`activity_type` to exist. (`frontend/src/screens/operations-management.js`)
- Relax `isOfficialWorkshopListRow` checks so `type`/`activity_type` are optional and only act as filters when present (do not reject rows because those columns are missing). (`frontend/src/screens/operations-management.js`)
- Update `buildWorkshopStockMapFromLists` to prefer `workshop_stock` rows for building the stock map and fall back to `activity_names` only if no `workshop_stock` category is present; treat `active:false` rows as excluded. (`frontend/src/screens/shared/operations-activity-helpers.js`)
- Add a focused unit test that verifies `workshop_stock` items are listed even without matching activities and that `active:false` items are not shown. (`tests/operations-management-screen.test.mjs`)
- Rebuilt the frontend, updating `dist/index.html` to the new bundle; Service Worker files were not modified. (`dist/index.html`)
- Files changed: `frontend/src/api.js`, `frontend/src/screens/operations-management.js`, `frontend/src/screens/shared/operations-activity-helpers.js`, `tests/operations-management-screen.test.mjs`, and `dist/index.html`.

### Testing

- Ran `npm run check:changed`, which performed `node --check` on the modified files; the checks completed successfully.
- Ran `npm run check:build` (production `vite build` + postbuild); the build completed successfully and updated `dist/index.html` to the new bundle.
- Ran the focused unit tests with `node --test tests/operations-management-screen.test.mjs`; all tests passed (26/26).
- Verified service-worker cache/version alignment test passed and no manual SW/cache bump was required because `frontend/sw.js` and root `sw.js` were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fccf7200832bbd72cda066d5f27a)