### PR TITLE
תיקון טבלת פעילויות קיץ במסמך/הדפסה (preview/PDF)

### DIFF
--- a/dist/frontend/sw.js
+++ b/dist/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 789;
+const CACHE_VERSION = 790;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CQOA5lHI.js",
+  "./assets/index-CkudUEhg.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -67,7 +67,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-emrlNFio.css",
+  "./assets/style-Dhjw3Tcd.css",
   "./catalog/appendices/27342.pdf",
   "./catalog/appendices/46091.pdf",
   "./catalog/appendices/52279.pdf",

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <link rel="icon" href="./assets/favicon-D0Y9bj5H.ico" sizes="any" />
   <link rel="apple-touch-icon" href="./assets/apple-touch-icon-DZF9rhdV.png" />
   <title>Dashboard-Taasiyeda</title>
-  <script type="module" crossorigin src="./assets/index-CQOA5lHI.js"></script>
-  <link rel="stylesheet" crossorigin href="./assets/style-emrlNFio.css">
+  <script type="module" crossorigin src="./assets/index-CkudUEhg.js"></script>
+  <link rel="stylesheet" crossorigin href="./assets/style-Dhjw3Tcd.css">
 </head>
 <body>
   <main id="app"></main>

--- a/dist/sw.js
+++ b/dist/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 789;
+const CACHE_VERSION = 790;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 
@@ -42,7 +42,7 @@ const PRECACHE_URLS = [
   "./assets/favicon-32.png",
   "./assets/favicon-D0Y9bj5H.ico",
   "./assets/favicon.ico",
-  "./assets/index-CQOA5lHI.js",
+  "./assets/index-CkudUEhg.js",
   "./assets/invitations/backgrounds/.gitkeep",
   "./assets/invitations/backgrounds/background-1.png",
   "./assets/invitations/backgrounds/background-2.png",
@@ -67,7 +67,7 @@ const PRECACHE_URLS = [
   "./assets/pwa/icon-72.png",
   "./assets/pwa/icon-96.png",
   "./assets/pwa/icon-maskable-512.png",
-  "./assets/style-emrlNFio.css",
+  "./assets/style-Dhjw3Tcd.css",
   "./catalog/appendices/27342.pdf",
   "./catalog/appendices/46091.pdf",
   "./catalog/appendices/52279.pdf",

--- a/frontend/src/screens/proposals-agreements.js
+++ b/frontend/src/screens/proposals-agreements.js
@@ -1718,7 +1718,7 @@ function costTableRowsFromItem(item = {}) {
 // Customer-facing price breakdown, built only from saved proposal_agreement_items.
 // Rows without a real price are never shown. Selected bundle children become billed
 // rows; the parent row is omitted when children carry the actual prices.
-function proposalCostTableHtml(items = []) {
+function proposalCostTableHtml(items = [], options = {}) {
   const billedItems = (Array.isArray(items) ? items : []).filter((item) =>
     !isTestHoursItem(item) && text(item.proposal_display_mode) !== 'bundle_child');
   const rows = billedItems.flatMap((item) => costTableRowsFromItem(item));
@@ -1730,8 +1730,12 @@ function proposalCostTableHtml(items = []) {
     ? `<tr><td colspan="3">סה״כ לפני הנחה</td><td>${currencyAmountHtml(subtotal)}</td></tr>
        <tr><td colspan="3">הנחה</td><td>${currencyAmountHtml(-discount)}</td></tr>`
     : '';
-  return `<table class="pa-cost-table pa-activities-table">
-    <thead><tr><th>פעילות</th><th>כמות</th><th>מחיר יחידה</th><th>סה״כ שורה</th></tr></thead>
+  const tableClass = `pa-cost-table pa-activities-table${options.isSummer ? ' pa-summer-cost-table' : ''}`;
+  const totalHeader = options.isSummer ? 'סה״כ' : 'סה״כ שורה';
+  const colgroupHtml = options.isSummer ? '<colgroup><col class="pa-activity-col"><col class="pa-quantity-col"><col class="pa-unit-price-col"><col class="pa-total-col"></colgroup>' : '';
+  return `<table class="${tableClass}">
+    ${colgroupHtml}
+    <thead><tr><th>פעילות</th><th>כמות</th><th>מחיר יחידה</th><th>${totalHeader}</th></tr></thead>
     <tbody>${rows.map((row) => `<tr>
         <td>${escapeHtml(row.name)}</td>
         <td>${escapeHtml(formatCurrency(row.quantity))}</td>
@@ -1872,7 +1876,7 @@ function costsIntroBody(row = {}, items = []) {
       : 'להלן פירוט הקורסים והעלויות הכלולות בהצעה.';
   }
   if (isSummerProposalGroup(row.activity_type_group)) {
-    return 'פירוט הפעילויות והעלויות מוצג בטבלת העלויות שלהלן.';
+    return 'פירוט הפעילויות והעלויות:';
   }
   return visibleCount ? 'פירוט הפעילויות והעלויות מוצג בטבלת העלויות שלהלן.' : '';
 }
@@ -2222,7 +2226,7 @@ export function proposalPreviewBodyHtml(row, items = [], templateSections = [], 
   const proposalKind = proposalActivityKind(row, items);
   const costTableHtml = proposalKind === 'course'
     ? proposalItemDetailsTableHtml(items, activityTypeGroup)
-    : proposalCostTableHtml(items);
+    : proposalCostTableHtml(items, { isSummer: isSummerProposalGroup(activityTypeGroup) });
   const costsIntro = costsIntroBody(row, items);
   const costTableBlock = (costsIntro || costTableHtml)
     ? `<div class="pa-cost-table-block">${costsIntro ? `<p class="pa-costs-intro-heading">${escapeHtml(costsIntro)}</p>` : ''}${costTableHtml}</div>`

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -12068,6 +12068,27 @@ select.ds-input {
   text-align: left;
   direction: ltr;
 }
+
+.pa-cost-table.pa-summer-cost-table {
+  width: 65% !important;
+  max-width: 65%;
+  margin: 6px auto 8px !important;
+  table-layout: fixed;
+}
+.pa-cost-table.pa-summer-cost-table .pa-activity-col { width: 58%; }
+.pa-cost-table.pa-summer-cost-table .pa-quantity-col,
+.pa-cost-table.pa-summer-cost-table .pa-unit-price-col,
+.pa-cost-table.pa-summer-cost-table .pa-total-col { width: 14%; }
+.pa-cost-table.pa-summer-cost-table th:first-child,
+.pa-cost-table.pa-summer-cost-table td:first-child { width: auto; }
+.pa-cost-table.pa-summer-cost-table th:nth-child(2),
+.pa-cost-table.pa-summer-cost-table td:nth-child(2),
+.pa-cost-table.pa-summer-cost-table th:nth-child(3),
+.pa-cost-table.pa-summer-cost-table td:nth-child(3),
+.pa-cost-table.pa-summer-cost-table th:nth-child(4),
+.pa-cost-table.pa-summer-cost-table td:nth-child(4) {
+  width: auto;
+}
 .pa-discount-summary-table td:last-child {
   text-align: left;
   direction: ltr;
@@ -17199,4 +17220,17 @@ details[open] > .ds-fin-acc__summary::before { transform: rotate(90deg); }
 }
 @media (max-width: 540px) {
   .instr-page .ci-list--instr-grid { grid-template-columns: 1fr !important; }
+}
+
+@media print {
+  .pa-cost-table.pa-summer-cost-table {
+    width: 65% !important;
+    max-width: 65% !important;
+    margin: 8px auto 10px !important;
+    table-layout: fixed !important;
+  }
+  .pa-cost-table.pa-summer-cost-table .pa-activity-col { width: 58% !important; }
+  .pa-cost-table.pa-summer-cost-table .pa-quantity-col,
+  .pa-cost-table.pa-summer-cost-table .pa-unit-price-col,
+  .pa-cost-table.pa-summer-cost-table .pa-total-col { width: 14% !important; }
 }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -3,7 +3,7 @@
  * App shell, JS and CSS: network-first so a normal reload can pick up a new deploy.
  * API-like requests: network only, never cached. Bump CACHE_VERSION after deploy to drop old caches.
  */
-const CACHE_VERSION = 789;
+const CACHE_VERSION = 790;
 const CACHE_PREFIX = 'dashboard-static-v';
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,3 @@
 /* Entry at site root: default scope is `/` so navigations and all same-origin assets are controlled. */
-const SW_ENTRY_VERSION = 865;
+const SW_ENTRY_VERSION = 866;
 importScripts(new URL(`frontend/sw.js?v=${SW_ENTRY_VERSION}`, self.location).href);


### PR DESCRIPTION
### Motivation
- לשפר את מראה טבלת "פעילויות קיץ" במסמך ההצעה/תצוגת Preview/PDF zodat הטבלה תהיה מאוזנת וקריאה יותר מבלי להשפיע על מסכי עריכה או לוגיקה עסקית.

### Description
- שונה הכיתוב מעל הטבלה ל־`פירוט הפעילויות והעלויות:` במקום המשפט הקודם עבור קבוצות קיץ בלבד (שינוי ב־`frontend/src/screens/proposals-agreements.js`).
- טור הכותרת האחרון בטבלת קיץ הושלם כ־`סה״כ` במקום `סה״כ שורה`, והוספה לוגיקה שעוטפת את טבלת העלויות ב־`options.isSummer` כדי לא להשפיע על טבלאות אחרות (שינוי ב־`frontend/src/screens/proposals-agreements.js`).
- נוספו כללי CSS ייעודיים ל־class חדש `pa-summer-cost-table` שמצמצמים רוחב הטבלה ל־65% ומגדירים חלוקת עמודות כך שעמודת "פעילות" תשתמש בכ־58% והרוחב של שלוש העמודות המספריות יהיה כ־14% כל אחת, כולל override להדפסה (שינוי ב־`frontend/src/styles/main.css`).
- בוצע עדכון גרסת ה־Service Worker/Cache (`CACHE_VERSION` מ־789 ל־790 ו־`SW_ENTRY_VERSION` מ־865 ל־866) ובניית `dist` מחדש כדי לשקף את השינויים (שינויים ב־`frontend/sw.js`, `sw.js` ו־`dist/*`).

### Testing
- הרץ `node --check frontend/src/screens/proposals-agreements.js` והבדיקה עברה בהצלחה. 
- הרץ `npm run check:build` (מבנה `dist` דרך `vite build`) והבנייה עברה בהצלחה כאשר Vite הוציא אזהרת `chunk size` שאינה חוסמת את הפריסה.
- הובהר כי השינוי מופעל רק בהצגת מסמך/PDF של קבוצות קיץ ולא נגע במסכי עריכה, שמירה, חישובים, מרג'ין/הגדרות הדפסה כלליות או Supabase בהתאם לדרישות.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a88f666ac832bb61082274a4b7ddb)