### PR TITLE
Allow 'sent' proposals/agreements status (DB migration) and bump SW cache

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 858;
+const CACHE_VERSION = 860;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Bhj8TG2P.js",
+  "./assets/index-BgFr5tcd.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 858;
+const CACHE_VERSION = 860;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-Bhj8TG2P.js",
+  "./assets/index-BgFr5tcd.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 859;
+const CACHE_VERSION = 860;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/supabase/migrations/20260623_proposals_agreements_sent_status_constraint.sql
+++ b/supabase/migrations/20260623_proposals_agreements_sent_status_constraint.sql
@@ -1,0 +1,8 @@
+-- Allow signed proposals/agreements to be persisted with the business "sent" status.
+-- The application marks approval-and-signature completion as status='sent'.
+ALTER TABLE public.proposals_agreements
+  DROP CONSTRAINT IF EXISTS proposals_agreements_status_check;
+
+ALTER TABLE public.proposals_agreements
+  ADD CONSTRAINT proposals_agreements_status_check
+  CHECK (status IN ('draft', 'sent', 'pending_approval', 'returned_for_changes', 'approved', 'cancelled'));

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 859;
+const SW_ENTRY_VERSION = 860;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- Fix a DB constraint violation where the application writes `status='sent'` for approved-and-signed proposals but the `proposals_agreements_status_check` did not allow `sent`.
- Keep application logic, UI, PDF and return-to-edit behavior unchanged while enabling the approval + signature flow to persist to Supabase.
- Ensure deployed clients pick up the change by bumping the service worker cache version.

### Description
- Add a focused Supabase migration `supabase/migrations/20260623_proposals_agreements_sent_status_constraint.sql` that drops and recreates `proposals_agreements_status_check` to include `'sent'` in the allowed set.
- Bump service worker cache/version constants to `860` in `frontend/sw.js` and `sw.js` and update the built service worker artifacts so caches are invalidated on deploy.
- No changes were made to application logic, templates, styling, PDF generation, or return-to-edit code paths.
- Changed files: `supabase/migrations/20260623_proposals_agreements_sent_status_constraint.sql`, `frontend/sw.js`, `sw.js`, and updated built SW files in `dist`.

### Testing
- Ran focused checks with `npm run check:changed` and it completed successfully.
- Ran `npm run check:build` (build) and it completed successfully.
- Ran the proposals screen focused test `node --test tests/proposals-agreements-screen.test.mjs` which failed on existing proposal-screen assertions unrelated to this migration (no source logic was modified for proposal rendering or edit/save flows).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a2aae5e48832b9da81a8098bef415)