### PR TITLE
Optimize contacts screen loading diagnostics

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-C07r-7Lg.js"></script>
+  <script type="module" crossorigin src="./assets/index-Q6WUSKkN.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -493,6 +493,11 @@ async function selectActivitiesByDateRangeFromSupabase({
 
 const AUTHORITIES_CATALOG_COLUMNS = 'id,authority_name,authority_code,authority_type,hp_number,long_name,district,active';
 const SCHOOLS_CATALOG_COLUMNS = 'id,semel_mosad,school_name,authority,authority_id,district,city,active';
+const CONTACTS_INSTRUCTORS_SCREEN_COLUMNS = 'emp_id,full_name,mobile,email,address,employment_type,direct_manager,active,id';
+const CONTACTS_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
+let authoritySchoolCatalogCache = null;
+let authoritySchoolCatalogInflight = null;
+
 const CONTACTS_UNIFIED_VIEW_COLUMNS = [
   'contact_domain', 'client_type', 'client_name', 'authority_id', 'school_id', 'semel_mosad',
   'authority_name', 'authority', 'school_name', 'school', 'contact_name', 'contact_role',
@@ -559,17 +564,48 @@ async function readSchoolsCatalogFromSupabase() {
   }
 }
 
-async function readAuthoritySchoolCatalog() {
-  const [authorities, schools] = await Promise.all([
-    readAuthoritiesCatalogFromSupabase(),
-    readSchoolsCatalogFromSupabase()
-  ]);
-  return {
-    authorities,
-    schools,
-    authorityLookup: buildAuthorityCatalogLookup(authorities),
-    schoolLookup: buildSchoolCatalogLookup(schools)
-  };
+async function readAuthoritySchoolCatalog({ forceRefresh = false, perf = null } = {}) {
+  const now = Date.now();
+  if (!forceRefresh && authoritySchoolCatalogCache && now - authoritySchoolCatalogCache.t < CONTACTS_CATALOG_CACHE_TTL_MS) {
+    if (perf) {
+      perf.authorities_count = authoritySchoolCatalogCache.data.authorities.length;
+      perf.schools_count = authoritySchoolCatalogCache.data.schools.length;
+      perf.catalog_cache_hit = true;
+      perf.authorities_ms = 0;
+      perf.schools_ms = 0;
+    }
+    return authoritySchoolCatalogCache.data;
+  }
+  if (!forceRefresh && authoritySchoolCatalogInflight) return authoritySchoolCatalogInflight;
+  const started = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  authoritySchoolCatalogInflight = (async () => {
+    const authorityStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const authoritiesPromise = readAuthoritiesCatalogFromSupabase().then((rows) => {
+      if (perf) perf.authorities_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - authorityStarted);
+      return rows;
+    });
+    const schoolStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const schoolsPromise = readSchoolsCatalogFromSupabase().then((rows) => {
+      if (perf) perf.schools_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - schoolStarted);
+      return rows;
+    });
+    const [authorities, schools] = await Promise.all([authoritiesPromise, schoolsPromise]);
+    const data = {
+      authorities,
+      schools,
+      authorityLookup: buildAuthorityCatalogLookup(authorities),
+      schoolLookup: buildSchoolCatalogLookup(schools)
+    };
+    authoritySchoolCatalogCache = { data, t: Date.now() };
+    if (perf) {
+      perf.authorities_count = authorities.length;
+      perf.schools_count = schools.length;
+      perf.catalog_cache_hit = false;
+      perf.catalog_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - started);
+    }
+    return data;
+  })().finally(() => { authoritySchoolCatalogInflight = null; });
+  return authoritySchoolCatalogInflight;
 }
 
 function buildAuthorityCatalogLookup(authorities = []) {
@@ -1011,24 +1047,54 @@ async function readUnifiedContactsFromSupabase({ requireAuth = false } = {}) {
 async function readContactsFromSupabase() {
   if (!supabase) return null;
 
+  const perfStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const perf = {
+    instructors_count: 0,
+    unified_count: 0,
+    authorities_count: 0,
+    schools_count: 0,
+    instructors_ms: 0,
+    unified_ms: 0,
+    authorities_ms: 0,
+    schools_ms: 0,
+    catalog_ms: 0,
+    catalog_cache_hit: false,
+    read_ms: 0
+  };
+
   const readInstructors = async () => {
-    const result = await supabase.from('contacts_instructors').select('*');
+    const started = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const result = await supabase.from('contacts_instructors').select(CONTACTS_INSTRUCTORS_SCREEN_COLUMNS);
+    perf.instructors_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - started);
     if (result.error) {
       // eslint-disable-next-line no-console
       console.warn('[supabase] Failed to load contacts_instructors:', result.error);
       return [];
     }
-    return Array.isArray(result.data) ? result.data : [];
+    const rows = Array.isArray(result.data) ? result.data : [];
+    perf.instructors_count = rows.length;
+    return rows;
+  };
+
+  const readUnified = async () => {
+    const started = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const rows = await readUnifiedContactsFromSupabase();
+    perf.unified_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - started);
+    perf.unified_count = Array.isArray(rows) ? rows.length : 0;
+    return rows;
   };
 
   try {
     const [instructor_rows, schoolRowsRaw, catalog] = await Promise.all([
       readInstructors(),
-      readUnifiedContactsFromSupabase(),
-      readAuthoritySchoolCatalog()
+      readUnified(),
+      readAuthoritySchoolCatalog({ perf })
     ]);
     const school_rows = (Array.isArray(schoolRowsRaw) ? schoolRowsRaw : [])
       .map((row) => enrichSchoolContactRow(row, catalog.authorityLookup, catalog.schoolLookup));
+    perf.read_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - perfStarted);
+    // eslint-disable-next-line no-console
+    console.info('[contacts-perf]', perf);
     return {
       instructor_rows,
       school_rows,
@@ -1036,9 +1102,13 @@ async function readContactsFromSupabase() {
       school_catalog: catalog.schools,
       can_view_instructors: true,
       can_view_schools: true,
-      _source: 'supabase'
+      _source: 'supabase',
+      _contacts_perf: perf
     };
   } catch (error) {
+    perf.read_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - perfStarted);
+    // eslint-disable-next-line no-console
+    console.info('[contacts-perf]', perf);
     // eslint-disable-next-line no-console
     console.warn('[supabase] Unexpected contacts fetch error:', error);
     return {
@@ -1046,7 +1116,8 @@ async function readContactsFromSupabase() {
       school_rows: [],
       can_view_instructors: true,
       can_view_schools: true,
-      _source: 'supabase'
+      _source: 'supabase',
+      _contacts_perf: perf
     };
   }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1241,7 +1241,7 @@ function maybePersistScreenCacheEntry(key, entry) {
 async function loadScreenDataWithCache(screen) {
   if (!screen.load) return {};
   const routeName = String(state.route || '');
-  const routePerfEnabled = routeName === 'dashboard' || routeName === 'activities' || routeName === 'week' || routeName === 'month';
+  const routePerfEnabled = routeName === 'dashboard' || routeName === 'activities' || routeName === 'week' || routeName === 'month' || routeName === 'contacts';
   const routePerfStart = routePerfEnabled ? (typeof performance !== 'undefined' ? performance.now() : Date.now()) : 0;
   const key = screenDataCacheKey();
   if (routeName === 'proposals-agreements') {

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -18,6 +18,26 @@ const AVATAR_COLORS = [
   '#f43f5e', '#a855f7'
 ];
 const CONTACTS_SCOPE = 'contacts';
+const CONTACTS_SEARCH_DEBOUNCE_MS = 350;
+const CONTACTS_SEARCH_PREP_CACHE = new WeakMap();
+
+function nowMs() {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function prepareContactsRowsForSearch(rows, fields) {
+  const list = Array.isArray(rows) ? rows : [];
+  let byFields = CONTACTS_SEARCH_PREP_CACHE.get(list);
+  const fieldsKey = Array.isArray(fields) ? fields.join('|') : '';
+  if (byFields?.has(fieldsKey)) return list;
+  prepareRowsForSearch(list, fields);
+  if (!byFields) {
+    byFields = new Set();
+    CONTACTS_SEARCH_PREP_CACHE.set(list, byFields);
+  }
+  byFields.add(fieldsKey);
+  return list;
+}
 
 const INSTR_SEARCH_FIELDS = [
   'full_name', 'mobile', 'email', 'contact_role', 'role', 'employment_type'
@@ -589,13 +609,14 @@ export const contactsScreen = {
   render(data, { state } = {}) {
     const instrRows  = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows)     ? data.school_rows     : [];
-    prepareRowsForSearch(instrRows, [
+    const renderStarted = nowMs();
+    prepareContactsRowsForSearch(instrRows, [
       'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
       'mobile', 'phone', 'email', 'authority', 'school',
       'role', 'contact_role', 'employment_type', 'direct_manager', 'active',
       'notes', 'address', 'activity_name', 'activity_type'
     ]);
-    prepareRowsForSearch(schoolRows, [
+    prepareContactsRowsForSearch(schoolRows, [
       'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
       'mobile', 'phone', 'email', 'authority', 'authority_name', 'school', 'school_name',
       'role', 'contact_role', 'position', 'active', 'notes', 'address', 'city', 'district',
@@ -621,11 +642,11 @@ export const contactsScreen = {
       : filtersToolbarHtml(CONTACTS_SCOPE, schoolRows, state, {
         searchPlaceholder: 'חיפוש לפי שם / תפקיד / טלפון / מייל / רשות / מספר רשות / בית ספר / סמל מוסד…',
         filterFields: SCHOOL_FILTER_FIELDS,
-        dependent: true,
+        dependent: false,
         search: true
       });
 
-    return dsScreenStack(`
+    const html = dsScreenStack(`
       <div class="ds-chip-group contacts-tab-bar" dir="rtl">${tabBtns}</div>
       <div class="ds-screen-top-row contacts-toolbar-row">
         ${searchInput}
@@ -633,9 +654,25 @@ export const contactsScreen = {
       </div>
       <div class="contacts-list-wrap" dir="rtl">${listHtml}</div>
     `);
+    const renderMs = Math.round(nowMs() - renderStarted);
+    const basePerf = data?._contacts_perf || {};
+    basePerf.render_ms = renderMs;
+    // eslint-disable-next-line no-console
+    console.info('[contacts-perf]', {
+      instructors_count: instrRows.length,
+      unified_count: schoolRows.length,
+      authorities_count: basePerf.authorities_count || data?.authority_catalog?.length || 0,
+      schools_count: basePerf.schools_count || data?.school_catalog?.length || 0,
+      read_ms: basePerf.read_ms || 0,
+      render_ms: renderMs,
+      bind_ms: basePerf.bind_ms || 0,
+      total_ms: (basePerf.read_ms || 0) + renderMs + (basePerf.bind_ms || 0)
+    });
+    return html;
   },
 
   bind({ root, data, state, ui, rerender, api }) {
+    const bindStarted = nowMs();
     const instrRows = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows) ? data.school_rows : [];
     const hideEmpIds = !!state?.clientSettings?.hide_emp_id_on_screens;
@@ -701,8 +738,22 @@ export const contactsScreen = {
     bindContactsListInteractions(root);
 
     bindLocalFilters(root, state, CONTACTS_SCOPE, rerender, {
-      debounceMs: 200,
+      debounceMs: CONTACTS_SEARCH_DEBOUNCE_MS,
       onClear: () => { state.contactsAlphaLetter = ''; }
+    });
+
+    const bindMs = Math.round(nowMs() - bindStarted);
+    const basePerf = data?._contacts_perf || {};
+    // eslint-disable-next-line no-console
+    console.info('[contacts-perf]', {
+      instructors_count: instrRows.length,
+      unified_count: schoolRows.length,
+      authorities_count: basePerf.authorities_count || data?.authority_catalog?.length || 0,
+      schools_count: basePerf.schools_count || data?.school_catalog?.length || 0,
+      read_ms: basePerf.read_ms || 0,
+      render_ms: basePerf.render_ms || 0,
+      bind_ms: bindMs,
+      total_ms: (basePerf.read_ms || 0) + (basePerf.render_ms || 0) + bindMs
     });
 
     const decodePayload = (node) => {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 823;
+const CACHE_VERSION = 824;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 823;
+const SW_ENTRY_VERSION = 824;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The "Contacts" screen was slow due to broad Supabase reads and repeated client-side processing of large row sets.
- We need focused, safe fixes that allow measurement before larger refactors and without changing UI, permissions, or data.
- The goal is to reduce unnecessary payload and CPU work on screen load and make bottlenecks visible in logs.

### Description
- Added focused performance instrumentation that logs instructors/unified/authorities/schools counts and timings under `console.info('[contacts-perf]', ...)`. (changes in `frontend/src/api.js` and `frontend/src/screens/contacts.js`).
- Reduced `contacts_instructors` fetch from `select('*')` to a targeted columns list and added a cached, TTL'd in-memory catalog with in-flight dedupe for `authorities`/`schools` used for enrichment. (changes in `frontend/src/api.js`).
- Avoided repeated work by memoizing `prepareRowsForSearch` for unchanged row arrays, disabled `dependent` filter option for the contacts screen to stop heavy per-field scans, and increased search debounce to 350ms. (changes in `frontend/src/screens/contacts.js` and `frontend/src/screens/shared/activity-list-filters.js` behavior used).
- Enabled route load measurement for `contacts` in `loadScreenDataWithCache` and bumped service-worker cache versions in both `frontend/sw.js` and root `sw.js`; updated built bundle reference in `dist/index.html`. (changes in `frontend/src/main.js`, `frontend/sw.js`, `sw.js`, and `dist/index.html`).

### Testing
- Ran syntax checks: `node --check frontend/src/api.js && node --check frontend/src/screens/contacts.js && node --check frontend/src/main.js && node --check frontend/sw.js && node --check sw.js`, which completed without errors.
- Ran focused verification: `npm run check:changed`, which reported focused checks complete with no mapped screen tests failing.
- Built the frontend: `npm run check:build` / `npm run build`, which succeeded (Vite build succeeded with a warning about a large chunk >500kB). 
- All automated checks above passed in this environment and the new console diagnostics will provide before/after timings when run against a live Supabase/browser session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37deeb3674832b83836e471263cdcd)