### PR TITLE
Fix dashboard Supabase exception fallback and add Supabase diagnostics

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BazAf3nb.js"></script>
+  <script type="module" crossorigin src="./assets/index-C07r-7Lg.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -466,7 +466,11 @@ async function selectActivitiesByDateRangeFromSupabase({
   }
   const result = await query;
   if (result.error && fallbackSelect && isMissingSupabaseColumnError(result.error)) {
-    console.warn('[supabase][dashboard] activity column select failed; retrying minimal select', result.error);
+    logDashboardSupabaseReadError('[supabase][dashboard] activities select failed; retrying minimal select', result.error, {
+      table: 'public.activities',
+      columns: select,
+      operation: 'select.activities_by_date_range'
+    });
     return selectActivitiesByDateRangeFromSupabase({
       startDate,
       endDate,
@@ -476,7 +480,14 @@ async function selectActivitiesByDateRangeFromSupabase({
       overlapByStartEnd
     });
   }
-  if (result.error) throw new Error(result.error.message || 'activities_date_range_read_failed');
+  if (result.error) {
+    const diagnostic = logDashboardSupabaseReadError('[supabase][dashboard] activities read failed', result.error, {
+      table: 'public.activities',
+      columns: select,
+      operation: 'select.activities_by_date_range'
+    });
+    throw new Error(`activities_date_range_read_failed: ${diagnostic.message}`);
+  }
   return (Array.isArray(result.data) ? result.data : []).map(normalizeActivityRow);
 }
 
@@ -1575,6 +1586,36 @@ function isMissingSupabaseColumnError(error) {
   return msg.includes('column') || msg.includes('schema cache') || msg.includes('could not find');
 }
 
+
+function describeSupabaseReadError(error, context = {}) {
+  const table = context.table || 'unknown_table';
+  const columns = context.columns || context.select || '*';
+  const operation = context.operation || 'select';
+  const message = String(error?.message || error || 'supabase_read_failed');
+  const details = String(error?.details || '').trim();
+  const hint = String(error?.hint || '').trim();
+  const code = String(error?.code || '').trim();
+  return {
+    table,
+    columns,
+    operation,
+    code: code || null,
+    message,
+    details: details || null,
+    hint: hint || null,
+    permission_hint: /permission|policy|rls|not authorized|denied/i.test(`${message} ${details} ${hint}`),
+    missing_column_hint: isMissingSupabaseColumnError(error)
+  };
+}
+
+function logDashboardSupabaseReadError(label, error, context = {}) {
+  const diagnostic = describeSupabaseReadError(error, context);
+  try {
+    console.error(label || '[supabase][dashboard] read failed', diagnostic);
+  } catch { /* ignore */ }
+  return diagnostic;
+}
+
 function warnDashboardSupabasePathFailed(reason, extra = {}) {
   try {
     console.warn('[supabase][dashboard] path failed', { reason: String(reason || 'unknown'), ...extra });
@@ -1618,12 +1659,16 @@ async function dashboardReadModelFromSupabase(month) {
 
     const exceptionSummary = await readExceptionsFromSupabase({ month: monthPrefix, activityRows: allRangeRows });
     const exceptionError = exceptionSummary?.error || exceptionSummary?._debug?.error;
-    if (!exceptionSummary || exceptionError) {
-      warnDashboardSupabasePathFailed(exceptionError || 'exceptions_model_failed', { month: monthPrefix });
-      throw new Error('dashboard_exceptions_model_failed');
+    const exceptionsUnavailable = !exceptionSummary || !!exceptionError;
+    if (exceptionsUnavailable) {
+      warnDashboardSupabasePathFailed(exceptionError || 'exceptions_model_failed', {
+        month: monthPrefix,
+        path: 'readExceptionsFromSupabase',
+        impact: 'dashboard_continues_without_exceptions'
+      });
     }
-    const exceptionCounts = exceptionSummary.counts || {};
-    const exceptionsByDistrict = exceptionSummary.byDistrict || exceptionSummary.byManager || {};
+    const exceptionCounts = exceptionsUnavailable ? {} : (exceptionSummary.counts || {});
+    const exceptionsByDistrict = exceptionsUnavailable ? {} : (exceptionSummary.byDistrict || exceptionSummary.byManager || {});
 
     // Active (open-only) summary data
     const instructorIds = new Set();
@@ -1682,14 +1727,14 @@ async function dashboardReadModelFromSupabase(month) {
       delete stats._instructors;
       return stats;
     });
-    const exceptionsCount = Number(exceptionSummary.uniqueExceptionActivities || exceptionSummary.totalExceptionRows || 0);
+    const exceptionsCount = exceptionsUnavailable ? null : Number(exceptionSummary.uniqueExceptionActivities || exceptionSummary.totalExceptionRows || 0);
     const totals = {
       total_short_activities: allMonthRows.filter(isOneDayActivity).length,
       total_long_activities: allMonthRows.filter(isProgramActivity).length,
       total_activities: allMonthRows.length,
       total_instructors: instructorIds.size,
       total_course_endings_current_month: endingRows.length,
-      exceptions_count: exceptionsCount
+      exceptions_count: exceptionsUnavailable ? null : exceptionsCount
     };
     const summary = {
       active_type_counts: activeTypeCounts,
@@ -1703,17 +1748,18 @@ async function dashboardReadModelFromSupabase(month) {
       missing_date_count: Number(exceptionCounts.missing_start_date || 0),
       end_date_after_cutoff_count: Number(exceptionCounts.end_date_after_cutoff || 0),
       end_date_passed_count: Number(exceptionCounts.end_date_passed || 0),
-      operational_gaps_count: exceptionsCount,
-      operational_gaps_unique_count: Number(exceptionSummary.uniqueExceptionActivities || exceptionSummary.totalExceptionRows || 0),
-      operationalTotal: exceptionsCount,
-      exceptions_count: exceptionsCount,
-      totalExceptionRows: Number(exceptionSummary.totalExceptionRows || 0),
-      total_exception_rows: Number(exceptionSummary.totalExceptionRows || 0),
-      totalExceptionInstances: exceptionsCount,
-      counts: exceptionCounts
+      operational_gaps_count: exceptionsUnavailable ? null : exceptionsCount,
+      operational_gaps_unique_count: exceptionsUnavailable ? null : Number(exceptionSummary.uniqueExceptionActivities || exceptionSummary.totalExceptionRows || 0),
+      operationalTotal: exceptionsUnavailable ? null : exceptionsCount,
+      exceptions_count: exceptionsUnavailable ? null : exceptionsCount,
+      totalExceptionRows: exceptionsUnavailable ? null : Number(exceptionSummary.totalExceptionRows || 0),
+      total_exception_rows: exceptionsUnavailable ? null : Number(exceptionSummary.totalExceptionRows || 0),
+      totalExceptionInstances: exceptionsUnavailable ? null : exceptionsCount,
+      counts: exceptionCounts,
+      exceptions_unavailable: exceptionsUnavailable
     };
     // KPI cards use totalTypeCounts (all month rows including closed)
-    const kpi_cards = buildDashboardKpiCardsFromSupabase(totals, totalTypeCounts, exceptionsCount, instructorIds.size, endingRows.length);
+    const kpi_cards = buildDashboardKpiCardsFromSupabase(totals, totalTypeCounts, exceptionsUnavailable ? 'לא זמין' : exceptionsCount, instructorIds.size, endingRows.length);
     const noData = allMonthRows.length === 0;
     return {
       month: monthPrefix,
@@ -1723,7 +1769,8 @@ async function dashboardReadModelFromSupabase(month) {
       by_activity_manager,
       activeTypeCounts,
       totalTypeCounts,
-      exceptionCount: exceptionsCount,
+      exceptionCount: exceptionsUnavailable ? null : exceptionsCount,
+      exceptionsUnavailable,
       uniqueInstructorCount: instructorIds.size,
       courseEndings: endingRows.length,
       kpi_cards,
@@ -1733,7 +1780,12 @@ async function dashboardReadModelFromSupabase(month) {
       _source: 'supabase'
     };
   } catch (err) {
-    console.error('[supabase][dashboard] unexpected error:', err);
+    console.error('[supabase][dashboard] unexpected error:', {
+      message: String(err?.message || err),
+      month,
+      required_activity_columns: DASHBOARD_ACTIVITY_COLUMNS,
+      source_tables: ['public.activities', 'public.contacts_instructors', 'public.settings']
+    });
     return emptyDashboardPayload(month, { error: String(err?.message || err) });
   }
 }
@@ -1960,6 +2012,27 @@ function buildExceptionsFromRows(activityRows = [], month = '') {
   return buildExceptionsModelFromRows(activityRows, month, { include_rows: true }).rows;
 }
 
+
+async function readInstructorEmpIdsFromSupabase() {
+  if (!supabase) return [];
+  const columns = 'emp_id,active';
+  const { data, error } = await supabase
+    .from('contacts_instructors')
+    .select(columns);
+  if (error) {
+    const diagnostic = logDashboardSupabaseReadError('[supabase][dashboard] contacts_instructors read failed', error, {
+      table: 'public.contacts_instructors',
+      columns,
+      operation: 'select.instructor_emp_ids_for_exceptions'
+    });
+    throw new Error(`contacts_instructors_read_failed: ${diagnostic.message}`);
+  }
+  return (Array.isArray(data) ? data : [])
+    .filter((row) => row?.active !== false && row?.active !== 'false' && row?.active !== 0 && row?.active !== '0')
+    .map((row) => ({ emp_id: nullStr(row?.emp_id) }))
+    .filter((row) => row.emp_id);
+}
+
 async function readExceptionsFromSupabase(params = {}) {
   if (!supabase) return buildSupabaseErrorPayload({ rows: [], totalExceptionRows: 0, totalExceptionInstances: 0 }, 'no_supabase_client');
   const candidate = String(params?.month || params?.ym || '').trim();
@@ -1972,6 +2045,11 @@ async function readExceptionsFromSupabase(params = {}) {
       suppliedActivityRows ? Promise.resolve({ data: suppliedActivityRows, error: null }) : supabase.from('activities').select('*'),
       readInstructorEmpIdsFromSupabase().then((data) => ({ data, error: null })),
       readSettingsRowsFromSupabase().catch((error) => {
+        logDashboardSupabaseReadError('[supabase][dashboard] settings read failed', error, {
+          table: 'public.settings',
+          columns: SETTINGS_BOOTSTRAP_COLUMNS,
+          operation: 'select.settings_for_exceptions'
+        });
         warnLateEndDateThreshold('settings read failed', error?.message || error);
         return [];
       })

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -113,13 +113,16 @@ function renderStructuredSummary(summary, ym, byManager) {
   const endDatePassedCount = pickNumericFallback(counts, 'end_date_passed', summary?.end_date_passed_count);
   const exceptionsTotalField = getStrictNumericField(summary, 'totalExceptionInstances');
   const exceptionsTotalFallback = getStrictNumericField(summary, 'exceptions_count');
-  const exceptionsTotalResolved = exceptionsTotalField.ok
-    ? exceptionsTotalField.value
-    : (exceptionsTotalFallback.ok ? exceptionsTotalFallback.value : 0);
+  const exceptionsUnavailable = summary?.exceptions_unavailable === true;
+  const exceptionsTotalResolved = exceptionsUnavailable
+    ? 'לא זמין'
+    : (exceptionsTotalField.ok
+      ? exceptionsTotalField.value
+      : (exceptionsTotalFallback.ok ? exceptionsTotalFallback.value : 0));
 
   const endingCurrent = escapeHtml(String(endingCurrentField.ok ? endingCurrentField.value : 0));
   const operationalUniqueField = getStrictNumericField(summary, 'operational_gaps_unique_count');
-  const operationalUniqueCount = operationalUniqueField.ok ? operationalUniqueField.value : 0;
+  const operationalUniqueCount = exceptionsUnavailable ? 'לא זמין' : (operationalUniqueField.ok ? operationalUniqueField.value : 0);
   const missingInstructor = missingInstructorCount;
   const missingStartDate  = missingStartDateCount;
   const endDateAfterCutoff = escapeHtml(String(endDateAfterCutoffCount));
@@ -389,6 +392,9 @@ export const dashboardScreen = {
     }
     const kpiCards = filterKpiCards(_kpiSource, showOnly).map((card) => {
       if (card?.action !== 'kpi|exceptions') return card;
+      if (data?.exceptionsUnavailable === true || data?.summary?.exceptions_unavailable === true) {
+        return { ...card, value: 'לא זמין', title: 'לא זמין' };
+      }
       const totalExceptions =
         data?.summary?.totalExceptionInstances ??
         data?.summary?.exceptions_count ??

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 822;
+const CACHE_VERSION = 823;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 822;
+const SW_ENTRY_VERSION = 823;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Prevent a failure in the exceptions read-model from collapsing the entire dashboard when activity rows load successfully. 
- Improve diagnostics to make it clear which Supabase table/column/permission caused dashboard read failures. 

### Description
- Add detailed Supabase diagnostic helpers `describeSupabaseReadError` and `logDashboardSupabaseReadError` and use them when activity/settings/contacts reads fail (`frontend/src/api.js`).
- Restore and implement `readInstructorEmpIdsFromSupabase` to read `emp_id` from `public.contacts_instructors` for the exceptions model (`frontend/src/api.js`).
- Change `dashboardReadModelFromSupabase` so exceptions-model failures no longer throw and instead set `exceptions_unavailable` (dashboard continues to render activity data and non-exceptions KPIs) (`frontend/src/api.js`).
- Improve error handling for `selectActivitiesByDateRangeFromSupabase` to log a diagnostic with table/columns/operation and include the diagnostic message in thrown errors (`frontend/src/api.js`).
- Update dashboard rendering to show exceptions as temporarily unavailable (`'לא זמין'`) instead of fabricating zero KPIs (`frontend/src/screens/dashboard.js`).
- Bump service-worker cache/version from `822` to `823` and update built `dist/index.html` to the new bundle (`frontend/sw.js`, `sw.js`, `dist/index.html`).

### Testing
- Ran focused checks with `npm run check:changed` which passed without errors. 
- Built the frontend with `npm run build` and verified `dist` updated and bundle reference in `dist/index.html` changed, which completed successfully. 
- Ran `npm run check:build` (invokes the build) which also passed. 
- Ran focused JS tests `node --test tests/dashboard-readmodel-guard.test.mjs tests/dashboard-stability.test.mjs tests/dashboard-district-metrics.test.mjs`; most dashboard assertions passed but one focused test failed: `dashboard summer KPI drill opens activities on July 2026 with summer filter` (expected `activityQuickFamily === 'summer'`, actual `''`), which is out of scope for this focused exceptions fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d319bab4832b905f9235d3bb23fd)