### PR TITLE
Fix activity drawer date save mapping and verification

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5325,8 +5325,17 @@ export const api = {
     if (existingInstructorError) throw buildSupabaseMutationError('submitEditRequest', existingInstructorError, 'submit_edit_request_failed');
     await validateActivityInstructorBindingsOrThrow({ ...(existingInstructorRow || {}), ...syncedChanges });
     const reducedChanges = Object.entries(syncedChanges).reduce((acc, [key, value]) => {
-      if (value === undefined || value === null) return acc;
+      if (value === undefined) return acc;
+      const isDateField = key === 'start_date' || key === 'end_date' || /^date_\d+$/.test(key) || /^meeting_date_\d+$/.test(key);
+      if (value === null) {
+        if (isDateField) acc[key] = null;
+        return acc;
+      }
       const normalizedValue = String(value).trim();
+      if (!normalizedValue && isDateField) {
+        acc[key] = null;
+        return acc;
+      }
       acc[key] = normalizedValue;
       return acc;
     }, {});

--- a/frontend/src/screens/operations.js
+++ b/frontend/src/screens/operations.js
@@ -109,11 +109,11 @@ export const operationsScreen = {
         ui,
         clearScreenDataCache,
         rerender,
-        onRowSaved: ({ sourceRowId, changes }) => {
+        onRowSaved: ({ sourceRowId, changes, row }) => {
           const cached = detailCache.get(sourceRowId);
-          if (cached) Object.assign(cached, changes || {});
+          if (cached) Object.assign(cached, row || changes || {});
           const hit = rowById.get(String(sourceRowId));
-          if (hit) Object.assign(hit, changes || {});
+          if (hit) Object.assign(hit, row || changes || {});
         }
       });
     }

--- a/frontend/src/screens/shared/activity-detail-html.js
+++ b/frontend/src/screens/shared/activity-detail-html.js
@@ -825,6 +825,12 @@ export function patchDrawerDatesSection(sectionEl, datesData) {
     if (dateEl) dateEl.textContent = dateVal ? formatDateHe(dateVal) : '—';
     const weekdayEl = sectionEl.querySelector('[data-oneday-weekday-display]');
     if (weekdayEl) weekdayEl.textContent = dateVal ? fmtWeekdayShort(dateVal) : '—';
+    const oneDayInput = sectionEl.querySelector('[data-meeting-dates-edit] input[data-meeting-idx="0"]');
+    if (oneDayInput) oneDayInput.value = dateVal;
+    const form = sectionEl.closest('[data-drawer-form]');
+    if (form && typeof form._refreshInitialValues === 'function') {
+      form._refreshInitialValues();
+    }
     sectionEl.removeAttribute('data-dates-loading');
     return;
   }
@@ -849,6 +855,18 @@ export function patchDrawerDatesSection(sectionEl, datesData) {
 
   const chipsDiv = sectionEl.querySelector('[data-dates-view-chips]');
   if (chipsDiv) chipsDiv.innerHTML = buildDateChipsHtml(schedule, false);
+
+  const editGrid = sectionEl.querySelector('[data-meeting-dates-edit]');
+  if (editGrid) {
+    schedule.forEach((item, index) => {
+      const input = editGrid.querySelector(`input[data-meeting-idx="${index}"]`);
+      if (input) input.value = String(item?.date || '').trim();
+    });
+    const form = sectionEl.closest('[data-drawer-form]');
+    if (form && typeof form._refreshInitialValues === 'function') {
+      form._refreshInitialValues();
+    }
+  }
 
   sectionEl.removeAttribute('data-dates-loading');
 }

--- a/frontend/src/screens/shared/bind-activity-edit-form.js
+++ b/frontend/src/screens/shared/bind-activity-edit-form.js
@@ -225,14 +225,25 @@ function updateMoreDatesToggle(form) {
   syncMeetingRemoveButtons(form);
 }
 
-function buildMeetingDatesSnapshot(form) {
+function readMeetingDatePickerValues(form) {
+  const values = Array.from({ length: 35 }, () => '');
   const pickers = Array.from(form.querySelectorAll('[data-meeting-dates-edit] input[data-meeting-idx]')).sort(
     (a, b) => Number(a.dataset.meetingIdx) - Number(b.dataset.meetingIdx)
   );
-  const dates = pickers
-    .map((picker) => String(picker?.value || '').trim())
-    .filter((value) => value);
-  const normalized = Array.from({ length: 35 }, (_, idx) => String(dates[idx] || '').trim());
+  pickers.forEach((picker) => {
+    const idx = Number(picker.dataset.meetingIdx);
+    if (!Number.isFinite(idx) || idx < 0 || idx >= 35) return;
+    values[idx] = String(picker?.value || '').trim();
+  });
+  return values;
+}
+
+function initialMeetingDateValue(initialValues = {}, index = 0) {
+  return String(initialValues[`meeting_date_${index}`] ?? initialValues[`date_${index + 1}`] ?? '').trim();
+}
+
+function buildMeetingDatesSnapshot(form) {
+  const normalized = readMeetingDatePickerValues(form);
   let endDate = '';
   normalized.forEach((value) => {
     if (/^\d{4}-\d{2}-\d{2}$/.test(value)) endDate = value;
@@ -242,13 +253,82 @@ function buildMeetingDatesSnapshot(form) {
 }
 
 function hasMeetingDatesChanged(form, initialValues = {}) {
-  const { dates } = buildMeetingDatesSnapshot(form);
+  const dates = readMeetingDatePickerValues(form);
   for (let i = 0; i < 35; i++) {
-    const current = String(dates[i] || '').trim();
-    const prev = String(initialValues[`meeting_date_${i}`] ?? initialValues[`date_${i + 1}`] ?? '').trim();
-    if (current !== prev) return true;
+    if (String(dates[i] || '').trim() !== initialMeetingDateValue(initialValues, i)) return true;
   }
   return false;
+}
+
+function captureFormInitialValues(form) {
+  const initialValues = {};
+  form.querySelectorAll('[name]').forEach((el) => {
+    const name = el.getAttribute('name');
+    if (!name || name.startsWith('_')) return;
+    initialValues[name] = String(el.value ?? '').trim();
+  });
+  for (let i = 0; i < 35; i++) {
+    const meetingKey = `meeting_date_${i}`;
+    const dateKey = `date_${i + 1}`;
+    if (initialValues[meetingKey] && !initialValues[dateKey]) {
+      initialValues[dateKey] = initialValues[meetingKey];
+    } else if (!initialValues[meetingKey] && initialValues[dateKey]) {
+      initialValues[meetingKey] = initialValues[dateKey];
+    }
+  }
+  form._initialValues = initialValues;
+  return initialValues;
+}
+
+function normalizeStoredMeetingDate(value) {
+  const clean = String(value ?? '').trim();
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(clean);
+  return match ? match[1] : '';
+}
+
+function verifyMeetingDateChangesApplied(changes, row = {}) {
+  for (const [key, sentRaw] of Object.entries(changes || {})) {
+    const match = /^meeting_date_(\d+)$/.exec(key);
+    if (!match) continue;
+    const dateKey = `date_${Number(match[1]) + 1}`;
+    const expected = sentRaw === null || sentRaw === '' ? '' : normalizeStoredMeetingDate(sentRaw);
+    const actual = normalizeStoredMeetingDate(row[dateKey]);
+    if (expected !== actual) {
+      const err = new Error('activity_date_db_verify_failed');
+      err.code = 'activity_date_db_verify_failed';
+      err.field = dateKey;
+      err.expected = expected;
+      err.actual = actual;
+      throw err;
+    }
+  }
+}
+
+function collectMeetingDateChanges(form, initialValues = {}, changes = {}) {
+  const pickerValues = readMeetingDatePickerValues(form);
+  const isOnce = form.dataset.isOnce === 'yes';
+  let prevEndDate = '';
+  for (let j = 34; j >= 0; j--) {
+    const value = initialMeetingDateValue(initialValues, j);
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      prevEndDate = value;
+      break;
+    }
+  }
+
+  for (let i = 0; i < 35; i++) {
+    const current = String(pickerValues[i] || '').trim();
+    const prev = initialMeetingDateValue(initialValues, i);
+    if (current !== prev) {
+      changes[`meeting_date_${i}`] = current ? current : null;
+    }
+  }
+
+  const snapshot = buildMeetingDatesSnapshot(form);
+  const computedEndDate = isOnce ? snapshot.startDate : snapshot.endDate;
+  if (computedEndDate && computedEndDate !== prevEndDate) {
+    changes.end_date = computedEndDate;
+  }
 }
 
 export function bindActivityEditForm(contentRoot, {
@@ -292,6 +372,7 @@ export function bindActivityEditForm(contentRoot, {
     form.querySelectorAll('[name]').forEach((el) => {
       const name = el.getAttribute('name');
       if (!name || name.startsWith('_')) return;
+      if (/^meeting_date_\d+$/.test(name) || /^meeting_performed_\d+$/.test(name)) return;
       if (el.closest('[hidden]')) return;
       const rawValue = el.value;
       if (rawValue === undefined || rawValue === null) return;
@@ -308,30 +389,7 @@ export function bindActivityEditForm(contentRoot, {
       changes.status = 'פתוח';
     }
 
-    if (hasMeetingDatesChanged(form, initialValues)) {
-      const snapshot = buildMeetingDatesSnapshot(form);
-      const isOnce = form.dataset.isOnce === 'yes';
-
-      for (let i = 0; i < 35; i++) {
-        const current = String(snapshot.dates[i] || '').trim();
-        const prev = String(initialValues[`meeting_date_${i}`] ?? initialValues[`date_${i + 1}`] ?? '').trim();
-        if (current !== prev) {
-          changes[`meeting_date_${i}`] = current;
-        }
-      }
-
-      const prevEndDate = (() => {
-        for (let j = 34; j >= 0; j--) {
-          const v = String(initialValues[`meeting_date_${j}`] ?? initialValues[`date_${j + 1}`] ?? '').trim();
-          if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
-        }
-        return '';
-      })();
-      const computedEndDate = isOnce ? snapshot.startDate : snapshot.endDate;
-      if (computedEndDate && computedEndDate !== prevEndDate) {
-        changes.end_date = computedEndDate;
-      }
-    }
+    collectMeetingDateChanges(form, initialValues, changes);
 
     if (!validateActivityTypeAndName(form, statusEl)) return;
 
@@ -444,6 +502,10 @@ export function bindActivityEditForm(contentRoot, {
       let requestResult = null;
       if (canDirectEdit) {
         requestResult = await api.saveActivity(debugPayload);
+        if (!requestResult?.row) {
+          throw new Error('activity_update_no_row_returned');
+        }
+        verifyMeetingDateChangesApplied(changes, requestResult.row);
       } else if (canRequestEdit) {
         requestResult = await api.submitEditRequest(debugPayload);
       } else {
@@ -530,6 +592,7 @@ export function bindActivityEditForm(contentRoot, {
 
       if (ev.target.closest('[data-action="start-edit"]')) {
         setEditMode(form, true);
+        captureFormInitialValues(form);
         const nameSel = form.querySelector('[data-role="activity-name-select"]');
         if (nameSel && nameSel.options.length < 2) {
           // eslint-disable-next-line no-console
@@ -632,13 +695,8 @@ export function bindActivityEditForm(contentRoot, {
     const nameSel = form.querySelector('[data-role="activity-name-select"]');
     if (nameSel) nameSel.disabled = !normalizeActivityTypeKey(typeEl?.value);
     syncActivityNoFromName(form);
-    const initialValues = {};
-    form.querySelectorAll('[name]').forEach((el) => {
-      const name = el.getAttribute('name');
-      if (!name || name.startsWith('_')) return;
-      initialValues[name] = String(el.value ?? '').trim();
-    });
-    form._initialValues = initialValues;
+    captureFormInitialValues(form);
+    form._refreshInitialValues = () => captureFormInitialValues(form);
 
     form.addEventListener(
       'change',

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 854;
+const CACHE_VERSION = 855;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 854;
+const SW_ENTRY_VERSION = 855;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);

--- a/tests/edit-requests-flow.test.mjs
+++ b/tests/edit-requests-flow.test.mjs
@@ -90,7 +90,10 @@ test('user with can_edit_direct calls saveActivity and not submitEditRequest', a
 
   bindActivityEditForm(root, {
     api: {
-      saveActivity: async (...args) => calls.push(['saveActivity', ...args]),
+      saveActivity: async (...args) => {
+        calls.push(['saveActivity', ...args]);
+        return { ok: true, row: { row_id: 'ACT-1', activity_name: 'שם חדש', date_1: '2026-05-01' } };
+      },
       submitEditRequest: async (...args) => calls.push(['submitEditRequest', ...args])
     }
   });
@@ -132,7 +135,7 @@ test('activity edit form blocks duplicate save clicks while first save is in fli
   saveBtn.click();
   await wait(20);
   assert.equal(calls.filter(([name]) => name === 'saveActivity').length, 1);
-  resolveSave({ ok: true });
+  resolveSave({ ok: true, row: { row_id: 'ACT-1', activity_name: 'שם חדש', date_1: '2026-05-01' } });
   await wait(20);
 });
 
@@ -166,4 +169,137 @@ test('add activity UI remains gated by can_add_activity', async () => {
   assert.match(source, /const canAddActivity = !!state\?\.user\?\.can_add_activity;/);
   assert.match(source, /if \(canAddActivity && ui && addBtn\) \{/);
   assert.match(source, /await api\.addActivity\(payload\);/);
+});
+
+function buildMultiMeetingEditRoot() {
+  const root = document.createElement('div');
+  root.innerHTML = `
+    <form data-drawer-form data-source-sheet="activities" data-row-id="ACT-2" data-can-direct-edit="yes" data-can-request-edit="no">
+      <button type="button" data-action="start-edit">עריכה</button>
+      <input name="activity_name" value="קורס בדיקה">
+      <div data-meeting-dates-edit>
+        <div class="activity-drawer__date-card"><input name="meeting_date_0" data-meeting-idx="0" value="2026-05-01"></div>
+        <div class="activity-drawer__date-card"><input name="meeting_date_1" data-meeting-idx="1" value="2026-05-08"></div>
+        <div class="activity-drawer__date-card"><input name="meeting_date_2" data-meeting-idx="2" value=""></div>
+      </div>
+      <button type="button" data-action="save-edit">שמור</button>
+      <div class="ds-activity-edit-status"></div>
+    </form>`;
+  document.body.appendChild(root);
+  return root;
+}
+
+test('activity edit form maps meeting_date_N changes without collapsing empty meeting slots', async () => {
+  const bindSource = await fs.readFile(new URL('../frontend/src/screens/shared/bind-activity-edit-form.js', import.meta.url), 'utf8');
+  assert.match(bindSource, /readMeetingDatePickerValues/);
+  assert.match(bindSource, /collectMeetingDateChanges/);
+  assert.doesNotMatch(bindSource, /\.filter\(\(value\) => value\)/);
+  assert.match(bindSource, /changes\[`meeting_date_\$\{i\}`\] = current \? current : null/);
+  assert.match(bindSource, /verifyMeetingDateChangesApplied/);
+  assert.match(bindSource, /captureFormInitialValues\(form\)/);
+});
+
+test('direct save sends meeting_date changes and verifies returned row before success', async () => {
+  const { bindActivityEditForm } = await import(`${BIND_MODULE}?bust=${Date.now()}-${Math.random()}`);
+  const calls = [];
+  const root = buildMultiMeetingEditRoot();
+  const form = root.querySelector('[data-drawer-form]');
+
+  bindActivityEditForm(root, {
+    api: {
+      saveActivity: async (payload) => {
+        calls.push(payload);
+        return {
+          ok: true,
+          row: {
+            row_id: 'ACT-2',
+            date_1: '2026-05-01',
+            date_2: '2026-05-15',
+            date_3: ''
+          }
+        };
+      }
+    }
+  });
+
+  form.querySelector('[data-action="start-edit"]').click();
+  form.querySelector('[name="meeting_date_1"]').value = '2026-05-15';
+  form.querySelector('[data-action="save-edit"]').click();
+  await wait(30);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].changes.meeting_date_1, '2026-05-15');
+  assert.match(form.querySelector('.ds-activity-edit-status').textContent, /נשמרה בהצלחה/);
+});
+
+test('clearing a meeting date sends null in changes', async () => {
+  const { bindActivityEditForm } = await import(`${BIND_MODULE}?bust=${Date.now()}-${Math.random()}`);
+  const calls = [];
+  const root = buildMultiMeetingEditRoot();
+  const form = root.querySelector('[data-drawer-form]');
+
+  bindActivityEditForm(root, {
+    api: {
+      saveActivity: async (payload) => {
+        calls.push(payload);
+        return {
+          ok: true,
+          row: {
+            row_id: 'ACT-2',
+            date_1: '2026-05-01',
+            date_2: null,
+            date_3: ''
+          }
+        };
+      }
+    }
+  });
+
+  form.querySelector('[data-action="start-edit"]').click();
+  form.querySelector('[name="meeting_date_1"]').value = '';
+  form.querySelector('[data-action="save-edit"]').click();
+  await wait(30);
+
+  assert.equal(calls[0].changes.meeting_date_1, null);
+});
+
+test('direct save shows error when returned row date does not match sent value', async () => {
+  const { bindActivityEditForm } = await import(`${BIND_MODULE}?bust=${Date.now()}-${Math.random()}`);
+  const root = buildMultiMeetingEditRoot();
+  const form = root.querySelector('[data-drawer-form]');
+
+  bindActivityEditForm(root, {
+    api: {
+      saveActivity: async () => ({
+        ok: true,
+        row: {
+          row_id: 'ACT-2',
+          date_1: '2026-05-01',
+          date_2: '2026-05-08',
+          date_3: ''
+        }
+      })
+    }
+  });
+
+  form.querySelector('[data-action="start-edit"]').click();
+  form.querySelector('[name="meeting_date_1"]').value = '2026-05-15';
+  form.querySelector('[data-action="save-edit"]').click();
+  await wait(30);
+
+  const statusText = form.querySelector('.ds-activity-edit-status').textContent || '';
+  assert.doesNotMatch(statusText, /נשמרה בהצלחה/);
+  assert.match(statusText, /לא נשמר בפועל|שגיאה|⚠️/);
+});
+
+test('submitEditRequest preserves null meeting date deletions', async () => {
+  const source = await fs.readFile(new URL('../frontend/src/api.js', import.meta.url), 'utf8');
+  assert.match(source, /isDateField[\s\S]*acc\[key\] = null/);
+  assert.match(source, /mapMeetingDateFieldNamesToSupabase\(reducedChanges\)/);
+});
+
+test('patchDrawerDatesSection refreshes edit inputs and form initial values', async () => {
+  const source = await fs.readFile(new URL('../frontend/src/screens/shared/activity-detail-html.js', import.meta.url), 'utf8');
+  assert.match(source, /editGrid\.querySelector\(`input\[data-meeting-idx="\$\{index\}"\]`\)/);
+  assert.match(source, /form\._refreshInitialValues/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes activity date changes in the activity detail drawer not persisting after save/refresh.

### Root cause
`buildMeetingDatesSnapshot` filtered out empty date pickers before indexing, which shifted `meeting_date_N` values and caused wrong or missing `date_{N+1}` fields in `payload.changes`. Success could also be shown without confirming the returned Supabase row.

### Changes

**`bind-activity-edit-form.js`**
- Read picker values by `data-meeting-idx` (preserve slot index 0..34)
- `collectMeetingDateChanges`: map `meeting_date_N` → changes with `null` for cleared dates
- Skip `meeting_date_*` in generic field loop (dedicated date collector owns them)
- Refresh `_initialValues` on start-edit and expose `_refreshInitialValues`
- Direct save: require returned `row`, verify `date_N` matches sent values before success toast

**`activity-detail-html.js`**
- `patchDrawerDatesSection` syncs edit-mode date inputs after async load and refreshes form baseline

**`api.js`**
- `submitEditRequest` preserves `null` for date/meeting_date deletions (was dropped)

**`operations.js`**
- `onRowSaved` prefers returned `row` over raw `changes` for cache patch

**Service Worker**: cache version **855**

### Verification
- `node --check` on changed JS files
- Focused tests in `tests/edit-requests-flow.test.mjs` (meeting date mapping, null clear, mismatch error)
- `npm run check:build` passed

### Out of scope
- No DB schema changes
- No permission changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-903d5e44-307d-43c9-9299-2e05972735b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-903d5e44-307d-43c9-9299-2e05972735b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

