### PR TITLE
Fix proposals permissions after Auth cleanup

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2943,6 +2943,7 @@ async function readProposalsAgreementsFromSupabase() {
 }
 
 const USER_PUBLIC_COLUMNS = 'user_id,email,name,role,emp_id,is_active,permissions';
+const USER_PUBLIC_COLUMNS_EXTENDED = `${USER_PUBLIC_COLUMNS},can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements`;
 const PROFILE_PERSONAL_REPORTS_COLUMNS = 'id,is_active,can_access_personal_reports';
 const VALID_SUPABASE_ROLES = new Set(['admin', 'operation_manager', 'authorized_user', 'instructor', 'finance', 'activities_manager', 'domain_manager', 'instructor_manager', 'business_development_manager']);
 
@@ -3122,6 +3123,17 @@ function flattenUserRow(userRow = {}) {
   return flat;
 }
 
+function proposalPermissionFlagsFromFlatUser(flat = {}) {
+  const view = permissionFlagYes(flat.view_proposals_agreements) || permissionFlagYes(flat.manage_proposals_agreements);
+  const manage = permissionFlagYes(flat.manage_proposals_agreements);
+  const approve = permissionFlagYes(flat.approve_proposals_agreements);
+  return {
+    view_proposals_agreements: view ? 'yes' : undefined,
+    manage_proposals_agreements: manage ? 'yes' : undefined,
+    approve_proposals_agreements: approve ? 'yes' : undefined
+  };
+}
+
 function buildBootstrapFromUser(userRow, profileRow = null) {
   const flat = flattenUserRow(userRow);
   const role = normalizeSupabaseRole(flat.role);
@@ -3176,6 +3188,7 @@ function buildBootstrapFromUser(userRow, profileRow = null) {
     has_personal_reports_access: hasPersonalReportsAccess,
     has_personal_reports_manager: hasPersonalReportsManager,
     profile_is_active: profileRow?.is_active !== false,
+    ...proposalPermissionFlagsFromFlatUser(flat),
     profile: {
       full_name: flat.full_name,
       display_role2: flat.display_role2 || '',
@@ -3257,7 +3270,8 @@ async function loginWithSupabaseAuth(user_id, entry_code) {
 
   const { userRow, matchedBy } = await resolveActiveUserRowAfterAuth({
     supabase,
-    columns: USER_PUBLIC_COLUMNS,
+    baseColumns: USER_PUBLIC_COLUMNS,
+    extendedColumns: USER_PUBLIC_COLUMNS_EXTENDED,
     authEmail,
     username,
     authUserId
@@ -3304,7 +3318,8 @@ async function readCurrentUserBySession() {
   const username = String(state?.user?.user_id || state?.user?.username || '').trim().toLowerCase();
   const { userRow } = await resolveActiveUserRowAfterAuth({
     supabase,
-    columns: USER_PUBLIC_COLUMNS,
+    baseColumns: USER_PUBLIC_COLUMNS,
+    extendedColumns: USER_PUBLIC_COLUMNS_EXTENDED,
     authEmail,
     username,
     authUserId
@@ -4288,6 +4303,7 @@ export const api = {
     const token = makeSessionToken(user);
     const flat = flattenUserRow(user);
     const hasPersonalReportsAccess = profileCanAccessPersonalReports(profileRow);
+    const proposalFlags = proposalPermissionFlagsFromFlatUser(flat);
     return {
       token,
       user: {
@@ -4310,8 +4326,7 @@ export const api = {
         profile_is_active: profileRow?.is_active !== false,
         can_access_personal_reports: hasPersonalReportsAccess,
         personal_reports_manager: permissionFlagYes(flat.personal_reports_manager) ? 'yes' : 'no',
-        view_proposals_agreements: permissionFlagYes(flat.view_proposals_agreements) || permissionFlagYes(flat.manage_proposals_agreements) || undefined,
-        manage_proposals_agreements: permissionFlagYes(flat.manage_proposals_agreements) || undefined
+        ...proposalFlags
       },
       ...buildBootstrapFromUser(user, profileRow),
       client_settings: buildClientSettingsFromLists(listsData, settingsRows, instructorContactsRows)
@@ -5423,5 +5438,13 @@ export {
   sanitizeActivityPayload,
   sanitizeActivityPayloadForSupabase,
   normalizeOneDayActivityForSave,
-  canonicalOneDayActivityType
+  canonicalOneDayActivityType,
+  flattenUserRow,
+  buildBootstrapFromUser,
+  proposalPermissionFlagsFromFlatUser,
+  canUseProposalsAgreementsApi,
+  canManageProposalsAgreementsApi,
+  canApproveProposalsAgreementsApi,
+  USER_PUBLIC_COLUMNS,
+  USER_PUBLIC_COLUMNS_EXTENDED
 };

--- a/frontend/src/auth-user-resolve.js
+++ b/frontend/src/auth-user-resolve.js
@@ -1,22 +1,36 @@
 import { supabase } from './supabase-client.js';
 
 export const AUTH_USER_PUBLIC_COLUMNS = 'user_id,email,name,role,emp_id,is_active,permissions';
+export const AUTH_USER_PUBLIC_COLUMNS_EXTENDED = `${AUTH_USER_PUBLIC_COLUMNS},can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements`;
+
+function isMissingSupabaseColumnError(error) {
+  const msg = String(error?.message || error?.details || error?.hint || error || '').toLowerCase();
+  return msg.includes('column') || msg.includes('schema cache') || msg.includes('could not find');
+}
 
 async function fetchActiveUserRowByColumn(client, columns, column, value) {
-  if (!client || !column || value == null || value === '') return null;
+  if (!client || !column || value == null || value === '') {
+    return { userRow: null, missingColumnError: false };
+  }
   const { data, error } = await client
     .from('users')
     .select(columns)
     .eq(column, value)
     .eq('is_active', true)
     .maybeSingle();
-  if (error || !data) return null;
-  return data;
+  if (error) {
+    return {
+      userRow: null,
+      missingColumnError: isMissingSupabaseColumnError(error),
+      error
+    };
+  }
+  if (!data) return { userRow: null, missingColumnError: false };
+  return { userRow: data, missingColumnError: false };
 }
 
-export async function resolveActiveUserRowAfterAuth(options = {}) {
+async function resolveActiveUserRowWithColumns(options, columns) {
   const client = options.supabase || supabase;
-  const columns = String(options.columns || AUTH_USER_PUBLIC_COLUMNS);
   const authEmail = String(options.authEmail || '').trim().toLowerCase();
   const username = String(options.username || '').trim().toLowerCase();
   const authUserId = String(options.authUserId || '').trim();
@@ -29,8 +43,34 @@ export async function resolveActiveUserRowAfterAuth(options = {}) {
   if (authUserId) attempts.push(['auth_user_id', authUserId]);
 
   for (const [column, value] of attempts) {
-    const userRow = await fetchActiveUserRowByColumn(client, columns, column, value);
-    if (userRow) return { userRow, matchedBy: column };
+    const result = await fetchActiveUserRowByColumn(client, columns, column, value);
+    if (result.missingColumnError) {
+      return { userRow: null, matchedBy: '', missingColumnError: true };
+    }
+    if (result.userRow) {
+      return { userRow: result.userRow, matchedBy: column, missingColumnError: false };
+    }
   }
-  return { userRow: null, matchedBy: '' };
+  return { userRow: null, matchedBy: '', missingColumnError: false };
+}
+
+export async function resolveActiveUserRowAfterAuth(options = {}) {
+  const baseColumns = String(options.baseColumns || AUTH_USER_PUBLIC_COLUMNS);
+  const extendedColumns = String(options.extendedColumns || AUTH_USER_PUBLIC_COLUMNS_EXTENDED);
+  const explicitColumns = options.columns != null ? String(options.columns) : null;
+  const useExtendedColumnFallback = options.useExtendedColumnFallback !== false && !explicitColumns;
+
+  if (explicitColumns) {
+    return resolveActiveUserRowWithColumns(options, explicitColumns);
+  }
+
+  if (!useExtendedColumnFallback) {
+    return resolveActiveUserRowWithColumns(options, baseColumns);
+  }
+
+  const extendedResult = await resolveActiveUserRowWithColumns(options, extendedColumns);
+  if (extendedResult.missingColumnError) {
+    return resolveActiveUserRowWithColumns(options, baseColumns);
+  }
+  return extendedResult;
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -970,7 +970,8 @@ function enforceProposalsAgreementsRoute() {
   if ((state.effectiveRoutes || []).includes('proposals-agreements')) return;
   const role = String(state.user.role || '').trim();
   const hasRole = PROPOSALS_AGREEMENTS_NAV_ROLES.has(role);
-  const hasFlag = state.user.view_proposals_agreements === true || state.user.manage_proposals_agreements === true;
+  const hasFlag = permissionEnabled(state.user.view_proposals_agreements)
+    || permissionEnabled(state.user.manage_proposals_agreements);
   if (hasRole || hasFlag) {
     state.effectiveRoutes = [...(state.effectiveRoutes || []), 'proposals-agreements'];
     state.routes = state.effectiveRoutes;
@@ -1661,6 +1662,15 @@ function applyBootstrapUserFlags(bootstrap) {
   state.user.profile_is_active = bootstrap.profile_is_active !== false;
   state.user.can_access_personal_reports = !!bootstrap.has_personal_reports_access;
   state.user.personal_reports_manager = !!bootstrap.has_personal_reports_manager;
+  if (bootstrap.view_proposals_agreements != null) {
+    state.user.view_proposals_agreements = bootstrap.view_proposals_agreements;
+  }
+  if (bootstrap.manage_proposals_agreements != null) {
+    state.user.manage_proposals_agreements = bootstrap.manage_proposals_agreements;
+  }
+  if (bootstrap.approve_proposals_agreements != null) {
+    state.user.approve_proposals_agreements = bootstrap.approve_proposals_agreements;
+  }
   if (hasActivitiesRouteAccess() && !state.effectiveRoutes.includes('activities')) {
     state.effectiveRoutes = [...state.effectiveRoutes, 'activities'];
     state.routes = state.effectiveRoutes;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 839;
+const CACHE_VERSION = 840;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 839;
+const SW_ENTRY_VERSION = 840;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/auth-login-stabilization.test.mjs
+++ b/tests/auth-login-stabilization.test.mjs
@@ -119,6 +119,15 @@ test('USER_PUBLIC_COLUMNS selects granted users table fields only', async () => 
     'is_active',
     'permissions'
   ]);
+  assert.match(source, /USER_PUBLIC_COLUMNS_EXTENDED = `\$\{USER_PUBLIC_COLUMNS\},can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements`/);
+});
+
+test('auth user resolver supports extended column fallback after auth', async () => {
+  const source = await readFile(RESOLVE_FILE, 'utf8');
+  assert.match(source, /AUTH_USER_PUBLIC_COLUMNS_EXTENDED/);
+  assert.match(source, /missingColumnError/);
+  assert.match(source, /schema cache/);
+  assert.match(source, /resolveActiveUserRowWithColumns/);
 });
 
 test('auth user resolver tries email before user_id and emp_id', async () => {

--- a/tests/proposals-permissions-resolution.test.mjs
+++ b/tests/proposals-permissions-resolution.test.mjs
@@ -1,0 +1,283 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  AUTH_USER_PUBLIC_COLUMNS,
+  AUTH_USER_PUBLIC_COLUMNS_EXTENDED,
+  resolveActiveUserRowAfterAuth
+} from '../frontend/src/auth-user-resolve.js';
+
+if (!globalThis.sessionStorage) {
+  const sessionStore = new Map();
+  globalThis.sessionStorage = {
+    getItem: (key) => sessionStore.has(key) ? sessionStore.get(key) : null,
+    setItem: (key, value) => sessionStore.set(key, String(value)),
+    removeItem: (key) => sessionStore.delete(key),
+    clear: () => sessionStore.clear()
+  };
+}
+
+if (!globalThis.localStorage) {
+  const localStore = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => localStore.has(key) ? localStore.get(key) : null,
+    setItem: (key, value) => localStore.set(key, String(value)),
+    removeItem: (key) => localStore.delete(key),
+    clear: () => localStore.clear()
+  };
+}
+
+const {
+  flattenUserRow,
+  buildBootstrapFromUser,
+  proposalPermissionFlagsFromFlatUser,
+  canUseProposalsAgreementsApi,
+  canManageProposalsAgreementsApi,
+  canApproveProposalsAgreementsApi
+} = await import('../frontend/src/api.js');
+const { state } = await import('../frontend/src/state.js');
+const { canAccessProposalsAgreements, canManageProposalsAgreements } = await import('../frontend/src/screens/proposals-agreements.js');
+
+function createMockSupabase(responsesByColumn, options = {}) {
+  const { failExtendedColumns = false } = options;
+  return {
+    from() {
+      return {
+        select(columns) {
+          const isExtended = String(columns).includes('view_proposals_agreements');
+          return {
+            eq(column) {
+              const value = arguments[1];
+              return {
+                eq() {
+                  return {
+                    async maybeSingle() {
+                      if (failExtendedColumns && isExtended) {
+                        return {
+                          data: null,
+                          error: { message: 'column view_proposals_agreements does not exist in schema cache' }
+                        };
+                      }
+                      const row = responsesByColumn[column]?.[value] ?? null;
+                      return row ? { data: row, error: null } : { data: null, error: { message: 'not found' } };
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+function withUser(user, fn) {
+  const previous = state.user;
+  state.user = user;
+  try {
+    return fn();
+  } finally {
+    state.user = previous;
+  }
+}
+
+test('USER_PUBLIC_COLUMNS keeps base columns and extended list adds compatibility fields', async () => {
+  const source = await readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  const baseMatch = source.match(/const USER_PUBLIC_COLUMNS = '([^']+)'/);
+  assert.ok(baseMatch);
+  assert.equal(baseMatch[1], AUTH_USER_PUBLIC_COLUMNS);
+  assert.equal(
+    AUTH_USER_PUBLIC_COLUMNS_EXTENDED,
+    `${AUTH_USER_PUBLIC_COLUMNS},can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements`
+  );
+  assert.match(
+    source,
+    /USER_PUBLIC_COLUMNS_EXTENDED = `\$\{USER_PUBLIC_COLUMNS\},can_review_requests,view_proposals_agreements,manage_proposals_agreements,approve_proposals_agreements`/
+  );
+});
+
+test('flattenUserRow preserves JSONB permissions and top-level columns override JSON values', () => {
+  const flat = flattenUserRow({
+    user_id: 'u1',
+    name: 'Test User',
+    role: 'authorized_user',
+    is_active: true,
+    permissions: {
+      view_proposals_agreements: 'no',
+      manage_proposals_agreements: 'no',
+      approve_proposals_agreements: 'no'
+    },
+    view_proposals_agreements: 'yes',
+    manage_proposals_agreements: 'yes',
+    approve_proposals_agreements: 'yes'
+  });
+
+  assert.equal(flat.view_proposals_agreements, 'yes');
+  assert.equal(flat.manage_proposals_agreements, 'yes');
+  assert.equal(flat.approve_proposals_agreements, 'yes');
+});
+
+test('JSONB view_proposals_agreements allows proposals route and API access', () => {
+  const userRow = {
+    user_id: 'viewer',
+    role: 'authorized_user',
+    is_active: true,
+    permissions: { view_proposals_agreements: 'yes' }
+  };
+  const flat = flattenUserRow(userRow);
+  const bootstrap = buildBootstrapFromUser(userRow);
+  assert.ok(bootstrap.routes.includes('proposals-agreements'));
+
+  withUser(flat, () => {
+    assert.equal(canUseProposalsAgreementsApi(), true);
+    assert.equal(canAccessProposalsAgreements({ user: flat, effectiveRoutes: bootstrap.routes }), true);
+  });
+});
+
+test('top-level view_proposals_agreements allows proposals route and API access', () => {
+  const userRow = {
+    user_id: 'viewer-top',
+    role: 'authorized_user',
+    is_active: true,
+    permissions: {},
+    view_proposals_agreements: 'yes'
+  };
+  const flat = flattenUserRow(userRow);
+  const bootstrap = buildBootstrapFromUser(userRow);
+
+  assert.ok(bootstrap.routes.includes('proposals-agreements'));
+  withUser(flat, () => {
+    assert.equal(canUseProposalsAgreementsApi(), true);
+    assert.equal(canAccessProposalsAgreements({ user: flat, effectiveRoutes: bootstrap.routes }), true);
+  });
+});
+
+test('top-level manage_proposals_agreements allows management', () => {
+  const userRow = {
+    user_id: 'manager-top',
+    role: 'authorized_user',
+    is_active: true,
+    permissions: {},
+    manage_proposals_agreements: 'yes'
+  };
+  const flat = flattenUserRow(userRow);
+
+  withUser(flat, () => {
+    assert.equal(canManageProposalsAgreementsApi(), true);
+    assert.equal(canManageProposalsAgreements({ user: flat }), true);
+  });
+});
+
+test('top-level approve_proposals_agreements allows approval', () => {
+  const userRow = {
+    user_id: 'approver-top',
+    role: 'operation_manager',
+    is_active: true,
+    permissions: {},
+    approve_proposals_agreements: 'yes'
+  };
+  const flat = flattenUserRow(userRow);
+
+  withUser(flat, () => {
+    assert.equal(canApproveProposalsAgreementsApi(), true);
+  });
+});
+
+test('proposalPermissionFlagsFromFlatUser exposes yes flags for session user', () => {
+  const flags = proposalPermissionFlagsFromFlatUser(flattenUserRow({
+    user_id: 'flags',
+    role: 'authorized_user',
+    is_active: true,
+    permissions: { view_proposals_agreements: 'yes', approve_proposals_agreements: 'yes' }
+  }));
+  assert.equal(flags.view_proposals_agreements, 'yes');
+  assert.equal(flags.approve_proposals_agreements, 'yes');
+  assert.equal(flags.manage_proposals_agreements, undefined);
+});
+
+test('resolveActiveUserRowAfterAuth falls back to base columns when optional columns are missing', async () => {
+  const authEmail = 'viewer@think.org.il';
+  const mockSupabase = createMockSupabase({
+    email: {
+      [authEmail]: {
+        user_id: 'viewer',
+        email: authEmail,
+        name: 'Viewer',
+        role: 'authorized_user',
+        emp_id: 'viewer',
+        is_active: true,
+        permissions: { view_proposals_agreements: 'yes' }
+      }
+    }
+  }, { failExtendedColumns: true });
+
+  const { userRow, matchedBy } = await resolveActiveUserRowAfterAuth({
+    supabase: mockSupabase,
+    authEmail,
+    username: 'viewer',
+    authUserId: '00000000-0000-4000-8000-000000000010'
+  });
+
+  assert.equal(matchedBy, 'email');
+  assert.equal(userRow.user_id, 'viewer');
+  assert.deepEqual(userRow.permissions, { view_proposals_agreements: 'yes' });
+});
+
+test('resolveActiveUserRowAfterAuth uses extended columns when available', async () => {
+  const authEmail = 'manager@think.org.il';
+  const mockSupabase = createMockSupabase({
+    email: {
+      [authEmail]: {
+        user_id: 'manager',
+        email: authEmail,
+        name: 'Manager',
+        role: 'authorized_user',
+        emp_id: 'manager',
+        is_active: true,
+        permissions: {},
+        manage_proposals_agreements: 'yes'
+      }
+    }
+  });
+
+  const { userRow } = await resolveActiveUserRowAfterAuth({
+    supabase: mockSupabase,
+    authEmail,
+    username: 'manager',
+    authUserId: '00000000-0000-4000-8000-000000000011'
+  });
+
+  assert.equal(userRow.manage_proposals_agreements, 'yes');
+  const flat = flattenUserRow(userRow);
+  withUser(flat, () => {
+    assert.equal(canManageProposalsAgreementsApi(), true);
+  });
+});
+
+test('missing optional columns does not break login user resolution', async () => {
+  const authEmail = 'login@think.org.il';
+  const mockSupabase = createMockSupabase({
+    email: {
+      [authEmail]: {
+        user_id: 'login-user',
+        email: authEmail,
+        name: 'Login User',
+        role: 'domain_manager',
+        emp_id: 'login-user',
+        is_active: true,
+        permissions: {}
+      }
+    }
+  }, { failExtendedColumns: true });
+
+  const result = await resolveActiveUserRowAfterAuth({
+    supabase: mockSupabase,
+    authEmail,
+    username: 'login-user',
+    authUserId: '00000000-0000-4000-8000-000000000012'
+  });
+
+  assert.ok(result.userRow);
+  assert.equal(result.userRow.role, 'domain_manager');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores proposals/agreements permission resolution after the Auth cleanup removed optional user permission columns from the default user read path.

- Keeps a **base** user column list that always works across environments.
- Adds an **extended** column list with compatibility fields (`can_review_requests`, `view_proposals_agreements`, `manage_proposals_agreements`, `approve_proposals_agreements`).
- After Auth, user resolution tries extended columns first and falls back to base columns on missing-column/schema-cache errors — login does not fail when optional columns are absent.
- `flattenUserRow` continues spreading JSONB `permissions` and preserves top-level permission columns when present (top-level wins over JSON).
- Login/bootstrap now propagate all three proposals permission flags, including `approve_proposals_agreements`.
- Service worker cache version bumped (`839` → `840`).

## Files changed

- `frontend/src/auth-user-resolve.js` — extended column constants + safe fallback resolver
- `frontend/src/api.js` — extended columns, login/session reads, permission flag helpers, exports for tests
- `frontend/src/main.js` — bootstrap sync + route enforcement for proposals flags
- `frontend/sw.js`, `sw.js` — cache version bump
- `tests/auth-login-stabilization.test.mjs` — extended fallback coverage
- `tests/proposals-permissions-resolution.test.mjs` — new focused permission resolution tests

## Verification

- `tests/auth-login-stabilization.test.mjs` — pass
- `tests/emergency-cleanup-stabilization.test.mjs` — pass
- `tests/proposals-permissions-resolution.test.mjs` — pass (new)
- `npm run check:build` — pass
- `tests/proposals-agreements-screen.test.mjs` — 69/88 pass; remaining failures are pre-existing (missing migration fixture `20260616_proposals_agreements_approval_guard.sql` and unrelated UI test issues), not introduced by this PR

## Constraints honored

- No Supabase Auth changes
- No password changes
- No production data changes
- No migrations added/changed
- No Supabase reset/repair
- Auth login mechanism unchanged
- Frontend/user permission resolution only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23c01675-ef0b-4e3d-8029-5b2b52fc495c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23c01675-ef0b-4e3d-8029-5b2b52fc495c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

