### PR TITLE
Restore personal reports Supabase Auth login

### DIFF
--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -525,6 +525,26 @@ function normalizeAccessCode(value) {
   return String(value).trim();
 }
 
+function buildInternalAuthEmail(employeeCode) {
+  const code = String(employeeCode || '').trim();
+  return code.includes('@') ? code : `${code}@think.org.il`;
+}
+
+function personalReportsLoginIdentifier(user) {
+  return String(user?.user_id || user?.username || user?.email || user?.work_email || user?.emp_id || user?.employee_id || '').trim();
+}
+
+function sameDashboardUser(userRow, dashboardUser) {
+  const expected = [dashboardUser?.user_id, dashboardUser?.username, dashboardUser?.email, dashboardUser?.work_email, dashboardUser?.emp_id, dashboardUser?.employee_id]
+    .map((value) => String(value || '').trim().toLowerCase())
+    .filter(Boolean);
+  const actual = [userRow?.user_id, userRow?.username, userRow?.email, userRow?.emp_id]
+    .map((value) => String(value || '').trim().toLowerCase())
+    .filter(Boolean);
+  if (!expected.length || !actual.length) return false;
+  return expected.some((value) => actual.includes(value));
+}
+
 function internalLoginErrorMessage(error) {
   const raw = String(error?.message || error?.code || error || '').trim();
   if (/missing_employee_uuid/i.test(raw)) {
@@ -837,56 +857,41 @@ function authUnavailableHtml(message = 'לא נמצא משתמש מחובר במ
 
 async function authenticateInternalEmployee(dashboardUser, accessCode) {
   const user = dashboardUser || dashboardUserForAuth();
-  const enteredCode = normalizeAccessCode(accessCode);
-  if (!enteredCode) {
+  const login = personalReportsLoginIdentifier(user);
+  const password = normalizeAccessCode(accessCode);
+  if (!login || !password) {
     throw new Error('invalid_credentials');
   }
 
-  // Step 1: resolve the Supabase auth email.
-  // Primary: wait for (or read) the existing Supabase session (persisted from previous login).
-  // Fallback: use the dashboard user's authenticated email — they already passed main-app auth.
-  const currentSession = await waitForSupabaseAuthSession({ timeoutMs: 3000 });
-  const sessionEmail = currentSession?.user?.email
-    || String(user?.email || user?.work_email || '').trim();
-  if (!sessionEmail) {
-    console.error('[personal-reports] could not resolve auth email — no Supabase session and no dashboard email');
-    throw new Error('invalid_credentials');
-  }
-
-  // Step 2: re-authenticate against Supabase Auth using the resolved email
-  // and the code the user typed. No DB tables, no entry_code column, no UUIDs.
-  const { error: authError } = await supabase.auth.signInWithPassword({
-    email: sessionEmail,
-    password: enteredCode
+  const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
+    email: buildInternalAuthEmail(login),
+    password
   });
-  if (authError) {
+  if (authError || !authData?.user?.id) {
     throw new Error('invalid_credentials');
   }
 
-  // Reset the cached auth-session promise so that the next waitForSupabaseAuthSession()
-  // call (e.g. in fetchReportEligibleEmployees) gets a fresh promise that resolves with
-  // the newly-established session instead of a stale null from an earlier timeout.
   resetSupabaseAuthSessionWait();
 
-  // Step 3: the UUID for report queries comes exclusively from the
-  // already-authenticated dashboard session — never from the entered code.
-  const authUserId = firstUuid(
-    user?.auth_user_id,
-    user?.personal_reports_user_id,
-    user?.supabase_user_id,
-    user?.id
-  );
-  if (!isUuid(authUserId)) {
-    throw new Error('missing_employee_uuid');
+  const authUserId = authData.user.id;
+  const { data: userRow, error: userError } = await supabase
+    .from('users')
+    .select('user_id,username,email,name,role,display_role,emp_id,is_active,auth_user_id')
+    .eq('auth_user_id', authUserId)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (userError || !userRow || !sameDashboardUser(userRow, user)) {
+    throw new Error('invalid_credentials');
   }
 
   const profile = {
     id: authUserId,
-    email: sessionEmail,
-    full_name: String(user?.full_name || sessionEmail).trim(),
-    role: isAdminRole(user?.display_role || user?.role) ? 'admin' : 'employee',
-    display_role: String(user?.display_role || user?.role || '').trim(),
-    emp_id: String(user?.emp_id || user?.employee_id || '').trim(),
+    email: String(userRow.email || authData.user.email || '').trim(),
+    full_name: String(userRow.name || userRow.email || login).trim(),
+    role: isAdminRole(userRow.role) ? 'admin' : 'employee',
+    display_role: String(userRow.display_role || userRow.role || '').trim(),
+    emp_id: String(userRow.emp_id || userRow.user_id || login).trim(),
     personal_reports_manager: permissionYes(user?.personal_reports_manager) ? 'yes' : 'no',
     can_manage_personal_reports: canManagePersonalReports(user)
   };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 836;
+const CACHE_VERSION = 837;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 836;
+const SW_ENTRY_VERSION = 837;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -79,10 +79,14 @@ test('source keeps personal reports auth temporary and maps verified login to au
   assert.match(source, /function resetPersonalReportsAuth/);
   assert.match(source, /isPersonalReportsUnlocked = false/);
   assert.match(source, /function authenticateInternalEmployee/);
+  assert.match(source, /buildInternalAuthEmail/);
   assert.match(source, /auth\.signInWithPassword/);
-  assert.match(source, /const authUserId = firstUuid\(/);
-  assert.match(source, /user\?\.auth_user_id/);
+  assert.match(source, /const authUserId = authData\.user\.id/);
+  assert.match(source, /\.eq\('auth_user_id', authUserId\)/);
+  assert.match(source, /sameDashboardUser\(userRow, user\)/);
   assert.match(source, /assertEmployeeUuid\(employeeId\)/);
+  assert.doesNotMatch(source, /login_user_by_entry_code/);
+  assert.doesNotMatch(source, /verify_personal_reports_entry_code/);
   assert.doesNotMatch(source, /localStorage|sessionStorage/);
   assert.match(source, /אימות נוסף לדוחות אישיים/);
   assert.match(source, /הקוד שהוזן אינו תקין\. יש לבדוק ולנסות שוב\./);
@@ -230,7 +234,9 @@ test('internal login keeps access code as trimmed string and uses current dashbo
   assert.match(source, /normalizeAccessCode\(fd\.get\('access_code'\)\)/);
   assert.match(source, /const dashboardUser = dashboardUserForAuth\(\)/);
   assert.match(source, /authenticateInternalEmployee\(dashboardUser, accessCode\)/);
-  assert.match(source, /firstUuid\([\s\S]*user\?\.auth_user_id[\s\S]*user\?\.personal_reports_user_id[\s\S]*user\?\.supabase_user_id[\s\S]*user\?\.id/);
+  assert.match(source, /personalReportsLoginIdentifier\(user\)/);
+  assert.match(source, /buildInternalAuthEmail\(login\)/);
+  assert.match(source, /sameDashboardUser\(userRow, user\)/);
   assert.doesNotMatch(source, /Number\(fd\.get\('access_code'\)/);
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Emergency cleanup: restores personal reports internal login to Supabase Auth and removes the accidental entry_code/RPC path introduced in commit `2997e9e`.

## Auth flow (restored)

1. Resolve dashboard user login via `personalReportsLoginIdentifier`
2. Build auth email with `buildInternalAuthEmail` → `{username}@think.org.il`
3. `supabase.auth.signInWithPassword({ email, password })`
4. Load `public.users` by `auth_user_id`
5. Validate row belongs to the same dashboard user via `sameDashboardUser`
6. `needsInternalAuth` behavior unchanged

## Changed files

- `frontend/src/screens/personal-reports.js`
- `frontend/sw.js` (CACHE_VERSION 836 → 837)
- `sw.js` (SW_ENTRY_VERSION 836 → 837)
- `tests/personal-reports-screen.test.mjs`

## Safety

- No Supabase Auth users or passwords changed
- No production data changed
- No migrations changed

## Verification

- `node --test tests/personal-reports-screen.test.mjs` — 27/27 pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bf056ed-c866-4daa-b731-5cd613b913be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bf056ed-c866-4daa-b731-5cd613b913be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

