### PR TITLE
Extend ensure_contact_school_from_proposal RPC with school catalog IDs

### DIFF
--- a/supabase/migrations/20260622150000_ensure_contact_school_from_proposal_school_ids.sql
+++ b/supabase/migrations/20260622150000_ensure_contact_school_from_proposal_school_ids.sql
@@ -1,0 +1,266 @@
+-- Extend ensure_contact_school_from_proposal with school catalog linkage.
+-- Backward compatible: existing 11 text arguments remain; new args are optional.
+
+DROP FUNCTION IF EXISTS public.ensure_contact_school_from_proposal(
+  text, text, text, text, text, text, text, text, text, text, text
+);
+
+CREATE OR REPLACE FUNCTION public.ensure_contact_school_from_proposal(
+  p_client_type   text,
+  p_client_name   text,
+  p_authority     text,
+  p_school        text DEFAULT NULL,
+  p_contact_name  text DEFAULT NULL,
+  p_contact_role  text DEFAULT NULL,
+  p_phone         text DEFAULT NULL,
+  p_mobile        text DEFAULT NULL,
+  p_email         text DEFAULT NULL,
+  p_address       text DEFAULT NULL,
+  p_notes         text DEFAULT NULL,
+  p_school_id     uuid DEFAULT NULL,
+  p_authority_id  uuid DEFAULT NULL,
+  p_semel_mosad   text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_client_type   text;
+  v_client_name   text;
+  v_authority     text;
+  v_school        text;
+  v_contact_name  text;
+  v_contact_role  text;
+  v_phone         text;
+  v_mobile        text;
+  v_email         text;
+  v_address       text;
+  v_notes         text;
+
+  v_school_id     uuid;
+  v_authority_id  uuid;
+  v_semel_mosad   text;
+
+  v_match_count   integer;
+  v_existing_id   bigint;
+BEGIN
+  v_client_type := lower(nullif(btrim(coalesce(p_client_type, '')), ''));
+  v_client_name := nullif(btrim(coalesce(p_client_name, '')), '');
+  v_authority := nullif(btrim(coalesce(p_authority, '')), '');
+  v_school := nullif(btrim(coalesce(p_school, '')), '');
+  v_contact_name := coalesce(nullif(btrim(coalesce(p_contact_name, '')), ''), '');
+  v_contact_role := nullif(btrim(coalesce(p_contact_role, '')), '');
+  v_phone := nullif(btrim(coalesce(p_phone, '')), '');
+  v_mobile := nullif(btrim(coalesce(p_mobile, '')), '');
+  v_email := nullif(btrim(coalesce(p_email, '')), '');
+  v_address := nullif(btrim(coalesce(p_address, '')), '');
+  v_notes := nullif(btrim(coalesce(p_notes, '')), '');
+
+  IF v_authority IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF v_client_type IS NULL OR v_client_type NOT IN ('school', 'authority', 'other') THEN
+    v_client_type := CASE
+      WHEN v_school IS NOT NULL AND v_school IS DISTINCT FROM v_authority THEN 'school'
+      ELSE 'authority'
+    END;
+  END IF;
+
+  IF v_client_name IS NULL THEN
+    v_client_name := CASE
+      WHEN v_client_type = 'school' THEN coalesce(v_school, v_authority)
+      ELSE v_authority
+    END;
+  END IF;
+
+  IF v_client_type = 'authority' THEN
+    v_school := NULL;
+  ELSIF v_client_type = 'school' AND v_school IS NULL THEN
+    v_school := v_client_name;
+  END IF;
+
+  v_school_id := p_school_id;
+  v_authority_id := p_authority_id;
+  v_semel_mosad := nullif(btrim(coalesce(p_semel_mosad, '')), '');
+
+  IF p_school_id IS NOT NULL THEN
+    SELECT
+      s.id,
+      coalesce(s.authority_id, p_authority_id),
+      coalesce(nullif(btrim(coalesce(s.semel_mosad, '')), ''), nullif(btrim(coalesce(p_semel_mosad, '')), ''))
+    INTO v_school_id, v_authority_id, v_semel_mosad
+    FROM public.schools s
+    WHERE s.id = p_school_id
+      AND coalesce(lower(btrim(coalesce(s.active::text, 'yes'))), 'yes') NOT IN ('no', '0', 'false')
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      v_school_id := p_school_id;
+      v_authority_id := coalesce(p_authority_id, v_authority_id);
+      v_semel_mosad := coalesce(nullif(btrim(coalesce(p_semel_mosad, '')), ''), v_semel_mosad);
+    END IF;
+  ELSIF v_client_type = 'school' AND v_school IS NOT NULL THEN
+    SELECT count(*)::integer
+      INTO v_match_count
+    FROM public.schools s
+    LEFT JOIN public.authorities a ON a.id = s.authority_id
+    WHERE lower(btrim(coalesce(s.school_name, ''))) = lower(v_school)
+      AND (
+        lower(btrim(coalesce(s.authority, ''))) = lower(v_authority)
+        OR lower(btrim(coalesce(a.authority_name, ''))) = lower(v_authority)
+      )
+      AND coalesce(lower(btrim(coalesce(s.active::text, 'yes'))), 'yes') NOT IN ('no', '0', 'false');
+
+    IF v_match_count = 1 THEN
+      SELECT
+        s.id,
+        coalesce(s.authority_id, p_authority_id),
+        coalesce(nullif(btrim(coalesce(s.semel_mosad, '')), ''), nullif(btrim(coalesce(p_semel_mosad, '')), ''))
+      INTO v_school_id, v_authority_id, v_semel_mosad
+      FROM public.schools s
+      LEFT JOIN public.authorities a ON a.id = s.authority_id
+      WHERE lower(btrim(coalesce(s.school_name, ''))) = lower(v_school)
+        AND (
+          lower(btrim(coalesce(s.authority, ''))) = lower(v_authority)
+          OR lower(btrim(coalesce(a.authority_name, ''))) = lower(v_authority)
+        )
+        AND coalesce(lower(btrim(coalesce(s.active::text, 'yes'))), 'yes') NOT IN ('no', '0', 'false')
+      LIMIT 1;
+    END IF;
+  END IF;
+
+  IF v_authority_id IS NULL AND p_authority_id IS NOT NULL THEN
+    v_authority_id := p_authority_id;
+  END IF;
+
+  IF v_semel_mosad IS NULL AND p_semel_mosad IS NOT NULL THEN
+    v_semel_mosad := nullif(btrim(coalesce(p_semel_mosad, '')), '');
+  END IF;
+
+  IF v_school_id IS NOT NULL THEN
+    UPDATE public.contacts_schools cs
+    SET
+      school_id = v_school_id,
+      authority_id = coalesce(v_authority_id, cs.authority_id),
+      semel_mosad = coalesce(v_semel_mosad, cs.semel_mosad)
+    WHERE (
+      cs.school_id = v_school_id
+      OR (
+        cs.school_id IS NULL
+        AND v_school IS NOT NULL
+        AND lower(btrim(coalesce(cs.school, ''))) = lower(v_school)
+        AND lower(btrim(coalesce(cs.authority, ''))) = lower(v_authority)
+      )
+    )
+    AND coalesce(nullif(btrim(coalesce(cs.contact_name, '')), ''), '') = v_contact_name;
+  END IF;
+
+  SELECT cs.id
+    INTO v_existing_id
+  FROM public.contacts_schools cs
+  WHERE lower(btrim(coalesce(cs.authority, ''))) = lower(v_authority)
+    AND coalesce(nullif(btrim(coalesce(cs.school, '')), ''), '') = coalesce(v_school, '')
+    AND coalesce(nullif(btrim(coalesce(cs.contact_name, '')), ''), '') = v_contact_name
+  ORDER BY cs.id
+  LIMIT 1;
+
+  IF v_existing_id IS NULL AND v_school_id IS NOT NULL AND v_client_type = 'school' THEN
+    SELECT cs.id
+      INTO v_existing_id
+    FROM public.contacts_schools cs
+    WHERE cs.school_id = v_school_id
+      AND coalesce(nullif(btrim(coalesce(cs.contact_name, '')), ''), '') = v_contact_name
+    ORDER BY cs.id
+    LIMIT 1;
+  END IF;
+
+  IF v_existing_id IS NOT NULL THEN
+    UPDATE public.contacts_schools
+    SET
+      client_type = v_client_type,
+      client_name = coalesce(v_client_name, client_name),
+      authority = v_authority,
+      school = coalesce(v_school, ''),
+      authority_id = coalesce(v_authority_id, authority_id),
+      school_id = CASE WHEN v_client_type = 'school' THEN coalesce(v_school_id, school_id) ELSE NULL END,
+      semel_mosad = CASE WHEN v_client_type = 'school' THEN coalesce(v_semel_mosad, semel_mosad) ELSE semel_mosad END,
+      contact_role = coalesce(v_contact_role, contact_role),
+      phone = coalesce(v_phone, phone),
+      mobile = coalesce(v_mobile, mobile),
+      email = coalesce(v_email, email),
+      address = coalesce(v_address, address),
+      notes = coalesce(v_notes, notes),
+      active = coalesce(active, 'פעיל')
+    WHERE id = v_existing_id;
+
+    RETURN v_existing_id;
+  END IF;
+
+  INSERT INTO public.contacts_schools (
+    client_type,
+    client_name,
+    authority,
+    school,
+    contact_name,
+    contact_role,
+    phone,
+    mobile,
+    email,
+    address,
+    notes,
+    authority_id,
+    school_id,
+    semel_mosad,
+    active
+  ) VALUES (
+    v_client_type,
+    v_client_name,
+    v_authority,
+    coalesce(v_school, ''),
+    v_contact_name,
+    coalesce(v_contact_role, ''),
+    coalesce(v_phone, ''),
+    coalesce(v_mobile, ''),
+    coalesce(v_email, ''),
+    coalesce(v_address, ''),
+    coalesce(v_notes, ''),
+    v_authority_id,
+    CASE WHEN v_client_type = 'school' THEN v_school_id ELSE NULL END,
+    CASE WHEN v_client_type = 'school' THEN v_semel_mosad ELSE NULL END,
+    'פעיל'
+  )
+  ON CONFLICT ON CONSTRAINT contacts_schools_authority_school_contact_name_key
+  DO UPDATE SET
+    client_type = EXCLUDED.client_type,
+    client_name = EXCLUDED.client_name,
+    authority_id = coalesce(EXCLUDED.authority_id, contacts_schools.authority_id),
+    school_id = coalesce(EXCLUDED.school_id, contacts_schools.school_id),
+    semel_mosad = coalesce(EXCLUDED.semel_mosad, contacts_schools.semel_mosad),
+    contact_role = coalesce(nullif(EXCLUDED.contact_role, ''), contacts_schools.contact_role),
+    phone = coalesce(nullif(EXCLUDED.phone, ''), contacts_schools.phone),
+    mobile = coalesce(nullif(EXCLUDED.mobile, ''), contacts_schools.mobile),
+    email = coalesce(nullif(EXCLUDED.email, ''), contacts_schools.email),
+    address = coalesce(nullif(EXCLUDED.address, ''), contacts_schools.address),
+    notes = coalesce(nullif(EXCLUDED.notes, ''), contacts_schools.notes),
+    active = coalesce(contacts_schools.active, 'פעיל')
+  RETURNING id INTO v_existing_id;
+
+  RETURN v_existing_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.ensure_contact_school_from_proposal(
+  text, text, text, text, text, text, text, text, text, text, text, uuid, uuid, text
+) TO authenticated;
+
+-- Acceptance check (run after deploy):
+-- select
+--   p.oid::regprocedure::text as signature,
+--   pg_get_function_arguments(p.oid) as arguments
+-- from pg_proc p
+-- join pg_namespace n on n.oid = p.pronamespace
+-- where n.nspname = 'public'
+--   and p.proname = 'ensure_contact_school_from_proposal';

--- a/tests/ensure-contact-school-rpc-migration.test.mjs
+++ b/tests/ensure-contact-school-rpc-migration.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const MIGRATION_FILE = new URL(
+  '../supabase/migrations/20260622150000_ensure_contact_school_from_proposal_school_ids.sql',
+  import.meta.url
+);
+
+test('ensure_contact_school_from_proposal migration adds school catalog parameters', async () => {
+  const sql = await readFile(MIGRATION_FILE, 'utf8');
+
+  assert.match(sql, /drop function if exists public\.ensure_contact_school_from_proposal\(/i);
+  assert.match(sql, /create or replace function public\.ensure_contact_school_from_proposal\(/i);
+  assert.match(sql, /p_school_id\s+uuid\s+default\s+null/i);
+  assert.match(sql, /p_authority_id\s+uuid\s+default\s+null/i);
+  assert.match(sql, /p_semel_mosad\s+text\s+default\s+null/i);
+  assert.match(sql, /grant execute on function public\.ensure_contact_school_from_proposal\(/i);
+  assert.doesNotMatch(sql, /grant execute[\s\S]* to anon/i);
+  assert.doesNotMatch(sql, /create view/i);
+  assert.doesNotMatch(sql, /alter table public\.contacts_schools/i);
+});
+
+test('ensure_contact_school_from_proposal migration resolves schools and backfills contacts_schools', async () => {
+  const sql = await readFile(MIGRATION_FILE, 'utf8');
+
+  assert.match(sql, /if p_school_id is not null then/i);
+  assert.match(sql, /from public\.schools s/i);
+  assert.match(sql, /v_match_count = 1/i);
+  assert.match(sql, /update public\.contacts_schools cs/i);
+  assert.match(sql, /school_id = v_school_id/i);
+  assert.match(sql, /authority_id = coalesce\(v_authority_id, cs\.authority_id\)/i);
+  assert.match(sql, /semel_mosad = coalesce\(v_semel_mosad, cs\.semel_mosad\)/i);
+  assert.match(sql, /on conflict on constraint contacts_schools_authority_school_contact_name_key/i);
+});
+
+test('ensure_contact_school_from_proposal migration documents signature verification query', async () => {
+  const sql = await readFile(MIGRATION_FILE, 'utf8');
+
+  assert.match(sql, /pg_get_function_arguments\(p\.oid\)/i);
+  assert.match(sql, /p_school_id/i);
+  assert.match(sql, /p_authority_id/i);
+  assert.match(sql, /p_semel_mosad/i);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #778 עדכן את ה-frontend לשלוח `p_school_id`, `p_authority_id`, `p_semel_mosad` ל-RPC — אבל הפונקציה ב-Supabase עדיין תומכת רק ב-11 פרמטרי `text`.

Migration זה מרחיב את `public.ensure_contact_school_from_proposal` בצורה תואמת לאחור.

## מה השתנה

**קובץ:** `supabase/migrations/20260622150000_ensure_contact_school_from_proposal_school_ids.sql`

- `DROP` של החתימה הישנה (11×`text`)
- `CREATE OR REPLACE` עם 3 פרמטרים חדשים בסוף (עם `DEFAULT NULL`):
  - `p_school_id uuid`
  - `p_authority_id uuid`
  - `p_semel_mosad text`
- לוגיקה:
  1. אם `p_school_id` נשלח — משתמש בו ומעשיר מ-`public.schools` כשאפשר
  2. אחרת — התאמה ודאית לפי `p_school` + `p_authority` ב-`public.schools` (רק כשיש התאמה יחידה)
  3. עדכון `contacts_schools` קיימים עם `school_id` / `authority_id` / `semel_mosad`
  4. find-or-create עם `ON CONFLICT` על `(authority, school, contact_name)`
- `GRANT EXECUTE` ל-`authenticated` בלבד (ללא שינוי anon / views / RLS)

## בדיקות

- `tests/ensure-contact-school-rpc-migration.test.mjs` — 3/3 עברו

## בדיקת קבלה ב-Supabase (אחרי deploy)

```sql
select
  p.oid::regprocedure::text as signature,
  pg_get_function_arguments(p.oid) as arguments
from pg_proc p
join pg_namespace n on n.oid = p.pronamespace
where n.nspname = 'public'
  and p.proname = 'ensure_contact_school_from_proposal';
```

צפוי לראות: `p_school_id`, `p_authority_id`, `p_semel_mosad`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33b0bf7d-c23d-4309-a8a4-d773eb3b9fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33b0bf7d-c23d-4309-a8a4-d773eb3b9fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

