### PR TITLE
fix activity add instructor identity binding

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-qIb9tOFM.js"></script>
+  <script type="module" crossorigin src="./assets/index-BazAf3nb.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Cjg9s1pX.js"></script>
+  <script type="module" crossorigin src="./assets/index-qIb9tOFM.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import { state, setSession, clearScreenDataCache } from './state.js';
 import { deletePersistedCacheByPrefixes } from './cache-persist.js';
 import { hebrewRole } from './screens/shared/ui-hebrew.js';
-import { cleanActivityManagerName, getRosterUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeOneDayActivityType, resolveActivityInstructorName, syncInstructorEmpFields, buildContactsInstructorLookup, resolveCanonicalInstructorPair } from './screens/shared/activity-options.js';
+import { cleanActivityManagerName, getContactsInstructorUsers, getRosterUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeOneDayActivityType, resolveActivityInstructorName, buildContactsInstructorLookup, resolveCanonicalInstructorPair, validateInstructorIdentityPayload } from './screens/shared/activity-options.js';
 import { EXCEPTION_TYPE_ORDER, normalizedExceptionTypes } from './screens/shared/exceptions-metrics.js';
 import { isSummerActivity, normalizeActivitySeason } from './screens/shared/summer-activity.js';
 import { supabase, supabaseConfig, waitForSupabaseAuthSession } from './supabase-client.js';
@@ -96,8 +96,8 @@ let settingsRowsCache = null;
 let settingsRowsPromise = null;
 let listsRowsCache = null;
 let listsRowsPromise = null;
-let instructorEmpIdsCache = null;
-let instructorEmpIdsPromise = null;
+let instructorContactsCache = null;
+let instructorContactsPromise = null;
 
 function clearBootstrapReadCaches() {
   settingsRowsCache = null;
@@ -106,20 +106,20 @@ function clearBootstrapReadCaches() {
   listsRowsPromise = null;
 }
 
-async function readInstructorEmpIdsFromSupabase() {
+async function readInstructorContactsRowsForBootstrap() {
   if (!supabase) return [];
-  if (instructorEmpIdsCache) return instructorEmpIdsCache;
-  if (instructorEmpIdsPromise) return instructorEmpIdsPromise;
-  instructorEmpIdsPromise = (async () => {
-    const { data, error } = await supabase.from('contacts_instructors').select('emp_id');
+  if (instructorContactsCache) return instructorContactsCache;
+  if (instructorContactsPromise) return instructorContactsPromise;
+  instructorContactsPromise = (async () => {
+    const { data, error } = await supabase.from('contacts_instructors').select('emp_id,full_name,name,active');
     if (error) {
-      console.warn('[supabase] contacts_instructors emp_id read failed:', error);
+      console.warn('[supabase] contacts_instructors read failed:', error);
       return [];
     }
-    instructorEmpIdsCache = Array.isArray(data) ? data : [];
-    return instructorEmpIdsCache;
-  })().finally(() => { instructorEmpIdsPromise = null; });
-  return instructorEmpIdsPromise;
+    instructorContactsCache = Array.isArray(data) ? data : [];
+    return instructorContactsCache;
+  })().finally(() => { instructorContactsPromise = null; });
+  return instructorContactsPromise;
 }
 /** Logs direct heavy reads for performance diagnostics. */
 const HEAVY_GUARDED_READ_ACTIONS = new Set([
@@ -1117,7 +1117,7 @@ async function readListsFromSupabase() {
  * activity-options.js and the add-activity form.
  * Handles many category name variants so the lists table can use any naming.
  */
-function buildClientSettingsFromLists(listsData, settingsRows = []) {
+function buildClientSettingsFromLists(listsData, settingsRows = [], instructorContactsRows = []) {
   const categories = Array.isArray(listsData?.categories) ? listsData.categories : [];
   const settingValue = (key) => {
     const row = (Array.isArray(settingsRows) ? settingsRows : []).find((item) => String(item?.key || '').trim() === key);
@@ -1160,6 +1160,10 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
     name:   normalizeHumanName(i.label || i.value),
     emp_id: String(i._row?.emp_id || i._row?.employee_id || '').trim()
   }));
+  const contactsInstructorUsers = (Array.isArray(instructorContactsRows) ? instructorContactsRows : []).map((row) => ({
+    name: normalizeHumanName(row?.full_name || row?.name),
+    emp_id: String(row?.emp_id || '').trim()
+  })).filter((user) => user.name && user.emp_id);
 
   const activityNames = activityNameItems.map((i) => ({
     label:         i.label || i.value,
@@ -1232,6 +1236,7 @@ function buildClientSettingsFromLists(listsData, settingsRows = []) {
       instructor_name:          instructorUsers.map((u) => u.name),
       instructor_names:         instructorUsers.map((u) => u.name),
       instructor_users:         instructorUsers,
+      contacts_instructor_users: contactsInstructorUsers,
       activity_names:           activityNames,
       activity_season:          activitySeasonItems.map((item) => ({
         value: normalizeActivitySeason(item.value),
@@ -3411,29 +3416,43 @@ function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true 
   return sanitized;
 }
 
-const INSTRUCTOR_SYNC_KEYS = [
-  'instructor_name',
-  'instructor_name_2',
-  'emp_id',
-  'emp_id_2'
-];
-
-function rosterFromClientSettings() {
-  return getRosterUsers(state?.clientSettings || {});
+async function validateActivityInstructorBindingsOrThrow(payload = {}) {
+  const contactsRows = await readInstructorContactsRowsForBootstrap();
+  const contactsUsers = contactsRows
+    .map((row) => ({ emp_id: String(row?.emp_id || '').trim(), name: normalizeHumanName(row?.full_name || row?.name) }))
+    .filter((user) => user.emp_id && user.name);
+  const result = validateInstructorIdentityPayload(payload, contactsUsers);
+  if (!result.valid) {
+    const err = new Error('activity_instructor_not_in_contacts');
+    err.code = result.errors[0]?.code || 'activity_instructor_not_in_contacts';
+    err.field = result.errors[0]?.field || '';
+    throw err;
+  }
 }
 
 function applyInstructorEmpSync(source = {}, { strict = true } = {}) {
+  void strict;
   const payload = { ...(source || {}) };
-  const hasInstructorFields = INSTRUCTOR_SYNC_KEYS.some((key) => Object.prototype.hasOwnProperty.call(payload, key));
-  if (!hasInstructorFields) return payload;
-  const { changes, errors } = syncInstructorEmpFields(payload, rosterFromClientSettings(), { strict });
-  if (errors.length) {
-    const err = new Error(String(errors[0]?.code || 'instructor_sync_failed'));
-    err.code = errors[0]?.code || 'instructor_sync_failed';
-    err.field = errors[0]?.field || '';
-    throw err;
+  const pairs = [
+    { nameKey: 'instructor_name', empKey: 'emp_id' },
+    { nameKey: 'instructor_name_2', empKey: 'emp_id_2' }
+  ];
+  for (const { nameKey, empKey } of pairs) {
+    if (!Object.prototype.hasOwnProperty.call(payload, nameKey)) continue;
+    const nameValue = normalizeHumanName(payload[nameKey]);
+    const empId = String(payload[empKey] || '').trim();
+    if (!nameValue) {
+      payload[empKey] = null;
+      continue;
+    }
+    if (!empId) {
+      const err = new Error('instructor_missing_emp_id');
+      err.code = 'instructor_missing_emp_id';
+      err.field = nameKey;
+      throw err;
+    }
   }
-  return changes;
+  return payload;
 }
 
 async function saveActivitySchoolsForActivity(activityRow = {}, source = {}) {
@@ -3455,6 +3474,7 @@ async function saveActivitySchoolsForActivity(activityRow = {}, source = {}) {
 
 async function upsertActivityToSupabase(payload = {}) {
   const act = applyInstructorEmpSync(payload?.activity || payload || {});
+  await validateActivityInstructorBindingsOrThrow(act);
   const row = sanitizeActivityPayloadForSupabase(synchronizeStartDateAndFirstMeeting(sanitizeActivityPayload(act)), { includeRowId: true });
   const rawSchoolIds = Array.isArray(act.school_ids) ? act.school_ids.map((id) => String(id || '').trim()).filter(Boolean) : [];
   if (rawSchoolIds.length > 1 && !act.school_id) row.school_id = null;
@@ -3495,6 +3515,13 @@ async function updateActivityInSupabase(payload = {}) {
   const sourceSheet = String(payload?.source_sheet || 'activities').trim() || 'activities';
   if (!rowId) throw new Error('missing_row_id');
   const rawChanges = applyInstructorEmpSync({ ...(payload?.changes || {}) });
+  const { data: existingInstructorRow, error: existingInstructorError } = await supabase
+    .from('activities')
+    .select('instructor_name,instructor_name_2,emp_id,emp_id_2')
+    .eq('row_id', rowId)
+    .maybeSingle();
+  if (existingInstructorError) throw buildSupabaseMutationError('saveActivity', existingInstructorError, 'save_failed');
+  await validateActivityInstructorBindingsOrThrow({ ...(existingInstructorRow || {}), ...rawChanges });
   let existingForNormalization = null;
   const needsExisting = Object.keys(rawChanges).some((key) => ['activity_type', 'item_type', 'activity_family', 'activity_name', 'start_date', 'end_date', 'date_1', 'status'].includes(key) || /^date_\d+$/.test(key));
   if (needsExisting) {
@@ -4049,10 +4076,11 @@ async function readCatalogProgramsFromSupabase() {
 }
 export const api = {
   login: async (user_id, entry_code) => {
-    const [{ userRow: user, profileRow }, listsData, settingsRows] = await Promise.all([
+    const [{ userRow: user, profileRow }, listsData, settingsRows, instructorContactsRows] = await Promise.all([
       loginWithSupabaseAuth(user_id, entry_code),
       readListsFromSupabase().catch(() => null),
-      readSettingsRowsFromSupabase().catch(() => [])
+      readSettingsRowsFromSupabase().catch(() => []),
+      readInstructorContactsRowsForBootstrap().catch(() => [])
     ]);
     const token = makeSessionToken(user);
     const flat = flattenUserRow(user);
@@ -4083,19 +4111,20 @@ export const api = {
         manage_proposals_agreements: permissionFlagYes(flat.manage_proposals_agreements) || undefined
       },
       ...buildBootstrapFromUser(user, profileRow),
-      client_settings: buildClientSettingsFromLists(listsData, settingsRows)
+      client_settings: buildClientSettingsFromLists(listsData, settingsRows, instructorContactsRows)
     };
   },
   bootstrap: async () => {
     await waitForSupabaseAuthSession();
-    const [{ userRow: user, profileRow }, listsData, settingsRows] = await Promise.all([
+    const [{ userRow: user, profileRow }, listsData, settingsRows, instructorContactsRows] = await Promise.all([
       readCurrentUserBySession(),
       readListsFromSupabase().catch(() => null),
-      readSettingsRowsFromSupabase().catch(() => [])
+      readSettingsRowsFromSupabase().catch(() => []),
+      readInstructorContactsRowsForBootstrap().catch(() => [])
     ]);
     return {
       ...buildBootstrapFromUser(user, profileRow),
-      client_settings: buildClientSettingsFromLists(listsData, settingsRows)
+      client_settings: buildClientSettingsFromLists(listsData, settingsRows, instructorContactsRows)
     };
   },
   dashboard: (filters) => api.dashboardReadModel(filters || {}),
@@ -4791,7 +4820,15 @@ export const api = {
     const rowId = String(requestPayload?.source_row_id || source_row_id || '').trim();
     const sourceSheet = String(requestPayload?.source_sheet || source_sheet || 'activities').trim() || 'activities';
     const rawChanges = requestPayload?.changes || changes || {};
-    const reducedChanges = Object.entries(applyInstructorEmpSync(rawChanges)).reduce((acc, [key, value]) => {
+    const syncedChanges = applyInstructorEmpSync(rawChanges);
+    const { data: existingInstructorRow, error: existingInstructorError } = await supabase
+      .from('activities')
+      .select('instructor_name,instructor_name_2,emp_id,emp_id_2')
+      .eq('row_id', rowId)
+      .maybeSingle();
+    if (existingInstructorError) throw buildSupabaseMutationError('submitEditRequest', existingInstructorError, 'submit_edit_request_failed');
+    await validateActivityInstructorBindingsOrThrow({ ...(existingInstructorRow || {}), ...syncedChanges });
+    const reducedChanges = Object.entries(syncedChanges).reduce((acc, [key, value]) => {
       if (value === undefined || value === null) return acc;
       const normalizedValue = String(value).trim();
       acc[key] = normalizedValue;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'fix-proposals-contacts-auth-session-20260621-v1'
+  HOTFIX_VERSION: 'fix-activity-add-instructor-identity-binding-20260621-v1'
 };

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -46,5 +46,5 @@ if (!resolvedUrl) {
 export const config = {
   apiUrl: resolvedUrl,
   DIAGNOSTICS_UI_ENABLED: false,
-  HOTFIX_VERSION: 'fix-activity-add-instructor-identity-binding-20260621-v1'
+  HOTFIX_VERSION: 'block-invalid-activity-instructor-emp-id-20260621-v1'
 };

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -26,6 +26,7 @@ import {
   getActivityCatalog,
   getActivityTypesByFamily,
   getRosterUsers,
+  getValidInstructorUsers,
   activityTypeDisplayLabel,
   activityTypeMatches,
   normalizeActivityTypeKey,
@@ -690,7 +691,7 @@ function instructorOptionsHtml(rosterUsers, selected = '', placeholder = '—') 
 function addActivityModalHtml(settings) {
   const allActivityNames = getActivityCatalog(settings);
   const allTypes = ADD_ACTIVITY_TYPE_ORDER.slice();
-  const rosterUsers = getRosterUsers(settings);
+  const rosterUsers = getValidInstructorUsers(settings);
   const managerRoleNames = getManagerUsers(settings);
   const fundingOptions = mergeOptions(settings, ['funding', 'fundings']);
   const gradeOptions = resolveGradeOptions(settings);
@@ -2486,7 +2487,7 @@ export const activitiesScreen = {
       const instructor1 = resolveInstructorSelectionByEmpId(selectedInstructorEmpId, roster);
       const instructor2 = resolveInstructorSelectionByEmpId(selectedInstructor2EmpId, roster);
       if (instructor1.error || instructor2.error) {
-        setAddActivityStatus(statusEl, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, { isError: true });
+        setAddActivityStatus(statusEl, instructor1.error === 'instructor_not_in_contacts' || instructor2.error === 'instructor_not_in_contacts' ? 'לא ניתן לשמור: המדריך שנבחר לא קיים בטבלת המדריכים. יש לעדכן את רשימת המדריכים.' : INSTRUCTOR_IDENTITY_ERROR_MESSAGE, { isError: true });
         resetAddActivitySavingState(form, submitBtn);
         return;
       }
@@ -2636,7 +2637,7 @@ export const activitiesScreen = {
       }
       const instructorPayloadGuard = validateInstructorIdentityPayload(payload, roster);
       if (!instructorPayloadGuard.valid) {
-        setAddActivityStatus(statusEl, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, { isError: true });
+        setAddActivityStatus(statusEl, 'לא ניתן לשמור: המדריך שנבחר לא קיים בטבלת המדריכים. יש לעדכן את רשימת המדריכים.', { isError: true });
         resetAddActivitySavingState(form, submitBtn);
         return;
       }

--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -34,9 +34,10 @@ import {
   getFilterOptionOverrides,
   cleanUnique,
   humanDisplayText,
-  instructorSyncErrorMessage,
+  INSTRUCTOR_IDENTITY_ERROR_MESSAGE,
   NO_ACTIVITY_MANAGER_LABEL,
-  resolveEmpIdForInstructorName,
+  resolveInstructorSelectionByEmpId,
+  validateInstructorIdentityPayload,
   resolveGradeOptions
 } from './shared/activity-options.js';
 import { readActivitiesGapFromQuery, syncActivitiesGapQuery, isActivitiesGapQueryValue } from './shared/route-query.js';
@@ -669,11 +670,27 @@ function datalistHtml(id, values) {
   return `<datalist id="${escapeHtml(id)}">${values.map((v) => `<option value="${escapeHtml(v)}">`).join('')}</datalist>`;
 }
 
+
+function instructorOptionsHtml(rosterUsers, selected = '', placeholder = '—') {
+  const safeSelected = String(selected || '').trim();
+  const valid = (Array.isArray(rosterUsers) ? rosterUsers : [])
+    .map((u) => ({ name: humanDisplayText(u?.name), emp_id: String(u?.emp_id || '').trim() }))
+    .filter((u) => u.name && u.emp_id);
+  const seen = new Set();
+  const unique = valid.filter((u) => {
+    if (seen.has(u.emp_id)) return false;
+    seen.add(u.emp_id);
+    return true;
+  });
+  return [`<option value="">${escapeHtml(placeholder)}</option>`]
+    .concat(unique.map((u) => `<option value="${escapeHtml(u.emp_id)}"${u.emp_id === safeSelected ? ' selected' : ''}>${escapeHtml(u.name)}</option>`))
+    .join('');
+}
+
 function addActivityModalHtml(settings) {
   const allActivityNames = getActivityCatalog(settings);
   const allTypes = ADD_ACTIVITY_TYPE_ORDER.slice();
   const rosterUsers = getRosterUsers(settings);
-  const rosterNames = rosterUsers.map((u) => u.name);
   const managerRoleNames = getManagerUsers(settings);
   const fundingOptions = mergeOptions(settings, ['funding', 'fundings']);
   const gradeOptions = resolveGradeOptions(settings);
@@ -683,7 +700,6 @@ function addActivityModalHtml(settings) {
   const managerOptions = managerRoleNames.length
     ? managerRoleNames
     : mergeOptions(settings, ['activity_manager', 'activity_managers']);
-  const instructorOptions = rosterNames.length ? rosterNames : mergeOptions(settings, ['instructor_name', 'instructor_names']);
   const initialType = '';
   const initialActivityNames = [];
   const sessionsList = Array.from({ length: 35 }, (_, i) => String(i + 1));
@@ -754,10 +770,8 @@ function addActivityModalHtml(settings) {
 
         <p class="ds-activity-add-section">צוות וניהול</p>
         <label class="ds-activity-add-field"><span>מנהל פעילות</span><select class="ds-input" name="activity_manager">${optionsHtml(managerOptions, '', NO_ACTIVITY_MANAGER_LABEL)}</select></label>
-        <label class="ds-activity-add-field"><span>מדריך/ה ראשי/ת</span><select class="ds-input" name="instructor_name" data-add-instructor>${optionsHtml(instructorOptions)}</select></label>
-        <input type="hidden" name="emp_id" value="">
-        <label class="ds-activity-add-field" data-field-instructor2><span>מדריך/ה נוסף/ת (אופציונלי)</span><select class="ds-input" name="instructor_name_2" data-add-instructor-2>${optionsHtml(instructorOptions)}</select></label>
-        <input type="hidden" name="emp_id_2" value="">
+        <label class="ds-activity-add-field"><span>מדריך/ה ראשי/ת</span><select class="ds-input" name="emp_id" data-add-instructor>${instructorOptionsHtml(rosterUsers)}</select></label>
+        <label class="ds-activity-add-field" data-field-instructor2><span>מדריך/ה נוסף/ת (אופציונלי)</span><select class="ds-input" name="emp_id_2" data-add-instructor-2>${instructorOptionsHtml(rosterUsers)}</select></label>
 
         <p class="ds-activity-add-section">הערות</p>
         <label class="ds-activity-add-field ds-activity-add-field--span2"><span>הערות</span><textarea class="ds-input" name="notes" rows="2"></textarea></label>
@@ -2467,16 +2481,23 @@ export const activitiesScreen = {
         resetAddActivitySavingState(form, submitBtn);
         return;
       }
-      const instructor1Name = humanDisplayText(get('instructor_name'));
-      const instructor2Name = humanDisplayText(get('instructor_name_2'));
-      const instructor1 = resolveEmpIdForInstructorName(instructor1Name, roster);
-      const instructor2 = resolveEmpIdForInstructorName(instructor2Name, roster);
-      for (const [name, result] of [[instructor1Name, instructor1], [instructor2Name, instructor2]]) {
-        if (!name || !result.error) continue;
-        setAddActivityStatus(statusEl, instructorSyncErrorMessage({ code: result.error }), { isError: true });
+      const selectedInstructorEmpId = get('emp_id');
+      const selectedInstructor2EmpId = get('emp_id_2');
+      const instructor1 = resolveInstructorSelectionByEmpId(selectedInstructorEmpId, roster);
+      const instructor2 = resolveInstructorSelectionByEmpId(selectedInstructor2EmpId, roster);
+      if (instructor1.error || instructor2.error) {
+        setAddActivityStatus(statusEl, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, { isError: true });
         resetAddActivitySavingState(form, submitBtn);
         return;
       }
+      const instructor1Name = instructor1.name;
+      const instructor2Name = instructor2.name;
+      console.info('[activity-add:instructor-selection]', {
+        selectedInstructorEmpId,
+        selectedInstructorName: instructor1Name,
+        selectedInstructor2EmpId,
+        selectedInstructor2Name: instructor2Name
+      });
       const sessionsValue = get('sessions') || '1';
       const isOneDay = isOneDayActivityTypeValue(get('activity_type'));
       const oneDayDate = String(get('one_day_date') || get('start_date') || get('end_date') || '').trim();
@@ -2610,6 +2631,12 @@ export const activitiesScreen = {
       }
       if (!String(payload.activity_no || '').trim()) {
         setAddActivityStatus(statusEl, 'לא ניתן לשמור: חסר מזהה פעילות מקור', { isError: true });
+        resetAddActivitySavingState(form, submitBtn);
+        return;
+      }
+      const instructorPayloadGuard = validateInstructorIdentityPayload(payload, roster);
+      if (!instructorPayloadGuard.valid) {
+        setAddActivityStatus(statusEl, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, { isError: true });
         resetAddActivitySavingState(form, submitBtn);
         return;
       }

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatDateHeWithWeekday, formatTimeShort, formatTimeRangeShort, formatActivityDateColumnsHe } from './format-date.js';
-import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, humanDisplayText, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName, resolveGradeOptions } from './activity-options.js';
+import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, getRosterUsers, humanDisplayText, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName, resolveGradeOptions } from './activity-options.js';
 import { ACTIVITY_SEASON_OPTIONS, activitySeasonLabel, normalizeActivitySeason } from './summer-activity.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
@@ -139,6 +139,23 @@ function normalizeActivityNameOptions(raw) {
     }
   });
   return out;
+}
+
+function instructorSelectHtml({ name, value, rosterUsers, klass = 'ds-input', placeholder = '—', attrs = '' }) {
+  const safeValue = String(value || '').trim();
+  const seen = new Set();
+  const opts = [`<option value="">${escapeHtml(placeholder)}</option>`]
+    .concat((Array.isArray(rosterUsers) ? rosterUsers : [])
+      .map((u) => ({ name: humanDisplayText(u?.name), emp_id: String(u?.emp_id || '').trim() }))
+      .filter((u) => u.name && u.emp_id)
+      .filter((u) => {
+        if (seen.has(u.emp_id)) return false;
+        seen.add(u.emp_id);
+        return true;
+      })
+      .map((u) => `<option value="${escapeHtml(u.emp_id)}"${u.emp_id === safeValue ? ' selected' : ''}>${escapeHtml(u.name)}</option>`))
+    .join('');
+  return `<select class="${escapeHtml(klass)}" name="${escapeHtml(name)}" ${attrs}>${opts}</select>`;
 }
 
 function selectHtml({ name, value, options, klass = 'ds-input', placeholder = '—', attrs = '' }) {
@@ -458,18 +475,22 @@ function blockAssignment(row, { settings = {} } = {}) {
 function blockTeamTimes(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
   const managers = getManagerUsers(settings || {});
-  const instructors = mergeListStrings(options, ['instructor_name', 'instructor_names']);
+  const rosterUsers = getRosterUsers(settings || {});
   const instructorLookup = buildInstructorLookup(settings);
   const instructor1Display = resolveActivityInstructorName(row) || resolveInstructorDisplayName(row.instructor_name, row.emp_id, instructorLookup);
   const instructor2Display = resolveActivityInstructorName(row, { secondary: true }) || resolveInstructorDisplayName(row.instructor_name_2, row.emp_id_2, instructorLookup);
+  const instructor1EmpId = String(row.emp_id || '').trim();
+  const instructor2EmpId = String(row.emp_id_2 || '').trim();
   const activityType = normalizeActivityTypeKey(row.activity_type || row.item_type);
   const twoInstructors = activityType === 'workshop' || activityType === 'escape_room';
   const instructorEditHtml = twoInstructors
     ? `<div class="activity-drawer__field-controls activity-drawer__field-controls--stacked">
-        ${selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors })}
-        ${selectHtml({ name: 'instructor_name_2', value: instructor2Display, options: instructors })}
+        <input type="hidden" name="instructor_name" value="${escapeHtml(instructor1Display)}">
+        <input type="hidden" name="instructor_name_2" value="${escapeHtml(instructor2Display)}">
+        ${instructorSelectHtml({ name: 'emp_id', value: instructor1EmpId, rosterUsers })}
+        ${instructorSelectHtml({ name: 'emp_id_2', value: instructor2EmpId, rosterUsers })}
       </div>`
-    : selectHtml({ name: 'instructor_name', value: instructor1Display, options: instructors });
+    : `<input type="hidden" name="instructor_name" value="${escapeHtml(instructor1Display)}">${instructorSelectHtml({ name: 'emp_id', value: instructor1EmpId, rosterUsers })}`;
 
   return `
     <section class="activity-drawer__section activity-drawer__section--edit-group" data-mode="edit" hidden>

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './html.js';
 import { formatDateHe, formatDateHeWithWeekday, formatTimeShort, formatTimeRangeShort, formatActivityDateColumnsHe } from './format-date.js';
-import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, getRosterUsers, humanDisplayText, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName, resolveGradeOptions } from './activity-options.js';
+import { activityManagerDisplayName, activityTypeDisplayLabel, activityTypeMatches, cleanActivityManagerName, getManagerUsers, getValidInstructorUsers, humanDisplayText, INVALID_ACTIVITY_INSTRUCTOR_STATUS, validateInstructorBinding, NO_ACTIVITY_MANAGER_LABEL, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveActivityInstructorName, resolveGradeOptions } from './activity-options.js';
 import { ACTIVITY_SEASON_OPTIONS, activitySeasonLabel, normalizeActivitySeason } from './summer-activity.js';
 
 const ONCE_TYPES = ['workshop', 'tour', 'escape_room'];
@@ -116,6 +116,12 @@ function resolveInstructorDisplayName(name, empId, lookup) {
   const emp = String(empId || '').trim();
   if (emp && lookup?.[emp]) return lookup[emp];
   return '';
+}
+
+function instructorViewDisplay(name, empId, contactsUsers) {
+  const result = validateInstructorBinding({ empId, instructorName: name }, contactsUsers);
+  if (!result.valid && (empId || name)) return INVALID_ACTIVITY_INSTRUCTOR_STATUS;
+  return result.name || name;
 }
 
 function normalizeActivityNameOptions(raw) {
@@ -475,22 +481,30 @@ function blockAssignment(row, { settings = {} } = {}) {
 function blockTeamTimes(row, { settings = {} } = {}) {
   const options = settings?.dropdown_options || {};
   const managers = getManagerUsers(settings || {});
-  const rosterUsers = getRosterUsers(settings || {});
+  const rosterUsers = getValidInstructorUsers(settings || {});
   const instructorLookup = buildInstructorLookup(settings);
+  const contactsUsers = getValidInstructorUsers(settings || {});
   const instructor1Display = resolveActivityInstructorName(row) || resolveInstructorDisplayName(row.instructor_name, row.emp_id, instructorLookup);
   const instructor2Display = resolveActivityInstructorName(row, { secondary: true }) || resolveInstructorDisplayName(row.instructor_name_2, row.emp_id_2, instructorLookup);
   const instructor1EmpId = String(row.emp_id || '').trim();
   const instructor2EmpId = String(row.emp_id_2 || '').trim();
   const activityType = normalizeActivityTypeKey(row.activity_type || row.item_type);
   const twoInstructors = activityType === 'workshop' || activityType === 'escape_room';
+  const instructorBindingWarning = [
+    validateInstructorBinding({ empId: instructor1EmpId, instructorName: instructor1Display }, rosterUsers),
+    validateInstructorBinding({ empId: instructor2EmpId, instructorName: instructor2Display }, rosterUsers)
+  ].some((result) => !result.valid)
+    ? '<p class="ds-error-text">בפעילות זו קיים שיוך למדריך שאינו קיים בטבלת המדריכים. יש לבחור מדריך מחדש.</p>'
+    : '';
   const instructorEditHtml = twoInstructors
     ? `<div class="activity-drawer__field-controls activity-drawer__field-controls--stacked">
         <input type="hidden" name="instructor_name" value="${escapeHtml(instructor1Display)}">
         <input type="hidden" name="instructor_name_2" value="${escapeHtml(instructor2Display)}">
         ${instructorSelectHtml({ name: 'emp_id', value: instructor1EmpId, rosterUsers })}
         ${instructorSelectHtml({ name: 'emp_id_2', value: instructor2EmpId, rosterUsers })}
+        ${instructorBindingWarning}
       </div>`
-    : `<input type="hidden" name="instructor_name" value="${escapeHtml(instructor1Display)}">${instructorSelectHtml({ name: 'emp_id', value: instructor1EmpId, rosterUsers })}`;
+    : `<input type="hidden" name="instructor_name" value="${escapeHtml(instructor1Display)}">${instructorSelectHtml({ name: 'emp_id', value: instructor1EmpId, rosterUsers })}${instructorBindingWarning}`;
 
   return `
     <section class="activity-drawer__section activity-drawer__section--edit-group" data-mode="edit" hidden>
@@ -536,8 +550,9 @@ function blockExtraEditInfo(row, { settings = {} } = {}) {
 
 function blockCentralInfo(row, { settings = {}, hideFunding = false } = {}) {
   const instructorLookup = buildInstructorLookup(settings);
-  const instructor1Display = resolveActivityInstructorName(row) || resolveInstructorDisplayName(row.instructor_name, row.emp_id, instructorLookup);
-  const instructor2Display = resolveActivityInstructorName(row, { secondary: true }) || resolveInstructorDisplayName(row.instructor_name_2, row.emp_id_2, instructorLookup);
+  const contactsUsers = getValidInstructorUsers(settings || {});
+  const instructor1Display = instructorViewDisplay(resolveActivityInstructorName(row) || resolveInstructorDisplayName(row.instructor_name, row.emp_id, instructorLookup), row.emp_id, contactsUsers);
+  const instructor2Display = instructorViewDisplay(resolveActivityInstructorName(row, { secondary: true }) || resolveInstructorDisplayName(row.instructor_name_2, row.emp_id_2, instructorLookup), row.emp_id_2, contactsUsers);
   const activityType = normalizeActivityTypeKey(row.activity_type || row.item_type);
   const twoInstructors = activityType === 'workshop' || activityType === 'escape_room';
   const gradeVal = String(row.grade || '').trim();

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -247,10 +247,62 @@ export function getRosterUsers(settings) {
     .map((user) => ({ name: humanDisplayText(user?.name), emp_id: text(user?.emp_id) }))
     .filter((user) => user.name)
     .filter((user) => {
-      if (seen.has(user.name)) return false;
-      seen.add(user.name);
+      const key = `${user.emp_id}::${user.name}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
       return true;
     });
+}
+
+export const INSTRUCTOR_IDENTITY_ERROR_MESSAGE = 'לא ניתן לשמור: שיוך המדריך אינו חד־משמעי. יש לבחור מדריך מתוך הרשימה.';
+
+function normalizeInstructorEmpId(value) {
+  return text(value);
+}
+
+export function findRosterInstructorByEmpId(empId, rosterUsers = []) {
+  const cleanEmpId = normalizeInstructorEmpId(empId);
+  if (!cleanEmpId) return null;
+  const matches = (Array.isArray(rosterUsers) ? rosterUsers : [])
+    .map((user) => ({ name: humanDisplayText(user?.name), emp_id: normalizeInstructorEmpId(user?.emp_id) }))
+    .filter((user) => user.emp_id === cleanEmpId && user.name);
+  if (matches.length !== 1) return null;
+  return matches[0];
+}
+
+export function resolveInstructorSelectionByEmpId(empId, rosterUsers = [], { optional = true } = {}) {
+  const cleanEmpId = normalizeInstructorEmpId(empId);
+  if (!cleanEmpId) {
+    return optional
+      ? { emp_id: null, name: '', error: null }
+      : { emp_id: null, name: '', error: 'instructor_missing_emp_id' };
+  }
+  const match = findRosterInstructorByEmpId(cleanEmpId, rosterUsers);
+  if (!match) return { emp_id: null, name: '', error: 'instructor_emp_id_not_in_roster' };
+  const sameNameEmpIds = new Set((Array.isArray(rosterUsers) ? rosterUsers : [])
+    .map((user) => ({ name: humanDisplayText(user?.name), emp_id: normalizeInstructorEmpId(user?.emp_id) }))
+    .filter((user) => user.name === match.name && user.emp_id)
+    .map((user) => user.emp_id));
+  if (sameNameEmpIds.size > 1) return { emp_id: null, name: '', error: 'instructor_name_ambiguous' };
+  return { emp_id: match.emp_id, name: match.name, error: null };
+}
+
+export function validateInstructorIdentityPayload(payload = {}, rosterUsers = []) {
+  const errors = [];
+  for (const { nameKey, empKey } of INSTRUCTOR_FIELD_PAIRS) {
+    const nameValue = humanDisplayText(payload?.[nameKey]);
+    const empId = normalizeInstructorEmpId(payload?.[empKey]);
+    if (nameValue && !empId) {
+      errors.push({ field: nameKey, code: 'instructor_missing_emp_id' });
+      continue;
+    }
+    if (!empId) continue;
+    const match = findRosterInstructorByEmpId(empId, rosterUsers);
+    if (!match || (nameValue && match.name !== nameValue)) {
+      errors.push({ field: nameKey, code: 'instructor_emp_mismatch' });
+    }
+  }
+  return { valid: !errors.length, errors };
 }
 
 function normalizeInstructorLookupName(value) {
@@ -292,7 +344,8 @@ export function instructorSyncErrorMessage(error = {}) {
     instructor_name_ambiguous: 'לא ניתן לשייך מדריך — יש יותר ממדריך אחד עם שם זה',
     instructor_name_not_in_roster: 'יש לבחור מדריך מתוך הרשימה',
     instructor_missing_emp_id: 'למדריך שנבחר אין מספר עובד — פנה למנהל המערכת',
-    instructor_emp_mismatch: 'שם המדריך ומספר העובד אינם תואמים'
+    instructor_emp_mismatch: 'שם המדריך ומספר העובד אינם תואמים',
+    instructor_emp_id_not_in_roster: INSTRUCTOR_IDENTITY_ERROR_MESSAGE
   };
   return messages[error.code] || 'שגיאה בשיוך המדריך';
 }

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -254,7 +254,32 @@ export function getRosterUsers(settings) {
     });
 }
 
+export function getContactsInstructorUsers(settings) {
+  const raw = Array.isArray(settings?.dropdown_options?.contacts_instructor_users)
+    ? settings.dropdown_options.contacts_instructor_users
+    : [];
+  const seen = new Set();
+  return raw
+    .map((user) => ({ name: humanDisplayText(user?.name || user?.full_name), emp_id: text(user?.emp_id) }))
+    .filter((user) => user.name && user.emp_id)
+    .filter((user) => {
+      if (seen.has(user.emp_id)) return false;
+      seen.add(user.emp_id);
+      return true;
+    });
+}
+
+export function getValidInstructorUsers(settings) {
+  const roster = getRosterUsers(settings);
+  const contacts = getContactsInstructorUsers(settings);
+  if (!contacts.length) return [];
+  const rosterEmpIds = new Set(roster.map((user) => text(user.emp_id)).filter(Boolean));
+  return contacts.filter((contact) => rosterEmpIds.has(contact.emp_id));
+}
+
 export const INSTRUCTOR_IDENTITY_ERROR_MESSAGE = 'לא ניתן לשמור: שיוך המדריך אינו חד־משמעי. יש לבחור מדריך מתוך הרשימה.';
+export const INSTRUCTOR_CONTACTS_MISSING_ERROR_MESSAGE = 'לא ניתן לשמור: המדריך שנבחר לא קיים בטבלת המדריכים. יש לעדכן את רשימת המדריכים.';
+export const INVALID_ACTIVITY_INSTRUCTOR_STATUS = 'מדריך לא תקף / לא קיים במערכת';
 
 function normalizeInstructorEmpId(value) {
   return text(value);
@@ -278,7 +303,7 @@ export function resolveInstructorSelectionByEmpId(empId, rosterUsers = [], { opt
       : { emp_id: null, name: '', error: 'instructor_missing_emp_id' };
   }
   const match = findRosterInstructorByEmpId(cleanEmpId, rosterUsers);
-  if (!match) return { emp_id: null, name: '', error: 'instructor_emp_id_not_in_roster' };
+  if (!match) return { emp_id: null, name: '', error: 'instructor_not_in_contacts' };
   const sameNameEmpIds = new Set((Array.isArray(rosterUsers) ? rosterUsers : [])
     .map((user) => ({ name: humanDisplayText(user?.name), emp_id: normalizeInstructorEmpId(user?.emp_id) }))
     .filter((user) => user.name === match.name && user.emp_id)
@@ -287,20 +312,26 @@ export function resolveInstructorSelectionByEmpId(empId, rosterUsers = [], { opt
   return { emp_id: match.emp_id, name: match.name, error: null };
 }
 
+export function validateInstructorBinding({ empId, instructorName } = {}, contactsUsers = []) {
+  const cleanEmpId = normalizeInstructorEmpId(empId);
+  const cleanName = humanDisplayText(instructorName);
+  if (!cleanEmpId && !cleanName) return { valid: true, emp_id: null, name: '', error: null };
+  if (!cleanEmpId) return { valid: false, emp_id: null, name: cleanName, error: 'instructor_missing_emp_id' };
+  const match = findRosterInstructorByEmpId(cleanEmpId, contactsUsers);
+  if (!match) return { valid: false, emp_id: cleanEmpId, name: cleanName, error: 'instructor_not_in_contacts' };
+  if (cleanName && cleanName !== match.name) {
+    return { valid: false, emp_id: cleanEmpId, name: match.name, error: 'instructor_emp_mismatch' };
+  }
+  return { valid: true, emp_id: match.emp_id, name: match.name, error: null };
+}
+
 export function validateInstructorIdentityPayload(payload = {}, rosterUsers = []) {
   const errors = [];
   for (const { nameKey, empKey } of INSTRUCTOR_FIELD_PAIRS) {
     const nameValue = humanDisplayText(payload?.[nameKey]);
     const empId = normalizeInstructorEmpId(payload?.[empKey]);
-    if (nameValue && !empId) {
-      errors.push({ field: nameKey, code: 'instructor_missing_emp_id' });
-      continue;
-    }
-    if (!empId) continue;
-    const match = findRosterInstructorByEmpId(empId, rosterUsers);
-    if (!match || (nameValue && match.name !== nameValue)) {
-      errors.push({ field: nameKey, code: 'instructor_emp_mismatch' });
-    }
+    const result = validateInstructorBinding({ empId, instructorName: nameValue }, rosterUsers);
+    if (!result.valid) errors.push({ field: nameKey, code: result.error });
   }
   return { valid: !errors.length, errors };
 }
@@ -345,7 +376,8 @@ export function instructorSyncErrorMessage(error = {}) {
     instructor_name_not_in_roster: 'יש לבחור מדריך מתוך הרשימה',
     instructor_missing_emp_id: 'למדריך שנבחר אין מספר עובד — פנה למנהל המערכת',
     instructor_emp_mismatch: 'שם המדריך ומספר העובד אינם תואמים',
-    instructor_emp_id_not_in_roster: INSTRUCTOR_IDENTITY_ERROR_MESSAGE
+    instructor_emp_id_not_in_roster: INSTRUCTOR_IDENTITY_ERROR_MESSAGE,
+    instructor_not_in_contacts: INSTRUCTOR_CONTACTS_MISSING_ERROR_MESSAGE
   };
   return messages[error.code] || 'שגיאה בשיוך המדריך';
 }

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -2,7 +2,7 @@ import { translateApiErrorForUser } from './ui-hebrew.js';
 import { showToast } from './toast.js';
 import { formatDateHe } from './format-date.js';
 import { escapeHtml } from './html.js';
-import { activityTypeMatches, getRosterUsers, humanDisplayText, instructorSyncErrorMessage, normalizeActivityTypeKey, normalizeOneDayActivityType, syncInstructorEmpFields } from './activity-options.js';
+import { activityTypeMatches, getRosterUsers, humanDisplayText, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveInstructorSelectionByEmpId, validateInstructorIdentityPayload } from './activity-options.js';
 import { state } from '../../state.js';
 
 function setEditMode(form, editing) {
@@ -370,15 +370,39 @@ export function bindActivityEditForm(contentRoot, {
     }
 
     const roster = getRosterUsers(state?.clientSettings || {});
-    const instructorSync = syncInstructorEmpFields(changes, roster, { strict: true });
-    if (instructorSync.errors.length) {
-      const firstError = instructorSync.errors[0];
-      const message = instructorSyncErrorMessage(firstError);
-      setStatus(statusEl, 'is-error', message);
-      showToast(message, 'error', 2600);
+    const selectedInstructorEmpId = Object.prototype.hasOwnProperty.call(changes, 'emp_id')
+      ? changes.emp_id
+      : String(form.querySelector('[name="emp_id"]')?.value ?? initialValues.emp_id ?? '').trim();
+    const selectedInstructor2EmpId = Object.prototype.hasOwnProperty.call(changes, 'emp_id_2')
+      ? changes.emp_id_2
+      : String(form.querySelector('[name="emp_id_2"]')?.value ?? initialValues.emp_id_2 ?? '').trim();
+    const instructor1 = resolveInstructorSelectionByEmpId(selectedInstructorEmpId, roster);
+    const instructor2 = resolveInstructorSelectionByEmpId(selectedInstructor2EmpId, roster);
+    if (instructor1.error || instructor2.error) {
+      setStatus(statusEl, 'is-error', INSTRUCTOR_IDENTITY_ERROR_MESSAGE);
+      showToast(INSTRUCTOR_IDENTITY_ERROR_MESSAGE, 'error', 2600);
       return;
     }
-    Object.assign(changes, instructorSync.changes);
+    if (Object.prototype.hasOwnProperty.call(changes, 'emp_id')) {
+      changes.instructor_name = instructor1.name;
+      changes.emp_id = instructor1.emp_id;
+    }
+    if (Object.prototype.hasOwnProperty.call(changes, 'emp_id_2')) {
+      changes.instructor_name_2 = instructor2.name;
+      changes.emp_id_2 = instructor2.emp_id;
+    }
+    const instructorGuardPayload = {
+      instructor_name: Object.prototype.hasOwnProperty.call(changes, 'instructor_name') ? changes.instructor_name : initialValues.instructor_name,
+      emp_id: Object.prototype.hasOwnProperty.call(changes, 'emp_id') ? changes.emp_id : initialValues.emp_id,
+      instructor_name_2: Object.prototype.hasOwnProperty.call(changes, 'instructor_name_2') ? changes.instructor_name_2 : initialValues.instructor_name_2,
+      emp_id_2: Object.prototype.hasOwnProperty.call(changes, 'emp_id_2') ? changes.emp_id_2 : initialValues.emp_id_2
+    };
+    const instructorGuard = validateInstructorIdentityPayload(instructorGuardPayload, roster);
+    if (!instructorGuard.valid) {
+      setStatus(statusEl, 'is-error', INSTRUCTOR_IDENTITY_ERROR_MESSAGE);
+      showToast(INSTRUCTOR_IDENTITY_ERROR_MESSAGE, 'error', 2600);
+      return;
+    }
 
     try {
       if (!Object.keys(changes).length) {

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -2,7 +2,7 @@ import { translateApiErrorForUser } from './ui-hebrew.js';
 import { showToast } from './toast.js';
 import { formatDateHe } from './format-date.js';
 import { escapeHtml } from './html.js';
-import { activityTypeMatches, getRosterUsers, humanDisplayText, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveInstructorSelectionByEmpId, validateInstructorIdentityPayload } from './activity-options.js';
+import { activityTypeMatches, getValidInstructorUsers, humanDisplayText, INSTRUCTOR_CONTACTS_MISSING_ERROR_MESSAGE, INSTRUCTOR_IDENTITY_ERROR_MESSAGE, normalizeActivityTypeKey, normalizeOneDayActivityType, resolveInstructorSelectionByEmpId, validateInstructorIdentityPayload } from './activity-options.js';
 import { state } from '../../state.js';
 
 function setEditMode(form, editing) {
@@ -369,7 +369,7 @@ export function bindActivityEditForm(contentRoot, {
       }
     }
 
-    const roster = getRosterUsers(state?.clientSettings || {});
+    const roster = getValidInstructorUsers(state?.clientSettings || {});
     const selectedInstructorEmpId = Object.prototype.hasOwnProperty.call(changes, 'emp_id')
       ? changes.emp_id
       : String(form.querySelector('[name="emp_id"]')?.value ?? initialValues.emp_id ?? '').trim();
@@ -379,8 +379,9 @@ export function bindActivityEditForm(contentRoot, {
     const instructor1 = resolveInstructorSelectionByEmpId(selectedInstructorEmpId, roster);
     const instructor2 = resolveInstructorSelectionByEmpId(selectedInstructor2EmpId, roster);
     if (instructor1.error || instructor2.error) {
-      setStatus(statusEl, 'is-error', INSTRUCTOR_IDENTITY_ERROR_MESSAGE);
-      showToast(INSTRUCTOR_IDENTITY_ERROR_MESSAGE, 'error', 2600);
+      const message = instructor1.error === 'instructor_not_in_contacts' || instructor2.error === 'instructor_not_in_contacts' ? INSTRUCTOR_CONTACTS_MISSING_ERROR_MESSAGE : INSTRUCTOR_IDENTITY_ERROR_MESSAGE;
+      setStatus(statusEl, 'is-error', message);
+      showToast(message, 'error', 2600);
       return;
     }
     if (Object.prototype.hasOwnProperty.call(changes, 'emp_id')) {
@@ -399,8 +400,8 @@ export function bindActivityEditForm(contentRoot, {
     };
     const instructorGuard = validateInstructorIdentityPayload(instructorGuardPayload, roster);
     if (!instructorGuard.valid) {
-      setStatus(statusEl, 'is-error', INSTRUCTOR_IDENTITY_ERROR_MESSAGE);
-      showToast(INSTRUCTOR_IDENTITY_ERROR_MESSAGE, 'error', 2600);
+      setStatus(statusEl, 'is-error', INSTRUCTOR_CONTACTS_MISSING_ERROR_MESSAGE);
+      showToast(INSTRUCTOR_CONTACTS_MISSING_ERROR_MESSAGE, 'error', 2600);
       return;
     }
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 820;
+const CACHE_VERSION = 821;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 821;
+const CACHE_VERSION = 822;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
 </head>
 <body>
   <main id="app"></main>
-  <script type="module" src="./frontend/src/dashboard-kpi-corrections.js?v=20260620-ops-mgmt-1"></script>
-  <script type="module" src="./frontend/src/main.js?v=20260620-ops-mgmt-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-summer-training-matrix.js?v=20260620-ops-mgmt-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-authorities-cleanup.js?v=20260620-ops-mgmt-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-visual-tweaks.js?v=20260620-ops-mgmt-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-inventory-polish.js?v=20260620-ops-mgmt-1"></script>
+  <script type="module" src="./frontend/src/dashboard-kpi-corrections.js?v=20260621-activity-instructor-identity-1"></script>
+  <script type="module" src="./frontend/src/main.js?v=20260621-activity-instructor-identity-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-summer-training-matrix.js?v=20260621-activity-instructor-identity-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-authorities-cleanup.js?v=20260621-activity-instructor-identity-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-visual-tweaks.js?v=20260621-activity-instructor-identity-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-inventory-polish.js?v=20260621-activity-instructor-identity-1"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
 </head>
 <body>
   <main id="app"></main>
-  <script type="module" src="./frontend/src/dashboard-kpi-corrections.js?v=20260621-activity-instructor-identity-1"></script>
-  <script type="module" src="./frontend/src/main.js?v=20260621-activity-instructor-identity-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-summer-training-matrix.js?v=20260621-activity-instructor-identity-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-authorities-cleanup.js?v=20260621-activity-instructor-identity-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-visual-tweaks.js?v=20260621-activity-instructor-identity-1"></script>
-  <script type="module" src="./frontend/src/screens/operations-inventory-polish.js?v=20260621-activity-instructor-identity-1"></script>
+  <script type="module" src="./frontend/src/dashboard-kpi-corrections.js?v=20260621-block-invalid-instructor-emp-1"></script>
+  <script type="module" src="./frontend/src/main.js?v=20260621-block-invalid-instructor-emp-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-summer-training-matrix.js?v=20260621-block-invalid-instructor-emp-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-authorities-cleanup.js?v=20260621-block-invalid-instructor-emp-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-visual-tweaks.js?v=20260621-block-invalid-instructor-emp-1"></script>
+  <script type="module" src="./frontend/src/screens/operations-inventory-polish.js?v=20260621-block-invalid-instructor-emp-1"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 820;
+const SW_ENTRY_VERSION = 821;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 821;
+const SW_ENTRY_VERSION = 822;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/activity-instructor-emp-sync.test.mjs
+++ b/tests/activity-instructor-emp-sync.test.mjs
@@ -114,7 +114,9 @@ test('validateActivityInstructors accepts fully consistent instructor pairs', ()
 
 import {
   resolveInstructorSelectionByEmpId,
-  validateInstructorIdentityPayload
+  validateInstructorIdentityPayload,
+  getValidInstructorUsers,
+  validateInstructorBinding
 } from '../frontend/src/screens/shared/activity-options.js';
 
 test('add activity instructor selection uses selected emp_id canonical name', () => {
@@ -158,4 +160,38 @@ test('activity save guard allows activity without optional instructor', () => {
   }, roster);
   assert.equal(result.valid, true);
   assert.deepEqual(result.errors, []);
+});
+
+
+test('activity with emp_id missing from contacts_instructors is blocked', () => {
+  const result = validateInstructorBinding({ empId: '1525', instructorName: 'אסאלה ברהום' }, contacts);
+  assert.equal(result.valid, false);
+  assert.equal(result.error, 'instructor_not_in_contacts');
+});
+
+test('valid instructor picker options exclude list entries missing from contacts_instructors', () => {
+  const settings = {
+    dropdown_options: {
+      instructor_users: [
+        { name: 'אלכס זפקה', emp_id: '1600' },
+        { name: 'אסאלה ברהום', emp_id: '1525' },
+        { name: 'ללא עובד', emp_id: '' }
+      ],
+      contacts_instructor_users: contacts.map((c) => ({ name: c.full_name, emp_id: c.emp_id }))
+    }
+  };
+  const result = getValidInstructorUsers(settings);
+  assert.deepEqual(result.map((user) => user.emp_id), ['1600']);
+});
+
+test('contacts validation does not fallback by instructor name', () => {
+  const result = validateInstructorBinding({ empId: '1525', instructorName: 'אלכס זפקה' }, contacts);
+  assert.equal(result.valid, false);
+  assert.equal(result.error, 'instructor_not_in_contacts');
+});
+
+test('contacts validation does not auto-select another instructor by name', () => {
+  const result = validateInstructorBinding({ empId: '9999', instructorName: 'הילה הזן' }, contacts);
+  assert.equal(result.valid, false);
+  assert.equal(result.error, 'instructor_not_in_contacts');
 });

--- a/tests/activity-instructor-emp-sync.test.mjs
+++ b/tests/activity-instructor-emp-sync.test.mjs
@@ -111,3 +111,51 @@ test('validateActivityInstructors accepts fully consistent instructor pairs', ()
   assert.equal(result.valid, true);
   assert.deepEqual(result.errors, []);
 });
+
+import {
+  resolveInstructorSelectionByEmpId,
+  validateInstructorIdentityPayload
+} from '../frontend/src/screens/shared/activity-options.js';
+
+test('add activity instructor selection uses selected emp_id canonical name', () => {
+  const result = resolveInstructorSelectionByEmpId('1500', roster);
+  assert.equal(result.error, null);
+  assert.equal(result.emp_id, '1500');
+  assert.equal(result.name, 'הילה הזן');
+});
+
+test('add activity blocks duplicate instructor names with different emp_id values', () => {
+  const result = resolveInstructorSelectionByEmpId('2000', [
+    { name: 'שם זהה', emp_id: '2000' },
+    { name: 'שם זהה', emp_id: '2001' }
+  ]);
+  assert.equal(result.error, 'instructor_name_ambiguous');
+  assert.equal(result.emp_id, null);
+});
+
+test('add activity blocks instructor roster entries without emp_id', () => {
+  const result = resolveInstructorSelectionByEmpId('', [
+    { name: 'מדריך ללא עובד', emp_id: '' }
+  ], { optional: false });
+  assert.equal(result.error, 'instructor_missing_emp_id');
+});
+
+test('activity save guard rejects mismatched instructor_name and emp_id', () => {
+  const result = validateInstructorIdentityPayload({
+    instructor_name: 'אלכס זפקה',
+    emp_id: '1500'
+  }, roster);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors[0].code, 'instructor_emp_mismatch');
+});
+
+test('activity save guard allows activity without optional instructor', () => {
+  const result = validateInstructorIdentityPayload({
+    instructor_name: '',
+    emp_id: '',
+    instructor_name_2: '',
+    emp_id_2: ''
+  }, roster);
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.errors, []);
+});


### PR DESCRIPTION
### Motivation
- Prevent incorrect instructor associations caused by relying on free-text names when adding or editing activities by binding selections to canonical `emp_id` values.
- Ensure payloads saved to the API contain unambiguous instructor identity (`emp_id`) and canonical instructor names derived from the roster.

### Description
- Change add-activity UI to render instructor selects whose `value` is the canonical `emp_id` and whose labels are the instructor names, excluding roster entries without `emp_id`, and removing free-text name selection. (changes in `frontend/src/screens/activities.js`).
- Add helper functions to `frontend/src/screens/shared/activity-options.js` (`findRosterInstructorByEmpId`, `resolveInstructorSelectionByEmpId`, `validateInstructorIdentityPayload`), an `INSTRUCTOR_IDENTITY_ERROR_MESSAGE` constant, and tighten roster deduplication to use `emp_id::name` keys.
- Update add/save flow to read `emp_id` from the selects, resolve the canonical name from the roster, include `emp_id` and canonical `instructor_name` (and secondary instructor fields) in the payload, and block save when `emp_id` is missing/ambiguous/mismatched; add the requested diagnostic log during save. (changes in `frontend/src/screens/activities.js`).
- Update edit form UI and save handler to expose `emp_id` selects (keep human name in hidden fields), ensure changes to instructor update `emp_id`, validate identity pairs before update, and block mismatches instead of auto-fixing by name. (changes in `frontend/src/screens/shared/activity-detail-html.js` and `frontend/src/screens/shared/bind-activity-edit-form.js`).
- Keep behavior limited to identity binding and validation only; no UI styling, permissions, or bulk data fixes were performed.

### Testing
- Focused unit tests: ran `node --test tests/activity-instructor-emp-sync.test.mjs`, which passed (all tests green).
- Focused checks: ran `npm run check:changed` (checked modified JS files) and `npm run check:build` (frontend build); both completed successfully and produced a `dist` build.
- SW/cache/version bumped: `frontend/sw.js` `CACHE_VERSION` and root `sw.js` `SW_ENTRY_VERSION` were incremented, and `frontend/src/config.js` `HOTFIX_VERSION` plus script query strings in `index.html` (and `dist/index.html`) were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37c0994a6c832b9e6eeedd2fe3b1ab)