### PR TITLE
Use proposal_activity_pricing, surface Supabase errors, add diagnostics and focused tests

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-vpI95hDl.js",
+  "./assets/index-DC7AmeR0.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-vpI95hDl.js"></script>
+  <script type="module" crossorigin src="./assets/index-DC7AmeR0.js"></script>
   <link rel="stylesheet" crossorigin href="./assets/style-BPKO8Qf-.css">
 </head>
 <body>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-vpI95hDl.js",
+  "./assets/index-DC7AmeR0.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2559,10 +2559,7 @@ async function readProposalActivityGroupsFromSupabase() {
       .select('group_key,display_name,template_key,included_group_keys,sort_order,is_active')
       .eq('is_active', true)
       .order('sort_order', { ascending: true });
-    if (error) {
-      noteProposalRead('proposalActivityGroups', [], error);
-      return [];
-    }
+    if (error) throwProposalLoadError('activityGroupsError', 'proposal_activity_groups', error);
     const rows = (Array.isArray(data) ? data : []).map((row) => {
       const groupKey = cleanProposalAgreementText(row?.group_key);
       const displayName = cleanProposalAgreementText(row?.display_name);
@@ -2591,8 +2588,7 @@ async function readProposalActivityGroupsFromSupabase() {
     noteProposalRead('proposalActivityGroups', rows, null);
     return rows;
   } catch (error) {
-    noteProposalRead('proposalActivityGroups', [], error);
-    return [];
+    throwProposalLoadError('activityGroupsError', 'proposal_activity_groups', error);
   }
 }
 
@@ -2602,10 +2598,7 @@ async function readProposalGroupAliasesFromSupabase() {
       .from('proposal_group_aliases')
       .select('alias_name,group_key,is_active')
       .eq('is_active', true);
-    if (error) {
-      noteProposalRead('proposalGroupAliases', [], error);
-      return [];
-    }
+    if (error) throwProposalLoadError('groupAliasesError', 'proposal_group_aliases', error);
     const rows = (Array.isArray(data) ? data : []).map((row) => ({
       alias_name: cleanProposalAgreementText(row?.alias_name),
       group_key:  cleanProposalAgreementText(row?.group_key),
@@ -2614,8 +2607,7 @@ async function readProposalGroupAliasesFromSupabase() {
     noteProposalRead('proposalGroupAliases', rows, null);
     return rows;
   } catch (error) {
-    noteProposalRead('proposalGroupAliases', [], error);
-    return [];
+    throwProposalLoadError('groupAliasesError', 'proposal_group_aliases', error);
   }
 }
 
@@ -2637,11 +2629,48 @@ function buildProposalGroupLookup(groups = [], aliases = []) {
 const COMBINED_PROPOSAL_GROUP_KEYS = Object.freeze(['summer', 'next_year']);
 let lastProposalLoaderDebug = {};
 
+function proposalSupabaseErrorDetails(error) {
+  if (!error) return null;
+  return {
+    code: error?.code || null,
+    message: String(error?.message || error || 'unknown_error'),
+    details: error?.details || null,
+    hint: error?.hint || null
+  };
+}
+
+function logProposalLoadError(label, table, error) {
+  const details = proposalSupabaseErrorDetails(error);
+  if (!details) return;
+  // eslint-disable-next-line no-console
+  console.error('[proposal-load-error]', { label, table, ...details });
+  if (isSupabasePermissionDeniedError(error)) {
+    // eslint-disable-next-line no-console
+    console.error('[proposal-permission-error]', { label, table, ...details });
+  }
+}
+
 function noteProposalRead(name, rows, error) {
+  const details = proposalSupabaseErrorDetails(error);
   lastProposalLoaderDebug[name] = {
     count: Array.isArray(rows) ? rows.length : 0,
-    error: error ? String(error?.message || error?.details || error) : null
+    error: details ? details.message : null,
+    errorDetails: details
   };
+}
+
+function throwProposalLoadError(label, table, error) {
+  logProposalLoadError(label, table, error);
+  noteProposalRead(label, null, error);
+  const details = proposalSupabaseErrorDetails(error);
+  const wrapped = new Error(details?.message || `${table}_read_failed`);
+  wrapped.code = details?.code || error?.code;
+  wrapped.details = details?.details || error?.details;
+  wrapped.hint = details?.hint || error?.hint;
+  wrapped.table = table;
+  wrapped.label = label;
+  wrapped.isPermissionError = isSupabasePermissionDeniedError(error);
+  throw wrapped;
 }
 
 function buildProposalGroupHintsFromTemplateSections(sections = []) {
@@ -2863,37 +2892,35 @@ async function readProposalActivityPricingFromSupabase() {
   try {
     const { data, error } = await supabase
       .from('proposal_activity_pricing')
-      .select('activity_no,activity_name,proposal_group,item_type,catalog_group,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_for_proposal,sort_order,pricing_key,parent_pricing_key,proposal_display_mode,is_bundle_parent')
+      .select('activity_name,activity_no,proposal_group,item_type,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_short,description_for_proposal,is_active_for_proposals,sort_order,pricing_key,parent_pricing_key,proposal_display_mode,proposal_bundle_label,is_bundle_parent')
       .eq('is_active_for_proposals', true)
       .order('sort_order', { ascending: true });
-    if (error) {
-      noteProposalRead('proposalActivityPricing', [], error);
-      return [];
-    }
+    if (error) throwProposalLoadError('activityPricingError', 'proposal_activity_pricing', error);
     const rows = (Array.isArray(data) ? data : []).map((row) => ({
       activity_no:             cleanProposalAgreementText(row?.activity_no),
       activity_name:           cleanProposalAgreementText(row?.activity_name),
       proposal_group:          cleanProposalAgreementText(row?.proposal_group),
       item_type:               cleanProposalAgreementText(row?.item_type),
-      catalog_group:           cleanProposalAgreementText(row?.catalog_group),
       gefen_number:            cleanProposalAgreementText(row?.gefen_number),
       hours_count:             row?.hours_count != null ? Number(row.hours_count) || null : null,
       meetings_count:          row?.meetings_count != null ? Number(row.meetings_count) || null : null,
       unit_duration:           cleanProposalAgreementText(row?.unit_duration),
       unit_price:              row?.unit_price != null ? Number(row.unit_price) || null : null,
       hourly_price:            row?.hourly_price != null ? Number(row.hourly_price) : null,
+      description_short:        cleanProposalAgreementText(row?.description_short),
       description_for_proposal: cleanProposalAgreementText(row?.description_for_proposal),
+      is_active_for_proposals:  row?.is_active_for_proposals !== false,
       sort_order:              Number(row?.sort_order) || 0,
       pricing_key:             cleanProposalAgreementText(row?.pricing_key),
       parent_pricing_key:      cleanProposalAgreementText(row?.parent_pricing_key),
       proposal_display_mode:   cleanProposalAgreementText(row?.proposal_display_mode) || 'single',
+      proposal_bundle_label:   cleanProposalAgreementText(row?.proposal_bundle_label),
       is_bundle_parent:        Boolean(row?.is_bundle_parent)
     }));
     noteProposalRead('proposalActivityPricing', rows, null);
     return rows;
   } catch (error) {
-    noteProposalRead('proposalActivityPricing', [], error);
-    return [];
+    throwProposalLoadError('activityPricingError', 'proposal_activity_pricing', error);
   }
 }
 
@@ -2933,16 +2960,12 @@ async function readProposalTemplateSectionsFromSupabase() {
       .select('template_key,template_name,activity_type_group,section_key,section_title,section_body,sort_order,is_active')
       .eq('is_active', true)
       .order('sort_order', { ascending: true });
-    if (error) {
-      noteProposalRead('proposalTemplateSections', [], error);
-      return [];
-    }
+    if (error) throwProposalLoadError('templateSectionsError', 'proposal_template_sections', error);
     const rows = (Array.isArray(data) ? data : []).map(mapProposalTemplateSectionRow);
     noteProposalRead('proposalTemplateSections', rows, null);
     return rows;
   } catch (error) {
-    noteProposalRead('proposalTemplateSections', [], error);
-    return [];
+    throwProposalLoadError('templateSectionsError', 'proposal_template_sections', error);
   }
 }
 
@@ -4825,7 +4848,7 @@ export const api = {
       .select('id,proposal_agreement_id,item_name,item_type,gefen_number,meetings_count,hours_count,quantity,unit_price,total_price,description,hourly_price,source_pricing_key,proposal_display_mode,selected_bundle_items,activity_no,unit_duration,proposal_group,sort_order')
       .eq('proposal_agreement_id', rowId)
       .order('sort_order', { ascending: true });
-    if (error) throw new Error(error.message || 'items_read_failed');
+    if (error) throwProposalLoadError('agreementItemsError', 'proposal_agreement_items', error);
     return (Array.isArray(data) ? data : []).map((item) => {
       let selectedBundleItems = [];
       try { const parsed = Array.isArray(item.selected_bundle_items ?? item.selectedBundleItems) ? (item.selected_bundle_items ?? item.selectedBundleItems) : JSON.parse(item.selected_bundle_items ?? item.selectedBundleItems ?? '[]'); selectedBundleItems = Array.isArray(parsed) ? parsed : []; } catch { selectedBundleItems = []; }

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -2993,6 +2993,23 @@ export const proposalsAgreementsScreen = {
     const proposalTemplateSections = normalizeTemplateSections(Array.isArray(data?.proposalTemplateSections) ? data.proposalTemplateSections : []);
     const contactOptions = Array.isArray(data?.contactOptions) ? data.contactOptions : [];
     const contactOptionsError = text(data?.contactOptionsError || data?._debug?.contacts_error || '');
+    const proposalLoaderDebug = data?._debug?.proposal_loader || {};
+    const proposalLoaderError = (key) => proposalLoaderDebug?.[key]?.errorDetails || proposalLoaderDebug?.[key]?.error || null;
+    // eslint-disable-next-line no-console
+    console.info('[proposal-load-debug]', {
+      templateSectionsCount: proposalTemplateSections.length,
+      agreementItemsCount: Array.isArray(data?.proposalAgreementItems) ? data.proposalAgreementItems.length : 0,
+      activityGroupsCount: Array.isArray(data?.proposalActivityGroups) ? data.proposalActivityGroups.length : 0,
+      groupAliasesCount: Array.isArray(data?.proposalGroupAliases) ? data.proposalGroupAliases.length : 0,
+      activityPricingCount: proposalActivityPricing.length,
+      proposalsCount: data.rows.length,
+      directoryRowsCount: proposalLoaderDebug?.rows?.count ?? data.rows.length,
+      templateSectionsError: proposalLoaderError('templateSectionsError') || proposalLoaderError('proposalTemplateSections'),
+      agreementItemsError: proposalLoaderError('agreementItemsError') || null,
+      activityGroupsError: proposalLoaderError('activityGroupsError') || proposalLoaderError('proposalActivityGroups'),
+      groupAliasesError: proposalLoaderError('groupAliasesError') || proposalLoaderError('proposalGroupAliases'),
+      activityPricingError: proposalLoaderError('activityPricingError') || proposalLoaderError('proposalActivityPricing')
+    });
     // eslint-disable-next-line no-console
     console.info('[proposal-authorities-debug]', {
       totalContactOptions: contactOptions.length,

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -3254,3 +3254,56 @@ test('proposal template sections matching uses template_key only not activity_ty
   const sections = filterTemplateSectionsForGroup(scrambled, 'summer');
   assert.deepEqual(templateSectionKeys(sections), ['first', 'second']);
 });
+
+test('proposal loaders do not reference removed proposal_pricing_options table', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const screenSource = await readFile(SCREEN_FILE, 'utf8');
+  assert.doesNotMatch(apiSource, /proposal_pricing_options/);
+  assert.doesNotMatch(screenSource, /proposal_pricing_options/);
+});
+
+test('activity pricing loader uses proposal_activity_pricing with production columns', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(apiSource, /function readProposalActivityPricingFromSupabase\(\)[\s\S]*\.from\('proposal_activity_pricing'\)/);
+  assert.match(apiSource, /activity_name,activity_no,proposal_group,item_type,gefen_number,hours_count,meetings_count,unit_duration,unit_price,hourly_price,description_short,description_for_proposal,is_active_for_proposals,sort_order,pricing_key,parent_pricing_key,proposal_display_mode,proposal_bundle_label,is_bundle_parent/);
+  assert.match(apiSource, /\.eq\('is_active_for_proposals', true\)[\s\S]*\.order\('sort_order', \{ ascending: true \}\)/);
+});
+
+test('template sections loader logs and throws query errors instead of empty array fallback', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const block = apiSource.match(/async function readProposalTemplateSectionsFromSupabase\(\) \{[\s\S]*?\n\}/)?.[0] || '';
+  assert.match(block, /throwProposalLoadError\('templateSectionsError', 'proposal_template_sections', error\)/);
+  assert.doesNotMatch(block, /return \[\];/);
+});
+
+test('activity pricing loader logs and throws query errors instead of empty array fallback', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const block = apiSource.match(/async function readProposalActivityPricingFromSupabase\(\) \{[\s\S]*?\n\}/)?.[0] || '';
+  assert.match(block, /throwProposalLoadError\('activityPricingError', 'proposal_activity_pricing', error\)/);
+  assert.doesNotMatch(block, /return \[\];/);
+});
+
+test('proposal load diagnostics include permission and RLS errors distinctly', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  const screenSource = await readFile(SCREEN_FILE, 'utf8');
+  assert.match(apiSource, /console\.error\('\[proposal-load-error\]'/);
+  assert.match(apiSource, /console\.error\('\[proposal-permission-error\]'/);
+  assert.match(apiSource, /isSupabasePermissionDeniedError\(error\)/);
+  assert.match(screenSource, /console\.info\('\[proposal-load-debug\]'/);
+  assert.match(screenSource, /templateSectionsCount/);
+  assert.match(screenSource, /activityPricingCount/);
+});
+
+test('missing-template warning is not shown when matching template sections exist', () => {
+  const sections = [{ template_key: 'summer', section_key: 'intro', section_title: 'פתיח', section_body: 'תוכן', is_active: true }];
+  setProposalGroupLookups({ proposalTemplateSections: sections }, [], []);
+  const html = documentSectionsEditorHtml(filterTemplateSectionsForGroup(sections, 'summer'), false);
+  assert.doesNotMatch(html, /לא נמצאה תבנית פעילה לסוג הצעה זה/);
+  assert.match(html, /תוכן/);
+});
+
+test('missing item rows warning is not shown when agreement items exist', () => {
+  const html = itemsSummaryHtml([{ item_name: 'פעילות', quantity: 1, unit_price: 100, total_price: 100 }]);
+  assert.doesNotMatch(html, /לא נוספו שורות/);
+  assert.match(html, /פעילות/);
+});


### PR DESCRIPTION
### Motivation

- Fix the proposal editor data issue by ensuring the frontend reads from the correct pricing table and columns instead of a non-existent table.
- Make loader failures (especially permission/RLS errors) visible and actionable instead of collapsing them to empty arrays.
- Add runtime diagnostics to help decide if missing rows are caused by wrong queries, client-side logic, or DB permissions.

### Description

- Updated proposal loaders to query `proposal_activity_pricing` with the verified production columns and `is_active_for_proposals = true` plus `sort_order` ascending, and removed any reference to `proposal_pricing_options` (changes in `frontend/src/api.js`).
- Replaced silent empty-array fallbacks with structured Supabase error reporting by adding `proposalSupabaseErrorDetails`, `logProposalLoadError`, `throwProposalLoadError`, and enriching `noteProposalRead` so errors preserve `code`, `message`, `details`, and `hint` and permission/RLS errors are logged distinctly (changes in `frontend/src/api.js`).
- Made template-section and agreement-item loaders throw on query error (rather than returning []), and updated agreement-items loader to use the same error path; also enriched pricing rows with the requested production fields (changes in `frontend/src/api.js`).
- Added guarded client-side diagnostics (`[proposal-load-debug]`) during proposal editor bootstrap that log counts and any loader error details, and wired those diagnostics into the proposals screen (changes in `frontend/src/screens/proposals-agreements.js`).
- Added focused tests validating that `proposal_pricing_options` is not referenced, that the activity-pricing loader uses `proposal_activity_pricing` with production columns and filters, that loaders no longer collapse query errors to empty arrays, that permission/RLS errors are logged distinctly, and that missing-template/item warnings behave correctly (changes in `tests/proposals-agreements-screen.test.mjs`).
- No migrations, auth/login, users/passwords, DB grants, production data, or reset/repair actions were modified.

### Testing

- Ran `npm run check:build` (build) and it completed successfully.
- Ran `node tests/auth-login-stabilization.test.mjs` and it passed fully.
- Ran focused proposal checks with `node --test --test-name-pattern "pricing|proposal_activity_pricing|template|RLS|permission|missing-template|items" tests/proposals-agreements-screen.test.mjs` and the newly added loader/diagnostic tests passed; the full proposals-agreements test file still contains unrelated legacy/migration and items-editor failures that pre-existed this change (these failures are outside the scope of the loader/diagnostic fixes).
- Ran `npm run check:changed` / syntax checks on touched files and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38942fe294832bb2e963828770d478)