### PR TITLE
Grant authenticated user profile select

### DIFF
--- a/supabase/migrations/20260622_grant_authenticated_users_profile_select.sql
+++ b/supabase/migrations/20260622_grant_authenticated_users_profile_select.sql
@@ -1,0 +1,48 @@
+-- Restore authenticated profile lookup after Supabase Auth login.
+-- RLS policies are not enough without table/column SELECT privileges.
+-- This migration grants SELECT only on the existing safe profile columns used by the app.
+
+grant usage on schema public to authenticated;
+
+do $$
+declare
+  allowed_columns text[] := array[
+    'user_id',
+    'entry_code',
+    'name',
+    'full_name',
+    'role',
+    'email',
+    'display_role',
+    'default_view',
+    'is_active',
+    'permissions',
+    'auth_user_id',
+    'auth_email',
+    'migrated_to_auth',
+    'can_review_requests',
+    'username',
+    'view_certificates',
+    'view_proposals_agreements',
+    'manage_proposals_agreements',
+    'approve_proposals_agreements',
+    'emp_id'
+  ];
+  existing_columns text;
+begin
+  select string_agg(quote_ident(column_name), ', ' order by array_position(allowed_columns, column_name))
+    into existing_columns
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'users'
+    and column_name = any(allowed_columns);
+
+  if existing_columns is null then
+    raise exception 'No allowed public.users columns found for authenticated SELECT grant';
+  end if;
+
+  execute format(
+    'grant select (%s) on table public.users to authenticated',
+    existing_columns
+  );
+end $$;

--- a/tests/auth-login-stabilization.test.mjs
+++ b/tests/auth-login-stabilization.test.mjs
@@ -165,6 +165,24 @@ test('optional stabilize/reconcile migrations were removed', async () => {
   );
 });
 
+test('authenticated users profile SELECT grant migration is safe and minimal', async () => {
+  const migrationPath = new URL('../supabase/migrations/20260622_grant_authenticated_users_profile_select.sql', import.meta.url);
+  const sql = await readFile(migrationPath, 'utf8');
+  const normalized = sql.toLowerCase();
+
+  assert.match(normalized, /grant usage on schema public to authenticated/);
+  assert.match(normalized, /grant select/);
+  assert.match(normalized, /on table public\.users/);
+  assert.match(normalized, /to authenticated/);
+  assert.match(normalized, /information_schema\.columns/);
+
+  assert.doesNotMatch(normalized, /\bto\s+anon\b/);
+  assert.doesNotMatch(normalized, /grant all/);
+  assert.doesNotMatch(normalized, /grant insert/);
+  assert.doesNotMatch(normalized, /grant update/);
+  assert.doesNotMatch(normalized, /grant delete/);
+});
+
 test('restored migrations contain real SQL; true placeholders remain no-ops', async () => {
   const restored = [
     '../supabase/migrations/20260530151253_exact_proposal_templates_multiline.sql',

--- a/tests/emergency-cleanup-stabilization.test.mjs
+++ b/tests/emergency-cleanup-stabilization.test.mjs
@@ -101,3 +101,21 @@ test('personal reports policies use drop before create in access migration', asy
   assert.match(sql, /DROP POLICY IF EXISTS "reports_select_own" ON public\.personal_reports;/);
   assert.match(sql, /CREATE POLICY "reports_select_own" ON public\.personal_reports/);
 });
+
+test('authenticated users profile grant migration avoids anon and write privileges', async () => {
+  const sql = await readFile(
+    new URL('../supabase/migrations/20260622_grant_authenticated_users_profile_select.sql', import.meta.url),
+    'utf8'
+  );
+  const normalized = sql.toLowerCase();
+
+  assert.match(normalized, /grant select/);
+  assert.match(normalized, /on table public\.users/);
+  assert.match(normalized, /to authenticated/);
+  assert.match(normalized, /information_schema\.columns/);
+  assert.doesNotMatch(normalized, /\bto\s+anon\b/);
+  assert.doesNotMatch(normalized, /grant all/);
+  assert.doesNotMatch(normalized, /grant insert/);
+  assert.doesNotMatch(normalized, /grant update/);
+  assert.doesNotMatch(normalized, /grant delete/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production error `permission denied for table users` after Supabase Auth login.

Supabase Auth succeeds, but the app cannot load the current user profile from `public.users` because `authenticated` lacks column-level `SELECT` grants. RLS policies alone are insufficient without table/column privileges.

## Changes

- Add `supabase/migrations/20260622_grant_authenticated_users_profile_select.sql`
  - `GRANT USAGE ON SCHEMA public TO authenticated`
  - Dynamic column-level `GRANT SELECT` on `public.users` for safe profile columns only
  - Uses `information_schema.columns` so optional/missing compatibility columns do not break the migration
- Add migration safety assertions in auth/emergency stabilization tests

## Safety constraints

- Authenticated-only grant (no `anon`)
- No `GRANT ALL`
- No `INSERT` / `UPDATE` / `DELETE` grants
- No RLS policy changes
- No Auth/login code changes
- No proposal UI/template changes

## Verification

- `npm run check:build` — passed
- `node tests/auth-login-stabilization.test.mjs` — 11/11 passed
- `node --test --test-name-pattern "users|grant|authenticated|permission" tests/emergency-cleanup-stabilization.test.mjs` — 1/1 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-601c8880-0329-46b6-bf15-1b6d69ba7aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-601c8880-0329-46b6-bf15-1b6d69ba7aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

