### PR TITLE
Fix proposals school search when contacts_unified_view fails

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2975,73 +2975,142 @@ async function readProposalTemplateSectionsFromSupabase() {
   }
 }
 
-async function readContactsSchoolsForProposals() {
-  try {
-    const [catalog, unifiedRows] = await Promise.all([
-      readAuthoritySchoolCatalog(),
-      readUnifiedContactsFromSupabase({ requireAuth: true })
-    ]);
-    const contactsResult = (Array.isArray(unifiedRows) ? unifiedRows : []).map((c) => {
-      const authorityName = cleanProposalAgreementText(c.authority_name || c.authority || c.client_name);
-      const schoolName = cleanProposalAgreementText(c.school_name || c.school);
-      return {
-        id:           cleanProposalAgreementText(c.source_id || c.id),
-        client_type:  cleanProposalAgreementText(c.client_type),
-        client_name:  cleanProposalAgreementText(c.client_name) || schoolName || authorityName,
-        authority_id: c.authority_id ?? null,
-        school_id:    c.school_id ?? null,
-        semel_mosad:  cleanProposalAgreementText(c.semel_mosad),
-        authority_code: cleanProposalAgreementText(c.authority_code),
-        authority_type: cleanProposalAgreementText(c.authority_type),
-        authority_name: authorityName,
-        school_name:  schoolName,
-        district:     cleanProposalAgreementText(c.district),
-        authority:    authorityName,
-        school:       schoolName,
-        contact_name: cleanProposalAgreementText(c.contact_name),
-        contact_role: cleanProposalAgreementText(c.contact_role),
-        phone:        cleanProposalAgreementText(c.phone || ''),
-        mobile:       cleanProposalAgreementText(c.mobile || ''),
-        email:        cleanProposalAgreementText(c.email || ''),
-        source_table: cleanProposalAgreementText(c.source_table),
-        active:       'yes'
-      };
-    }).filter((c) => c.authority_name || c.school_name || c.authority || c.school);
-
-    // eslint-disable-next-line no-console
-    console.info('[proposal-catalog-authorities]', {
-      count: catalog.authorities?.length,
-      sample: catalog.authorities?.slice(0, 5)
-    });
-    // eslint-disable-next-line no-console
-    console.info('[proposal-catalog-schools]', {
-      count: catalog.schools?.length,
-      sample: catalog.schools?.slice(0, 5)
-    });
-    // eslint-disable-next-line no-console
-    console.info('[proposal-contact-options]', {
-      count: contactsResult?.length,
-      sample: contactsResult?.slice(0, 5)
-    });
-
+function mapUnifiedContactsForProposals(unifiedRows) {
+  return (Array.isArray(unifiedRows) ? unifiedRows : []).map((c) => {
+    const authorityName = cleanProposalAgreementText(c.authority_name || c.authority || c.client_name);
+    const schoolName = cleanProposalAgreementText(c.school_name || c.school);
     return {
-      contactOptions: buildProposalClientSearchOptions(contactsResult, catalog.authorityLookup, catalog.schoolLookup),
-      contactOptionsError: null,
-      _debug: { contacts_count: contactsResult.length }
+      id:           cleanProposalAgreementText(c.source_id || c.id),
+      client_type:  cleanProposalAgreementText(c.client_type),
+      client_name:  cleanProposalAgreementText(c.client_name) || schoolName || authorityName,
+      authority_id: c.authority_id ?? null,
+      school_id:    c.school_id ?? null,
+      semel_mosad:  cleanProposalAgreementText(c.semel_mosad),
+      authority_code: cleanProposalAgreementText(c.authority_code),
+      authority_type: cleanProposalAgreementText(c.authority_type),
+      authority_name: authorityName,
+      school_name:  schoolName,
+      district:     cleanProposalAgreementText(c.district),
+      authority:    authorityName,
+      school:       schoolName,
+      contact_name: cleanProposalAgreementText(c.contact_name),
+      contact_role: cleanProposalAgreementText(c.contact_role),
+      phone:        cleanProposalAgreementText(c.phone || ''),
+      mobile:       cleanProposalAgreementText(c.mobile || ''),
+      email:        cleanProposalAgreementText(c.email || ''),
+      source_table: cleanProposalAgreementText(c.source_table),
+      active:       'yes'
     };
+  }).filter((c) => c.authority_name || c.school_name || c.authority || c.school);
+}
+
+function resolveProposalContactsLoadError(error) {
+  const message = cleanProposalAgreementText(error?.message) || 'contacts_load_error';
+  return message === 'contacts_unified_view_requires_auth_session' || message === 'contacts_unified_view_permission_denied'
+    ? message
+    : 'contacts_load_error';
+}
+
+function hasActiveProposalCatalogSchools(catalog) {
+  return Array.isArray(catalog?.schoolLookup?.list)
+    && catalog.schoolLookup.list.some((school) => isCatalogActive(school.active) && school.school_name);
+}
+
+async function readContactsSchoolsForProposals() {
+  let catalog = {
+    authorities: [],
+    schools: [],
+    authorityLookup: { list: [], byId: new Map(), byName: new Map() },
+    schoolLookup: { list: [], byId: new Map(), bySemel: new Map(), byAuthoritySchool: new Map() }
+  };
+  let catalogError = null;
+  try {
+    catalog = await readAuthoritySchoolCatalog();
   } catch (error) {
-    const message = cleanProposalAgreementText(error?.message) || 'contacts_load_error';
-    const contactOptionsError = message === 'contacts_unified_view_requires_auth_session' || message === 'contacts_unified_view_permission_denied'
-      ? message
-      : 'contacts_load_error';
+    catalogError = error;
     // eslint-disable-next-line no-console
-    console.warn('[supabase] Failed to load proposal contact options:', error);
+    console.warn('[supabase] Failed to load proposal authority/school catalog:', error);
+  }
+
+  let unifiedRows = [];
+  let contactsLoadError = null;
+  try {
+    unifiedRows = await readUnifiedContactsFromSupabase({ requireAuth: true });
+  } catch (error) {
+    contactsLoadError = resolveProposalContactsLoadError(error);
+    // eslint-disable-next-line no-console
+    console.warn('[supabase] Failed to load proposal unified contacts:', error);
+  }
+
+  const contactsResult = mapUnifiedContactsForProposals(unifiedRows);
+  const catalogHasSchools = hasActiveProposalCatalogSchools(catalog);
+  const contactOptions = buildProposalClientSearchOptions(
+    contactsResult,
+    catalog.authorityLookup,
+    catalog.schoolLookup
+  );
+
+  // eslint-disable-next-line no-console
+  console.info('[proposal-catalog-authorities]', {
+    count: catalog.authorities?.length,
+    sample: catalog.authorities?.slice(0, 5)
+  });
+  // eslint-disable-next-line no-console
+  console.info('[proposal-catalog-schools]', {
+    count: catalog.schools?.length,
+    sample: catalog.schools?.slice(0, 5)
+  });
+  // eslint-disable-next-line no-console
+  console.info('[proposal-contact-options]', {
+    count: contactsResult?.length,
+    catalog_options_count: contactOptions.length,
+    sample: contactsResult?.slice(0, 5)
+  });
+
+  if (contactsLoadError) {
+    if (catalogHasSchools) {
+      // eslint-disable-next-line no-console
+      console.warn('[supabase] Proposal contacts failed; continuing with schools catalog only:', contactsLoadError);
+      return {
+        contactOptions,
+        contactOptionsError: null,
+        _debug: {
+          contacts_error: contactsLoadError,
+          contacts_count: contactsResult.length,
+          catalog_schools_count: catalog.schools?.length ?? 0,
+          catalog_fallback: 'schools_only'
+        }
+      };
+    }
     return {
-      contactOptions: [],
-      contactOptionsError,
-      _debug: { contacts_error: contactOptionsError }
+      contactOptions: contactOptions.length ? contactOptions : [],
+      contactOptionsError: contactsLoadError,
+      _debug: {
+        contacts_error: contactsLoadError,
+        catalog_error: cleanProposalAgreementText(catalogError?.message) || null
+      }
     };
   }
+
+  if (catalogError && !catalogHasSchools) {
+    const catalogMessage = cleanProposalAgreementText(catalogError?.message) || 'catalog_load_error';
+    // eslint-disable-next-line no-console
+    console.warn('[supabase] Proposal catalog failed; using contacts only:', catalogError);
+    return {
+      contactOptions,
+      contactOptionsError: contactsResult.length ? null : catalogMessage,
+      _debug: {
+        contacts_count: contactsResult.length,
+        catalog_error: catalogMessage
+      }
+    };
+  }
+
+  return {
+    contactOptions,
+    contactOptionsError: null,
+    _debug: { contacts_count: contactsResult.length }
+  };
 }
 
 async function readProposalsAgreementsFromSupabase() {

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -564,7 +564,7 @@ function normalizeDocumentSection(section = {}) {
 }
 
 function normalizeSearch(value) {
-  return text(value).toLowerCase();
+  return text(value).toLowerCase().normalize('NFKC');
 }
 
 export function buildProposalsAgreementsSearchText(row = {}) {
@@ -3088,7 +3088,7 @@ export const proposalsAgreementsScreen = {
     setProposalPricingLookup(proposalActivityPricing);
     const proposalTemplateSections = normalizeTemplateSections(Array.isArray(data?.proposalTemplateSections) ? data.proposalTemplateSections : []);
     const contactOptions = Array.isArray(data?.contactOptions) ? data.contactOptions : [];
-    const contactOptionsError = text(data?.contactOptionsError || data?._debug?.contacts_error || '');
+    const contactOptionsError = text(data?.contactOptionsError || '');
     const proposalLoaderDebug = data?._debug?.proposal_loader || {};
     const proposalLoaderError = (key) => proposalLoaderDebug?.[key]?.errorDetails || proposalLoaderDebug?.[key]?.error || null;
     // eslint-disable-next-line no-console

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 854;
+const CACHE_VERSION = 855;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 854;
+const SW_ENTRY_VERSION = 855;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/proposals-agreements-screen.test.mjs
+++ b/tests/proposals-agreements-screen.test.mjs
@@ -1069,8 +1069,21 @@ test('proposals contact loader uses contacts_unified_view and not directory fall
   const loaderBlock = apiSource.match(/async function readContactsSchoolsForProposals\(\) \{[\s\S]*?\n\}/);
   assert.ok(loaderBlock, 'readContactsSchoolsForProposals should exist');
   assert.match(loaderBlock[0], /readUnifiedContactsFromSupabase\(\{ requireAuth: true \}\)/);
+  assert.match(loaderBlock[0], /readAuthoritySchoolCatalog\(\)/);
+  assert.match(loaderBlock[0], /catalog_fallback:\s*'schools_only'/);
+  assert.doesNotMatch(loaderBlock[0], /Promise\.all\(\[[\s\S]*readAuthoritySchoolCatalog[\s\S]*readUnifiedContactsFromSupabase/);
   assert.doesNotMatch(loaderBlock[0], /contacts_directory_view/);
   assert.doesNotMatch(loaderBlock[0], /contacts_schools/);
+});
+
+test('proposals contact loader keeps schools catalog when unified contacts fail', async () => {
+  const apiSource = await readFile(API_FILE, 'utf8');
+  assert.match(apiSource, /hasActiveProposalCatalogSchools/);
+  assert.match(apiSource, /contactOptionsError:\s*null[\s\S]*catalog_fallback:\s*'schools_only'/);
+  assert.doesNotMatch(
+    apiSource.match(/async function readContactsSchoolsForProposals\(\) \{[\s\S]*?\n\}/)?.[0] || '',
+    /contactsLoadError[\s\S]*contactOptions:\s*\[\]/
+  );
 });
 
 
@@ -1090,6 +1103,63 @@ test('proposals contact load error is shown in recipient/contact area', async ()
       assert.match(sidebarText, /לא ניתן לטעון אנשי קשר/);
       assert.match(sidebarText, /להתחבר מחדש/);
       assert.ok(form.querySelector('[data-pa-contact-options-error]'), 'contact options error alert should be rendered');
+    }
+  );
+});
+
+test('school catalog remains searchable when contacts load fails but schools catalog is available', async () => {
+  const schoolOnlyAfterContactsFailure = [
+    ...sampleCatalogAuthorities,
+    {
+      _catalog_source: 'schools',
+      client_type: 'school',
+      client_name: 'בית  ספר   ללא איש קשר',
+      authority_id: 'auth-a',
+      school_id: 'school-no-contact',
+      authority_name: 'רשות א',
+      authority: 'רשות א',
+      school_name: 'בית  ספר   ללא איש קשר',
+      school: 'בית  ספר   ללא איש קשר',
+      semel_mosad: '44444',
+      contact_name: '',
+      contact_role: '',
+      phone: '',
+      email: '',
+      mobile: ''
+    }
+  ];
+
+  await withJSDOM(
+    proposalsAgreementsScreen.render({
+      rows: [],
+      contactOptions: schoolOnlyAfterContactsFailure,
+      contactOptionsError: null,
+      _debug: { contacts_error: 'contacts_unified_view_permission_denied', catalog_fallback: 'schools_only' }
+    }, { state: stateFor('admin') }),
+    (root, dom) => {
+      proposalsAgreementsScreen.bind({
+        root,
+        data: {
+          rows: [],
+          activityNameOptions: [],
+          contactOptions: schoolOnlyAfterContactsFailure,
+          contactOptionsError: null,
+          _debug: { contacts_error: 'contacts_unified_view_permission_denied', catalog_fallback: 'schools_only' }
+        },
+        state: stateFor('admin'),
+        api: {}
+      });
+
+      const form = openNewProposalForm(root, dom);
+      assert.equal(form.querySelector('[data-pa-contact-options-error]'), null, 'internal contacts failure should not block school search UI');
+      selectClientResult(form, dom, 'רשות א');
+      const schoolSearchInput = form.querySelector('[data-pa-school-search-input]');
+      schoolSearchInput.value = '  ללא   איש  ';
+      schoolSearchInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+      const schoolResults = form.querySelector('[data-pa-school-results]');
+      assert.match(schoolResults.textContent, /ללא איש קשר/);
+      selectClientResult(form, dom, 'ללא איש');
+      assert.equal(form.querySelector('input[name="school_framework"]').value, 'בית ספר ללא איש קשר');
     }
   );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where schools visible in the system catalog did not appear in proposal client search when `contacts_unified_view` loading failed.

- Load `readAuthoritySchoolCatalog()` independently from `readUnifiedContactsFromSupabase({ requireAuth: true })`
- On contacts failure, continue building `contactOptions` from active `public.schools` via `buildProposalClientSearchOptions`
- Keep contacts failure as an internal warning in `_debug` (`catalog_fallback: 'schools_only'`) without clearing school options
- Only show the user-facing contacts error when no catalog schools are available
- Improve Hebrew partial search normalization (`NFKC` + whitespace collapse)
- Bump Service Worker cache version to **855** in `frontend/sw.js` and root `sw.js`

## Root cause

`readContactsSchoolsForProposals` used `Promise.all` for catalog + contacts. When unified contacts failed, the catch block returned `contactOptions: []`, hiding all schools even though `public.schools` was readable.

## Verification

- `node --check frontend/src/api.js`
- `node --check frontend/src/screens/proposals-agreements.js`
- `node --test tests/proposals-agreements-screen.test.mjs` (focused new/updated tests pass: loader fallback + Hebrew school search)
- `npm run check:build` passed
- SW/cache version bumped consistently (854 → 855)

## Out of scope (per request)

- No DB schema changes
- No anon permission changes for proposal views
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-903d5e44-307d-43c9-9299-2e05972735b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-903d5e44-307d-43c9-9299-2e05972735b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

