### PR TITLE
Fix contact matching to preserve saved proposal data over directory

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1891,7 +1891,9 @@ function contactMatchesProposalRow(contact = {}, row = {}) {
   const nameMatch = text(contact.contact_name) === text(row.contact_name);
   const emailMatch = text(contact.email) && text(contact.email) === text(row.email);
   const phoneMatch = text(contact.phone || contact.mobile || '') && text(contact.phone || contact.mobile || '') === text(row.phone);
-  return Boolean((emailMatch || phoneMatch || (authorityMatch && schoolMatch && nameMatch)) && (nameMatch || emailMatch || phoneMatch));
+  // Name must match; email/phone/authority+school provide additional confirmation.
+  // Never match solely by email or phone when names differ — prevents wrong-contact substitution.
+  return Boolean(nameMatch && (emailMatch || phoneMatch || (authorityMatch && schoolMatch)));
 }
 
 function findContactForProposalRow(contactOptions = [], row = {}) {
@@ -2051,7 +2053,9 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
   const initRole = text(row.contact_role);
   const initPhone = text(row.phone);
   const initEmail = text(row.email);
-  const initContactSource = findContactForProposalRow(contactOptions, row) || buildContactSourceFromRow(row);
+  // Prefer building from the saved row data — the chosen contact is source of truth.
+  // Only fall back to directory lookup when the row has no authority_id (very old rows).
+  const initContactSource = buildContactSourceFromRow(row) || findContactForProposalRow(contactOptions, row);
   const isLocked = !!initAuth;
   const initClientType = text(initContactSource?.client_type) || text(row.client_type) || 'school';
   const initAuthorityOnly = initClientType === 'authority';
@@ -2662,6 +2666,8 @@ export const proposalsAgreementsScreen = {
     });
     const rowWithCentralContact = (row) => {
       if (!row) return row;
+      // The contact saved on the proposal is the source of truth — never override it.
+      if (text(row.contact_name)) return row;
       const contact = findContactForProposalRow(contactOptions, row);
       if (!contact) return row;
       return {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 817;
+const CACHE_VERSION = 818;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 816;
+const SW_ENTRY_VERSION = 817;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2104,7 +2104,9 @@ test('proposal preview renders recipient block before title without empty commas
   });
 });
 
-test('proposal preview uses updated central contact details when reopening', async () => {
+test('proposal preview preserves saved contact details and does not override with directory data', async () => {
+  // The contact saved on the proposal is the source of truth.
+  // A matching contact with updated role in the directory must NOT override the saved role.
   const row = {
     ...sampleRows[0],
     contact_name: 'דנה קשר',
@@ -2134,8 +2136,11 @@ test('proposal preview uses updated central contact details when reopening', asy
     await delay(20);
 
     const address = dom.window.document.querySelector('.pa-doc-address');
-    assert.match(address.textContent, /דנה קשר, מנהלת מעודכנת/);
-    assert.doesNotMatch(address.textContent, /תפקיד ישן|undefined|null|NaN/);
+    // Saved contact name must appear
+    assert.match(address.textContent, /דנה קשר/);
+    // Saved role (not the directory's updated role) must appear
+    assert.match(address.textContent, /תפקיד ישן/);
+    assert.doesNotMatch(address.textContent, /מנהלת מעודכנת|undefined|null|NaN/);
   });
 });
 


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where contact information saved on proposals was being overridden by updated directory data. The changes ensure that saved contact details (particularly roles) are treated as the source of truth and are never replaced with directory information.

## Key Changes

- **Contact matching logic** (`contactMatchesProposalRow`): Reversed the priority so that name matching is required first, with email/phone/authority+school providing additional confirmation. This prevents matching contacts solely by email or phone when names differ, which could cause wrong-contact substitution.

- **Contact source initialization** (`initContactSource`): Changed the fallback order to prefer building contact data from the saved row first, only falling back to directory lookup for very old rows without `authority_id`.

- **Row contact enrichment** (`rowWithCentralContact`): Added an early return that skips directory lookup entirely if the row already has a saved `contact_name`, ensuring saved data is never overridden.

- **Test updates**: Updated test expectations to verify that saved contact roles are preserved and not replaced with updated directory roles.

- **Cache version bumps**: Incremented service worker cache versions (817 → 818 in `frontend/sw.js` and 816 → 817 in `sw.js`) to ensure clients pick up the updated logic.

## Notable Implementation Details

The fix addresses a subtle but important distinction: when a contact exists in both the proposal record and the directory, the proposal's saved data should always take precedence. This is critical for maintaining data integrity, especially for fields like contact role which may have been intentionally set differently from the directory at the time the proposal was created.

https://claude.ai/code/session_016twT8ADxiWZFKSu9aWo8HR