### PR TITLE
Bump dashboard performance hotfix version to v4

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'dashboard-performance-hotfix-20260620-v3'
+  HOTFIX_VERSION: 'dashboard-performance-hotfix-20260620-v4'
 };


### PR DESCRIPTION
## Summary
Updated the hotfix version identifier for dashboard performance improvements from v3 to v4.

## Changes
- Incremented `HOTFIX_VERSION` from `dashboard-performance-hotfix-20260620-v3` to `dashboard-performance-hotfix-20260620-v4` in the frontend configuration

## Details
This version bump allows the application to reference the latest iteration of the dashboard performance hotfix, ensuring users receive the most recent performance optimizations.

https://claude.ai/code/session_0117duYh9e9vrwwKScd9sfi8