### PR TITLE
Restore Proposals Agreements interface to stable behavior

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2559,8 +2559,11 @@ async function readProposalActivityGroupsFromSupabase() {
       .select('group_key,display_name,template_key,included_group_keys,sort_order,is_active')
       .eq('is_active', true)
       .order('sort_order', { ascending: true });
-    if (error) return [];
-    return (Array.isArray(data) ? data : []).map((row) => ({
+    if (error) {
+      noteProposalRead('proposalActivityGroups', [], error);
+      return [];
+    }
+    const rows = (Array.isArray(data) ? data : []).map((row) => ({
       group_key:           cleanProposalAgreementText(row?.group_key),
       display_name:        cleanProposalAgreementText(row?.display_name),
       template_key:        cleanProposalAgreementText(row?.template_key) || cleanProposalAgreementText(row?.group_key),
@@ -2570,7 +2573,10 @@ async function readProposalActivityGroupsFromSupabase() {
       sort_order:          Number(row?.sort_order) || 0,
       is_active:           row?.is_active !== false
     })).filter((row) => row.group_key);
-  } catch {
+    noteProposalRead('proposalActivityGroups', rows, null);
+    return rows;
+  } catch (error) {
+    noteProposalRead('proposalActivityGroups', [], error);
     return [];
   }
 }
@@ -2581,13 +2587,19 @@ async function readProposalGroupAliasesFromSupabase() {
       .from('proposal_group_aliases')
       .select('alias_name,group_key,is_active')
       .eq('is_active', true);
-    if (error) return [];
-    return (Array.isArray(data) ? data : []).map((row) => ({
+    if (error) {
+      noteProposalRead('proposalGroupAliases', [], error);
+      return [];
+    }
+    const rows = (Array.isArray(data) ? data : []).map((row) => ({
       alias_name: cleanProposalAgreementText(row?.alias_name),
       group_key:  cleanProposalAgreementText(row?.group_key),
       is_active:  row?.is_active !== false
     })).filter((row) => row.alias_name && row.group_key);
-  } catch {
+    noteProposalRead('proposalGroupAliases', rows, null);
+    return rows;
+  } catch (error) {
+    noteProposalRead('proposalGroupAliases', [], error);
     return [];
   }
 }
@@ -2607,6 +2619,57 @@ function buildProposalGroupLookup(groups = [], aliases = []) {
   return { groups, aliases, aliasToKey, groupByKey };
 }
 
+const COMBINED_PROPOSAL_GROUP_KEYS = Object.freeze(['summer', 'next_year']);
+let lastProposalLoaderDebug = {};
+
+function noteProposalRead(name, rows, error) {
+  lastProposalLoaderDebug[name] = {
+    count: Array.isArray(rows) ? rows.length : 0,
+    error: error ? String(error?.message || error?.details || error) : null
+  };
+}
+
+function buildProposalGroupHintsFromTemplateSections(sections = []) {
+  const aliasToKey = new Map();
+  const groupByKey = new Map();
+  const groups = [];
+  (Array.isArray(sections) ? sections : []).forEach((section) => {
+    const templateKey = cleanProposalAgreementText(section?.template_key);
+    const activityGroup = cleanProposalAgreementText(section?.activity_type_group);
+    const templateName = cleanProposalAgreementText(section?.template_name);
+    if (!templateKey) return;
+    if (!groupByKey.has(templateKey)) {
+      const group = {
+        group_key: templateKey,
+        display_name: templateName || activityGroup || templateKey,
+        template_key: templateKey,
+        included_group_keys: templateKey === 'combined' ? [...COMBINED_PROPOSAL_GROUP_KEYS] : [],
+        sort_order: 0,
+        is_active: true
+      };
+      groupByKey.set(templateKey, group);
+      groups.push(group);
+      aliasToKey.set(templateKey, templateKey);
+    }
+    if (activityGroup) aliasToKey.set(activityGroup, templateKey);
+    if (templateName) aliasToKey.set(templateName, templateKey);
+  });
+  return { groups, aliases: [], aliasToKey, groupByKey };
+}
+
+function mergeProposalGroupLookups(primary = {}, hints = {}) {
+  const aliasToKey = new Map(hints.aliasToKey || []);
+  for (const [key, value] of (primary.aliasToKey || new Map())) aliasToKey.set(key, value);
+  const groupByKey = new Map(hints.groupByKey || []);
+  for (const [key, value] of (primary.groupByKey || new Map())) groupByKey.set(key, value);
+  return {
+    groups: [...groupByKey.values()],
+    aliases: Array.isArray(primary.aliases) ? primary.aliases : [],
+    aliasToKey,
+    groupByKey
+  };
+}
+
 function normalizeProposalGroupValue(value, groupLookup = proposalGroupLookupCache) {
   const raw = cleanProposalAgreementText(value);
   if (!raw) return '';
@@ -2615,11 +2678,15 @@ function normalizeProposalGroupValue(value, groupLookup = proposalGroupLookupCac
 
 async function getProposalGroupLookup() {
   if (proposalGroupLookupCache) return proposalGroupLookupCache;
-  const [groups, aliases] = await Promise.all([
+  const [groups, aliases, templateSections] = await Promise.all([
     readProposalActivityGroupsFromSupabase(),
-    readProposalGroupAliasesFromSupabase()
+    readProposalGroupAliasesFromSupabase(),
+    readProposalTemplateSectionsFromSupabase()
   ]);
-  proposalGroupLookupCache = buildProposalGroupLookup(groups, aliases);
+  proposalGroupLookupCache = mergeProposalGroupLookups(
+    buildProposalGroupLookup(groups, aliases),
+    buildProposalGroupHintsFromTemplateSections(templateSections)
+  );
   return proposalGroupLookupCache;
 }
 
@@ -2784,8 +2851,11 @@ async function readProposalActivityPricingFromSupabase() {
       .select('activity_no,activity_name,proposal_group,item_type,catalog_group,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order,pricing_key,parent_pricing_key,proposal_display_mode,is_bundle_parent')
       .eq('is_active_for_proposals', true)
       .order('sort_order', { ascending: true });
-    if (error) return [];
-    return (Array.isArray(data) ? data : []).map((row) => ({
+    if (error) {
+      noteProposalRead('proposalActivityPricing', [], error);
+      return [];
+    }
+    const rows = (Array.isArray(data) ? data : []).map((row) => ({
       activity_no:             cleanProposalAgreementText(row?.activity_no),
       activity_name:           cleanProposalAgreementText(row?.activity_name),
       proposal_group:          cleanProposalAgreementText(row?.proposal_group),
@@ -2804,7 +2874,10 @@ async function readProposalActivityPricingFromSupabase() {
       proposal_display_mode:   cleanProposalAgreementText(row?.proposal_display_mode) || 'single',
       is_bundle_parent:        Boolean(row?.is_bundle_parent)
     }));
-  } catch {
+    noteProposalRead('proposalActivityPricing', rows, null);
+    return rows;
+  } catch (error) {
+    noteProposalRead('proposalActivityPricing', [], error);
     return [];
   }
 }
@@ -2817,8 +2890,11 @@ async function readProposalTemplateSectionsFromSupabase() {
       .eq('is_active', true)
       .order('template_key', { ascending: true })
       .order('sort_order', { ascending: true });
-    if (error) return [];
-    return (Array.isArray(data) ? data : []).map((row) => ({
+    if (error) {
+      noteProposalRead('proposalTemplateSections', [], error);
+      return [];
+    }
+    const rows = (Array.isArray(data) ? data : []).map((row) => ({
       template_key: cleanProposalAgreementText(row?.template_key),
       template_name: cleanProposalAgreementText(row?.template_name),
       activity_type_group: cleanProposalAgreementText(row?.activity_type_group),
@@ -2827,7 +2903,10 @@ async function readProposalTemplateSectionsFromSupabase() {
       section_body: normalizeProposalAgreementMultilineText(row?.section_body),
       sort_order: Number(row?.sort_order) || 0
     }));
-  } catch {
+    noteProposalRead('proposalTemplateSections', rows, null);
+    return rows;
+  } catch (error) {
+    noteProposalRead('proposalTemplateSections', [], error);
     return [];
   }
 }
@@ -2903,6 +2982,8 @@ async function readContactsSchoolsForProposals() {
 
 async function readProposalsAgreementsFromSupabase() {
   assertCanUseProposalsAgreementsApi();
+  await waitForSupabaseAuthSession();
+  lastProposalLoaderDebug = {};
   const [paResult, contactsResult, rawProposalActivityPricing, proposalTemplateSections, proposalActivityGroups, proposalGroupAliases] = await Promise.all([
     supabase
       .from('proposals_agreements_directory_view')
@@ -2918,11 +2999,15 @@ async function readProposalsAgreementsFromSupabase() {
     readProposalGroupAliasesFromSupabase()
   ]);
   if (paResult.error) throw new Error(paResult.error.message || 'proposals_agreements_read_failed');
+  noteProposalRead('rows', Array.isArray(paResult.data) ? paResult.data : [], null);
   const contactOptions = Array.isArray(contactsResult?.contactOptions) ? contactsResult.contactOptions : [];
   const contactOptionsError = contactsResult?.contactOptionsError || null;
   // Group/alias normalization happens here in the loader so the frontend receives
   // logical group keys (e.g. summer/next_year/combined) instead of legacy Hebrew labels.
-  proposalGroupLookupCache = buildProposalGroupLookup(proposalActivityGroups, proposalGroupAliases);
+  proposalGroupLookupCache = mergeProposalGroupLookups(
+    buildProposalGroupLookup(proposalActivityGroups, proposalGroupAliases),
+    buildProposalGroupHintsFromTemplateSections(proposalTemplateSections)
+  );
   const proposalActivityPricing = enrichProposalPricingRows(rawProposalActivityPricing, proposalGroupLookupCache);
   const activityNameOptions = await readProposalActivityNamesFromSupabase();
   return {
@@ -2936,7 +3021,8 @@ async function readProposalsAgreementsFromSupabase() {
     proposalTemplateSections,
     _debug: {
       ...(contactsResult?._debug || {}),
-      ...(contactOptionsError ? { contacts_error: contactOptionsError } : {})
+      ...(contactOptionsError ? { contacts_error: contactOptionsError } : {}),
+      proposal_loader: { ...lastProposalLoaderDebug }
     },
     _source: 'supabase'
   };
@@ -5467,6 +5553,9 @@ export {
   canonicalOneDayActivityType,
   flattenUserRow,
   buildBootstrapFromUser,
+  buildProposalGroupLookup,
+  buildProposalGroupHintsFromTemplateSections,
+  mergeProposalGroupLookups,
   proposalPermissionFlagsFromFlatUser,
   proposalSessionUserFlagsFromFlatUser,
   canUseProposalsAgreementsApi,

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -98,6 +98,8 @@ const EMPTY_PROPOSAL_GROUP_LOOKUPS = Object.freeze({
   aliasToKey: new Map()
 });
 let proposalGroupLookups = EMPTY_PROPOSAL_GROUP_LOOKUPS;
+const COMBINED_TEMPLATE_GROUP_KEYS = Object.freeze(['summer', 'next_year']);
+let proposalTemplateSectionsLookup = [];
 
 function toArray(value) {
   if (Array.isArray(value)) return value;
@@ -139,13 +141,35 @@ function dataGroupAliasRows(data = {}) {
     : Array.isArray(data.proposal_group_aliases) ? data.proposal_group_aliases : [];
 }
 
+function collectTemplateSectionGroupHints(sections = []) {
+  const hints = [];
+  const seen = new Set();
+  (Array.isArray(sections) ? sections : []).forEach((section) => {
+    const templateKey = text(section.template_key);
+    const activityGroup = text(section.activity_type_group);
+    const templateName = text(section.template_name);
+    if (!templateKey || seen.has(templateKey)) return;
+    seen.add(templateKey);
+    hints.push({
+      group_key: templateKey,
+      display_name: templateName || activityGroup || templateKey,
+      template_key: templateKey,
+      included_group_keys: templateKey === 'combined' ? [...COMBINED_TEMPLATE_GROUP_KEYS] : [],
+      is_combined: templateKey === 'combined',
+      is_active: true
+    });
+  });
+  return hints;
+}
+
 function collectGroupRecords(data = {}, rows = [], pricingOptions = []) {
   const directGroups = [
     data.proposalActivityGroups,
     data.proposalGroups,
     data.activityTypeGroups,
-    data.proposal_activity_groups
-  ].find(Array.isArray) || [];
+    data.proposal_activity_groups,
+    collectTemplateSectionGroupHints(data.proposalTemplateSections || data.proposal_template_sections)
+  ].filter(Array.isArray).flat();
   const groups = [];
   const seen = new Set();
   // Names already covered by Supabase groups/aliases must not become standalone groups.
@@ -179,7 +203,10 @@ function collectGroupRecords(data = {}, rows = [], pricingOptions = []) {
 }
 
 function setProposalGroupLookups(data = {}, rows = [], pricingOptions = []) {
-  const groups = collectGroupRecords(data, rows, pricingOptions);
+  proposalTemplateSectionsLookup = Array.isArray(data?.proposalTemplateSections)
+    ? data.proposalTemplateSections
+    : Array.isArray(data?.proposal_template_sections) ? data.proposal_template_sections : [];
+  const groups = collectGroupRecords({ ...data, proposalTemplateSections: proposalTemplateSectionsLookup }, rows, pricingOptions);
   const groupByKey = new Map();
   const aliasToKey = new Map();
   groups.forEach((group) => {
@@ -194,6 +221,29 @@ function setProposalGroupLookups(data = {}, rows = [], pricingOptions = []) {
       const groupKey = text(aliasRow.group_key || aliasRow.target_group_key || aliasRow.proposal_group_key);
       if (alias && groupKey) aliasToKey.set(alias, groupKey);
     });
+  proposalTemplateSectionsLookup.forEach((section) => {
+    const templateKey = text(section.template_key);
+    const activityGroup = text(section.activity_type_group);
+    const templateName = text(section.template_name);
+    if (!templateKey) return;
+    if (!groupByKey.has(templateKey)) {
+      const normalized = normalizeProposalGroupRecord({
+        group_key: templateKey,
+        display_name: templateName || activityGroup || templateKey,
+        template_key: templateKey,
+        included_group_keys: templateKey === 'combined' ? [...COMBINED_TEMPLATE_GROUP_KEYS] : [],
+        is_combined: templateKey === 'combined',
+        is_active: true
+      });
+      if (normalized) {
+        groupByKey.set(templateKey, normalized);
+        groups.push(normalized);
+        aliasToKey.set(templateKey, templateKey);
+      }
+    }
+    if (activityGroup) aliasToKey.set(activityGroup, templateKey);
+    if (templateName) aliasToKey.set(templateName, templateKey);
+  });
   proposalGroupLookups = { groups, groupByKey, aliasToKey };
   return proposalGroupLookups;
 }
@@ -216,9 +266,30 @@ function proposalGroupDisplayName(value) {
   return meta?.display_name || raw;
 }
 
-function proposalGroupTemplateKey(value) {
+function resolveProposalTemplateKey(value) {
   const meta = proposalGroupMeta(value);
-  return text(meta?.template_key || normalizeProposalGroup(value));
+  const normalized = normalizeProposalGroup(value);
+  const resolved = text(meta?.template_key || normalized || value);
+  const sections = proposalTemplateSectionsLookup;
+  if (sections.some((section) => text(section.template_key) === resolved)) return resolved;
+  const raw = text(value);
+  const match = sections.find((section) => {
+    const templateKey = text(section.template_key);
+    const activityGroup = text(section.activity_type_group);
+    return activityGroup && (activityGroup === raw || activityGroup === normalized)
+      || templateKey && (templateKey === raw || templateKey === normalized);
+  });
+  return match ? text(match.template_key) : resolved;
+}
+
+function proposalGroupTemplateKey(value) {
+  return resolveProposalTemplateKey(value);
+}
+
+function filterTemplateSectionsForGroup(templateSections = [], activityTypeGroup = '') {
+  const templateKey = resolveProposalTemplateKey(activityTypeGroup);
+  return (Array.isArray(templateSections) ? templateSections : [])
+    .filter((section) => !text(section.template_key) || text(section.template_key) === templateKey);
 }
 
 function isCombinedProposalGroup(value) {
@@ -2600,6 +2671,15 @@ function ensureCatalogAppendixNotice(previewArea, row = {}, items = []) {
 }
 
 
+export {
+  setProposalGroupLookups,
+  resolveProposalTemplateKey,
+  proposalGroupTemplateKey,
+  filterTemplateSectionsForGroup,
+  documentSectionsEditorHtml,
+  itemsSummaryHtml
+};
+
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
 export const proposalsAgreementsScreen = {
@@ -3249,8 +3329,7 @@ export const proposalsAgreementsScreen = {
         id: text(form.dataset.paId),
         proposal_date: payload.proposal_date || localDateInputValue()
       });
-      const templateKey = proposalGroupTemplateKey(row.activity_type_group);
-      const templateSections = proposalTemplateSections.filter((section) => text(section.template_key) === templateKey);
+      const templateSections = filterTemplateSectionsForGroup(proposalTemplateSections, row.activity_type_group);
       previewHost.innerHTML = proposalPreviewBodyHtml(row, payload._items || [], templateSections);
     };
 
@@ -3444,8 +3523,7 @@ export const proposalsAgreementsScreen = {
       const savedRow = data.rows.find((r) => text(r.id) === text(row.id));
       const mergedRow = savedRow ? { ...savedRow, ...row } : row;
       const freshRow = rowWithCentralContact(mergedRow);
-      const templateKey = proposalGroupTemplateKey(freshRow.activity_type_group);
-      const templateSections = proposalTemplateSections.filter((s) => text(s.template_key) === templateKey);
+      const templateSections = filterTemplateSectionsForGroup(proposalTemplateSections, freshRow.activity_type_group);
       document.getElementById('pa-preview-overlay')?.remove();
       const overlay = document.createElement('div');
       overlay.id = 'pa-preview-overlay';
@@ -3950,9 +4028,7 @@ export const proposalsAgreementsScreen = {
           showToast('הצעה שנשלחה נעולה ולא ניתן לערוך אותה.', 'error');
           return;
         }
-        const templateKey = proposalGroupTemplateKey(row.activity_type_group);
-        const loadedTemplateSections = proposalTemplateSections.filter((s) => text(s.template_key) === templateKey);
-        const templateSections = loadedTemplateSections;
+        const templateSections = filterTemplateSectionsForGroup(proposalTemplateSections, row.activity_type_group);
         const workingSections = resolveDocumentSections(row, templateSections).map((section) => ({
           section_key: text(section.section_key),
           section_title: text(section.section_title),
@@ -3979,9 +4055,7 @@ export const proposalsAgreementsScreen = {
         const row = data.rows.find((r) => text(r.id) === id);
         const wrap = docSaveBtn.closest('[data-pa-doc-edit-wrap]');
         if (!row || !wrap) return;
-        const templateKey = proposalGroupTemplateKey(row.activity_type_group);
-        const loadedTemplateSections = proposalTemplateSections.filter((s) => text(s.template_key) === templateKey);
-        const templateSections = loadedTemplateSections;
+        const templateSections = filterTemplateSectionsForGroup(proposalTemplateSections, row.activity_type_group);
         const sections = templateSections.map((section) => ({
           section_key: text(section.section_key),
           section_title: text(section.section_title),

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 843;
+const CACHE_VERSION = 844;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 843;
+const SW_ENTRY_VERSION = 844;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2898,3 +2898,68 @@ test('rollback: login session flags restore stable view/manage mapping without a
   assert.match(apiSource, /resolveActiveUserRowAfterAuth\(/, 'auth login resolver must remain intact');
   assert.match(apiSource, /signInWithPassword\(/, 'Supabase Auth login must remain intact');
 });
+
+const {
+  setProposalGroupLookups,
+  resolveProposalTemplateKey,
+  filterTemplateSectionsForGroup,
+  documentSectionsEditorHtml,
+  itemsSummaryHtml
+} = await import('../frontend/src/screens/proposals-agreements.js');
+const {
+  buildProposalGroupHintsFromTemplateSections,
+  mergeProposalGroupLookups,
+  buildProposalGroupLookup
+} = await import('../frontend/src/api.js');
+
+const SAMPLE_TEMPLATE_SECTIONS = [
+  { template_key: 'summer', template_name: 'הצעת מחיר לפעילויות תעשיידע | קיץ תשפ״ו', activity_type_group: 'קיץ תשפ״ו', section_key: 'intro', section_title: 'פתיח', section_body: 'פתיח להצעה' },
+  { template_key: 'summer', template_name: 'הצעת מחיר לפעילויות תעשיידע | קיץ תשפ״ו', activity_type_group: 'קיץ תשפ״ו', section_key: 'payment_terms', section_title: 'תנאי תשלום', section_body: 'תנאי תשלום' }
+];
+
+test('template sections loader merges activity_type_group hints when groups are empty', () => {
+  const hints = buildProposalGroupHintsFromTemplateSections(SAMPLE_TEMPLATE_SECTIONS);
+  const merged = mergeProposalGroupLookups(buildProposalGroupLookup([], []), hints);
+  assert.equal(merged.aliasToKey.get('קיץ תשפ״ו'), 'summer');
+  assert.equal(merged.groupByKey.get('summer')?.template_key, 'summer');
+});
+
+test('alias activity type resolves to correct template_key from template sections', () => {
+  setProposalGroupLookups({ proposalTemplateSections: SAMPLE_TEMPLATE_SECTIONS }, [], []);
+  assert.equal(resolveProposalTemplateKey('קיץ תשפ״ו'), 'summer');
+  assert.equal(resolveProposalTemplateKey('summer'), 'summer');
+});
+
+test('document editor does not show missing-template alert when sections exist for alias activity type', () => {
+  setProposalGroupLookups({ proposalTemplateSections: SAMPLE_TEMPLATE_SECTIONS }, [], []);
+  const sections = filterTemplateSectionsForGroup(SAMPLE_TEMPLATE_SECTIONS, 'קיץ תשפ״ו');
+  const html = documentSectionsEditorHtml(sections, false);
+  assert.doesNotMatch(html, /לא נמצאה תבנית פעילה לסוג הצעה זה/);
+  assert.match(html, /פתיח להצעה/);
+  assert.match(html, /תנאי תשלום/);
+});
+
+test('items summary does not show missing-rows alert when active items exist', () => {
+  const html = itemsSummaryHtml([
+    { item_name: 'רובוטיקה', item_type: 'סדנה', quantity: 1, unit_price: 1200, total_price: 1200, proposal_group: 'summer' }
+  ]);
+  assert.doesNotMatch(html, /לא נשמרו שורות פעילות להצעה זו/);
+  assert.match(html, /רובוטיקה/);
+});
+
+test('readProposalsAgreementsFromSupabase waits for auth session and records loader debug', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(apiSource, /async function readProposalsAgreementsFromSupabase\(\) \{[\s\S]*await waitForSupabaseAuthSession\(\)/);
+  assert.match(apiSource, /proposal_loader: \{ \.\.\.lastProposalLoaderDebug \}/);
+  assert.match(apiSource, /mergeProposalGroupLookups\([\s\S]*buildProposalGroupHintsFromTemplateSections\(proposalTemplateSections\)/);
+});
+
+test('saveProposalAgreementItems keeps valid priced item rows in payload', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const saveBlock = apiSource.match(/saveProposalAgreementItems: async \(proposalId, items\) => \{[\s\S]*?\n  \},/);
+  assert.ok(saveBlock, 'saveProposalAgreementItems should exist');
+  assert.match(saveBlock[0], /filter\(\(i\) => cleanProposalAgreementText\(i\.item_name\) && !isProposalTestHoursItem\(i\)\)/);
+  assert.match(saveBlock[0], /item_name:/);
+  assert.match(saveBlock[0], /unit_price:/);
+  assert.match(saveBlock[0], /total_price:/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes broken Proposals/Agreements templates and item rows after the partial PR #760 rollback.

## Root causes

### Missing templates (`לא נמצאה תבנית פעילה לסוג הצעה זה`)
- Proposal rows often store Hebrew `activity_type_group` values such as `קיץ תשפ״ו`.
- Supabase template sections use English `template_key` values such as `summer`.
- When `proposal_activity_groups` / `proposal_group_aliases` reads returned empty (RLS/network/error swallowed as `[]`), the UI created fallback groups with `template_key = Hebrew label` and filtered out all real template sections.

### Missing item rows (`לא נשמרו שורות פעילות להצעה זו`)
- Same unresolved group alias mapping caused pricing filters to return no options for the selected proposal type.
- Valid rows could not be selected/saved/reloaded when pricing/group normalization failed.

## DB verification
Supabase MCP was unavailable in this environment, so no live read-only SQL was executed here. Repo migrations confirm expected data exists/seeds for:
- `proposal_template_sections` (`summer`, `next_year`, `combined`)
- `proposal_activity_groups` / `proposal_group_aliases`
- `proposal_activity_pricing`
- `proposal_agreement_items`

Issue classification: **frontend loader + template_key/alias resolution**, not login/auth changes.

## Fix
- Wait for Supabase auth session before proposal loader queries.
- Merge template-section hints (`activity_type_group` → `template_key`) into group lookup when groups/aliases are missing.
- Resolve template keys from template sections in the screen editor/preview.
- Record loader counts/errors in `_debug.proposal_loader` (no noisy console spam).
- Add regression tests for template resolution, document editor, item summary, loader debug, and save payload shape.

## Not changed
- Supabase Auth login / `auth-user-resolve.js`
- No migrations
- No DB grants / Auth users / passwords / production data

## Verification
- `npm run check:build` — pass
- New regression tests — pass
- `tests/proposals-permissions-resolution.test.mjs` — pass
- `tests/auth-login-stabilization.test.mjs` — pass
- `tests/personal-reports-screen.test.mjs` — pass
- `tests/emergency-cleanup-stabilization.test.mjs` — pass
- `tests/proposals-agreements-screen.test.mjs` — 138/157 pass; 19 legacy pre-existing failures unrelated to this fix

## SW cache
Bumped to **844** in `frontend/sw.js` and `sw.js`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d81310f1-abce-43d2-b908-e81463cea2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d81310f1-abce-43d2-b908-e81463cea2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

