### PR TITLE
Fix Supabase env vars, auth login schema, and Preview migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Frontend (Vite build / local dev)
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+VITE_BASE=./
+
+# Supabase Preview / hosting integrations may inject these without the VITE_ prefix
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+
+# Optional Next.js-style aliases (supported by supabase-client.js)
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# One-off maintenance scripts only (never commit real keys)
+SUPABASE_SERVICE_ROLE_KEY=

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2941,7 +2941,7 @@ async function readProposalsAgreementsFromSupabase() {
   };
 }
 
-const USER_PUBLIC_COLUMNS = 'user_id,username,email,name,role,display_role,is_active,permissions,auth_user_id,can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements';
+const USER_PUBLIC_COLUMNS = 'user_id,username,email,name,role,display_role,is_active,permissions,auth_user_id';
 const PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_reports';
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 
@@ -3098,7 +3098,7 @@ function flattenUserRow(userRow = {}) {
   const customDisplayRole = String(userRow.display_role || '').trim();
   const flat = {
     user_id: String(userRow.user_id || ''),
-    username: String(userRow.username || ''),
+    username: String(userRow.username || userRow.user_id || '').trim().toLowerCase(),
     full_name: String(userRow.name || ''),
     role,
     display_role: role,

--- a/frontend/src/supabase-client.js
+++ b/frontend/src/supabase-client.js
@@ -1,14 +1,26 @@
 import { createClient } from '@supabase/supabase-js';
 
-const FALLBACK_SUPABASE_URL = 'https://szinlhjuwyiyszdpsdop.supabase.co';
-const FALLBACK_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_k0IbDJlgPA9KTVuDWrCyFw_Zsa5kZIM';
-
 const viteEnv = import.meta.env || {};
-const supabaseUrl = viteEnv.VITE_SUPABASE_URL || viteEnv.NEXT_PUBLIC_SUPABASE_URL || FALLBACK_SUPABASE_URL;
-const supabaseAnonKey =
-  viteEnv.VITE_SUPABASE_ANON_KEY ||
-  viteEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  FALLBACK_SUPABASE_PUBLISHABLE_KEY;
+
+function readEnvValue(...keys) {
+  for (const key of keys) {
+    const value = String(viteEnv[key] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+const supabaseUrl = readEnvValue(
+  'VITE_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'SUPABASE_URL'
+);
+const supabaseAnonKey = readEnvValue(
+  'VITE_SUPABASE_ANON_KEY',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_PUBLISHABLE_KEY'
+);
 
 let supabase = null;
 let authSessionWaitPromise = null;
@@ -18,15 +30,14 @@ if (supabaseUrl && supabaseAnonKey) {
 } else {
   // eslint-disable-next-line no-console
   console.error(
-    '[supabase] Missing configuration. Expected VITE_SUPABASE_URL/VITE_SUPABASE_ANON_KEY or NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    '[supabase] Missing configuration. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY (or SUPABASE_URL / SUPABASE_ANON_KEY for Preview integrations).'
   );
 }
 
 export const supabaseConfig = {
   url: supabaseUrl,
   hasAnonKey: Boolean(supabaseAnonKey),
-  usesFallbackUrl: supabaseUrl === FALLBACK_SUPABASE_URL,
-  usesFallbackAnonKey: supabaseAnonKey === FALLBACK_SUPABASE_PUBLISHABLE_KEY
+  isConfigured: Boolean(supabaseUrl && supabaseAnonKey)
 };
 
 export function resetSupabaseAuthSessionWait() {

--- a/scripts/migrate-users-to-auth.mjs
+++ b/scripts/migrate-users-to-auth.mjs
@@ -68,7 +68,7 @@ async function main() {
       continue;
     }
 
-    const email = String(user.auth_email || '').trim() || `${userId}@taasiyeda.local`;
+    const email = String(user.auth_email || '').trim() || `${userId}@think.org.il`.toLowerCase();
     const password = String(user.entry_code || '').trim();
 
     if (!password) {

--- a/scripts/migrate_users_to_auth_once.mjs
+++ b/scripts/migrate_users_to_auth_once.mjs
@@ -15,7 +15,7 @@ function asText(value) {
 }
 
 function buildAuthEmail(userId) {
-  return `${asText(userId)}@taasiyeda.local`.toLowerCase();
+  return `${asText(userId)}@think.org.il`.toLowerCase();
 }
 
 async function listAllAuthUsers(supabase) {

--- a/supabase/migrations/20260614224709_add_proposal_directory_compat_aliases.sql
+++ b/supabase/migrations/20260614224709_add_proposal_directory_compat_aliases.sql
@@ -1,2 +1,2 @@
--- Placeholder migration retained for Supabase version alignment.
-SELECT 'noop';
+-- No-op migration placeholder for Supabase history alignment.
+SELECT 1;

--- a/supabase/migrations/20260614224918_grant_proposals_agreements_directory_view_select.sql
+++ b/supabase/migrations/20260614224918_grant_proposals_agreements_directory_view_select.sql
@@ -1,4 +1,2 @@
--- This migration was previously applied remotely in Supabase.
--- Added to align the local repository migration history with Supabase remote migration history.
--- No-op: this file intentionally does not change the database.
-
+-- No-op migration placeholder for Supabase history alignment.
+SELECT 1;

--- a/supabase/migrations/20260614224924_grant_proposals_agreements_directory_view_dependencies.sql
+++ b/supabase/migrations/20260614224924_grant_proposals_agreements_directory_view_dependencies.sql
@@ -1,2 +1,2 @@
--- Placeholder migration retained for Supabase version alignment.
-SELECT 'noop';
+-- No-op migration placeholder for Supabase history alignment.
+SELECT 1;

--- a/supabase/migrations/20260617214409_grant_workshop_stock_distributions_client_access.sql
+++ b/supabase/migrations/20260617214409_grant_workshop_stock_distributions_client_access.sql
@@ -1,4 +1,2 @@
--- This migration was previously applied remotely in Supabase.
--- Added to align the local repository migration history with Supabase remote migration history.
--- No-op: this file intentionally does not change the database.
-
+-- No-op migration placeholder for Supabase history alignment.
+SELECT 1;

--- a/supabase/migrations/20260620155322_add_participants_count_to_activities.sql
+++ b/supabase/migrations/20260620155322_add_participants_count_to_activities.sql
@@ -1,2 +1,2 @@
--- Placeholder migration retained for Supabase version alignment.
-SELECT 'noop';
+-- No-op migration placeholder for Supabase history alignment.
+SELECT 1;

--- a/supabase/migrations/20260621090000_reconcile_migration_history.sql
+++ b/supabase/migrations/20260621090000_reconcile_migration_history.sql
@@ -1,2 +1,2 @@
 -- No-op migration to retrigger Supabase protected-branch migration sync after aligning local migration history.
--- Intentionally empty.
+SELECT 1;

--- a/supabase/migrations/20260621120000_stabilize_auth_login_and_grants.sql
+++ b/supabase/migrations/20260621120000_stabilize_auth_login_and_grants.sql
@@ -1,0 +1,56 @@
+-- Stabilize Supabase Auth login reads for Preview and production branches.
+-- Idempotent: safe to run on branches that already have partial schema.
+
+alter table public.users add column if not exists username text;
+alter table public.users add column if not exists display_role text;
+alter table public.users add column if not exists auth_user_id uuid;
+
+create unique index if not exists users_auth_user_id_idx on public.users(auth_user_id);
+
+-- Login maps username input (e.g. idann) to public.users.username.
+update public.users
+set username = lower(
+  coalesce(
+    nullif(trim(username), ''),
+    nullif(trim(user_id), ''),
+    nullif(split_part(lower(trim(coalesce(email, ''))), '@', 1), '')
+  )
+)
+where coalesce(trim(username), '') = '';
+
+-- Keep browser reads explicit. entry_code stays excluded from column grants.
+do $$
+declare
+  users_select_columns text;
+begin
+  if to_regclass('public.users') is null then
+    raise notice 'Table public.users does not exist — skipped login column grants';
+  else
+    revoke all on public.users from anon, authenticated;
+
+    select string_agg(quote_ident(column_name), ', ' order by array_position(
+      array[
+        'user_id', 'username', 'email', 'name', 'role', 'display_role',
+        'emp_id', 'is_active', 'permissions', 'auth_user_id', 'created_at', 'updated_at'
+      ],
+      column_name
+    ))
+    into users_select_columns
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'users'
+      and column_name = any (
+        array[
+          'user_id', 'username', 'email', 'name', 'role', 'display_role',
+          'emp_id', 'is_active', 'permissions', 'auth_user_id', 'created_at', 'updated_at'
+        ]
+      );
+
+    if users_select_columns is null then
+      raise notice 'No compatible public.users columns found — skipped login column grants';
+    else
+      execute format('grant select (%s) on public.users to anon, authenticated', users_select_columns);
+      raise notice 'Granted SELECT on public.users columns: %', users_select_columns;
+    end if;
+  end if;
+end $$;

--- a/tests/auth-login-stabilization.test.mjs
+++ b/tests/auth-login-stabilization.test.mjs
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
+const CLIENT_FILE = new URL('../frontend/src/supabase-client.js', import.meta.url);
+const VITE_FILE = new URL('../vite.config.js', import.meta.url);
+const MIGRATION_FILE = new URL('../supabase/migrations/20260621120000_stabilize_auth_login_and_grants.sql', import.meta.url);
+
+test('login uses Supabase Auth email domain and loads users by auth_user_id + username', async () => {
+  const source = await readFile(API_FILE, 'utf8');
+  const loginBlock = source.match(/async function loginWithSupabaseAuth[\s\S]*?^}/m);
+  assert.ok(loginBlock, 'loginWithSupabaseAuth should exist');
+  assert.match(loginBlock[0], /@think\.org\.il/);
+  assert.match(loginBlock[0], /signInWithPassword\(/);
+  assert.match(loginBlock[0], /\.eq\('auth_user_id', authUserId\)/);
+  assert.match(loginBlock[0], /\.eq\('username', username\)/);
+  assert.doesNotMatch(loginBlock[0], /login_user_by_entry_code/);
+  assert.doesNotMatch(loginBlock[0], /\.eq\('entry_code'/);
+});
+
+test('USER_PUBLIC_COLUMNS selects only real users table fields needed for auth bootstrap', async () => {
+  const source = await readFile(API_FILE, 'utf8');
+  const match = source.match(/const USER_PUBLIC_COLUMNS = '([^']+)'/);
+  assert.ok(match, 'USER_PUBLIC_COLUMNS should exist');
+  const columns = match[1].split(',');
+  assert.deepEqual(columns, [
+    'user_id',
+    'username',
+    'email',
+    'name',
+    'role',
+    'display_role',
+    'is_active',
+    'permissions',
+    'auth_user_id'
+  ]);
+});
+
+test('supabase client resolves env vars without hardcoded production fallbacks', async () => {
+  const source = await readFile(CLIENT_FILE, 'utf8');
+  assert.match(source, /VITE_SUPABASE_URL/);
+  assert.match(source, /SUPABASE_URL/);
+  assert.match(source, /VITE_SUPABASE_ANON_KEY/);
+  assert.match(source, /SUPABASE_ANON_KEY/);
+  assert.doesNotMatch(source, /FALLBACK_SUPABASE_URL/);
+  assert.doesNotMatch(source, /usesFallbackUrl/);
+  assert.match(source, /isConfigured/);
+});
+
+test('vite exposes SUPABASE_ env prefix for Preview integrations', async () => {
+  const source = await readFile(VITE_FILE, 'utf8');
+  assert.match(source, /envPrefix:\s*\[[^\]]*'SUPABASE_'/);
+});
+
+test('auth login stabilization migration adds username and auth read grants', async () => {
+  const sql = await readFile(MIGRATION_FILE, 'utf8');
+  assert.match(sql, /add column if not exists username text/i);
+  assert.match(sql, /add column if not exists auth_user_id uuid/i);
+  assert.match(sql, /grant select \(%s\) on public\.users to anon, authenticated/i);
+  assert.match(sql, /'auth_user_id'/);
+  assert.match(sql, /'username'/);
+});
+
+test('placeholder migrations use valid no-op SQL for Supabase Preview', async () => {
+  const files = [
+    '../supabase/migrations/20260614224918_grant_proposals_agreements_directory_view_select.sql',
+    '../supabase/migrations/20260617214409_grant_workshop_stock_distributions_client_access.sql',
+    '../supabase/migrations/20260621090000_reconcile_migration_history.sql',
+    '../supabase/migrations/20260620155322_add_participants_count_to_activities.sql',
+    '../supabase/migrations/20260614224924_grant_proposals_agreements_directory_view_dependencies.sql',
+    '../supabase/migrations/20260614224709_add_proposal_directory_compat_aliases.sql'
+  ];
+
+  for (const rel of files) {
+    const sql = await readFile(new URL(rel, import.meta.url), 'utf8');
+    assert.match(sql, /SELECT\s+1\s*;/i, `${rel} should contain SELECT 1; no-op`);
+  }
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig(() => {
   return {
     root: __dirname,
     base,
+    envPrefix: ['VITE_', 'NEXT_PUBLIC_', 'SUPABASE_'],
     publicDir: 'frontend/public',
     appType: 'spa',
     plugins: [manifestLinkPlugin()],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores a stable Supabase Auth login path and fixes environment-variable handling so Preview branches no longer silently fall back to production credentials or fail on empty migration files.

## Changes

### Supabase Auth login (unchanged flow, fixed data access)
- Login still maps username → `{username}@think.org.il` and authenticates via `signInWithPassword`
- After Auth success, loads `public.users` by **`auth_user_id` + `username`**
- Does **not** use `entry_code` RPC login or DB password validation

### New migration: `20260621120000_stabilize_auth_login_and_grants.sql`
- Adds/backfills `public.users.username` from `user_id` / email local-part
- Ensures `auth_user_id` and `display_role` columns exist
- Re-grants client `SELECT` on login-required columns including `auth_user_id` and `username`

### Environment variables
- Removed hardcoded production Supabase URL/anon key fallbacks from `supabase-client.js`
- Resolves `VITE_*`, `NEXT_PUBLIC_*`, and `SUPABASE_*` env vars (Preview integrations)
- Vite `envPrefix` now includes `SUPABASE_`
- Added `.env.example`

### Supabase Preview stability
- Normalized empty/invalid placeholder migrations to valid `SELECT 1;` no-ops
- Replaced `SELECT 'noop'` placeholders with `SELECT 1;`

### Other
- `USER_PUBLIC_COLUMNS` now selects only real `users` table columns (permission flags still come from `permissions` JSONB)
- Migrate scripts updated to use `@think.org.il` email domain (repo only; not executed against live data)

## Verification

- `node --test tests/auth-login-stabilization.test.mjs` — pass (6/6)
- `node --check` on changed JS files — pass
- `npm run check:build` with sample `VITE_SUPABASE_*` env vars — pass

## Notes

- No production data changes, no Supabase reset/repair, no auth user/password changes
- Preview branches will pick up the new migration automatically; ensure Preview deploy env vars point at the Preview Supabase project (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` or `SUPABASE_*`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bf056ed-c866-4daa-b731-5cd613b913be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bf056ed-c866-4daa-b731-5cd613b913be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

