### PR TITLE
Add stock-related columns to lists bootstrap data

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CULty5ig.js"></script>
+  <script type="module" crossorigin src="./assets/index-DsI6AWgp.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DymUQe6d.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -91,7 +91,7 @@ const DASHBOARD_ACTIVITY_COLUMNS = [
 ].join(',');
 const DASHBOARD_ACTIVITY_MIN_COLUMNS = 'row_id,activity_family,activity_manager,activity_name,authority,school,instructor_name,instructor_name_2,emp_id,emp_id_2,start_date,end_date,status,activity_type';
 const SETTINGS_BOOTSTRAP_COLUMNS = 'key,value,description';
-const LISTS_BOOTSTRAP_COLUMNS = 'category,value,label,active,category_order,sort_order';
+const LISTS_BOOTSTRAP_COLUMNS = 'category,value,label,active,category_order,sort_order,activity_no,activity_name,activity_type,type,stock_quantity,stock_group_key,stock_group_name';
 let settingsRowsCache = null;
 let settingsRowsPromise = null;
 let listsRowsCache = null;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 812;
+const CACHE_VERSION = 813;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 812;
+const SW_ENTRY_VERSION = 813;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
Extended the lists bootstrap columns configuration to include stock and activity-related fields, enabling the dashboard to access additional inventory and activity data from the backend.

## Key Changes
- **API Configuration**: Added 8 new columns to `LISTS_BOOTSTRAP_COLUMNS` in `frontend/src/api.js`:
  - Activity fields: `activity_no`, `activity_name`, `activity_type`
  - Stock fields: `type`, `stock_quantity`, `stock_group_key`, `stock_group_name`
  
- **Cache Invalidation**: Bumped service worker cache version from 812 to 813 in both `frontend/sw.js` and `sw.js` to ensure clients fetch the updated bootstrap data

## Implementation Details
The new columns extend the existing bootstrap list structure (which already included `category`, `value`, `label`, `active`, `category_order`, `sort_order`) to support stock management and activity tracking features. The cache version increment ensures all clients clear their cached bootstrap data and fetch the updated column set on next load.

https://claude.ai/code/session_01X8YCQtAaE21Ds7NDprUjjr