### PR TITLE
fix proposals contacts auth session handling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Yw_nuiml.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-DymUQe6d.css">
+  <script type="module" crossorigin src="./assets/index-Cjg9s1pX.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>
   <main id="app"></main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -941,8 +941,25 @@ function compareUnifiedContactRows(a, b) {
  *
  * ⚠️ permissions table is intentionally excluded — login credentials must never be read client-side.
  */
-async function readUnifiedContactsFromSupabase() {
+function isSupabasePermissionDeniedError(error) {
+  const haystack = [
+    error?.code,
+    error?.message,
+    error?.details,
+    error?.hint,
+    error?.name
+  ].map((value) => String(value || '').toLowerCase()).join(' ');
+  return haystack.includes('42501')
+    || haystack.includes('permission denied')
+    || haystack.includes('insufficient_privilege');
+}
+
+async function readUnifiedContactsFromSupabase({ requireAuth = false } = {}) {
   if (!supabase) return [];
+  if (requireAuth) {
+    const session = await waitForSupabaseAuthSession({ timeoutMs: 6000 });
+    if (!session?.user?.id) throw new Error('contacts_unified_view_requires_auth_session');
+  }
   try {
     const { data, error } = await supabase
       .from('contacts_unified_view')
@@ -954,6 +971,10 @@ async function readUnifiedContactsFromSupabase() {
     if (error) {
       // eslint-disable-next-line no-console
       console.warn('[supabase] Failed to load contacts_unified_view:', error);
+      if (requireAuth && isSupabasePermissionDeniedError(error)) {
+        throw new Error('contacts_unified_view_permission_denied');
+      }
+      if (requireAuth) throw new Error(error.message || 'contacts_unified_view_read_failed');
       return [];
     }
     return (Array.isArray(data) ? data : [])
@@ -962,6 +983,11 @@ async function readUnifiedContactsFromSupabase() {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.warn('[supabase] Unexpected contacts_unified_view fetch error:', error);
+    if (requireAuth) {
+      if (error?.message === 'contacts_unified_view_permission_denied') throw error;
+      if (isSupabasePermissionDeniedError(error)) throw new Error('contacts_unified_view_permission_denied');
+      throw error;
+    }
     return [];
   }
 }
@@ -2618,7 +2644,7 @@ async function readContactsSchoolsForProposals() {
   try {
     const [catalog, unifiedRows] = await Promise.all([
       readAuthoritySchoolCatalog(),
-      readUnifiedContactsFromSupabase()
+      readUnifiedContactsFromSupabase({ requireAuth: true })
     ]);
     const contactsResult = (Array.isArray(unifiedRows) ? unifiedRows : []).map((c) => {
       const authorityName = cleanProposalAgreementText(c.authority_name || c.authority || c.client_name);
@@ -2663,15 +2689,29 @@ async function readContactsSchoolsForProposals() {
       sample: contactsResult?.slice(0, 5)
     });
 
-    return buildProposalClientSearchOptions(contactsResult, catalog.authorityLookup, catalog.schoolLookup);
-  } catch {
-    return [];
+    return {
+      contactOptions: buildProposalClientSearchOptions(contactsResult, catalog.authorityLookup, catalog.schoolLookup),
+      contactOptionsError: null,
+      _debug: { contacts_count: contactsResult.length }
+    };
+  } catch (error) {
+    const message = cleanProposalAgreementText(error?.message) || 'contacts_load_error';
+    const contactOptionsError = message === 'contacts_unified_view_requires_auth_session' || message === 'contacts_unified_view_permission_denied'
+      ? message
+      : 'contacts_load_error';
+    // eslint-disable-next-line no-console
+    console.warn('[supabase] Failed to load proposal contact options:', error);
+    return {
+      contactOptions: [],
+      contactOptionsError,
+      _debug: { contacts_error: contactOptionsError }
+    };
   }
 }
 
 async function readProposalsAgreementsFromSupabase() {
   assertCanUseProposalsAgreementsApi();
-  const [paResult, contactOptions, rawProposalActivityPricing, proposalTemplateSections, proposalActivityGroups, proposalGroupAliases] = await Promise.all([
+  const [paResult, contactsResult, rawProposalActivityPricing, proposalTemplateSections, proposalActivityGroups, proposalGroupAliases] = await Promise.all([
     supabase
       .from('proposals_agreements_directory_view')
       .select(PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS)
@@ -2686,6 +2726,8 @@ async function readProposalsAgreementsFromSupabase() {
     readProposalGroupAliasesFromSupabase()
   ]);
   if (paResult.error) throw new Error(paResult.error.message || 'proposals_agreements_read_failed');
+  const contactOptions = Array.isArray(contactsResult?.contactOptions) ? contactsResult.contactOptions : [];
+  const contactOptionsError = contactsResult?.contactOptionsError || null;
   // Group/alias normalization happens here in the loader so the frontend receives
   // logical group keys (e.g. summer/next_year/combined) instead of legacy Hebrew labels.
   proposalGroupLookupCache = buildProposalGroupLookup(proposalActivityGroups, proposalGroupAliases);
@@ -2695,10 +2737,15 @@ async function readProposalsAgreementsFromSupabase() {
     rows: (Array.isArray(paResult.data) ? paResult.data : []).map(normalizeProposalAgreementRow),
     activityNameOptions,
     contactOptions,
+    contactOptionsError,
     proposalActivityGroups,
     proposalGroupAliases,
     proposalActivityPricing,
     proposalTemplateSections,
+    _debug: {
+      ...(contactsResult?._debug || {}),
+      ...(contactOptionsError ? { contacts_error: contactOptionsError } : {})
+    },
     _source: 'supabase'
   };
 }

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'proposals-footer-badge-fix-20260621-v1'
+  HOTFIX_VERSION: 'fix-proposals-contacts-auth-session-20260621-v1'
 };

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -745,6 +745,14 @@ function clientSearchHtml(_contactOptions, row = {}) {
   </div>`;
 }
 
+
+const CONTACT_OPTIONS_LOAD_ERROR_MESSAGE = 'לא ניתן לטעון אנשי קשר. יש לרענן את הדף או להתחבר מחדש. אם הבעיה נמשכת, יש לבדוק הרשאות Supabase.';
+
+function contactOptionsLoadErrorHtml(contactOptionsError) {
+  if (!text(contactOptionsError)) return '';
+  return `<div class="ds-pa-inline-alert ds-pa-inline-alert--warning" data-pa-contact-options-error role="alert" style="margin:8px 0;padding:8px 10px;border:1px solid #f59e0b;border-radius:10px;background:#fffbeb;color:#92400e;font-size:0.82rem;line-height:1.45">${escapeHtml(CONTACT_OPTIONS_LOAD_ERROR_MESSAGE)}</div>`;
+}
+
 function contactPickerHtml(contactOptions, authority, school, selectedContactName, authorityId = null, schoolId = null, authorityOnly = false) {
   const contacts = filterContactsForClient(contactOptions, { authorityId, schoolId, authorityOnly });
   if (!authorityId) return '';
@@ -2042,7 +2050,7 @@ function catalogAttachHtml(row = {}) {
   </div>`;
 }
 
-function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [], items = [], pricingOptions = [], state = null) {
+function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [], items = [], pricingOptions = [], state = null, contactOptionsError = '') {
   const title = mode === 'edit' ? 'עריכת הצעת מחיר' : 'יצירת הצעת מחיר';
   const normalizedActivityGroup = normalizeProposalGroup(row.activity_type_group);
   const filteredPricing = filterPricingByProposalType(pricingOptions, normalizedActivityGroup);
@@ -2105,6 +2113,7 @@ function formHtml(mode, row = {}, activityNameOptions = [], contactOptions = [],
       <h4 class="pa-sidebar-section-title">פרטי נמען</h4>
       <div data-pa-step-panel="client">
         <div class="ds-pa-client-search-block" data-pa-client-search-row${isLocked ? ' hidden' : ''}>
+          ${contactOptionsLoadErrorHtml(contactOptionsError)}
           ${clientSearchHtml(contactOptions, row)}
         </div>
         <div data-pa-client-card${isLocked ? '' : ' hidden'}>${isLocked ? clientLockedBannerHtml(initAuth, initSchool, initContact, initRole, initPhone, initEmail, initClientName) : ''}</div>
@@ -2656,6 +2665,7 @@ export const proposalsAgreementsScreen = {
     setProposalPricingLookup(proposalActivityPricing);
     const proposalTemplateSections = Array.isArray(data?.proposalTemplateSections) ? data.proposalTemplateSections : [];
     const contactOptions = Array.isArray(data?.contactOptions) ? data.contactOptions : [];
+    const contactOptionsError = text(data?.contactOptionsError || data?._debug?.contacts_error || '');
     // eslint-disable-next-line no-console
     console.info('[proposal-authorities-debug]', {
       totalContactOptions: contactOptions.length,
@@ -3394,7 +3404,7 @@ export const proposalsAgreementsScreen = {
         } catch { items = []; }
       }
       formHost.hidden = false;
-      formHost.innerHTML = formHtml(mode, row, activityNameOptions, contactOptions, items, proposalActivityPricing, state);
+      formHost.innerHTML = formHtml(mode, row, activityNameOptions, contactOptions, items, proposalActivityPricing, state, contactOptionsError);
       setupTypeChangeHandler(formHost);
       setupClientSelector(formHost);
       setupActivityPickers(formHost);

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 819;
+const CACHE_VERSION = 820;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 819;
+const SW_ENTRY_VERSION = 820;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1051,9 +1051,30 @@ test('proposals contact loader uses contacts_unified_view and not directory fall
   const apiSource = await readFile(API_FILE, 'utf8');
   const loaderBlock = apiSource.match(/async function readContactsSchoolsForProposals\(\) \{[\s\S]*?\n\}/);
   assert.ok(loaderBlock, 'readContactsSchoolsForProposals should exist');
-  assert.match(loaderBlock[0], /readUnifiedContactsFromSupabase\(\)/);
+  assert.match(loaderBlock[0], /readUnifiedContactsFromSupabase\(\{ requireAuth: true \}\)/);
   assert.doesNotMatch(loaderBlock[0], /contacts_directory_view/);
   assert.doesNotMatch(loaderBlock[0], /contacts_schools/);
+});
+
+
+
+test('proposals contact load error is shown in recipient/contact area', async () => {
+  await withJSDOM(
+    proposalsAgreementsScreen.render({ rows: [], contactOptions: [], contactOptionsError: 'contacts_unified_view_permission_denied' }, { state: stateFor('admin') }),
+    async (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: { rows: [], activityNameOptions: [], contactOptions: [], contactOptionsError: 'contacts_unified_view_permission_denied' },
+        state: stateFor('admin'),
+        api: {}
+      });
+      const form = openNewProposalForm(root, dom);
+      const sidebarText = form.querySelector('.pa-sidebar')?.textContent || '';
+      assert.match(sidebarText, /לא ניתן לטעון אנשי קשר/);
+      assert.match(sidebarText, /להתחבר מחדש/);
+      assert.ok(form.querySelector('[data-pa-contact-options-error]'), 'contact options error alert should be rendered');
+    }
+  );
 });
 
 test('school principal from schools source appears in proposal contact picker', async () => {


### PR DESCRIPTION
### Motivation
- Prevent proposal UI from silently showing empty contact lists when Supabase requests run as `anon` or before an auth session is restored.
- Surface clear errors for missing auth or permission-denied reads of `contacts_unified_view` instead of swallowing them and hiding the real cause from users.
- Keep proposal data (rows, pricing, templates, groups) loading even if contact loading fails, and show a user-facing message in the recipient/contact area.

### Description
- Update `readUnifiedContactsFromSupabase` to accept an options object `({ requireAuth = false } = {})`, wait for `waitForSupabaseAuthSession` (6000ms) when `requireAuth` is true, and throw `contacts_unified_view_requires_auth_session` for missing session.
- Detect Supabase permission errors and throw `contacts_unified_view_permission_denied` when appropriate instead of returning `[]` silently; helper `isSupabasePermissionDeniedError` added in `frontend/src/api.js`.
- Change `readContactsSchoolsForProposals` to call `readUnifiedContactsFromSupabase({ requireAuth: true })` and return an object `{ contactOptions, contactOptionsError, _debug }` so loaders can surface errors.
- Change `readProposalsAgreementsFromSupabase` to continue loading proposals/pricing/templates/groups even when contacts fail, and to include `contactOptionsError` and debug info in its returned payload.
- Render a clear Hebrew error alert in the proposals form recipient/contact area when `contactOptionsError` is present by wiring `contactOptionsError` into `formHtml` and adding `contactOptionsLoadErrorHtml` in `frontend/src/screens/proposals-agreements.js`.
- Add focused tests in `tests/proposals-agreements-screen.test.mjs` to assert `readContactsSchoolsForProposals` calls `readUnifiedContactsFromSupabase({ requireAuth: true })` and to verify the contact-load error message appears in the recipient/contact area.
- Bump service worker/cache versions (`frontend/sw.js`, `sw.js`) and update `HOTFIX_VERSION` in `frontend/src/config.js`; build output (`dist/index.html`) updated.

### Testing
- Syntax/type checks: `node --check frontend/src/api.js && node --check frontend/src/screens/proposals-agreements.js && node --check tests/proposals-agreements-screen.test.mjs && node --check frontend/src/config.js && node --check frontend/sw.js && node --check sw.js` succeeded.
- Focused unit/screen tests: `node --test --test-name-pattern "proposals contact loader uses|proposals contact load error|client selector fills school fields without auto-selecting contact" tests/proposals-agreements-screen.test.mjs` passed (new contact-auth and contact-load-error tests green).
- Frontend build: `npm run check:build` (vite build + postbuild) succeeded and produced updated `dist` assets.
- Broader `proposals-agreements` test suite still contains pre-existing/unrelated failures in this environment; only focused contact-related tests were added/verified and they pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a15f0bd8832ba349ebb536968c60)