### PR TITLE
Fix contacts_instructors loading, enforce emp_id usage and defer heavy unified contact reads

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-Q6WUSKkN.js"></script>
+  <script type="module" crossorigin src="./assets/index-D66xsnYY.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -111,9 +111,9 @@ async function readInstructorContactsRowsForBootstrap() {
   if (instructorContactsCache) return instructorContactsCache;
   if (instructorContactsPromise) return instructorContactsPromise;
   instructorContactsPromise = (async () => {
-    const { data, error } = await supabase.from('contacts_instructors').select('emp_id,full_name,name,active');
+    const { data, error } = await supabase.from('contacts_instructors').select('emp_id,full_name,active');
     if (error) {
-      console.warn('[supabase] contacts_instructors read failed:', error);
+      console.error('[contacts][contacts_instructors] read failed', { columns: 'emp_id,full_name,active', code: error?.code, message: error?.message, error });
       return [];
     }
     instructorContactsCache = Array.isArray(data) ? data : [];
@@ -493,7 +493,7 @@ async function selectActivitiesByDateRangeFromSupabase({
 
 const AUTHORITIES_CATALOG_COLUMNS = 'id,authority_name,authority_code,authority_type,hp_number,long_name,district,active';
 const SCHOOLS_CATALOG_COLUMNS = 'id,semel_mosad,school_name,authority,authority_id,district,city,active';
-const CONTACTS_INSTRUCTORS_SCREEN_COLUMNS = 'emp_id,full_name,mobile,email,address,employment_type,direct_manager,active,id';
+const CONTACTS_INSTRUCTORS_SCREEN_COLUMNS = 'emp_id,full_name,mobile,email,address,employment_type,direct_manager,active';
 const CONTACTS_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 let authoritySchoolCatalogCache = null;
 let authoritySchoolCatalogInflight = null;
@@ -1001,16 +1001,39 @@ function isSupabasePermissionDeniedError(error) {
     || haystack.includes('insufficient_privilege');
 }
 
-async function readUnifiedContactsFromSupabase({ requireAuth = false } = {}) {
+async function readUnifiedContactsFromSupabase({ requireAuth = false, letter = '', search = '' } = {}) {
   if (!supabase) return [];
   if (requireAuth) {
     const session = await waitForSupabaseAuthSession({ timeoutMs: 6000 });
     if (!session?.user?.id) throw new Error('contacts_unified_view_requires_auth_session');
   }
   try {
-    const { data, error } = await supabase
+    let query = supabase
       .from('contacts_unified_view')
-      .select(CONTACTS_UNIFIED_VIEW_COLUMNS)
+      .select(CONTACTS_UNIFIED_VIEW_COLUMNS);
+    const safeLetter = String(letter || '').trim().replace(/[%,()]/g, '');
+    if (safeLetter) {
+      query = query.or(`authority_name.ilike.${safeLetter}%,authority.ilike.${safeLetter}%,client_name.ilike.${safeLetter}%`);
+    }
+    const safeSearch = String(search || '').trim().replace(/[%,()]/g, '');
+    if (safeSearch) {
+      const term = `%${safeSearch}%`;
+      query = query.or([
+        `client_name.ilike.${term}`,
+        `authority_name.ilike.${term}`,
+        `authority.ilike.${term}`,
+        `school_name.ilike.${term}`,
+        `school.ilike.${term}`,
+        `contact_name.ilike.${term}`,
+        `contact_role.ilike.${term}`,
+        `phone.ilike.${term}`,
+        `mobile.ilike.${term}`,
+        `email.ilike.${term}`,
+        `authority_code.ilike.${term}`,
+        `semel_mosad.ilike.${term}`
+      ].join(','));
+    }
+    const { data, error } = await query
       .order('authority_name', { ascending: true })
       .order('school_name', { ascending: true })
       .order('contact_domain', { ascending: true })
@@ -1044,7 +1067,7 @@ async function readUnifiedContactsFromSupabase({ requireAuth = false } = {}) {
  *
  * ⚠️ permissions table is intentionally excluded — login credentials must never be read client-side.
  */
-async function readContactsFromSupabase() {
+async function readContactsFromSupabase({ includeUnified = false, letter = '', search = '' } = {}) {
   if (!supabase) return null;
 
   const perfStarted = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -1068,8 +1091,13 @@ async function readContactsFromSupabase() {
     perf.instructors_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - started);
     if (result.error) {
       // eslint-disable-next-line no-console
-      console.warn('[supabase] Failed to load contacts_instructors:', result.error);
-      return [];
+      console.error('[contacts][contacts_instructors] read failed', {
+        columns: CONTACTS_INSTRUCTORS_SCREEN_COLUMNS,
+        code: result.error?.code,
+        message: result.error?.message,
+        error: result.error
+      });
+      throw new Error(result.error.message || 'contacts_instructors_read_failed');
     }
     const rows = Array.isArray(result.data) ? result.data : [];
     perf.instructors_count = rows.length;
@@ -1078,7 +1106,7 @@ async function readContactsFromSupabase() {
 
   const readUnified = async () => {
     const started = typeof performance !== 'undefined' ? performance.now() : Date.now();
-    const rows = await readUnifiedContactsFromSupabase();
+    const rows = await readUnifiedContactsFromSupabase({ letter, search });
     perf.unified_ms = Math.round((typeof performance !== 'undefined' ? performance.now() : Date.now()) - started);
     perf.unified_count = Array.isArray(rows) ? rows.length : 0;
     return rows;
@@ -1087,8 +1115,8 @@ async function readContactsFromSupabase() {
   try {
     const [instructor_rows, schoolRowsRaw, catalog] = await Promise.all([
       readInstructors(),
-      readUnified(),
-      readAuthoritySchoolCatalog({ perf })
+      includeUnified ? readUnified() : Promise.resolve([]),
+      includeUnified ? readAuthoritySchoolCatalog({ perf }) : Promise.resolve({ authorities: [], schools: [], authorityLookup: new Map(), schoolLookup: new Map() })
     ]);
     const school_rows = (Array.isArray(schoolRowsRaw) ? schoolRowsRaw : [])
       .map((row) => enrichSchoolContactRow(row, catalog.authorityLookup, catalog.schoolLookup));
@@ -1116,6 +1144,7 @@ async function readContactsFromSupabase() {
       school_rows: [],
       can_view_instructors: true,
       can_view_schools: true,
+      instructors_load_error: true,
       _source: 'supabase',
       _contacts_perf: perf
     };
@@ -1129,7 +1158,7 @@ async function readContactsFromSupabase() {
 async function readInstructorContactsFromSupabase() {
   if (!supabase) return null;
   try {
-    const result = await supabase.from('contacts_instructors').select('*');
+    const result = await supabase.from('contacts_instructors').select(CONTACTS_INSTRUCTORS_SCREEN_COLUMNS);
     if (result.error) {
       // eslint-disable-next-line no-console
       console.error('[supabase] Failed to load contacts_instructors:', result.error);
@@ -1243,7 +1272,7 @@ function buildClientSettingsFromLists(listsData, settingsRows = [], instructorCo
     emp_id: String(i._row?.emp_id || i._row?.employee_id || '').trim()
   }));
   const contactsInstructorUsers = (Array.isArray(instructorContactsRows) ? instructorContactsRows : []).map((row) => ({
-    name: normalizeHumanName(row?.full_name || row?.name),
+    name: normalizeHumanName(row?.full_name),
     emp_id: String(row?.emp_id || '').trim()
   })).filter((user) => user.name && user.emp_id);
 
@@ -1341,7 +1370,7 @@ async function readInstructorsFromSupabase() {
   try {
     const [activityRows, contactsResult] = await Promise.all([
       selectActivitiesFromSupabase('*'),
-      supabase.from('contacts_instructors').select('*')
+      supabase.from('contacts_instructors').select(CONTACTS_INSTRUCTORS_SCREEN_COLUMNS)
     ]);
 
     if (contactsResult.error) {
@@ -1398,8 +1427,8 @@ async function readInstructorsFromSupabase() {
     const contacts = Array.isArray(contactsResult.data) ? contactsResult.data : [];
     const contactsLookup = buildContactsInstructorLookup(contacts);
     contacts.forEach((contact) => {
-      const empId = String(contact?.emp_id || contact?.employee_id || contact?.id || '').trim();
-      const name = normalizeName(contact?.full_name || contact?.name || contact?.instructor_name || contact?.guide);
+      const empId = String(contact?.emp_id || contact?.employee_id || '').trim();
+      const name = normalizeName(contact?.full_name || contact?.instructor_name || contact?.guide);
       const stats = ensureStats(empId || name, name || empId);
       if (stats) {
         if (empId) addAlias(empId, stats.emp_id);
@@ -3568,7 +3597,7 @@ function sanitizeActivityPayloadForSupabase(payload = {}, { includeRowId = true 
 async function validateActivityInstructorBindingsOrThrow(payload = {}) {
   const contactsRows = await readInstructorContactsRowsForBootstrap();
   const contactsUsers = contactsRows
-    .map((row) => ({ emp_id: String(row?.emp_id || '').trim(), name: normalizeHumanName(row?.full_name || row?.name) }))
+    .map((row) => ({ emp_id: String(row?.emp_id || '').trim(), name: normalizeHumanName(row?.full_name) }))
     .filter((user) => user.emp_id && user.name);
   const result = validateInstructorIdentityPayload(payload, contactsUsers);
   if (!result.valid) {
@@ -4387,8 +4416,8 @@ export const api = {
     if (supabaseData) return supabaseData;
     return buildSupabaseErrorPayload({ rows: [] }, 'instructor_contacts_supabase_failed');
   },
-  contacts: async () => {
-    const supabaseData = await readContactsFromSupabase();
+  contacts: async (params = {}) => {
+    const supabaseData = await readContactsFromSupabase(params || {});
     if (supabaseData) return supabaseData;
     return buildSupabaseErrorPayload({ instructor_rows: [], school_rows: [], can_view_instructors: true, can_view_schools: true }, 'contacts_supabase_failed');
   },

--- a/frontend/src/screens/contacts.js
+++ b/frontend/src/screens/contacts.js
@@ -262,17 +262,18 @@ function contactEmptyState(rows, filters) {
   return dsEmptyState('לא נמצאו אנשי קשר');
 }
 
-function instrEmptyState(rows, filters) {
+function instrEmptyState(rows, filters, loadError = false) {
+  if (loadError) return dsEmptyState('לא ניתן לטעון מדריכים כרגע');
   if (Array.isArray(rows) && rows.length && hasActiveInstrFilters(filters)) {
     return dsEmptyState('לא נמצאו מדריכים לפי הסינון הנוכחי');
   }
   return dsEmptyState('לא נמצאו מדריכים');
 }
 
-function instrTabHtml(rows, filters) {
+function instrTabHtml(rows, filters, loadError = false) {
   const filtered = applyInstrFilters(rows, filters);
   const body = filtered.length === 0
-    ? instrEmptyState(rows, filters)
+    ? instrEmptyState(rows, filters, loadError)
     : `<div class="ci-person-grid">${filtered.map((r) => renderInstrCard(r)).join('')}</div>`;
   return { filtered, body };
 }
@@ -531,8 +532,8 @@ function schoolFormHtml(row = {}) {
   `;
 }
 
-function contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr = true, canViewSchool = true, activeLetter = '') {
-  if (tab === 'instr' && canViewInstr) return instrTabHtml(instrRows, filters).body;
+function contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr = true, canViewSchool = true, activeLetter = '', instructorsLoadError = false) {
+  if (tab === 'instr' && canViewInstr) return instrTabHtml(instrRows, filters, instructorsLoadError).body;
   if (tab === 'school' && canViewSchool) return schoolTabHtml(schoolRows, filters, activeLetter).body;
   return dsEmptyState('לא נמצאו אנשי קשר');
 }
@@ -551,10 +552,6 @@ function schoolTabHtml(rows, filters, activeLetter = '') {
   const authorityMap = groupByAuthorityStructured(filtered);
   const stats = computeSchoolTabStats(authorityMap, activeLetter);
 
-  if (!stats.authorities && !stats.contacts) {
-    return { filtered, stats, body: contactEmptyState(rows, filters) };
-  }
-
   const letterMap = new Map();
   authorityMap.forEach((bucket, authority) => {
     if (!countAuthorityBucket(bucket).schoolCount && !countAuthorityBucket(bucket).contactCount) return;
@@ -563,7 +560,7 @@ function schoolTabHtml(rows, filters, activeLetter = '') {
     letterMap.get(letter).push(authority);
   });
 
-  const availableLetters = new Set(letterMap.keys());
+  const availableLetters = activeLetter ? new Set(letterMap.keys()) : new Set(HE_ALPHA);
   const alphaBtns = HE_ALPHA.map((letter) =>
     `<button type="button" class="sc-alpha-btn${activeLetter === letter ? ' is-active' : ''}${availableLetters.has(letter) ? '' : ' is-empty'}" data-alpha-btn="${escapeHtml(letter)}" aria-expanded="${activeLetter === letter ? 'true' : 'false'}" title="${availableLetters.has(letter) ? '' : 'אין רשויות באות זו'}">${escapeHtml(letter)}</button>`
   ).join('');
@@ -604,20 +601,20 @@ function schoolTabHtml(rows, filters, activeLetter = '') {
 /* ─── Screen ─── */
 
 export const contactsScreen = {
-  load: ({ api }) => api.contacts(),
+  load: ({ api, state }) => api.contacts({ includeUnified: state?.contactsTab === 'school' && !!state?.contactsAlphaLetter, letter: state?.contactsAlphaLetter || '' }),
 
   render(data, { state } = {}) {
     const instrRows  = Array.isArray(data?.instructor_rows) ? data.instructor_rows : [];
     const schoolRows = Array.isArray(data?.school_rows)     ? data.school_rows     : [];
     const renderStarted = nowMs();
     prepareContactsRowsForSearch(instrRows, [
-      'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
+      'full_name', 'contact_name', 'emp_id', 'employee_id',
       'mobile', 'phone', 'email', 'authority', 'school',
       'role', 'contact_role', 'employment_type', 'direct_manager', 'active',
       'notes', 'address', 'activity_name', 'activity_type'
     ]);
     prepareContactsRowsForSearch(schoolRows, [
-      'full_name', 'name', 'contact_name', 'emp_id', 'employee_id',
+      'full_name', 'contact_name', 'emp_id', 'employee_id',
       'mobile', 'phone', 'email', 'authority', 'authority_name', 'school', 'school_name',
       'role', 'contact_role', 'position', 'active', 'notes', 'address', 'city', 'district',
       'instructor_name', 'activity_name', 'activity_type', 'client_type', 'client_name',
@@ -635,7 +632,7 @@ export const contactsScreen = {
       `<button type="button" class="ds-chip--tab${tab === t.key ? ' is-active' : ''}" data-contacts-tab="${t.key}">${escapeHtml(t.label)}</button>`
     ).join('');
 
-    const listHtml = contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr, canViewSchool, activeLetter);
+    const listHtml = contactListHtml(tab, instrRows, schoolRows, filters, canViewInstr, canViewSchool, activeLetter, !!data?.instructors_load_error);
 
     const searchInput = tab === 'instr'
       ? instrToolbarHtml(CONTACTS_SCOPE, state)
@@ -679,9 +676,13 @@ export const contactsScreen = {
     const managerOptions = getManagerUsers(state?.clientSettings || {});
 
     root.querySelectorAll('[data-contacts-tab]').forEach((btn) => {
-      btn.addEventListener('click', () => {
+      btn.addEventListener('click', async () => {
         state.contactsTab = btn.dataset.contactsTab;
-        if (state.contactsTab !== 'school') state.contactsAlphaLetter = '';
+        if (state.contactsTab !== 'school') {
+          state.contactsAlphaLetter = '';
+          rerender();
+          return;
+        }
         rerender();
       });
     });
@@ -720,10 +721,16 @@ export const contactsScreen = {
       container.querySelectorAll('[data-alpha-btn]').forEach((btn) => {
         if (btn.dataset.alphaBound === 'yes') return;
         btn.dataset.alphaBound = 'yes';
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', async () => {
           const letter = btn.dataset.alphaBtn;
           const isOpen = state.contactsAlphaLetter === letter;
           state.contactsAlphaLetter = isOpen ? '' : letter;
+          if (state.contactsAlphaLetter) {
+            const next = await api.contacts({ includeUnified: true, letter: state.contactsAlphaLetter });
+            Object.assign(data, next, { _school_loaded: true });
+          } else {
+            data.school_rows = [];
+          }
           rerender();
         });
       });
@@ -769,7 +776,7 @@ export const contactsScreen = {
     const openInstructorEditor = (row, isCreate = false) => {
       if (!ui) return;
       const target = row || {};
-      const originalId = target.id != null ? target.id : null;
+      const originalEmpId = target.emp_id != null ? String(target.emp_id) : null;
       ui.openModal({
         title: isCreate ? 'הוספת איש קשר מדריך' : 'עריכת איש קשר מדריך',
         content: instructorFormHtml(target, managerOptions),
@@ -793,7 +800,7 @@ export const contactsScreen = {
           direct_manager: get('direct_manager'),
           active: get('active') || 'yes'
         };
-        if (!isCreate && originalId != null) payload.id = originalId;
+        if (!isCreate && originalEmpId != null) payload.emp_id = originalEmpId;
         if (!payload.emp_id) {
           if (statusEl) statusEl.textContent = 'יש להזין מזהה מדריך';
           return;

--- a/frontend/src/screens/shared/activity-options.js
+++ b/frontend/src/screens/shared/activity-options.js
@@ -411,10 +411,8 @@ export function buildContactsInstructorLookup(contacts = []) {
   const byName = new Map();
   const byEmpId = new Map();
   for (const contact of contacts) {
-    const empId = text(contact?.emp_id || contact?.employee_id || contact?.id);
-    const name = humanDisplayText(
-      contact?.full_name || contact?.name || contact?.instructor_name || contact?.guide
-    );
+    const empId = text(contact?.emp_id || contact?.employee_id);
+    const name = humanDisplayText(contact?.full_name || contact?.instructor_name || contact?.guide);
     if (empId) byEmpId.set(empId, { emp_id: empId, name });
     if (name) byName.set(normalizeInstructorLookupName(name), { emp_id: empId, name });
   }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 824;
+const CACHE_VERSION = 825;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 824;
+const SW_ENTRY_VERSION = 825;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The contacts UI was showing "לא נמצאו מדריכים" while Supabase contained instructor rows because queries selected non-existent `name`/`id` columns from `contacts_instructors`, causing 400 errors. 
- The contacts screen also pulled the large `contacts_unified_view` eagerly causing client-side performance/UX problems when entering the screen.
- The intent is to use `emp_id` as the instructor identifier and `full_name` for names, expose real load errors to the UI, and avoid fetching the entire unified view unnecessarily.

### Description
- Stop selecting non-existent columns from `contacts_instructors` by changing the bootstrap read to `select('emp_id,full_name,active')` and standardizing `CONTACTS_INSTRUCTORS_SCREEN_COLUMNS` to `emp_id,full_name,mobile,email,address,employment_type,direct_manager,active` in `frontend/src/api.js`.
- Add explicit error logging for instructor reads using `console.error('[contacts][contacts_instructors] read failed', { columns, code, message, error })` and throw on instructor-read failures to surface load errors.
- Ensure all instructor identification and lookups use `emp_id` and `full_name` only by removing fallbacks to `id`/`name` in `frontend/src/screens/shared/activity-options.js` and other places that built instructor lookups.
- Reduce startup work and add focused server-side filters by making `readContactsFromSupabase` accept `{ includeUnified, letter, search }`, deferring `contacts_unified_view` and catalog reads until the customers tab / a letter is requested, and add `letter`/`search` parameters to `readUnifiedContactsFromSupabase` so the server can filter instead of pulling the whole dataset.
- Update the contacts screen UI to render a loading-error empty state (`'לא ניתן לטעון מדריכים כרגע'`) when instructor reads fail, preserve `emp_id` when editing instructors (no `id` usage), and fetch unified contacts only on demand when the school tab and an alphabet letter are selected in `frontend/src/screens/contacts.js`.
- Bump service worker cache versions in `frontend/sw.js` and `sw.js` (from `824` to `825`) and rebuild the `dist` bundle so deployed caches will be dropped.

### Testing
- Changed files: `frontend/src/api.js`, `frontend/src/screens/contacts.js`, `frontend/src/screens/shared/activity-options.js`, `frontend/sw.js`, `sw.js` and rebuilt `dist`.
- Focused static checks: ran `node --check frontend/src/api.js`, `node --check frontend/src/screens/contacts.js`, and `node --check frontend/src/screens/shared/activity-options.js`, which passed.
- Focused verification: ran `npm run check:changed` which completed without mapped screen-test failures.
- Build verification: ran `npm run build` and `npm run check:build`, both succeeded and produced an updated `dist`; service worker `CACHE_VERSION` and `SW_ENTRY_VERSION` were bumped to `825`.
- No additional legacy test suites were run per agent testing policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38058e291c832bb4737377966445a3)