### PR TITLE
Fix proposal footer alignment and approved-only nav badge

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'proposals-ui-overhaul-20260620-v1'
+  HOTFIX_VERSION: 'proposals-footer-badge-fix-20260621-v1'
 };

--- a/frontend/src/screens/shared/proposals-pending-count.js
+++ b/frontend/src/screens/shared/proposals-pending-count.js
@@ -11,13 +11,7 @@ function normalizeProposalStatus(status) {
 
 export function isProposalApprovedPendingSend(row) {
   if (!row || typeof row !== 'object') return false;
-  const status = normalizeProposalStatus(row.status);
-  if (status === 'sent' || status === 'cancelled') return false;
-  if (status === 'approved') return true;
-  if (status === 'draft') {
-    return Boolean(row.approved_at) || Boolean(row.signature_meta?.signature?.image);
-  }
-  return false;
+  return normalizeProposalStatus(row.status) === 'approved';
 }
 
 export function countPendingApprovedProposals(rows) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16624,6 +16624,14 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   letter-spacing: 0;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
   border-radius: 0;
+  display: flex;
+  flex-direction: column;
+}
+.proposal-document.pa-document .proposal-document-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 .proposal-document.pa-document .proposal-document-content {
   max-width: none;
@@ -16767,14 +16775,12 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   page-break-inside: avoid;
 }
 .pa-footer-signature .pa-blessing {
-  display: block;
-  width: max-content;
-  max-width: 100%;
-  margin: 0 0 10px auto;
   font-size: 12.5px;
-  text-align: right;
+  margin-bottom: 10px;
+  text-align: center;
 }
 .pa-signer-block {
+  margin-top: 4.4em;
   display: inline-flex;
   flex-direction: column;
   align-items: stretch;
@@ -16806,12 +16812,12 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   margin: 0 0 6px;
 }
 .pa-page-footer {
-  margin-top: auto !important;
+  margin-top: auto;
   border-top: 1px solid #bbb;
-  padding: 8px 0 10px !important;
+  padding: 8px 0 10px;
   font-size: 10px;
   color: #666;
-  display: flex !important;
+  display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
@@ -16837,6 +16843,14 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     border-radius: 0 !important;
     font-size: 11.5px !important;
     line-height: 1.58 !important;
+    display: flex !important;
+    flex-direction: column !important;
+  }
+  .proposal-document.pa-document .proposal-document-body {
+    display: flex !important;
+    flex-direction: column !important;
+    flex: 1 1 auto !important;
+    padding: 0 !important;
   }
   .proposal-preview-area,
   .pa-preview-canvas { padding: 0 !important; }
@@ -16853,6 +16867,12 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
     position: relative !important;
     border-top: 1px solid #bbb !important;
     padding: 5px 0 7px !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 8px !important;
+    font-size: 10px !important;
+    color: #666 !important;
   }
   .pa-page-footer .pa-page-footer-logo { height: 18px !important; max-height: 18px !important; }
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 818;
+const CACHE_VERSION = 819;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 817;
+const SW_ENTRY_VERSION = 819;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -310,7 +310,7 @@ test('proposals-agreements route is registered and role-gated in route definitio
   assert.doesNotMatch(apiSource, /instructor: \[[^\]]*'proposals-agreements'/);
 });
 
-test('pending approved proposals nav count includes approved unsigned sent excludes sent and cancelled', () => {
+test('pending approved proposals nav count includes only approved status rows', () => {
   const approved = { id: '1', status: 'approved' };
   const signed = { id: '2', status: 'draft', approved_at: '2026-06-01T10:00:00Z' };
   const signatureOnly = { id: '3', status: 'draft', signature_meta: { signature: { image: 'proposals/signature-idan-nahum.png' } } };
@@ -318,15 +318,17 @@ test('pending approved proposals nav count includes approved unsigned sent exclu
   const pendingAlias = { id: '5', status: 'pending_approval', approved_at: '2026-06-01T10:00:00Z' };
   const cancelled = { id: '6', status: 'cancelled', approved_at: '2026-06-01T10:00:00Z' };
   const draft = { id: '7', status: 'draft' };
+  const returned = { id: '8', status: 'returned_for_changes', approved_at: '2026-06-01T10:00:00Z' };
 
   assert.equal(isProposalApprovedPendingSend(approved), true);
-  assert.equal(isProposalApprovedPendingSend(signed), true);
-  assert.equal(isProposalApprovedPendingSend(signatureOnly), true);
+  assert.equal(isProposalApprovedPendingSend(signed), false);
+  assert.equal(isProposalApprovedPendingSend(signatureOnly), false);
   assert.equal(isProposalApprovedPendingSend(sent), false);
   assert.equal(isProposalApprovedPendingSend(pendingAlias), false);
   assert.equal(isProposalApprovedPendingSend(cancelled), false);
   assert.equal(isProposalApprovedPendingSend(draft), false);
-  assert.equal(countPendingApprovedProposals([approved, signed, sent, draft, signatureOnly]), 3);
+  assert.equal(isProposalApprovedPendingSend(returned), false);
+  assert.equal(countPendingApprovedProposals([approved, signed, sent, draft, signatureOnly, returned]), 1);
 });
 
 test('sidebar proposals pending badge is wired in main shell nav', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two targeted fixes for the proposals screen:

1. **Footer and signature alignment** — Align `pa-document` footer/signature CSS with `frontend/public/proposals/Proposaleditor.html` (flex column page, `margin-top: auto` footer, reference spacing between "בברכה" and signer).
2. **Sidebar red badge** — Count only proposals whose normalized status is `approved`; ignore `approved_at`, `signature_meta`, and all other statuses.

## Changes

- `frontend/src/styles/main.css` — Footer flex layout for screen/print; signature spacing (`margin-top: 4.4em` on signer block, centered blessing).
- `frontend/src/screens/shared/proposals-pending-count.js` — `isProposalApprovedPendingSend()` returns true only when `normalizeProposalStatus(row.status) === 'approved'`.
- `tests/proposals-agreements-screen.test.mjs` — Updated badge-count test cases.
- SW/cache bump: `CACHE_VERSION` 819, `SW_ENTRY_VERSION` 819, `HOTFIX_VERSION` `proposals-footer-badge-fix-20260621-v1`.

## Verification

- `node --check frontend/src/screens/proposals-agreements.js` — pass
- `node --check frontend/src/screens/shared/proposals-pending-count.js` — pass
- `node --test tests/proposals-agreements-screen.test.mjs` — badge test pass; 17 unrelated legacy screen tests still fail in this environment
- `npm run check:build` — pass

## Deploy note

After deploy, users should hard-refresh (`Ctrl+Shift+R`) once so the new service worker/cache version loads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3debf5e3-2029-4ba7-804b-386b9e3cde8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3debf5e3-2029-4ba7-804b-386b9e3cde8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

