### PR TITLE
Improve proposal print PDF layout

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 851;
+const CACHE_VERSION = 852;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BZ6KW27P.js",
+  "./assets/index-Co1fot_Q.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -67,7 +67,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-CYIY5IoK.css",
+  "./assets/style-CLOmZXsz.css",
   "./catalog/appendices/27342.pdf",
   "./catalog/appendices/46091.pdf",
   "./catalog/appendices/52279.pdf",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-BZ6KW27P.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-CYIY5IoK.css">
+  <script type="module" crossorigin src="./assets/index-Co1fot_Q.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-CLOmZXsz.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 851;
+const CACHE_VERSION = 852;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-BZ6KW27P.js",
+  "./assets/index-Co1fot_Q.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -67,7 +67,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-CYIY5IoK.css",
+  "./assets/style-CLOmZXsz.css",
   "./catalog/appendices/27342.pdf",
   "./catalog/appendices/46091.pdf",
   "./catalog/appendices/52279.pdf",

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1777,6 +1777,15 @@ function proposalItemDetailsTableHtml(items = [], contextGroup = '') {
   ];
   const footerRow = `<tr>${footerCells.map((cell) => `<td>${cell.html ? (cell.value || '') : escapeHtml(cell.value || '')}</td>`).join('')}</tr>`;
   return `<table class="${tableClass}">
+    <colgroup>
+      <col class="pa-course-col">
+      <col class="pa-gefen-col">
+      <col class="pa-meetings-col">
+      <col class="pa-groups-col">
+      <col class="pa-hours-col">
+      <col class="pa-hourly-price-col">
+      <col class="pa-total-price-col">
+    </colgroup>
     <thead><tr><th>קורס / תוכנית</th><th>מס׳ גפ״ן</th><th>מפגשים</th><th>קבוצות</th><th>שעות</th><th>מחיר לשעה</th><th>סה״כ</th></tr></thead>
     <tbody>${rows.join('')}</tbody>
     <tfoot>${footerRow}</tfoot>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -16902,6 +16902,163 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
   .pa-page-footer .pa-page-footer-logo { height: 18px !important; max-height: 18px !important; }
 }
 
+
+/* Proposal print/PDF readability overrides: allow natural A4 pagination instead of fit-to-page compression. */
+@media print {
+  @page {
+    size: A4 portrait;
+    margin: 12mm 15mm;
+  }
+
+  html,
+  body {
+    font-size: 12px !important;
+    overflow: visible !important;
+  }
+
+  #pa-preview-overlay,
+  .proposal-preview-area,
+  .pa-preview-canvas,
+  .proposal-document,
+  .proposal-document.pa-document,
+  .proposal-document.pa-document .proposal-document-body,
+  .proposal-document.pa-document .proposal-document-content {
+    height: auto !important;
+    min-height: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+    transform: none !important;
+    scale: none !important;
+    zoom: 1 !important;
+  }
+
+  .proposal-document,
+  .proposal-document.pa-document {
+    width: 180mm !important;
+    max-width: 180mm !important;
+    margin: 0 auto !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+    border: 0 !important;
+    display: block !important;
+    font-size: 12px !important;
+    line-height: 1.5 !important;
+    page-break-after: auto !important;
+  }
+
+  .proposal-document.pa-document .proposal-document-body,
+  .proposal-document.pa-document .proposal-document-content {
+    display: block !important;
+    width: 100% !important;
+    max-width: 180mm !important;
+    padding: 0 !important;
+  }
+
+  .pa-logo-area .proposal-logo {
+    height: auto !important;
+    max-height: 18mm !important;
+    max-width: 50mm !important;
+  }
+
+  .pa-to-block,
+  .pa-section-text,
+  .pa-intro-text,
+  .proposal-document .pa-proposal-list li,
+  .pa-cost-table,
+  .pa-item-details-table,
+  .pa-activities-table {
+    font-size: 12px !important;
+    line-height: 1.45 !important;
+  }
+
+  .pa-doc-title {
+    font-size: 16px !important;
+    line-height: 1.35 !important;
+    margin: 6px 0 10px !important;
+  }
+
+  .pa-section-heading,
+  .pa-costs-intro-heading {
+    font-size: 14px !important;
+    line-height: 1.35 !important;
+    margin-top: 8px !important;
+  }
+
+  .pa-section,
+  .pa-cost-section,
+  .pa-cost-table-block,
+  .pa-catalog-appendix-notice,
+  .pa-footer-signature,
+  .pa-page-footer {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .pa-cost-table-block {
+    margin-top: 6px !important;
+  }
+
+  .pa-cost-table,
+  .pa-item-details-table,
+  .proposal-document .pa-item-details-table.pa-next-year-course-table,
+  .pa-activities-table {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 8px 0 10px !important;
+    table-layout: fixed !important;
+    border-collapse: collapse !important;
+    page-break-inside: auto !important;
+  }
+
+  .pa-cost-table thead,
+  .pa-item-details-table thead,
+  .pa-activities-table thead { display: table-header-group; }
+  .pa-cost-table tfoot,
+  .pa-item-details-table tfoot,
+  .pa-activities-table tfoot { display: table-footer-group; }
+  .pa-cost-table tr,
+  .pa-item-details-table tr,
+  .pa-activities-table tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .pa-cost-table th,
+  .pa-cost-table td,
+  .pa-item-details-table th,
+  .pa-item-details-table td,
+  .pa-activities-table th,
+  .pa-activities-table td {
+    padding: 5px 7px !important;
+    white-space: normal !important;
+    overflow-wrap: anywhere !important;
+    vertical-align: top !important;
+  }
+
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-course-col { width: 34%; }
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-gefen-col { width: 12%; }
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-meetings-col,
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-groups-col,
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-hours-col { width: 8%; }
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-hourly-price-col { width: 14%; }
+  .proposal-document .pa-item-details-table.pa-next-year-course-table .pa-total-price-col { width: 16%; }
+
+  .proposal-document .pa-item-details-table.pa-next-year-course-table th:first-child,
+  .proposal-document .pa-item-details-table.pa-next-year-course-table td:first-child { width: auto !important; }
+  .proposal-document .pa-item-details-table.pa-next-year-course-table th:not(:first-child),
+  .proposal-document .pa-item-details-table.pa-next-year-course-table td:not(:first-child) { width: auto !important; }
+
+  .pa-footer-signature {
+    margin-top: 18px !important;
+    padding-top: 0 !important;
+  }
+  .pa-signer-block { margin-top: 12px !important; }
+  .pa-page-footer {
+    margin-top: 18px !important;
+    position: static !important;
+  }
+}
+
 .ds-pa-status-select {
   max-width: 112px;
   min-width: 92px;

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 851;
+const CACHE_VERSION = 852;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 851;
+const SW_ENTRY_VERSION = 852;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- The current proposal PDF/print output was being force-compressed to a single page with tiny text, dense tables and the signature pushed too low, making next-year course proposals hard to read.
- The change aims to fix print-only presentation problems without touching business logic or data, allowing natural A4 pagination and readable typography.
- Ensure the commercial/course tables for `next_year` proposals are clear, keep rows intact across pages, and avoid transforms/scale that force everything onto one page.

### Description
- Add dedicated print CSS rules (`@media print` and `@page`) that set A4 portrait, margins of ~12mm–15mm, a natural document width up to ~180mm, remove fixed A4-height/overflow/scale/zoom and allow content to flow to additional pages (`frontend/src/styles/main.css`).
- Raise printed text sizes (regular >= 12px, subsection >= 14px, main title >= 16px) and tighten table padding/wrapping to improve readability while preventing unwanted clipping (`frontend/src/styles/main.css`).
- Make next-year course table columns explicit by inserting a `<colgroup>` and column classes so the course/program column is widest and other columns (gefen, meetings, groups, hours, price, total) stay compact (`frontend/src/screens/proposals-agreements.js`).
- Improve table print behavior: full-width content (max 180mm), `table-layout: fixed` for preview tables, repeat headers/footers, and `break-inside: avoid` on rows/blocks to prevent ugly breaks while not forcing a single-page fit (`frontend/src/styles/main.css`).
- Reduce the large spacing above the signature and keep the signature block in normal document flow instead of being fixed to the page bottom, and tighten footer spacing for printed pages (`frontend/src/styles/main.css`).
- Bump service-worker cache version references so browsers pick up the new styling and updated build assets (`frontend/sw.js`, `sw.js`) and updated distribution files were produced (`dist/*`).

### Testing
- Ran `node --check frontend/src/screens/proposals-agreements.js` which passed without syntax errors.
- Ran the focused verification `npm run check:changed` which executed the proposals screen tests; relevant next-year/course print-table assertions passed but the overall run exited non-zero due to pre-existing/unrelated failures in `tests/proposals-agreements-screen.test.mjs` (these are historical test failures outside the print styling changes).
- Ran `npm run check:build` which built the frontend and produced updated `dist` assets successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a391302ce68832b96deb194a084dbe0)