### PR TITLE
Fix next_year proposal preview course names and print table

### DIFF
--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1896,9 +1896,9 @@ function parseSectionBodyStructure(value, options = {}) {
 }
 
 
-function selectedCourseNamesText(items = [], row = {}, contextGroup = '') {
+function selectedCourseNamesList(items = [], row = {}, contextGroup = '') {
   const proposalGroup = normalizeProposalGroup(contextGroup || row.activity_type_group);
-  if (!isNextYearProposalGroup(proposalGroup) && !isNextYearProposalGroup(row.activity_type_group)) return '';
+  if (!isNextYearProposalGroup(proposalGroup) && !isNextYearProposalGroup(row.activity_type_group)) return [];
   const sourceItems = (Array.isArray(items) ? items : []).filter((item) => {
     if (isTestHoursItem(item) || text(item.proposal_display_mode) === 'bundle_child') return false;
     if (!publicActivityName(proposalField(item, 'item_name', 'itemName'))) return false;
@@ -1919,17 +1919,22 @@ function selectedCourseNamesText(items = [], row = {}, contextGroup = '') {
     seen.add(name);
     names.push(name);
   }
-  return names.join(', ');
+  return names;
 }
+
+const NEXT_YEAR_COURSES_INTRO_RE = /להלן הקורסים המוצעים לשנת הלימודים תשפ[״"']?ז\s*\./u;
 
 function nextYearActivityIntroWithCourseNames(body, row = {}, items = [], contextGroup = '') {
   const group = normalizeProposalGroup(contextGroup || row.activity_type_group);
   if (!isNextYearProposalGroup(group)) return body;
-  const courseNames = selectedCourseNamesText(items, row, contextGroup || group);
-  if (!courseNames) return body;
-  const courseLine = `הפעילויות המוצעות לשנת הלימודים: ${courseNames}`;
+  const courseNames = selectedCourseNamesList(items, row, contextGroup || group);
+  if (!courseNames.length) return body;
   const raw = normalizeMultilineText(body);
-  return raw ? `${raw}\n\n${courseLine}` : courseLine;
+  if (!raw || !NEXT_YEAR_COURSES_INTRO_RE.test(raw)) return body;
+  return raw.replace(
+    NEXT_YEAR_COURSES_INTRO_RE,
+    `להלן הקורסים המוצעים לשנת הלימודים תשפ״ז:\n${courseNames.join('\n')}`
+  );
 }
 
 function selectedCourseShortNamesText(row = {}, items = []) {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 849;
+const CACHE_VERSION = 850;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 849;
+const SW_ENTRY_VERSION = 850;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -2429,15 +2429,16 @@ test('course item details table keeps a row when only name and pricing fields ex
   });
 });
 
-test('next_year proposal preview appends selected course names after school-year intro', async () => {
+test('next_year proposal preview transforms school-year intro sentence with course names on new lines', async () => {
   const row = {
     ...sampleRows[0],
     id: 'next-year-course-names-row',
     activity_type_group: 'שנת הלימודים תשפ״ז',
     proposal_date: '2026-06-01'
   };
+  const courseName = 'ביומימיקרי – חדשנות סביבתית-טכנולוגית בהשראה מן הטבע';
   const items = [
-    { item_name: 'ביומימיקרי', item_type: 'קורס', proposal_group: 'שנת הלימודים תשפ״ז', quantity: 1, unit_price: 1000, total_price: 1000 },
+    { item_name: courseName, item_type: 'קורס', proposal_group: 'שנת הלימודים תשפ״ז', quantity: 1, unit_price: 1000, total_price: 1000 },
     { item_name: 'טכנולוגיות החלל', item_type: 'קורס', proposal_group: 'שנת הלימודים תשפ״ז', quantity: 1, unit_price: 2000, total_price: 2000 }
   ];
   const templateSections = [
@@ -2445,12 +2446,23 @@ test('next_year proposal preview appends selected course names after school-year
   ];
 
   await withJSDOM(proposalPreviewBodyHtml(row, items, templateSections), async (_root, dom) => {
-    const docText = dom.window.document.querySelector('.proposal-document')?.textContent || '';
-    assert.match(docText, /הפעילויות המוצעות לשנת הלימודים: ביומימיקרי, טכנולוגיות החלל/);
+    const doc = dom.window.document.querySelector('.proposal-document');
+    const docText = doc?.textContent || '';
+    const activityHeading = Array.from(doc.querySelectorAll('.pa-section-heading'))
+      .find((heading) => heading.textContent.includes('הפעילות המוצעת'));
+    assert.ok(activityHeading, 'section title should remain הפעילות המוצעת');
+    assert.match(docText, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז:/);
+    assert.match(docText, new RegExp(`${courseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    assert.match(docText, /טכנולוגיות החלל/);
+    assert.doesNotMatch(docText, /הפעילויות המוצעות לשנת הלימודים:/);
+    assert.doesNotMatch(docText, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז\.\s*ביומימיקרי/);
+    const activitySection = activityHeading.closest('.pa-section');
+    const html = activitySection?.innerHTML || '';
+    assert.match(html, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז:<br>/);
   });
 });
 
-test('next_year course names sentence deduplicates item names and skips test-hour rows', async () => {
+test('next_year course names deduplicate and skip test-hour rows after intro colon', async () => {
   const row = {
     ...sampleRows[0],
     activity_type_group: 'next_year',
@@ -2461,19 +2473,25 @@ test('next_year course names sentence deduplicates item names and skips test-hou
     { itemName: 'ביומימיקרי', item_type: 'קורס', proposal_group: 'next_year', quantity: 1, unit_price: 1000, total_price: 1000 },
     { item_name: 'שעות בדיקה', item_type: 'קורס', proposal_group: 'next_year', quantity: 1, unit_price: 0, total_price: 0 }
   ];
+  const templateSections = [
+    { template_key: 'next_year', section_key: 'activity_intro', section_title: 'הפעילות המוצעת', section_body: 'להלן הקורסים המוצעים לשנת הלימודים תשפ״ז.' }
+  ];
 
-  await withJSDOM(proposalPreviewBodyHtml(row, items, []), async (_root, dom) => {
-    const docText = dom.window.document.querySelector('.proposal-document')?.textContent || '';
-    assert.match(docText, /הפעילויות המוצעות לשנת הלימודים: ביומימיקרי/);
-    assert.doesNotMatch(docText, /הפעילויות המוצעות לשנת הלימודים:\s*$/);
-    assert.doesNotMatch(docText, /שעות בדיקה/);
-    const namesMatch = docText.match(/הפעילויות המוצעות לשנת הלימודים: ([^\n]+)/);
-    assert.ok(namesMatch);
-    assert.equal(namesMatch[1].split(',').map((part) => part.trim()).filter(Boolean).length, 1);
+  await withJSDOM(proposalPreviewBodyHtml(row, items, templateSections), async (_root, dom) => {
+    const doc = dom.window.document.querySelector('.proposal-document');
+    const activitySection = Array.from(doc.querySelectorAll('.pa-section h3'))
+      .find((heading) => heading.textContent.includes('הפעילות המוצעת'))
+      ?.closest('.pa-section');
+    const activityText = activitySection?.textContent || '';
+    assert.match(activityText, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז:/);
+    assert.match(activityText, /ביומימיקרי/);
+    assert.doesNotMatch(activityText, /הפעילויות המוצעות לשנת הלימודים:/);
+    assert.doesNotMatch(activityText, /שעות בדיקה/);
+    assert.equal((activityText.match(/ביומימיקרי/g) || []).length, 1);
   });
 });
 
-test('next_year proposal without course names keeps intro text without empty colon', async () => {
+test('next_year proposal without course names keeps original intro sentence unchanged', async () => {
   const row = {
     ...sampleRows[0],
     activity_type_group: 'שנת הלימודים תשפ״ז',
@@ -2490,7 +2508,8 @@ test('next_year proposal without course names keeps intro text without empty col
   await withJSDOM(proposalPreviewBodyHtml(row, items, templateSections), async (_root, dom) => {
     const docText = dom.window.document.querySelector('.proposal-document')?.textContent || '';
     assert.doesNotMatch(docText, /הפעילויות המוצעות לשנת הלימודים:/);
-    assert.match(docText, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז/);
+    assert.match(docText, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז\./);
+    assert.doesNotMatch(docText, /להלן הקורסים המוצעים לשנת הלימודים תשפ״ז:/);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `next_year` proposal preview/print: course names formatting correction + course table total row and print column widths (from prior commits on this branch).

## Course names format (latest correction)

Transforms the existing template sentence instead of appending a duplicate paragraph.

**Correct output:**
```
הפעילות המוצעת:
להלן הקורסים המוצעים לשנת הלימודים תשפ״ז:
ביומימיקרי – חדשנות סביבתית-טכנולוגית בהשראה מן הטבע
```

## Safety
- No Auth/login, migrations, grants, loaders, or permissions changes
- Scoped to `next_year` / combined `next_year_activity_intro` only

## Verification
- `npm run check:build` — passed
- Focused next_year/course-name tests — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-601c8880-0329-46b6-bf15-1b6d69ba7aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-601c8880-0329-46b6-bf15-1b6d69ba7aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

