### PR TITLE
Normalize activity-layout sent status and include undated summer schools in layout list

### DIFF
--- a/frontend/src/screens/activities.js
+++ b/frontend/src/screens/activities.js
@@ -1251,24 +1251,39 @@ function writeLocalActivityLayoutStatus(row) {
   }
 }
 
+function normalizeActivityLayoutSent(value) {
+  if (value === true || value === 1) return true;
+  const raw = cleanText(value).toLowerCase();
+  return raw === 'true' || raw === 'yes' || raw === '1' || raw === 'sent' || raw === 'נשלח';
+}
+
+function normalizeActivityLayoutStatusRow(row = {}) {
+  return {
+    ...row,
+    season: cleanText(row.season || ACTIVITY_LAYOUT_SEASON) || ACTIVITY_LAYOUT_SEASON,
+    authority: cleanText(row.authority),
+    school: cleanText(row.school),
+    sent: normalizeActivityLayoutSent(row.sent),
+    sent_at: row.sent_at || '',
+    sent_by: cleanText(row.sent_by)
+  };
+}
+
 function activityLayoutStatusesMap(rows = []) {
   const map = new Map();
   (Array.isArray(rows) ? rows : []).forEach((row) => {
-    const key = activityLayoutStatusKey(row);
-    if (key) map.set(key, row);
+    const normalized = normalizeActivityLayoutStatusRow(row);
+    const key = activityLayoutStatusKey(normalized);
+    if (key) map.set(key, normalized);
   });
   return map;
 }
 
 function readyActivityLayoutSchools(rows = [], statuses = []) {
   const groups = new Map();
-  const authoritySchoolsWithIncompleteRows = new Set();
   (Array.isArray(rows) ? rows : []).forEach((row) => {
     const authority = cleanText(row.authority);
     const school = cleanText(row.school);
-    if (authority && school && !isActivityLayoutRowComplete(row)) {
-      authoritySchoolsWithIncompleteRows.add(activityLayoutStatusKey({ authority, school }));
-    }
     if (!authority || !school) return;
     const key = activityLayoutStatusKey({ authority, school });
     if (!groups.has(key)) groups.set(key, { season: ACTIVITY_LAYOUT_SEASON, authority, school, rows: [], dates: [] });
@@ -1279,7 +1294,7 @@ function readyActivityLayoutSchools(rows = [], statuses = []) {
   });
   const statusMap = activityLayoutStatusesMap(statuses);
   return [...groups.values()]
-    .filter((group) => group.rows.length && !authoritySchoolsWithIncompleteRows.has(activityLayoutStatusKey(group)) && group.rows.every(isActivityLayoutRowComplete))
+    .filter((group) => group.rows.length)
     .map((group) => ({
       ...group,
       count: group.rows.length,

--- a/tests/activities-screen.test.mjs
+++ b/tests/activities-screen.test.mjs
@@ -995,3 +995,55 @@ test('activity add validation clears saving state and does not show duplicate in
     globalThis.FormData = previousFormData;
   }
 });
+
+test('activity layout drawer keeps saved sent statuses and includes undated summer activities', async () => {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousAbortController = globalThis.AbortController;
+  const dom = new JSDOM('<main id="root"></main><section class="ds-drawer__content"></section>', { url: 'https://example.test/dashboard?route=activities' });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.AbortController = dom.window.AbortController;
+  try {
+    const state = baseState();
+    state.activityPeriodTab = 'summer_2026';
+    state.activitiesMonthYm = '2026-08';
+    const data = {
+      rows: [
+        { RowID: 'SUMMER-SENT', activity_name: 'פעילות שנשלחה', activity_type: 'workshop', authority: 'רשות א', school: 'בית ספר א', start_date: '2026-07-10', status: 'פעיל', activity_season: 'summer_2026', start_time: '09:00', end_time: '10:00', grade: 'ד', instructor_name: 'מדריך א' },
+        { RowID: 'SUMMER-UNDATED', activity_name: 'פעילות קיץ ללא חודש מדויק', activity_type: 'workshop', authority: 'רשות ב', school: 'בית ספר ב', start_date: '', status: 'פעיל', activity_season: 'summer_2026', start_time: '11:00', end_time: '12:00', grade: 'ה', instructor_name: 'מדריך ב' },
+        { RowID: 'SCHOOL-REGULAR', activity_name: 'פעילות רגילה', activity_type: 'workshop', authority: 'רשות ג', school: 'בית ספר ג', start_date: '2026-06-10', status: 'פעיל', activity_season: 'regular', start_time: '11:00', end_time: '12:00', grade: 'ו', instructor_name: 'מדריך ג' }
+      ]
+    };
+    const api = {
+      activityLayoutStatuses: async () => ({ rows: [{ season: 'summer_2026', authority: 'רשות א', school: 'בית ספר א', sent: 'sent', sent_at: '2026-06-01T10:00:00.000Z', sent_by: 'בודק' }] })
+    };
+    const root = dom.window.document.querySelector('#root');
+    root.innerHTML = activitiesScreen.render(data, { state });
+    activitiesScreen.bind({
+      root,
+      data,
+      state,
+      rerender: () => {},
+      api,
+      ui: { openDrawer({ content }) { dom.window.document.querySelector('.ds-drawer__content').innerHTML = content; }, bindInteractiveCards() {} }
+    });
+
+    root.querySelector('[data-activity-layout-list]').click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const drawerText = dom.window.document.querySelector('.ds-drawer__content').textContent;
+    assert.match(drawerText, /בית ספר א/);
+    assert.match(drawerText, /נשלח/);
+    assert.match(drawerText, /בית ספר ב/);
+    assert.match(drawerText, /לא נשלח/);
+    assert.doesNotMatch(drawerText, /בית ספר ג/);
+  } finally {
+    if (previousWindow === undefined) delete globalThis.window;
+    else globalThis.window = previousWindow;
+    if (previousDocument === undefined) delete globalThis.document;
+    else globalThis.document = previousDocument;
+    if (previousAbortController === undefined) delete globalThis.AbortController;
+    else globalThis.AbortController = previousAbortController;
+  }
+});


### PR DESCRIPTION
### Motivation
- The activity layout drawer was showing saved "sent" statuses as "not sent" and excluded some summer schools when a single row in that school was incomplete or undated. The intent is to display the saved send-status faithfully and ensure all schools that should receive a layout are listed. 

### Description
- Added `normalizeActivityLayoutSent` and `normalizeActivityLayoutStatusRow` and updated `activityLayoutStatusesMap` to normalize incoming status rows so values like `true`, `1`, `yes`, `sent`, or `נשלח` are treated as sent. 
- Changed `readyActivityLayoutSchools` to stop excluding school groups just because one row is incomplete (removed the completeness-based exclusion), so undated/undetermined summer rows no longer hide the whole school. 
- Kept loading of layout data unchanged: statuses are still read from the `activity_layout_statuses` table (`season, authority, school, sent, sent_at, sent_by`) and activities for layout are still selected via `activityPeriodRows(..., ACTIVITY_LAYOUT_SEASON)` so month/tab navigation does not mutate send status. 
- Added a focused test `activity layout drawer keeps saved sent statuses and includes undated summer activities` in `tests/activities-screen.test.mjs` verifying saved sent rows render as "נשלח", unsent as "לא נשלח", that undated summer activities are included, and that non-summer rows are excluded from the layout list.

### Testing
- Changed files: `frontend/src/screens/activities.js` and `tests/activities-screen.test.mjs`.
- Focused checks run: `npm run check:changed` (checks passed) and `node --test --test-name-pattern "activity layout drawer keeps saved sent statuses" tests/activities-screen.test.mjs` (focused test passed).
- Frontend build: `npm run check:build` completed successfully; temporary `dist` artifacts were produced during the build but `dist` was not committed and SW/cache versions were not updated. 
- Full screen test run `node --test tests/activities-screen.test.mjs` showed unrelated legacy/focused assertions failing in other tests (focused new test passed); these unrelated failures were not debugged further per verification policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a792e4844832bb4c97dd5514a2666)