### PR TITLE
Fix proposal save: map UI sent status to pending_approval for DB

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2468,6 +2468,12 @@ const PA_STATUS_LABELS = {
   cancelled:            'בוטל'
 };
 
+function statusForDb(status) {
+  const value = String(status || '').trim();
+  if (value === 'sent') return 'pending_approval';
+  return value || 'draft';
+}
+
 function buildProposalAgreementSearchText(row = {}) {
   const activityNames = Array.isArray(row.activity_names) ? row.activity_names.join(' ') : '';
   const statusLabel = PA_STATUS_LABELS[cleanProposalAgreementText(row.status)] || cleanProposalAgreementText(row.status);
@@ -2777,7 +2783,7 @@ function sanitizeProposalAgreementPayload(payload = {}, groupLookup = proposalGr
     phone:               cleanProposalAgreementText(payload.phone),
     email:               cleanProposalAgreementText(payload.email),
     notes:               parseActivityNamesFromNotes(payload.notes).notes,
-    status:              PA_VALID_STATUSES_SET.has(rawStatus) ? (rawStatus === 'pending_approval' ? 'sent' : rawStatus) : 'draft',
+    status:              statusForDb(PA_VALID_STATUSES_SET.has(rawStatus) ? rawStatus : 'draft'),
     approval_note:       cleanProposalAgreementText(payload.approval_note),
     total_amount:        payload.total_amount != null ? Number(payload.total_amount) || null : null,
     custom_document_sections: Array.isArray(payload.custom_document_sections) ? payload.custom_document_sections : [],
@@ -4823,7 +4829,7 @@ export const api = {
       const cs = cleanProposalAgreementText(currentRow.status);
       if (cs === 'sent' || cs === 'pending_approval') throw new Error('הצעה שנשלחה נעולה ולא ניתן לשנות את סטטוסה.');
     }
-    const patch = { status: cleanStatus, approval_note: cleanProposalAgreementText(approvalNote) };
+    const patch = { status: statusForDb(cleanStatus), approval_note: cleanProposalAgreementText(approvalNote) };
     if (cleanStatus === 'approved') {
       patch.approved_by = state?.user?.auth_user_id || state?.user?.user_id || state?.user?.id || null;
       patch.approved_at = new Date().toISOString();
@@ -5661,6 +5667,8 @@ export {
   canUseProposalsAgreementsApi,
   canManageProposalsAgreementsApi,
   canApproveProposalsAgreementsApi,
+  statusForDb,
+  sanitizeProposalAgreementPayload,
   USER_PUBLIC_COLUMNS,
   USER_PUBLIC_COLUMNS_EXTENDED
 };

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 850;
+const CACHE_VERSION = 851;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 850;
+const SW_ENTRY_VERSION = 851;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1365,6 +1365,59 @@ test('status badge is rendered in table rows with correct labels', () => {
   assert.doesNotMatch(html, /נחתם/);
 });
 
+test('statusForDb maps UI sent to pending_approval for DB writes', async () => {
+  const { statusForDb } = await import('../frontend/src/api.js');
+  assert.equal(statusForDb('sent'), 'pending_approval');
+  assert.equal(statusForDb('draft'), 'draft');
+  assert.equal(statusForDb('returned_for_changes'), 'returned_for_changes');
+  assert.equal(statusForDb('approved'), 'approved');
+  assert.equal(statusForDb('cancelled'), 'cancelled');
+  assert.equal(statusForDb('pending_approval'), 'pending_approval');
+  assert.equal(statusForDb(''), 'draft');
+});
+
+test('proposal save DB payload never contains status sent', async () => {
+  const { sanitizeProposalAgreementPayload } = await import('../frontend/src/api.js');
+  const { state } = await import('../frontend/src/state.js');
+  const previousUser = state.user;
+  state.user = { role: 'admin' };
+  const emptyLookup = { aliasToKey: new Map(), groupByKey: new Map() };
+  const basePayload = {
+    client_authority: 'רשות בדיקה',
+    school_framework: 'בית ספר בדיקה',
+    document_type: 'הצעת מחיר',
+    activity_type_group: 'summer'
+  };
+  try {
+    for (const uiStatus of ['draft', 'sent', 'returned_for_changes', 'approved', 'cancelled', 'pending_approval']) {
+      const dbPayload = sanitizeProposalAgreementPayload({ ...basePayload, status: uiStatus }, emptyLookup);
+      assert.notEqual(dbPayload.status, 'sent', `UI status ${uiStatus} must not write sent to DB`);
+      if (uiStatus === 'sent') assert.equal(dbPayload.status, 'pending_approval');
+      if (uiStatus === 'draft') assert.equal(dbPayload.status, 'draft');
+      if (uiStatus === 'returned_for_changes') assert.equal(dbPayload.status, 'returned_for_changes');
+      if (uiStatus === 'approved') assert.equal(dbPayload.status, 'approved');
+      if (uiStatus === 'cancelled') assert.equal(dbPayload.status, 'cancelled');
+    }
+  } finally {
+    state.user = previousUser;
+  }
+});
+
+test('reading pending_approval from DB still displays נשלח in UI', () => {
+  const pendingRow = { ...sampleRows[0], status: 'pending_approval' };
+  const html = proposalsAgreementsScreen.render({ rows: [pendingRow] }, { state: stateFor('admin') });
+  assert.match(html, /נשלח/);
+});
+
+test('updateProposalAgreementStatus uses statusForDb before Supabase write', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(apiSource, /const patch = \{ status: statusForDb\(cleanStatus\), approval_note:/);
+  assert.doesNotMatch(
+    apiSource,
+    /sanitizeProposalAgreementPayload[\s\S]*pending_approval \? 'sent'/
+  );
+});
+
 test('multiple proposal item names are preserved on save', async () => {
   const savedPayloads = [];
   const mockApi = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production saves to `public.proposals_agreements` failed with:

```
new row for relation "proposals_agreements" violates check constraint "proposals_agreements_status_check"
```

The DB allows only `draft`, `pending_approval`, `returned_for_changes`, `approved`, and `cancelled`. The frontend was writing `status = sent`.

## Fix

- Added `statusForDb()` in `frontend/src/api.js` to convert `sent` → `pending_approval` at the final Supabase write point.
- Applied it in `sanitizeProposalAgreementPayload()` (insert/update) and `updateProposalAgreementStatus()`.
- Removed the incorrect reverse mapping (`pending_approval` → `sent`) from the DB payload sanitizer.

## Behavior preserved

- UI may continue using internal `sent` and showing the Hebrew label "נשלח".
- `normalizeProposalStatus` / `STATUS_ALIASES` remain UI-only for display.
- No DB constraint, migration, auth, or template changes.

## Verification

- Focused tests added in `tests/proposals-agreements-screen.test.mjs`
- `npm run check:build` passed
- Service worker cache bumped to 851
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61e6440d-7c83-4f47-857e-87697f5f30d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61e6440d-7c83-4f47-857e-87697f5f30d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

