### PR TITLE
Fix lists bootstrap columns and bump cache version

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-MNkrY_ZH.js"></script>
+  <script type="module" crossorigin src="./assets/index-BCFIA4ku.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-DymUQe6d.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -91,7 +91,7 @@ const DASHBOARD_ACTIVITY_COLUMNS = [
 ].join(',');
 const DASHBOARD_ACTIVITY_MIN_COLUMNS = 'row_id,activity_family,activity_manager,activity_name,authority,school,instructor_name,instructor_name_2,emp_id,emp_id_2,start_date,end_date,status,activity_type';
 const SETTINGS_BOOTSTRAP_COLUMNS = 'key,value,description';
-const LISTS_BOOTSTRAP_COLUMNS = 'category,value,label,active,category_order,sort_order,activity_no,activity_name,activity_type,type,stock_quantity,stock_group_key,stock_group_name';
+const LISTS_BOOTSTRAP_COLUMNS = 'category,value,label,active,category_order,sort_order,activity_no,activity_name,activity_type,type,stock_quantity,stock_group_key';
 let settingsRowsCache = null;
 let settingsRowsPromise = null;
 let listsRowsCache = null;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'dashboard-performance-hotfix-20260620-v4'
+  HOTFIX_VERSION: 'lists-bootstrap-fix-20260620-v5'
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 813;
+const CACHE_VERSION = 814;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 813;
+const SW_ENTRY_VERSION = 814;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
## Summary
This PR fixes an issue with the lists bootstrap columns configuration by removing an unnecessary column from the query, and bumps the cache version to ensure clients pick up the updated configuration.

## Key Changes
- **API Configuration**: Removed `stock_group_name` from `LISTS_BOOTSTRAP_COLUMNS` in `frontend/src/api.js`. This column was likely causing issues or is redundant given the presence of `stock_group_key`.
- **Version Bump**: Updated `HOTFIX_VERSION` in `frontend/src/config.js` from `dashboard-performance-hotfix-20260620-v4` to `lists-bootstrap-fix-20260620-v5` to reflect the fix.
- **Cache Invalidation**: Incremented `CACHE_VERSION` in both `frontend/sw.js` and `sw.js` from 813 to 814 to force clients to refresh cached assets and pick up the new configuration.
- **Build Output**: Updated the bundled JavaScript asset reference in `dist/index.html` to reflect the new build hash.

## Implementation Details
The removal of `stock_group_name` from the bootstrap columns suggests this field was either:
- Redundant with `stock_group_key`
- Causing performance issues in data loading
- Not being used by the frontend

The cache version bump ensures all clients will fetch the latest service worker and configuration, preventing stale data issues.

https://claude.ai/code/session_01UCWzH1DtfQw2ChNqYs9v8n