### PR TITLE
Restore Proposals Agreements interface to stable behavior

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3132,11 +3132,12 @@ function proposalPermissionFlagsFromFlatUser(flat = {}) {
 }
 
 function proposalSessionUserFlagsFromFlatUser(flat = {}) {
-  const flags = proposalPermissionFlagsFromFlatUser(flat);
-  if (!flags.view_proposals_agreements && permissionFlagYes(flat.manage_proposals_agreements)) {
-    flags.view_proposals_agreements = 'yes';
-  }
-  return flags;
+  const view = permissionFlagYes(flat.view_proposals_agreements) || permissionFlagYes(flat.manage_proposals_agreements);
+  const manage = permissionFlagYes(flat.manage_proposals_agreements);
+  return {
+    view_proposals_agreements: view || undefined,
+    manage_proposals_agreements: manage || undefined
+  };
 }
 
 function buildBootstrapFromUser(userRow, profileRow = null) {

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -561,11 +561,9 @@ function statusSelectHtml(row, enabled, canApprove = false) {
   return `<select class="ds-pa-status-select" data-pa-row-status data-pa-status-id="${escapeHtml(row?.id || '')}" data-pa-previous-status="${escapeHtml(currentStatus)}" aria-label="עדכון סטטוס הצעה"${disabled}>${options}</select>`;
 }
 
-function detailRowsHtml(row, state = null) {
-  const canManage = state ? canManageProposalsAgreements(state) : false;
+function detailRowsHtml(row) {
   return FORM_FIELDS.map((key) => {
     if (['contact_name', 'contact_role', 'phone', 'email', 'document_type'].includes(key)) return '';
-    if (key === 'notes' && !canManage) return '';
     let displayValue;
     if (key === 'activity_names') {
       const items = (Array.isArray(row[key]) ? row[key] : []).map(text).filter(Boolean);
@@ -2238,8 +2236,7 @@ function drawerActionButtons(row, state) {
 
 function drawerHtml(row, activityNameOptions = [], state = null) {
   if (!row) return `<aside class="ds-pa-drawer" data-pa-drawer hidden></aside>`;
-  const canApprove = state ? canApproveProposalsAgreements(state) : false;
-  const approvalNoteHtml = canApprove && text(row.approval_note) ? `
+  const approvalNoteHtml = text(row.approval_note) ? `
     <div class="ds-pa-detail-row">
       <span class="ds-pa-detail-label">${escapeHtml(FIELD_LABELS.approval_note)}</span>
       <span class="ds-pa-detail-value">${escapeHtml(text(row.approval_note))}</span>
@@ -2273,7 +2270,7 @@ function drawerHtml(row, activityNameOptions = [], state = null) {
         <button type="button" class="ds-btn ds-btn--sm" data-pa-close-drawer aria-label="סגירת פרטי רשומה">✕</button>
       </header>
       <div class="ds-pa-drawer-status" style="margin:6px 0 8px">${statusBadgeHtml(row.status)}${customBadge}</div>
-      <div class="ds-pa-detail-grid">${detailRowsHtml(row, state)}</div>
+      <div class="ds-pa-detail-grid">${detailRowsHtml(row)}</div>
       ${totalHtml}
       ${approvalNoteHtml}
       ${contactDetailRowsHtml(row)}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 842;
+const CACHE_VERSION = 843;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 842;
+const SW_ENTRY_VERSION = 843;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2856,3 +2856,45 @@ test('next_year template_name migration updates programs wording', async () => {
   assert.match(migration, /הצעת מחיר לתוכניות תעשיידע \| שנת הלימודים תשפ״ז/);
   assert.match(migration, /where template_key = 'next_year'/i);
 });
+
+const STABLE_COMMIT = '2c772f835cc19da52fd76528c0b19f667f23de79';
+const STABLE_DIRECTORY_COLUMNS = 'id,authority_id,authority_code,school_id,contact_school_id,authority_name,legacy_client_authority,contact_client_type,contact_client_name,school_name,legacy_school_framework,document_type,activity_type_group,proposal_date,activity_names,contact_name,contact_role,phone,email,notes,status,approval_note,total_amount,custom_document_sections,include_catalog,signature_meta,approved_by,approved_at,created_at,updated_at';
+
+test('rollback: proposals directory select fields match stable commit before emergency cleanup', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const columnsMatch = apiSource.match(/const PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS = '([^']+)'/);
+  assert.ok(columnsMatch, 'directory columns constant should be defined');
+  assert.equal(columnsMatch[1], STABLE_DIRECTORY_COLUMNS, `expected stable columns from ${STABLE_COMMIT}`);
+});
+
+test('rollback: view permission does not expose manage or approve row actions', () => {
+  const sentRow = { id: '22222222-2222-2222-2222-222222222222', status: 'sent', client_authority: 'רשות', school_framework: 'בית ספר' };
+  const viewState = { user: { role: 'authorized_user', view_proposals_agreements: 'yes' } };
+  const html = proposalsAgreementsScreen.render({ rows: [sentRow] }, { state: viewState });
+  assert.doesNotMatch(html, /data-pa-edit-row/);
+  assert.doesNotMatch(html, /חתום ואשר/);
+  assert.doesNotMatch(html, /אישור וחתימה/);
+});
+
+test('rollback: manage permission does not expose approve actions for non-admin', () => {
+  const sentRow = { id: '33333333-3333-3333-3333-333333333333', status: 'sent', client_authority: 'רשות', school_framework: 'בית ספר' };
+  const managerState = { user: { role: 'authorized_user', view_proposals_agreements: 'yes', manage_proposals_agreements: 'yes' } };
+  const html = proposalsAgreementsScreen.render({ rows: [sentRow] }, { state: managerState });
+  assert.doesNotMatch(html, /חתום ואשר/);
+  assert.doesNotMatch(html, /אישור וחתימה/);
+});
+
+test('rollback: approve permission exposes sign-and-approve for sent proposals', () => {
+  const sentRow = { id: '44444444-4444-4444-4444-444444444444', status: 'sent', client_authority: 'רשות', school_framework: 'בית ספר' };
+  const approverState = { user: { role: 'authorized_user', view_proposals_agreements: 'yes', approve_proposals_agreements: 'yes' } };
+  const html = proposalsAgreementsScreen.render({ rows: [sentRow] }, { state: approverState });
+  assert.match(html, /חתום ואשר/);
+});
+
+test('rollback: login session flags restore stable view/manage mapping without approve field', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(apiSource, /function proposalSessionUserFlagsFromFlatUser\(flat = \{\}\) \{[\s\S]*view_proposals_agreements: view \|\| undefined[\s\S]*manage_proposals_agreements: manage \|\| undefined[\s\S]*\}/);
+  assert.doesNotMatch(apiSource, /proposalSessionUserFlagsFromFlatUser[\s\S]*approve_proposals_agreements/);
+  assert.match(apiSource, /resolveActiveUserRowAfterAuth\(/, 'auth login resolver must remain intact');
+  assert.match(apiSource, /signInWithPassword\(/, 'Supabase Auth login must remain intact');
+});

--- a/tests/proposals-permissions-resolution.test.mjs
+++ b/tests/proposals-permissions-resolution.test.mjs
@@ -188,7 +188,25 @@ test('manage permission does not automatically grant approve permission', () => 
   });
   assert.equal(flags.approve_proposals_agreements, undefined);
   assert.equal(flags.view_proposals_agreements, undefined);
-  assert.equal(proposalSessionUserFlagsFromFlatUser(flat).view_proposals_agreements, 'yes');
+  assert.equal(proposalSessionUserFlagsFromFlatUser(flat).view_proposals_agreements, true);
+});
+
+test('login session proposal flags match stable behavior without approve in session user', () => {
+  const userRow = {
+    user_id: 'approver-top',
+    role: 'authorized_user',
+    is_active: true,
+    permissions: {},
+    view_proposals_agreements: 'yes',
+    manage_proposals_agreements: 'yes',
+    approve_proposals_agreements: 'yes'
+  };
+  const flat = flattenUserRow(userRow);
+  const sessionFlags = proposalSessionUserFlagsFromFlatUser(flat);
+
+  assert.equal(sessionFlags.view_proposals_agreements, true);
+  assert.equal(sessionFlags.manage_proposals_agreements, true);
+  assert.equal(sessionFlags.approve_proposals_agreements, undefined);
 });
 
 test('top-level approve_proposals_agreements allows approval only when explicit', () => {
@@ -334,7 +352,11 @@ test('missing optional columns does not grant extra proposal access', () => {
   });
 });
 
-test('view-only drawer does not expose internal approval note or notes fields', () => {
+test('view-only user keeps stable drawer field rendering and no manage or approve actions', async () => {
+  const screenSource = await readFile(new URL('../frontend/src/screens/proposals-agreements.js', import.meta.url), 'utf8');
+  assert.doesNotMatch(screenSource, /if \(key === 'notes' && !canManage\) return '';/);
+  assert.match(screenSource, /const approvalNoteHtml = text\(row\.approval_note\) \? `/);
+
   const row = {
     id: '11111111-1111-1111-1111-111111111111',
     client_authority: 'רשות א',
@@ -342,14 +364,17 @@ test('view-only drawer does not expose internal approval note or notes fields', 
     activity_type_group: 'קיץ',
     proposal_date: '2026-01-01',
     activity_names: ['רובוטיקה'],
-    notes: 'internal note',
-    approval_note: 'approval internal',
+    notes: 'customer-facing note',
+    approval_note: 'approval note text',
     status: 'draft',
-    total_amount: 100
+    total_amount: 100,
+    approved_by: 'admin-user',
+    auth_user_id: '00000000-0000-4000-8000-000000000001'
   };
-  const viewState = { user: { role: 'authorized_user', view_proposals_agreements: 'yes' } };
+  const viewState = { user: { role: 'authorized_user', view_proposals_agreements: 'yes' }, effectiveRoutes: ['proposals-agreements'] };
   const html = proposalsAgreementsScreen.render({ rows: [row] }, { state: viewState });
-  const drawer = html.match(/<aside class="ds-pa-drawer"[\s\S]*?<\/aside>/)?.[0] || '';
-  assert.doesNotMatch(drawer, /internal note/);
-  assert.doesNotMatch(drawer, /approval internal/);
+  assert.doesNotMatch(html, /admin-user/);
+  assert.doesNotMatch(html, /00000000-0000-4000-8000-000000000001/);
+  assert.doesNotMatch(html, /data-pa-edit-row/);
+  assert.doesNotMatch(html, /חתום ואשר/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surgical rollback of Proposals/Agreements frontend behavior to the last stable commit before emergency auth/migration cleanup (PRs #754–#757), while keeping the working Supabase Auth login and `auth-user-resolve` flow untouched.

## Stable source commit

`2c772f835cc19da52fd76528c0b19f667f23de79` — immediately before PR #754 merge (`31ffebc4`).

## Files restored / patched

- `frontend/src/api.js` — restored stable login session proposal flags (`view`/`manage` only; manage still implies view; `approve` no longer injected into session user)
- `frontend/src/screens/proposals-agreements.js` — reverted emergency drawer permission guards that hid `notes` and `approval_note` from view-only users
- `frontend/sw.js`, `sw.js` — cache bump to `843`
- `tests/proposals-permissions-resolution.test.mjs` — rollback regression coverage
- `tests/proposals-agreements-screen.test.mjs` — rollback regression coverage

## Functions restored

- `proposalSessionUserFlagsFromFlatUser()` — stable view/manage mapping without session-level approve flag
- `detailRowsHtml()` — stable signature (no manage gate on notes)
- `drawerHtml()` — stable signature (approval note visible whenever present)

Proposal API loaders (`readProposalsAgreementsFromSupabase`, directory columns, filters, sort, permission checks) already matched stable and were left unchanged.

## Removed incorrect emergency behavior

- Drawer no longer hides `notes` from view-only users
- Drawer no longer hides `approval_note` behind approve permission
- Login session user no longer exposes `approve_proposals_agreements` (stable behavior: approve checks still work via explicit DB/top-level flags during API calls and admin role)

## Filters / data scope restored

- `PROPOSALS_AGREEMENTS_DIRECTORY_COLUMNS` unchanged from stable
- Directory query order/filters unchanged (`authority_name`, `school_name`, `document_type`, `activity_type_group`)
- Role/permission route gating unchanged (`canUseProposalsAgreementsApi`, `canManageProposalsAgreementsApi`, `canApproveProposalsAgreementsApi`)

## Explicitly not changed

- Supabase Auth login / `signInWithPassword`
- `auth-user-resolve.js` resolver behavior
- No migrations added
- No DB grants / Auth users / passwords / production data changes

## Verification

- `npm run check:build` — pass
- `tests/proposals-permissions-resolution.test.mjs` — 58/58 pass
- `tests/auth-login-stabilization.test.mjs` — pass
- `tests/personal-reports-screen.test.mjs` — pass
- `tests/emergency-cleanup-stabilization.test.mjs` — pass
- `tests/proposals-agreements-screen.test.mjs` — 74/93 pass; all 5 new rollback tests pass. 19 legacy failures remain pre-existing (missing migration fixture file, outdated form/UI assertions unrelated to this rollback)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d81310f1-abce-43d2-b908-e81463cea2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d81310f1-abce-43d2-b908-e81463cea2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

