### PR TITLE
Fix Auth login user resolution fallback

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 838;
+const CACHE_VERSION = 839;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CFBRIyNo.js",
+  "./assets/index-R9dyxWT_.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CFBRIyNo.js"></script>
+  <script type="module" crossorigin src="./assets/index-R9dyxWT_.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 838;
+const CACHE_VERSION = 839;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CFBRIyNo.js",
+  "./assets/index-R9dyxWT_.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,6 +4,7 @@ import { hebrewRole } from './screens/shared/ui-hebrew.js';
 import { cleanActivityManagerName, getContactsInstructorUsers, getRosterUsers, NO_ACTIVITY_MANAGER_LABEL, normalizeOneDayActivityType, resolveActivityInstructorName, buildContactsInstructorLookup, resolveCanonicalInstructorPair, validateInstructorIdentityPayload } from './screens/shared/activity-options.js';
 import { EXCEPTION_TYPE_ORDER, normalizedExceptionTypes } from './screens/shared/exceptions-metrics.js';
 import { isSummerActivity, normalizeActivitySeason } from './screens/shared/summer-activity.js';
+import { resolveActiveUserRowAfterAuth } from './auth-user-resolve.js';
 import { supabase, supabaseConfig, waitForSupabaseAuthSession } from './supabase-client.js';
 import { isEmptyValue, nonEmptyString } from './utils/empty-value.js';
 import { permissionFlagYes, canEditDirect, canAddActivityDirect, canRequestEdit, canRequestCreateActivity, canReviewRequests } from './permissions.js';
@@ -3254,18 +3255,30 @@ async function loginWithSupabaseAuth(user_id, entry_code) {
 
   const authUserId = authData.user.id;
 
-  const { data: userRow, error: profileError } = await supabase
-    .from('users')
-    .select(USER_PUBLIC_COLUMNS)
-    .eq('user_id', username)
-    .eq('is_active', true)
-    .single();
+  const { userRow, matchedBy } = await resolveActiveUserRowAfterAuth({
+    supabase,
+    columns: USER_PUBLIC_COLUMNS,
+    authEmail,
+    username,
+    authUserId
+  });
 
-  if (profileError || !userRow) {
-    throwLoginError('invalid_credentials', { auth_user_id: authUserId, message: String(profileError?.message || '') });
+  if (!userRow) {
+    throwLoginError('auth_ok_user_row_not_found', {
+      auth_user_id: authUserId,
+      auth_email: authEmail,
+      username
+    });
   }
 
   userRow.auth_user_id = authUserId;
+  if (matchedBy) {
+    try {
+      console.info('[login-user-resolve]', { matchedBy, user_id: userRow.user_id, auth_email: authEmail });
+    } catch {
+      /* ignore */
+    }
+  }
 
   assertValidLoginUserRow(userRow);
   const profileRow = await readPersonalReportsProfile(authUserId);
@@ -3284,19 +3297,22 @@ function makeSessionToken(userRow) {
 
 async function readCurrentUserBySession() {
   if (!supabase) throw new Error('no_supabase_client');
-  const userId = String(state?.user?.user_id || '').trim();
-  if (!userId) throw new Error('unauthorized');
   const session = await waitForSupabaseAuthSession();
   if (!session?.user?.id) throw new Error('unauthorized');
-  const { data, error } = await supabase
-    .from('users')
-    .select(USER_PUBLIC_COLUMNS)
-    .eq('user_id', userId)
-    .single();
-  if (error || !data) throw new Error('unauthorized');
-  if (!data.is_active) throw new Error('unauthorized');
-  const profileRow = await readPersonalReportsProfile(data.auth_user_id);
-  return { userRow: data, profileRow };
+  const authUserId = session.user.id;
+  const authEmail = String(session.user.email || state?.user?.email || '').trim().toLowerCase();
+  const username = String(state?.user?.user_id || state?.user?.username || '').trim().toLowerCase();
+  const { userRow } = await resolveActiveUserRowAfterAuth({
+    supabase,
+    columns: USER_PUBLIC_COLUMNS,
+    authEmail,
+    username,
+    authUserId
+  });
+  if (!userRow) throw new Error('unauthorized');
+  userRow.auth_user_id = authUserId;
+  const profileRow = await readPersonalReportsProfile(authUserId);
+  return { userRow, profileRow };
 }
 
 function buildSupabaseMutationError(operation, error, fallback = 'server_error') {

--- a/frontend/src/auth-user-resolve.js
+++ b/frontend/src/auth-user-resolve.js
@@ -1,0 +1,36 @@
+import { supabase } from './supabase-client.js';
+
+export const AUTH_USER_PUBLIC_COLUMNS = 'user_id,email,name,role,emp_id,is_active,permissions';
+
+async function fetchActiveUserRowByColumn(client, columns, column, value) {
+  if (!client || !column || value == null || value === '') return null;
+  const { data, error } = await client
+    .from('users')
+    .select(columns)
+    .eq(column, value)
+    .eq('is_active', true)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data;
+}
+
+export async function resolveActiveUserRowAfterAuth(options = {}) {
+  const client = options.supabase || supabase;
+  const columns = String(options.columns || AUTH_USER_PUBLIC_COLUMNS);
+  const authEmail = String(options.authEmail || '').trim().toLowerCase();
+  const username = String(options.username || '').trim().toLowerCase();
+  const authUserId = String(options.authUserId || '').trim();
+
+  const attempts = [
+    ['email', authEmail],
+    ['user_id', username],
+    ['emp_id', username]
+  ];
+  if (authUserId) attempts.push(['auth_user_id', authUserId]);
+
+  for (const [column, value] of attempts) {
+    const userRow = await fetchActiveUserRowByColumn(client, columns, column, value);
+    if (userRow) return { userRow, matchedBy: column };
+  }
+  return { userRow: null, matchedBy: '' };
+}

--- a/frontend/src/screens/personal-reports.js
+++ b/frontend/src/screens/personal-reports.js
@@ -11,6 +11,7 @@
  */
 
 import { supabase, waitForSupabaseAuthSession, resetSupabaseAuthSessionWait } from '../supabase-client.js';
+import { resolveActiveUserRowAfterAuth } from '../auth-user-resolve.js';
 import { escapeHtml } from './shared/html.js';
 import { dsPageHeader, dsEmptyState, dsStatusChip, dsScreenStack } from './shared/layout.js';
 
@@ -589,7 +590,13 @@ function friendlyPersonalReportsError(error, fallback = 'אירעה תקלה ב�
   if (/invalid input syntax for type uuid|uuid/i.test(raw)) {
     return 'פרטי ההתחברות אינם תקינים. יש לבדוק את קוד העובד ולנסות שוב.';
   }
-  if (/invalid_credentials|entry_code_mismatch|user_not_found|not_found/i.test(raw)) {
+  if (/invalid_credentials|entry_code_mismatch/i.test(raw)) {
+    return 'שם משתמש או סיסמה שגויים';
+  }
+  if (/auth_ok_user_row_not_found/i.test(raw)) {
+    return 'לא נמצא פרופיל משתמש במערכת. יש לפנות למנהל המערכת.';
+  }
+  if (/user_not_found|not_found/i.test(raw)) {
     return 'שם משתמש או סיסמה שגויים';
   }
   if (/missing_employee_uuid/i.test(raw)) {
@@ -874,14 +881,26 @@ async function authenticateInternalEmployee(dashboardUser, accessCode) {
   resetSupabaseAuthSessionWait();
 
   const authUserId = authData.user.id;
-  const { data: userRow, error: userError } = await supabase
-    .from('users')
-    .select('user_id,email,name,role,emp_id,is_active')
-    .eq('user_id', login.toLowerCase())
-    .eq('is_active', true)
-    .maybeSingle();
+  const authEmail = buildInternalAuthEmail(login).trim().toLowerCase();
+  const username = login.toLowerCase();
+  const { userRow } = await resolveActiveUserRowAfterAuth({
+    supabase,
+    columns: 'user_id,email,name,role,emp_id,is_active',
+    authEmail,
+    username,
+    authUserId
+  });
 
-  if (userError || !userRow || !sameDashboardUser(userRow, user)) {
+  if (!userRow || !sameDashboardUser(userRow, user)) {
+    if (!userRow) {
+      console.warn('[login-diagnostic]', {
+        code: 'auth_ok_user_row_not_found',
+        auth_user_id: authUserId,
+        auth_email: authEmail,
+        username
+      });
+      throw new Error('auth_ok_user_row_not_found');
+    }
     throw new Error('invalid_credentials');
   }
 

--- a/frontend/src/screens/shared/ui-hebrew.js
+++ b/frontend/src/screens/shared/ui-hebrew.js
@@ -239,6 +239,7 @@ const API_ERROR_HE = {
   missing_row_id: 'חסר מזהה פעילות לשמירה',
   'user_id is required': 'יש להזין מזהה משתמש',
   invalid_credentials: 'שם משתמש או סיסמה שגויים',
+  auth_ok_user_row_not_found: 'לא נמצא פרופיל משתמש במערכת. יש לפנות למנהל המערכת.',
   no_supabase_client: 'חיבור Supabase אינו מוגדר — פנה למנהל המערכת',
   missing_user_id_or_entry_code: 'יש להזין מזהה משתמש וקוד כניסה',
   user_not_found: 'המשתמש/ת לא נמצא/ה במערכת',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 838;
+const CACHE_VERSION = 839;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 838;
+const SW_ENTRY_VERSION = 839;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/auth-login-stabilization.test.mjs
+++ b/tests/auth-login-stabilization.test.mjs
@@ -1,21 +1,108 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { resolveActiveUserRowAfterAuth } from '../frontend/src/auth-user-resolve.js';
 
 const API_FILE = new URL('../frontend/src/api.js', import.meta.url);
 const CLIENT_FILE = new URL('../frontend/src/supabase-client.js', import.meta.url);
 const VITE_FILE = new URL('../vite.config.js', import.meta.url);
+const RESOLVE_FILE = new URL('../frontend/src/auth-user-resolve.js', import.meta.url);
 
-test('login uses Supabase Auth email domain and loads users by user_id after Auth', async () => {
+function createMockSupabase(responsesByColumn) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            eq(column) {
+              const value = arguments[1];
+              return {
+                eq() {
+                  return {
+                    async maybeSingle() {
+                      const row = responsesByColumn[column]?.[value] ?? null;
+                      return row ? { data: row, error: null } : { data: null, error: { message: 'not found' } };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+test('login uses Supabase Auth email domain and resolves users with email-first fallback', async () => {
   const source = await readFile(API_FILE, 'utf8');
   const loginBlock = source.match(/async function loginWithSupabaseAuth[\s\S]*?^}/m);
   assert.ok(loginBlock, 'loginWithSupabaseAuth should exist');
   assert.match(loginBlock[0], /@think\.org\.il/);
   assert.match(loginBlock[0], /signInWithPassword\(/);
-  assert.match(loginBlock[0], /\.eq\('user_id', username\)/);
+  assert.match(loginBlock[0], /resolveActiveUserRowAfterAuth\(/);
+  assert.match(loginBlock[0], /auth_ok_user_row_not_found/);
   assert.match(loginBlock[0], /userRow\.auth_user_id = authUserId/);
   assert.doesNotMatch(loginBlock[0], /login_user_by_entry_code/);
   assert.doesNotMatch(loginBlock[0], /\.eq\('entry_code'/);
+  assert.doesNotMatch(loginBlock[0], /throwLoginError\('invalid_credentials', \{ auth_user_id/);
+});
+
+test('resolveActiveUserRowAfterAuth finds idann by email when user_id differs', async () => {
+  const authEmail = 'idann@think.org.il';
+  const mockSupabase = createMockSupabase({
+    email: {
+      [authEmail]: {
+        user_id: '1234',
+        email: authEmail,
+        name: 'Idan N',
+        role: 'admin',
+        emp_id: '1234',
+        is_active: true
+      }
+    },
+    user_id: {
+      idann: null
+    }
+  });
+
+  const { userRow, matchedBy } = await resolveActiveUserRowAfterAuth({
+    supabase: mockSupabase,
+    authEmail,
+    username: 'idann',
+    authUserId: '00000000-0000-4000-8000-000000000001'
+  });
+
+  assert.equal(matchedBy, 'email');
+  assert.equal(userRow.user_id, '1234');
+  assert.equal(userRow.email, authEmail);
+});
+
+test('resolveActiveUserRowAfterAuth falls back to user_id when email lookup misses', async () => {
+  const authEmail = 'worker@think.org.il';
+  const mockSupabase = createMockSupabase({
+    email: {},
+    user_id: {
+      worker: {
+        user_id: 'worker',
+        email: 'other@think.org.il',
+        name: 'Worker',
+        role: 'instructor',
+        emp_id: '9000',
+        is_active: true
+      }
+    }
+  });
+
+  const { userRow, matchedBy } = await resolveActiveUserRowAfterAuth({
+    supabase: mockSupabase,
+    authEmail,
+    username: 'worker',
+    authUserId: '00000000-0000-4000-8000-000000000002'
+  });
+
+  assert.equal(matchedBy, 'user_id');
+  assert.equal(userRow.user_id, 'worker');
 });
 
 test('USER_PUBLIC_COLUMNS selects granted users table fields only', async () => {
@@ -32,6 +119,18 @@ test('USER_PUBLIC_COLUMNS selects granted users table fields only', async () => 
     'is_active',
     'permissions'
   ]);
+});
+
+test('auth user resolver tries email before user_id and emp_id', async () => {
+  const source = await readFile(RESOLVE_FILE, 'utf8');
+  const emailIndex = source.indexOf("['email', authEmail]");
+  const userIdIndex = source.indexOf("['user_id', username]");
+  const empIdIndex = source.indexOf("['emp_id', username]");
+  assert.ok(emailIndex >= 0, 'email lookup should exist');
+  assert.ok(userIdIndex >= 0, 'user_id lookup should exist');
+  assert.ok(empIdIndex >= 0, 'emp_id lookup should exist');
+  assert.ok(emailIndex < userIdIndex, 'email should be tried before user_id');
+  assert.ok(userIdIndex < empIdIndex, 'user_id should be tried before emp_id');
 });
 
 test('supabase client prefers env vars and keeps production fallback when unset', async () => {

--- a/tests/emergency-cleanup-stabilization.test.mjs
+++ b/tests/emergency-cleanup-stabilization.test.mjs
@@ -31,8 +31,7 @@ test('frontend login uses Supabase Auth and not entry_code RPC', async () => {
   assert.doesNotMatch(api, /login_user_by_entry_code/);
 
   assert.match(pr, /signInWithPassword\(/);
-  assert.match(pr, /buildInternalAuthEmail\(login\)/);
-  assert.match(pr, /\.eq\('user_id', login\.toLowerCase\(\)\)/);
+  assert.match(pr, /resolveActiveUserRowAfterAuth/);
   assert.doesNotMatch(pr, /login_user_by_entry_code/);
   assert.doesNotMatch(pr, /verify_personal_reports_entry_code/);
 });

--- a/tests/personal-reports-screen.test.mjs
+++ b/tests/personal-reports-screen.test.mjs
@@ -82,7 +82,8 @@ test('source keeps personal reports auth temporary and maps verified login to au
   assert.match(source, /buildInternalAuthEmail/);
   assert.match(source, /auth\.signInWithPassword/);
   assert.match(source, /const authUserId = authData\.user\.id/);
-  assert.match(source, /\.eq\('user_id', login\.toLowerCase\(\)\)/);
+  assert.match(source, /resolveActiveUserRowAfterAuth/);
+  assert.match(source, /auth_ok_user_row_not_found/);
   assert.match(source, /sameDashboardUser\(userRow, user\)/);
   assert.match(source, /assertEmployeeUuid\(employeeId\)/);
   assert.doesNotMatch(source, /login_user_by_entry_code/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- After Supabase Auth succeeds, resolve the matching `public.users` row with an email-first fallback chain instead of requiring `user_id = username`.
- Preserve `auth_user_id` from the Auth session on the returned user object.
- Distinguish Auth-success / missing-profile failures (`auth_ok_user_row_not_found`) from invalid credentials in console diagnostics and UI translation.
- Apply the same resolver in personal reports internal auth and session bootstrap.
- Bump service worker cache version to `839`.

## Fallback order

1. `email = authEmail`
2. `user_id = normalized username`
3. `emp_id = normalized username`
4. `auth_user_id` (optional, when available)

## Constraints respected

- Login still uses `supabase.auth.signInWithPassword({ email: authEmail, password })`
- No password, Supabase Auth user, production data, migration, or reset/repair changes

## Verification

- `node --test tests/auth-login-stabilization.test.mjs`
- `node --test tests/personal-reports-screen.test.mjs`
- `npm run check:build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f9c7326-39c6-426e-855a-a816b21dac28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f9c7326-39c6-426e-855a-a816b21dac28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

